### PR TITLE
Create SignalPilot marketing landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,60 +3,916 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SignalPilot</title>
-  <meta name="description" content="SignalPilot — Cut through noise. Ship clear signals.">
+  <title>SignalPilot &middot; Incident intelligence without the noise</title>
+  <meta name="description" content="SignalPilot turns noisy monitoring data into the clear operational signals your teams need to act fast.">
   <style>
-    :root{
-      --bg:#0b0d12; --bg-elev:#11141b; --text:#e9edf7; --muted:#b9c2d6;
-      --brand:#5b8aff; --border:#1b2230; --maxw:1100px;
+    :root {
+      color-scheme: dark;
+      --bg: #05070d;
+      --bg-elev: #0c101b;
+      --bg-soft: #151c2d;
+      --bg-hero: radial-gradient(circle at top right, rgba(91, 138, 255, 0.22), transparent 50%),
+        radial-gradient(circle at 15% 25%, rgba(118, 221, 255, 0.18), transparent 45%),
+        var(--bg);
+      --border: rgba(102, 128, 214, 0.22);
+      --text: #ecf1ff;
+      --muted: #b5c0d8;
+      --muted-soft: #7784a1;
+      --brand: #5b8aff;
+      --brand-glow: rgba(91, 138, 255, 0.5);
+      --accent: #76ddff;
+      --success: #3ed598;
+      --warn: #f9a23c;
+      --radius: 16px;
+      --max-width: min(1160px, 92vw);
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
     }
-    html,body{height:100%}
-    body{margin:0;background:var(--bg);color:var(--text);
-         font:16px/1.6 system-ui,Segoe UI,Roboto,Inter,sans-serif}
-    /* Header */
-    .header{position:sticky;top:0;background:var(--bg);border-bottom:1px solid var(--border);z-index:10}
-    .row{max-width:var(--maxw);margin:0 auto;padding:.8rem 1rem;display:flex;gap:1rem;align-items:center}
-    .brand{display:flex;align-items:center;gap:.6rem;font-weight:700}
-    .brand svg{width:24px;height:24px}
-    .spacer{flex:1}
-    nav ul{display:flex;gap:.8rem;list-style:none;padding:0;margin:0}
-    nav a{padding:.45rem .6rem;border-radius:8px;text-decoration:none;color:var(--text)}
-    nav a:hover{background:var(--bg-elev)}
-    .btn{background:var(--brand);color:#fff;border-radius:10px;padding:.5rem .8rem;text-decoration:none}
-    /* Hero */
-    .hero{max-width:var(--maxw);margin:2.2rem auto;padding:0 1rem}
-    .hero h1{font-size:2.4rem;margin:.2rem 0 1rem}
-    .hero p{max-width:640px;color:var(--muted)}
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 16px/1.6 var(--font, "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif);
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    h1, h2, h3 {
+      font-weight: 700;
+      line-height: 1.2;
+      color: #fff;
+      margin: 0 0 0.75rem;
+    }
+
+    h1 {
+      font-size: clamp(2.6rem, 6vw, 3.8rem);
+      letter-spacing: -0.04em;
+    }
+
+    h2 {
+      font-size: clamp(2.1rem, 4vw, 2.8rem);
+      letter-spacing: -0.025em;
+    }
+
+    h3 {
+      font-size: 1.2rem;
+    }
+
+    p {
+      margin: 0 0 1.1rem;
+      color: var(--muted);
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .page-header {
+      position: sticky;
+      top: 0;
+      backdrop-filter: blur(18px);
+      background: color-mix(in srgb, var(--bg) 70%, transparent);
+      border-bottom: 1px solid rgba(91, 138, 255, 0.12);
+      z-index: 20;
+    }
+
+    .header-inner {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 0.75rem 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+    }
+
+    .brand {
+      display: inline-flex;
+      gap: 0.6rem;
+      align-items: center;
+      font-weight: 700;
+      font-size: 1.05rem;
+      letter-spacing: 0.02em;
+      text-decoration: none;
+    }
+
+    .brand svg {
+      width: 28px;
+      height: 28px;
+      color: var(--accent);
+      filter: drop-shadow(0 0 10px rgba(118, 221, 255, 0.35));
+    }
+
+    nav {
+      margin-left: auto;
+    }
+
+    .nav-list {
+      list-style: none;
+      display: flex;
+      gap: 0.5rem;
+      margin: 0;
+      padding: 0;
+    }
+
+    .nav-link {
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 500;
+      padding: 0.4rem 0.75rem;
+      border-radius: 999px;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      color: #fff;
+      background: rgba(91, 138, 255, 0.14);
+      outline: none;
+    }
+
+    .primary-btn {
+      background: linear-gradient(120deg, var(--brand), #7b9bff);
+      color: #fff;
+      border-radius: 999px;
+      padding: 0.55rem 1.2rem;
+      font-weight: 600;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      box-shadow: 0 12px 35px rgba(91, 138, 255, 0.25);
+    }
+
+    .primary-btn span {
+      font-size: 0.9rem;
+      letter-spacing: 0.02em;
+    }
+
+    .primary-btn svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .secondary-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .hero {
+      background: var(--bg-hero);
+      position: relative;
+    }
+
+    .hero::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at center, rgba(91, 138, 255, 0.3), transparent 70%);
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    .hero-inner {
+      position: relative;
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: clamp(3.5rem, 10vw, 6.5rem) 1.25rem clamp(4rem, 12vw, 7.5rem);
+      display: grid;
+      gap: clamp(2rem, 6vw, 3.5rem);
+    }
+
+    .hero-copy {
+      max-width: 620px;
+    }
+
+    .hero-copy p.lead {
+      font-size: clamp(1.1rem, 3vw, 1.3rem);
+      color: var(--muted);
+    }
+
+    .hero-metrics {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+    }
+
+    .metric {
+      padding: 1rem 1.35rem;
+      background: rgba(12, 16, 27, 0.7);
+      border: 1px solid rgba(91, 138, 255, 0.15);
+      border-radius: var(--radius);
+      min-width: 200px;
+      display: grid;
+      gap: 0.3rem;
+    }
+
+    .metric strong {
+      font-size: 1.8rem;
+      letter-spacing: -0.02em;
+    }
+
+    .content-section {
+      padding: clamp(3.5rem, 9vw, 5rem) 0;
+      border-top: 1px solid rgba(91, 138, 255, 0.08);
+    }
+
+    .section-inner {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 0 1.25rem;
+    }
+
+    .section-lead {
+      max-width: 680px;
+      margin-bottom: clamp(2rem, 6vw, 3rem);
+    }
+
+    .feature-grid {
+      display: grid;
+      gap: 1.6rem;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    }
+
+    .feature-card {
+      background: linear-gradient(160deg, rgba(12, 16, 27, 0.85), rgba(12, 16, 27, 0.55));
+      border-radius: var(--radius);
+      padding: 1.75rem;
+      border: 1px solid rgba(91, 138, 255, 0.14);
+      display: grid;
+      gap: 0.75rem;
+      min-height: 240px;
+    }
+
+    .feature-icon {
+      width: 44px;
+      height: 44px;
+      border-radius: 12px;
+      background: rgba(91, 138, 255, 0.16);
+      color: var(--accent);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: inset 0 0 0 1px rgba(91, 138, 255, 0.18);
+    }
+
+    .feature-icon svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    .feature-card ul {
+      list-style: disc;
+      margin: 0;
+      padding-left: 1.1rem;
+      color: var(--muted);
+      display: grid;
+      gap: 0.35rem;
+    }
+
+    .panel {
+      background: rgba(12, 16, 27, 0.75);
+      border: 1px solid rgba(91, 138, 255, 0.15);
+      border-radius: var(--radius);
+      padding: clamp(1.8rem, 3vw, 2.4rem);
+    }
+
+    .pipeline {
+      display: grid;
+      gap: 1.8rem;
+      margin-top: 2.5rem;
+    }
+
+    .pipeline-step {
+      display: grid;
+      gap: 0.4rem;
+      grid-template-columns: auto 1fr;
+      align-items: center;
+    }
+
+    .step-index {
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      border: 1px solid rgba(118, 221, 255, 0.45);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      color: var(--accent);
+      background: rgba(118, 221, 255, 0.1);
+    }
+
+    .step-body {
+      padding-left: 1rem;
+    }
+
+    .integrations {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1rem;
+    }
+
+    .integration-card {
+      border-radius: 14px;
+      border: 1px solid rgba(91, 138, 255, 0.1);
+      padding: 1rem 1.2rem;
+      background: rgba(12, 16, 27, 0.65);
+      color: var(--muted);
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-weight: 500;
+    }
+
+    .integration-card svg {
+      width: 22px;
+      height: 22px;
+      color: var(--accent);
+    }
+
+    .testimonials {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .testimonial {
+      background: rgba(12, 16, 27, 0.7);
+      padding: 1.8rem;
+      border-radius: var(--radius);
+      border: 1px solid rgba(91, 138, 255, 0.12);
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    blockquote {
+      margin: 0;
+      font-size: 1.05rem;
+      color: #f4f7ff;
+      line-height: 1.55;
+    }
+
+    cite {
+      font-style: normal;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .pricing-table {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    .pricing-card {
+      border-radius: var(--radius);
+      padding: 2rem 1.75rem;
+      border: 1px solid rgba(91, 138, 255, 0.14);
+      background: linear-gradient(160deg, rgba(12, 16, 27, 0.85), rgba(12, 16, 27, 0.55));
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .pricing-card.highlight {
+      border: 1px solid rgba(118, 221, 255, 0.45);
+      box-shadow: 0 18px 45px rgba(118, 221, 255, 0.18);
+    }
+
+    .price {
+      font-size: 2.35rem;
+      font-weight: 700;
+      color: #fff;
+      letter-spacing: -0.03em;
+    }
+
+    .price span {
+      font-size: 1rem;
+      color: var(--muted);
+      font-weight: 500;
+    }
+
+    .pricing-card ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.55rem;
+      color: var(--muted);
+    }
+
+    .cta-panel {
+      margin: 0 auto;
+      padding: clamp(2.5rem, 6vw, 3.8rem) clamp(1.75rem, 5vw, 3.5rem);
+      background: linear-gradient(130deg, rgba(91, 138, 255, 0.28), rgba(12, 16, 27, 0.85));
+      border-radius: calc(var(--radius) * 1.1);
+      border: 1px solid rgba(118, 221, 255, 0.35);
+      display: grid;
+      gap: 1.5rem;
+      text-align: center;
+      max-width: 760px;
+      box-shadow: 0 18px 55px rgba(91, 138, 255, 0.35);
+    }
+
+    footer {
+      margin-top: auto;
+      border-top: 1px solid rgba(91, 138, 255, 0.08);
+      background: rgba(5, 7, 13, 0.95);
+      padding: 2.5rem 0 3rem;
+    }
+
+    .footer-inner {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 0 1.25rem;
+      display: grid;
+      gap: 2rem;
+    }
+
+    .footer-columns {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .footer-columns h4 {
+      margin-bottom: 0.7rem;
+      font-size: 1rem;
+    }
+
+    .footer-columns ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.4rem;
+      color: var(--muted);
+    }
+
+    .footer-columns a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .footer-columns a:hover,
+    .footer-columns a:focus-visible {
+      color: #fff;
+      text-decoration: underline;
+    }
+
+    .footer-bottom {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      justify-content: space-between;
+      color: var(--muted-soft);
+      font-size: 0.85rem;
+    }
+
+    .tag {
+      display: inline-flex;
+      gap: 0.45rem;
+      align-items: center;
+      padding: 0.25rem 0.55rem;
+      border-radius: 999px;
+      background: rgba(62, 213, 152, 0.18);
+      color: var(--success);
+      font-size: 0.8rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .menu-toggle {
+      display: none;
+      background: rgba(12, 16, 27, 0.9);
+      border: 1px solid rgba(91, 138, 255, 0.2);
+      border-radius: 12px;
+      padding: 0.35rem 0.55rem;
+      color: var(--muted);
+    }
+
+    @media (max-width: 860px) {
+      nav {
+        position: fixed;
+        inset: 70px 1.25rem auto;
+        background: rgba(5, 7, 13, 0.96);
+        border: 1px solid rgba(91, 138, 255, 0.18);
+        border-radius: var(--radius);
+        padding: 1.1rem;
+        transform-origin: top right;
+        transform: scale(0.98);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+        box-shadow: 0 22px 55px rgba(5, 15, 35, 0.45);
+      }
+
+      nav.open {
+        opacity: 1;
+        transform: scale(1);
+        pointer-events: auto;
+      }
+
+      .nav-list {
+        flex-direction: column;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: auto;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .hero-metrics {
+        flex-direction: column;
+      }
+
+      .metric {
+        width: 100%;
+      }
+
+      .cta-panel {
+        text-align: left;
+      }
+    }
   </style>
 </head>
 <body>
-  <header class="header">
-    <div class="row">
-      <a class="brand" href="/">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
-          <circle cx="12" cy="12" r="9"></circle><path d="M12 3v9l6 6"></path>
+  <header class="page-header">
+    <div class="header-inner">
+      <a class="brand" href="#">
+        <svg viewBox="0 0 32 32" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6">
+          <circle cx="16" cy="16" r="12"></circle>
+          <path d="M16 4v11l7 7"></path>
         </svg>
         SignalPilot
       </a>
-      <nav aria-label="Primary">
-        <ul>
-          <li><a href="/product">Product</a></li>
-          <li><a href="/solutions">Solutions</a></li>
-          <li><a href="/pricing">Pricing</a></li>
-          <li><a href="/docs">Docs</a></li>
-          <li><a href="/resources">Resources</a></li>
-          <li><a href="/company">Company</a></li>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav id="primary-navigation" aria-label="Main navigation">
+        <ul class="nav-list">
+          <li><a class="nav-link" href="#platform">Platform</a></li>
+          <li><a class="nav-link" href="#workflow">Workflow</a></li>
+          <li><a class="nav-link" href="#integrations">Integrations</a></li>
+          <li><a class="nav-link" href="#pricing">Pricing</a></li>
+          <li><a class="nav-link" href="#resources">Resources</a></li>
         </ul>
       </nav>
-      <div class="spacer"></div>
-      <a class="btn" href="/signup">Get started</a>
+      <a class="primary-btn" href="#cta"><span>Start free</span>
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+          <path d="M3 8h10M9 4l4 4-4 4" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </a>
     </div>
   </header>
 
-  <main class="hero">
-    <h1>Cut through noise. Ship clear signals.</h1>
-    <p>SignalPilot detects anomalies, filters alert noise, and routes the right events to the right people — automatically.</p>
-    <p><a class="btn" href="/signup">Start free</a></p>
+  <main>
+    <section class="hero">
+      <div class="hero-inner">
+        <div class="hero-copy">
+          <div class="tag">Incident intelligence</div>
+          <h1>Cut through alert noise. Ship clear signals.</h1>
+          <p class="lead">SignalPilot ingests telemetry from every system, learns your normal, and surfaces only the incidents that matter. Give your responders precise context before they even open the alert.</p>
+          <div style="display:flex; flex-wrap:wrap; gap:1rem; align-items:center;">
+            <a class="primary-btn" href="#cta"><span>Launch the platform</span>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+                <path d="M3 8h10M9 4l4 4-4 4" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </a>
+            <a class="secondary-btn" href="#resources">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                <circle cx="8" cy="8" r="6"></circle>
+                <path d="m6.5 5.5 4 2.5-4 2.5V5.5Z" fill="currentColor"></path>
+              </svg>
+              Watch 3 min demo
+            </a>
+          </div>
+        </div>
+        <div class="hero-metrics" role="list">
+          <div class="metric" role="listitem">
+            <strong>87%</strong>
+            <span>reduction in alert fatigue in the first 30 days.</span>
+          </div>
+          <div class="metric" role="listitem">
+            <strong>5x</strong>
+            <span>faster time-to-detect for critical regressions.</span>
+          </div>
+          <div class="metric" role="listitem">
+            <strong>&lt; 2 min</strong>
+            <span>from detection to on-call routing with enriched context.</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section" id="platform">
+      <div class="section-inner">
+        <div class="section-lead">
+          <h2>The platform built for signal clarity</h2>
+          <p>SignalPilot continuously correlates metrics, traces, logs, and business events to understand what normal looks like for your systems. When something drifts, we automatically verify, suppress noise, and trigger action with confidence.</p>
+        </div>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <div class="feature-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                <path d="M4 12s2.5-4 8-4 8 4 8 4-2.5 4-8 4-8-4-8-4Z"></path>
+                <circle cx="12" cy="12" r="2.5"></circle>
+              </svg>
+            </div>
+            <h3>Adaptive observability</h3>
+            <p>Ingest every signal without retooling your existing stack. Our agents auto-discover services, baselines, and dependencies.</p>
+            <ul>
+              <li>Native support for OpenTelemetry, StatsD, CloudWatch, and more.</li>
+              <li>Dynamic service maps keep your topology current.</li>
+              <li>Edge collectors protect sensitive data on-prem.</li>
+            </ul>
+          </article>
+          <article class="feature-card">
+            <div class="feature-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                <path d="M4 7h16M4 12h16M4 17h16"></path>
+                <path d="M9 7v10M15 7v10"></path>
+              </svg>
+            </div>
+            <h3>Noise suppression engine</h3>
+            <p>We correlate symptoms across telemetry streams to eliminate false positives and redundant alerts before they hit your pager.</p>
+            <ul>
+              <li>AI-assisted deduplication groups related incidents in real time.</li>
+              <li>Auto-snooze for flapping monitors based on historical patterns.</li>
+              <li>Explainable scoring surfaces why an incident triggered.</li>
+            </ul>
+          </article>
+          <article class="feature-card">
+            <div class="feature-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+                <path d="M12 3v10"></path>
+                <path d="M6 13h12l-3.5 8h-5L6 13Z"></path>
+              </svg>
+            </div>
+            <h3>Incident autopilot</h3>
+            <p>Automate routing and remediation. Enrich every alert with runbooks, ownership, and live system context.</p>
+            <ul>
+              <li>Policy-driven escalations with schedule-aware on-call rotations.</li>
+              <li>Slack, Teams, and email responders with full audit trails.</li>
+              <li>Trigger webhooks or serverless runbooks to remediate instantly.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section" id="workflow">
+      <div class="section-inner">
+        <div class="section-lead">
+          <h2>From signal to action in four decisive steps</h2>
+          <p>Bring every telemetry stream into a single workflow. SignalPilot scores events, routes what matters, and gives engineers the full story before they respond.</p>
+        </div>
+        <div class="panel">
+          <div class="pipeline">
+            <div class="pipeline-step">
+              <div class="step-index">1</div>
+              <div class="step-body">
+                <h3>Ingest anything</h3>
+                <p>Drop-in collectors capture metrics, traces, logs, uptime, and business events from your cloud, on-prem, and edge environments.</p>
+              </div>
+            </div>
+            <div class="pipeline-step">
+              <div class="step-index">2</div>
+              <div class="step-body">
+                <h3>Detect and verify</h3>
+                <p>Machine learning models trained on your environment baseline detect anomalies and auto-verify using dependency context.</p>
+              </div>
+            </div>
+            <div class="pipeline-step">
+              <div class="step-index">3</div>
+              <div class="step-body">
+                <h3>Enrich the signal</h3>
+                <p>Attach runbooks, recent deploys, customer impact, and slack threads automatically so responders have answers, not questions.</p>
+              </div>
+            </div>
+            <div class="pipeline-step">
+              <div class="step-index">4</div>
+              <div class="step-body">
+                <h3>Route &amp; resolve</h3>
+                <p>Send incidents to the right teams through PagerDuty, Opsgenie, Jira, or any webhook. Close the loop with automated remediation.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section" id="integrations">
+      <div class="section-inner">
+        <div class="section-lead">
+          <h2>Connect SignalPilot to the stack you already use</h2>
+          <p>With 80+ prebuilt integrations and an open API, SignalPilot meets your teams where they work today.</p>
+        </div>
+        <div class="integrations">
+          <div class="integration-card">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 7h16v10H4z"></path><path d="m4 7 8 5 8-5"></path></svg>
+            Email &amp; SMS routing
+          </div>
+          <div class="integration-card">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 3 2 9l10 6 10-6-10-6Z"></path><path d="M2 15l10 6 10-6"></path></svg>
+            PagerDuty
+          </div>
+          <div class="integration-card">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M5 5h14v14H5z"></path><path d="M9 9h6v6H9z"></path></svg>
+            Opsgenie
+          </div>
+          <div class="integration-card">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="9"></circle><path d="M8.5 13.5 6 12l2.5-1.5M15.5 13.5 18 12l-2.5-1.5"></path></svg>
+            Slack &amp; Teams
+          </div>
+          <div class="integration-card">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 4h16v16H4z"></path><path d="M4 9h16M9 4v16"></path></svg>
+            Jira &amp; Linear
+          </div>
+          <div class="integration-card">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 3v18M3 12h18"></path></svg>
+            Webhooks &amp; API
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section" id="resources">
+      <div class="section-inner">
+        <div class="section-lead">
+          <h2>Teams trust SignalPilot to stay ahead of incidents</h2>
+          <p>Hear how high-growth engineering teams and global enterprises rely on SignalPilot to maintain reliability and win customer trust.</p>
+        </div>
+        <div class="testimonials">
+          <article class="testimonial">
+            <blockquote>
+              “SignalPilot cut our on-call volume in half. Engineers now get the full story with every alert, which means incidents resolve before customers even notice.”
+            </blockquote>
+            <cite>Riya Das &mdash; Director of SRE, HorizonPay</cite>
+          </article>
+          <article class="testimonial">
+            <blockquote>
+              “The automatic context from deploys and customer impact is game changing. Our MTTR dropped by 40% in the first quarter after rolling it out.”
+            </blockquote>
+            <cite>Samir Patel &mdash; Head of Platform, FleetIQ</cite>
+          </article>
+          <article class="testimonial">
+            <blockquote>
+              “We plugged SignalPilot into our legacy systems and cloud-native stack in days. The AI-powered noise suppression is the most accurate we’ve seen.”
+            </blockquote>
+            <cite>Alexis Morgan &mdash; VP Infrastructure, Northwind Health</cite>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section" id="pricing">
+      <div class="section-inner">
+        <div class="section-lead">
+          <h2>Simple, usage-based pricing for every stage</h2>
+          <p>Start free with unlimited integrations. Upgrade when you need advanced automation, governance, and enterprise scale.</p>
+        </div>
+        <div class="pricing-table">
+          <article class="pricing-card">
+            <div>
+              <h3>Starter</h3>
+              <p class="price">$0<span>/month</span></p>
+            </div>
+            <p>Everything you need to get your first teams on SignalPilot.</p>
+            <ul>
+              <li>Up to 5 team members</li>
+              <li>100k events processed / month</li>
+              <li>Email, Slack, and Teams routing</li>
+              <li>Community support</li>
+            </ul>
+            <a class="primary-btn" href="#cta"><span>Launch for free</span></a>
+          </article>
+          <article class="pricing-card highlight">
+            <div>
+              <h3>Growth</h3>
+              <p class="price">$349<span>/month</span></p>
+            </div>
+            <p>The best choice for scale-ups with multiple services and teams.</p>
+            <ul>
+              <li>Unlimited team members</li>
+              <li>10M events processed / month</li>
+              <li>Runbook automation &amp; custom scoring</li>
+              <li>Advanced RBAC and SSO</li>
+            </ul>
+            <a class="primary-btn" href="#cta"><span>Start a trial</span></a>
+          </article>
+          <article class="pricing-card">
+            <div>
+              <h3>Enterprise</h3>
+              <p class="price">Talk to us<span></span></p>
+            </div>
+            <p>Purpose-built for global operations, complex orgs, and compliance.</p>
+            <ul>
+              <li>Unlimited ingestion with volume discounts</li>
+              <li>Dedicated success architect</li>
+              <li>Private cloud or on-prem deployment</li>
+              <li>24/7 support &amp; compliance toolkit</li>
+            </ul>
+            <a class="primary-btn" href="mailto:hello@signalpilot.io"><span>Contact sales</span></a>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section" id="cta">
+      <div class="section-inner">
+        <div class="cta-panel">
+          <h2>Your signals deserve a co-pilot</h2>
+          <p>Stand up SignalPilot in under an hour. Start correlating incidents, removing noise, and giving your teams the clarity they deserve.</p>
+          <div style="display:flex; flex-wrap:wrap; justify-content:center; gap:1rem;">
+            <a class="primary-btn" href="https://app.signalpilot.io/signup"><span>Create your workspace</span></a>
+            <a class="secondary-btn" href="mailto:hello@signalpilot.io">Talk with our engineers</a>
+          </div>
+        </div>
+      </div>
+    </section>
   </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div class="footer-columns">
+        <div>
+          <a class="brand" href="#">
+            <svg viewBox="0 0 32 32" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6">
+              <circle cx="16" cy="16" r="12"></circle>
+              <path d="M16 4v11l7 7"></path>
+            </svg>
+            SignalPilot
+          </a>
+          <p style="max-width:280px; margin-top:1rem;">SignalPilot keeps modern operations teams focused on what matters by turning noisy telemetry into actionable intelligence.</p>
+        </div>
+        <div>
+          <h4>Product</h4>
+          <ul>
+            <li><a href="#platform">Platform</a></li>
+            <li><a href="#workflow">Workflow</a></li>
+            <li><a href="#integrations">Integrations</a></li>
+            <li><a href="#pricing">Pricing</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Company</h4>
+          <ul>
+            <li><a href="#resources">Customers</a></li>
+            <li><a href="mailto:hello@signalpilot.io">Contact</a></li>
+            <li><a href="#">Careers</a></li>
+            <li><a href="#">Security</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Resources</h4>
+          <ul>
+            <li><a href="#resources">Customer stories</a></li>
+            <li><a href="#">Incident response guide</a></li>
+            <li><a href="#">Reliability benchmarks</a></li>
+            <li><a href="#">Status page</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <div>&copy; <span id="year"></span> SignalPilot Labs, Inc. All rights reserved.</div>
+        <div style="display:flex; gap:1rem;">
+          <a href="#">Privacy</a>
+          <a href="#">Terms</a>
+          <a href="#">Subprocessors</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    const toggle = document.querySelector('.menu-toggle');
+    const nav = document.querySelector('nav');
+    toggle?.addEventListener('click', () => {
+      const isOpen = nav.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', String(isOpen));
+    });
+
+    document.querySelectorAll('.nav-link').forEach(link => {
+      link.addEventListener('click', () => {
+        nav.classList.remove('open');
+        toggle?.setAttribute('aria-expanded', 'false');
+      });
+    });
+
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the placeholder SignalPilot page with a full marketing landing layout
- add responsive navigation, hero metrics, product features, workflow, integrations, testimonials, pricing, and CTA sections
- include light JS for mobile menu toggling and dynamic footer year

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d87fc25b24832e9881834f4a5ff044