### PR TITLE
Add SignalPilot wordmark asset

### DIFF
--- a/assets/signalpilot-logo.svg
+++ b/assets/signalpilot-logo.svg
@@ -1,0 +1,24 @@
+<svg width="196" height="40" viewBox="0 0 196 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">SignalPilot wordmark</title>
+  <desc id="logoDesc">SignalPilot logomark with stylised signal beacon next to the SignalPilot name.</desc>
+  <defs>
+    <linearGradient id="pilotMark" x1="6" y1="6" x2="34" y2="34" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#76ddff" />
+      <stop offset="1" stop-color="#5b8aff" />
+    </linearGradient>
+    <linearGradient id="signalHighlight" x1="14" y1="10" x2="30" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="rgba(236, 241, 255, 0.9)" />
+      <stop offset="1" stop-color="rgba(236, 241, 255, 0.2)" />
+    </linearGradient>
+  </defs>
+  <g>
+    <rect x="4" y="4" width="32" height="32" rx="12" fill="url(#pilotMark)" />
+    <path d="M24.6 13.2c.88.58 1.12 1.84.48 2.7l-4.08 5.36c-.52.68-1.52.84-2.24.36l-2.36-1.56a1.6 1.6 0 0 1-.36-2.32l4.04-5.32c.64-.84 1.84-1.04 2.68-.52l1.84 1.2z" fill="#05070d" opacity="0.35" />
+    <path d="M16.7 17.3c-.86 1.16-.58 2.8.62 3.52l2.32 1.44a2.4 2.4 0 0 0 3.28-.72l4.12-5.4c.82-1.1.5-2.66-.7-3.38l-1.9-1.14a2.4 2.4 0 0 0-3.24.7l-4.5 5.98z" fill="url(#signalHighlight)" />
+    <path d="M28.2 14.1c.54-.74 1.58-.9 2.32-.36.74.54.9 1.58.36 2.32l-3.6 4.88c-.54.74-1.58.9-2.32.36-.74-.54-.9-1.58-.36-2.32l3.6-4.88z" fill="#ecf1ff" opacity="0.9" />
+    <path d="M13.2 20.8c-.54.74-1.58.9-2.32.36-.74-.54-.9-1.58-.36-2.32l3.56-4.84c.54-.74 1.58-.9 2.32-.36.74.54.9 1.58.36 2.32l-3.56 4.84z" fill="#ecf1ff" opacity="0.6" />
+  </g>
+  <text x="48" y="24" fill="#ecf1ff" font-size="18" font-weight="700" font-family="'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif" letter-spacing="0.02em">
+    Signal<tspan fill="#76ddff">Pilot</tspan>
+  </text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -101,8 +101,9 @@
     }
 
     .brand img {
-      width: 28px;
       height: 28px;
+      width: auto;
+      max-width: 160px;
       filter: drop-shadow(0 0 10px rgba(118, 221, 255, 0.35));
     }
 
@@ -553,7 +554,7 @@
   <header class="page-header">
     <div class="header-inner">
       <a class="brand" href="#">
-        <img src="assets/signalpilot-logo.svg" width="28" height="28" alt="SignalPilot logo" />
+        <img src="assets/signalpilot-logo.svg" alt="SignalPilot wordmark" />
         SignalPilot
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
@@ -915,7 +916,7 @@
       <div class="footer-columns">
         <div>
           <a class="brand" href="#">
-            <img src="assets/signalpilot-logo.svg" width="28" height="28" alt="SignalPilot logo" />
+            <img src="assets/signalpilot-logo.svg" alt="SignalPilot wordmark" />
             SignalPilot
           </a>
           <p style="max-width:280px; margin-top:1rem;">SignalPilot helps traders cut through noise and ship clear signals with TradingView scripts designed for education-first communities.</p>


### PR DESCRIPTION
## Summary
- replace the logo asset with the new SignalPilot wordmark SVG
- adjust brand image styling and alt text in the header and footer to accommodate the wider wordmark

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8963c61c4832eac60afb86e931ff1