### PR TITLE
Update mailto CTAs to use support inbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,7 +567,7 @@
           <li><a class="nav-link" href="#company">Company</a></li>
         </ul>
       </nav>
-      <a class="primary-btn" href="mailto:pro@signalpilot.io?subject=SignalPilot%20Pro%20Invite"><span>Request Pro access</span>
+      <a class="primary-btn" href="mailto:support@signalpilot.io?subject=SignalPilot%20Pro%20Invite"><span>Request Pro access</span>
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
           <path d="M3 8h10M9 4l4 4-4 4" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
@@ -591,7 +591,7 @@
               </svg>
               <span>Start free</span>
             </a>
-            <a class="secondary-btn" href="mailto:pro@signalpilot.io?subject=SignalPilot%20Pro%20Waitlist">
+            <a class="secondary-btn" href="mailto:support@signalpilot.io?subject=SignalPilot%20Pro%20Waitlist">
               <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <path d="M3 8h10M9 4l4 4-4 4" stroke-linecap="round" stroke-linejoin="round" />
               </svg>
@@ -857,7 +857,7 @@
               <li>Granular risk modules with equity curve safeguards.</li>
               <li>Live office hours and private Discord for strategy reviews.</li>
             </ul>
-            <a class="primary-btn" href="mailto:pro@signalpilot.io?subject=SignalPilot%20Pro%20Waitlist"><span>Join the waitlist</span></a>
+            <a class="primary-btn" href="mailto:support@signalpilot.io?subject=SignalPilot%20Pro%20Waitlist"><span>Join the waitlist</span></a>
           </article>
         </div>
         <p style="margin-top:2rem; color:var(--muted-soft); font-size:0.9rem;">SignalPilot Lite and Pro are educational tools. Trading involves risk and past performance from backtests or simulations is not indicative of future results.</p>
@@ -903,7 +903,7 @@
           <h2>Ready to trade with clarity?</h2>
           <p>Install Lite today to see the bias in real time, then request Pro when you’re ready for automation, risk controls, and advanced backtesting workflows.</p>
           <div style="display:flex; flex-wrap:wrap; justify-content:center; gap:1rem;">
-            <a class="primary-btn" href="mailto:pro@signalpilot.io?subject=SignalPilot%20Pro%20Waitlist"><span>Join the Pro waitlist</span></a>
+            <a class="primary-btn" href="mailto:support@signalpilot.io?subject=SignalPilot%20Pro%20Waitlist"><span>Join the Pro waitlist</span></a>
             <a class="secondary-btn" href="https://www.tradingview.com/script/signalpilot-lite/" target="_blank" rel="noopener">Download Lite indicator</a>
           </div>
         </div>
@@ -936,7 +936,7 @@
           <ul>
             <li><a href="#pricing">Lite vs Pro</a></li>
             <li><a href="https://www.tradingview.com/script/signalpilot-lite/" target="_blank" rel="noopener">Download Lite</a></li>
-            <li><a href="mailto:pro@signalpilot.io?subject=SignalPilot%20Pro%20Waitlist">Request Pro invite</a></li>
+            <li><a href="mailto:support@signalpilot.io?subject=SignalPilot%20Pro%20Waitlist">Request Pro invite</a></li>
             <li><a href="#pricing">Risk disclosures</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- update CTA mailto links across the homepage to point to the support inbox while keeping subjects intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d899187d8c832e8c9a3751a606f710