### PR TITLE
Update partnership email to support@signlapilot.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -884,14 +884,14 @@
             </div>
             <h3>Partner programs</h3>
             <p>We collaborate with trading education communities and prop firms to deliver white-labeled dashboards and custom risk templates.</p>
-            <p style="margin:0; color:var(--muted-soft);">Email <a href="mailto:partners@signalpilot.io" style="color:inherit;">partners@signalpilot.io</a> to discuss partnerships.</p>
+            <p style="margin:0; color:var(--muted-soft);">Email <a href="mailto:support@signlapilot.io" style="color:inherit;">support@signlapilot.io</a> to discuss partnerships.</p>
           </article>
           <article class="feature-card">
             <div class="feature-icon" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M6 8a6 6 0 1 1 12 0c0 3-6 13-6 13S6 11 6 8Z"></path><circle cx="12" cy="8" r="2"></circle></svg>
             </div>
             <h3>Contact</h3>
-            <p>Questions about the scripts or waitlist? Reach us at <a href="mailto:hello@signalpilot.io" style="color:inherit;">hello@signalpilot.io</a> or follow <a href="https://www.tradingview.com/u/signalpilot/" target="_blank" rel="noopener" style="color:inherit;">@signalpilot</a> on TradingView.</p>
+            <p>Questions about the scripts or waitlist? Reach us at <a href="mailto:support@signalpilot.io" style="color:inherit;">support@signalpilot.io</a> or follow <a href="https://www.tradingview.com/u/signalpilot/" target="_blank" rel="noopener" style="color:inherit;">@signalpilot</a> on TradingView.</p>
           </article>
         </div>
       </div>
@@ -962,7 +962,7 @@
           <h4>Company</h4>
           <ul>
             <li><a href="#company">About</a></li>
-            <li><a href="mailto:partners@signalpilot.io">Partnerships</a></li>
+            <li><a href="mailto:support@signlapilot.io">Partnerships</a></li>
             <li><a href="mailto:hello@signalpilot.io">Contact</a></li>
             <li><a href="https://www.tradingview.com/u/signalpilot/" target="_blank" rel="noopener">TradingView profile</a></li>
           </ul>


### PR DESCRIPTION
## Summary
- update the Company section partnership blurb to reference support@signlapilot.io
- ensure the footer partnerships contact uses the same support@signlapilot.io address

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d899197240832e825efbcfa9b8d46e