### PR TITLE
Add SignalPilot favicon and reference in head

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 40 40" role="img" aria-labelledby="faviconTitle faviconDesc">
+  <title id="faviconTitle">SignalPilot beacon mark</title>
+  <desc id="faviconDesc">Rounded square gradient beacon logomark for SignalPilot.</desc>
+  <defs>
+    <linearGradient id="spGradient" x1="6" y1="6" x2="34" y2="34" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#76ddff" />
+      <stop offset="1" stop-color="#5b8aff" />
+    </linearGradient>
+    <linearGradient id="spHighlight" x1="14" y1="10" x2="30" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="rgba(236, 241, 255, 0.9)" />
+      <stop offset="1" stop-color="rgba(236, 241, 255, 0.2)" />
+    </linearGradient>
+  </defs>
+  <g>
+    <rect x="4" y="4" width="32" height="32" rx="12" fill="url(#spGradient)" />
+    <path d="M24.6 13.2c.88.58 1.12 1.84.48 2.7l-4.08 5.36c-.52.68-1.52.84-2.24.36l-2.36-1.56a1.6 1.6 0 0 1-.36-2.32l4.04-5.32c.64-.84 1.84-1.04 2.68-.52l1.84 1.2z" fill="#05070d" opacity="0.35" />
+    <path d="M16.7 17.3c-.86 1.16-.58 2.8.62 3.52l2.32 1.44a2.4 2.4 0 0 0 3.28-.72l4.12-5.4c.82-1.1.5-2.66-.7-3.38l-1.9-1.14a2.4 2.4 0 0 0-3.24.7l-4.5 5.98z" fill="url(#spHighlight)" />
+    <path d="M28.2 14.1c.54-.74 1.58-.9 2.32-.36.74.54.9 1.58.36 2.32l-3.6 4.88c-.54.74-1.58.9-2.32.36-.74-.54-.9-1.58-.36-2.32l3.6-4.88z" fill="#ecf1ff" opacity="0.9" />
+    <path d="M13.2 20.8c-.54.74-1.58.9-2.32.36-.74-.54-.9-1.58-.36-2.32l3.56-4.84c.54-.74 1.58-.9 2.32-.36.74.54.9 1.58.36 2.32l-3.56 4.84z" fill="#ecf1ff" opacity="0.6" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>SignalPilot TradingView Scripts · Cut through noise. Ship clear signals.</title>
   <meta name="description" content="SignalPilot Pro and Lite TradingView scripts filter false trade setups for active traders. Cut through noise. Ship clear signals with configurable strategy modules for every market participant.">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <style>
     :root {
       color-scheme: dark;


### PR DESCRIPTION
## Summary
- add a SignalPilot beacon favicon in SVG format at the project root
- reference the favicon from the homepage head so browsers can load it

## Testing
- curl -I http://127.0.0.1:8000/favicon.svg

------
https://chatgpt.com/codex/tasks/task_e_68d9aadc3658832eacf029a1e6ea7f51