### PR TITLE
FIX: Proper video edge visibility fix - add wrapper padding + overflo…

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,8 +778,20 @@
       }
 
       /* Mobile video container - add padding so edges are visible */
-      .hero > div > div:nth-child(2) > div{
+      .hero > div > div:nth-child(2){
         padding:0 0.75rem !important;
+        margin-bottom:3rem !important;
+      }
+
+      /* Video wrapper with border - ensure it fits with margin */
+      .hero > div > div:nth-child(2) > div{
+        margin:0 auto !important;
+        max-width:100% !important;
+      }
+
+      /* Ensure hero container doesn't clip video */
+      .hero .container{
+        overflow-x:visible !important;
       }
 
       /* Caption below video on mobile */
@@ -848,8 +860,20 @@
       }
 
       /* Mobile video container - add padding so edges are visible */
-      .hero > div > div:nth-child(2) > div{
+      .hero > div > div:nth-child(2){
         padding:0 0.5rem !important;
+        margin-bottom:3rem !important;
+      }
+
+      /* Video wrapper with border - ensure it fits with margin */
+      .hero > div > div:nth-child(2) > div{
+        margin:0 auto !important;
+        max-width:100% !important;
+      }
+
+      /* Ensure hero container doesn't clip video */
+      .hero .container{
+        overflow-x:visible !important;
       }
 
       /* Caption below video on extra small mobile */


### PR DESCRIPTION
…w fix

The Problem:
- Video right edge still cut off despite previous padding attempt
- Container overflow-x:hidden was clipping video borders
- Padding was applied to wrong element in DOM hierarchy

The Fix:
- Add 0.75rem padding to video wrapper div (nth-child(2)) on mobile ≤768px
- Add 0.5rem padding to video wrapper div on extra small ≤480px
- Force max-width:100% on video container with border
- Override overflow-x:hidden with overflow-x:visible on hero container
- This ensures 2px border is fully visible with breathing room

Result: Video edges now fully visible with clear borders on mobile devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)