### PR TITLE
Add reusable SignalPilot logo asset

### DIFF
--- a/assets/signalpilot-logo.svg
+++ b/assets/signalpilot-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#76ddff" stroke-width="1.6">
+  <circle cx="16" cy="16" r="12" />
+  <path d="M16 4v11l7 7" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -100,10 +100,9 @@
       text-decoration: none;
     }
 
-    .brand svg {
+    .brand img {
       width: 28px;
       height: 28px;
-      color: var(--accent);
       filter: drop-shadow(0 0 10px rgba(118, 221, 255, 0.35));
     }
 
@@ -554,10 +553,7 @@
   <header class="page-header">
     <div class="header-inner">
       <a class="brand" href="#">
-        <svg viewBox="0 0 32 32" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6">
-          <circle cx="16" cy="16" r="12"></circle>
-          <path d="M16 4v11l7 7"></path>
-        </svg>
+        <img src="assets/signalpilot-logo.svg" width="28" height="28" alt="SignalPilot logo" />
         SignalPilot
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
@@ -919,10 +915,7 @@
       <div class="footer-columns">
         <div>
           <a class="brand" href="#">
-            <svg viewBox="0 0 32 32" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6">
-              <circle cx="16" cy="16" r="12"></circle>
-              <path d="M16 4v11l7 7"></path>
-            </svg>
+            <img src="assets/signalpilot-logo.svg" width="28" height="28" alt="SignalPilot logo" />
             SignalPilot
           </a>
           <p style="max-width:280px; margin-top:1rem;">SignalPilot helps traders cut through noise and ship clear signals with TradingView scripts designed for education-first communities.</p>


### PR DESCRIPTION
## Summary
- add a shared SignalPilot logo asset under assets/
- update header and footer branding to use the new logo image instead of inline SVG
- adjust brand styling to target the new <img> element while preserving the glow treatment

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8907e066c832eb86114bbe24222ee