### PR TITLE
FIX: Add padding for video edge visibility + captions below video on …

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,6 +776,39 @@
       .hero video ~ div[style*="bottom:0"]{
         display:none !important;
       }
+
+      /* Mobile video container - add padding so edges are visible */
+      .hero > div > div:nth-child(2) > div{
+        padding:0 0.75rem !important;
+      }
+
+      /* Caption below video on mobile */
+      .hero .mobile-video-caption{
+        display:block !important;
+        padding:1rem 0.5rem;
+        text-align:center;
+        font-size:0.8rem;
+        line-height:1.5;
+        color:rgba(255,255,255,0.85);
+      }
+
+      .hero .mobile-video-caption strong{
+        font-weight:700;
+      }
+
+      .hero .mobile-video-caption .legend{
+        display:block;
+        font-size:0.7rem;
+        opacity:0.7;
+        margin-top:0.5rem;
+      }
+    }
+
+    /* Desktop - ensure mobile caption is hidden */
+    @media (min-width:769px){
+      .hero .mobile-video-caption{
+        display:none !important;
+      }
     }
 
     /* Tablet optimizations */
@@ -812,6 +845,19 @@
       /* Hide video overlays on extra small screens too */
       .hero video ~ div[style*="position:absolute"]{
         display:none !important;
+      }
+
+      /* Mobile video container - add padding so edges are visible */
+      .hero > div > div:nth-child(2) > div{
+        padding:0 0.5rem !important;
+      }
+
+      /* Caption below video on extra small mobile */
+      .hero .mobile-video-caption{
+        display:block !important;
+        padding:1rem 0.5rem;
+        font-size:0.75rem;
+        line-height:1.4;
       }
 
       /* Small screen hero description */
@@ -1817,6 +1863,16 @@
               })();
             </script>
 
+            </div>
+
+            <!-- Mobile-only caption below video -->
+            <div class="mobile-video-caption" style="display:none">
+              <p style="margin:0">
+                <strong style="color:#3ed598">TD</strong> marks potential bottom. <strong style="color:#3ed598">GREEN</strong> regime confirms the shift. Price holds above <strong style="color:#5b8aff">PILOT</strong>—momentum building. Trend continues. <strong style="color:#ff6b9d">WRN/OUT</strong> fires? Exit or reverse. Complete cycle mapped from bottom to top.
+                <span class="legend">
+                  <strong>TD</strong>=Touchdown · <strong>IGN</strong>=Ignition · <strong>CAP</strong>=Capitulation · <strong>WRN</strong>=Warning · <strong>OUT</strong>=Reversal
+                </span>
+              </p>
             </div>
 
         </div>


### PR DESCRIPTION
…mobile

Critical Mobile UX Fixes:
- Added 0.75rem padding to video container on mobile (0.5rem on extra small)
- Video right edge no longer cut off - visible borders now
- Created mobile-only caption section that displays BELOW video
- Captions no longer overlay and obscure the video
- Desktop overlays remain intact (badge + gradient caption)
- Mobile caption hidden on desktop (min-width:769px)
- Better readability with 0.8rem font on mobile, 0.75rem on extra small

Result: Mobile users can see full video with clear edges AND read captions below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)