### PR TITLE
Ensure mobile navigation hidden state adapts responsively

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,10 @@
       margin-left: auto;
     }
 
+    [hidden] {
+      display: none !important;
+    }
+
     .nav-list {
       list-style: none;
       display: flex;
@@ -558,7 +562,7 @@
         SignalPilot
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">Menu</button>
-      <nav id="primary-navigation" aria-label="Main navigation">
+      <nav id="primary-navigation" aria-label="Main navigation" hidden>
         <ul class="nav-list">
           <li><a class="nav-link" href="#product">Product</a></li>
           <li><a class="nav-link" href="#pricing">Pricing</a></li>
@@ -981,18 +985,53 @@
 
   <script>
     const toggle = document.querySelector('.menu-toggle');
-    const nav = document.querySelector('nav');
+    const nav = document.getElementById('primary-navigation');
+    const desktopMedia = window.matchMedia('(min-width: 861px)');
+
+    const openNav = () => {
+      if (!nav) return;
+      nav.classList.add('open');
+      nav.removeAttribute('hidden');
+      toggle?.setAttribute('aria-expanded', 'true');
+    };
+
+    const closeNav = () => {
+      if (!nav) return;
+      nav.classList.remove('open');
+      if (!desktopMedia.matches) {
+        nav.setAttribute('hidden', '');
+      }
+      toggle?.setAttribute('aria-expanded', 'false');
+    };
+
     toggle?.addEventListener('click', () => {
-      const isOpen = nav.classList.toggle('open');
-      toggle.setAttribute('aria-expanded', String(isOpen));
+      if (nav?.classList.contains('open')) {
+        closeNav();
+      } else {
+        openNav();
+      }
     });
 
     document.querySelectorAll('.nav-link').forEach(link => {
       link.addEventListener('click', () => {
-        nav.classList.remove('open');
-        toggle?.setAttribute('aria-expanded', 'false');
+        closeNav();
       });
     });
+
+    const handleBreakpoint = event => {
+      if (!nav) return;
+      if (event.matches) {
+        nav.removeAttribute('hidden');
+        nav.classList.remove('open');
+        toggle?.setAttribute('aria-expanded', 'false');
+      } else if (!nav.classList.contains('open')) {
+        nav.setAttribute('hidden', '');
+        toggle?.setAttribute('aria-expanded', 'false');
+      }
+    };
+
+    handleBreakpoint(desktopMedia);
+    desktopMedia.addEventListener('change', handleBreakpoint);
 
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>

--- a/index.html
+++ b/index.html
@@ -986,52 +986,72 @@
   <script>
     const toggle = document.querySelector('.menu-toggle');
     const nav = document.getElementById('primary-navigation');
-    const desktopMedia = window.matchMedia('(min-width: 861px)');
+    const desktopMedia = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(min-width: 861px)')
+      : null;
+
+    const setToggleExpanded = expanded => {
+      if (toggle) {
+        toggle.setAttribute('aria-expanded', String(expanded));
+      }
+    };
 
     const openNav = () => {
       if (!nav) return;
       nav.classList.add('open');
       nav.removeAttribute('hidden');
-      toggle?.setAttribute('aria-expanded', 'true');
+      setToggleExpanded(true);
     };
 
     const closeNav = () => {
       if (!nav) return;
       nav.classList.remove('open');
-      if (!desktopMedia.matches) {
+      if (!desktopMedia || !desktopMedia.matches) {
         nav.setAttribute('hidden', '');
       }
-      toggle?.setAttribute('aria-expanded', 'false');
+      setToggleExpanded(false);
     };
 
-    toggle?.addEventListener('click', () => {
-      if (nav?.classList.contains('open')) {
-        closeNav();
-      } else {
-        openNav();
-      }
-    });
-
-    document.querySelectorAll('.nav-link').forEach(link => {
-      link.addEventListener('click', () => {
-        closeNav();
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
+        if (nav.classList.contains('open')) {
+          closeNav();
+        } else {
+          openNav();
+        }
       });
-    });
+    }
+
+    if (nav) {
+      document.querySelectorAll('.nav-link').forEach(link => {
+        link.addEventListener('click', () => {
+          closeNav();
+        });
+      });
+    }
 
     const handleBreakpoint = event => {
       if (!nav) return;
       if (event.matches) {
         nav.removeAttribute('hidden');
         nav.classList.remove('open');
-        toggle?.setAttribute('aria-expanded', 'false');
+        setToggleExpanded(false);
       } else if (!nav.classList.contains('open')) {
         nav.setAttribute('hidden', '');
-        toggle?.setAttribute('aria-expanded', 'false');
+        setToggleExpanded(false);
       }
     };
 
-    handleBreakpoint(desktopMedia);
-    desktopMedia.addEventListener('change', handleBreakpoint);
+    if (desktopMedia) {
+      handleBreakpoint(desktopMedia);
+      if (typeof desktopMedia.addEventListener === 'function') {
+        desktopMedia.addEventListener('change', handleBreakpoint);
+      } else if (typeof desktopMedia.addListener === 'function') {
+        desktopMedia.addListener(handleBreakpoint);
+      }
+    } else if (nav) {
+      nav.removeAttribute('hidden');
+    }
 
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>


### PR DESCRIPTION
## Summary
- add the `hidden` attribute to the mobile nav and hide it in CSS while preserving the existing open styles
- update the menu toggle script to synchronize the hidden attribute and `aria-expanded` state, including on nav link clicks
- listen for the desktop breakpoint so the nav is always exposed at large widths and re-hidden when returning to mobile

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9aada0e38832e8a783f1b64cdca90