### PR TITLE
Maximize video size on mobile - minimal padding + larger dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,10 +733,10 @@
       .proof-bar{justify-content:center}
       .section{padding:clamp(2rem,6vw,3rem) 0}
 
-      /* Mobile video fixes - AGGRESSIVE */
+      /* Mobile video fixes - AGGRESSIVE + MAXIMUM SIZE */
       #heroVideo{
-        min-height:250px !important;
-        max-height:400px !important;
+        min-height:280px !important;
+        max-height:500px !important;
         height:auto !important;
         width:100% !important;
         object-fit:contain !important;
@@ -747,14 +747,14 @@
 
       /* Video container mobile - force visibility */
       .hero video{
-        min-height:250px !important;
+        min-height:280px !important;
         display:block !important;
         visibility:visible !important;
       }
 
       /* Ensure video container is visible and has proper aspect ratio */
       .hero > div > div:nth-child(2) > div{
-        min-height:250px !important;
+        min-height:280px !important;
         display:block !important;
         visibility:visible !important;
         aspect-ratio:16/9;
@@ -764,7 +764,7 @@
       .hero > div > div:nth-child(2){
         display:block !important;
         visibility:visible !important;
-        min-height:250px !important;
+        min-height:280px !important;
       }
 
       /* HIDE video overlays on mobile - they block the video view */
@@ -777,9 +777,9 @@
         display:none !important;
       }
 
-      /* Mobile video container - add padding so edges are visible */
+      /* Mobile video container - minimal padding for maximum size */
       .hero > div > div:nth-child(2){
-        padding:0 0.75rem !important;
+        padding:0 0.35rem !important;
         margin-bottom:3rem !important;
       }
 
@@ -848,10 +848,10 @@
       .price{font-size:1.8rem}
       .cta-inner .bar .note{display:none}
 
-      /* Extra small screens - video */
+      /* Extra small screens - video - MAXIMUM SIZE */
       #heroVideo{
-        min-height:200px !important;
-        max-height:350px;
+        min-height:250px !important;
+        max-height:450px !important;
       }
 
       /* Hide video overlays on extra small screens too */
@@ -859,9 +859,9 @@
         display:none !important;
       }
 
-      /* Mobile video container - add padding so edges are visible */
+      /* Mobile video container - minimal padding for maximum size */
       .hero > div > div:nth-child(2){
-        padding:0 0.5rem !important;
+        padding:0 0.25rem !important;
         margin-bottom:3rem !important;
       }
 
@@ -1737,7 +1737,7 @@
         <div style="margin-bottom:3rem">
 
             <!-- PENTARCH CHART SHOWCASE -->
-            <div style="position:relative;border-radius:16px;overflow:hidden;border:2px solid rgba(91,138,255,.25);box-shadow:0 20px 80px rgba(91,138,255,.15);background:#0a0e18;max-width:1400px;margin:0 auto;min-height:300px;">
+            <div style="position:relative;border-radius:16px;overflow:hidden;border:2px solid rgba(91,138,255,.25);box-shadow:0 20px 80px rgba(91,138,255,.15);background:#0a0e18;max-width:1400px;margin:0 auto;min-height:280px;">
 
               <!-- Chart Video -->
               <video
@@ -1750,7 +1750,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:auto;display:block;object-fit:contain;min-height:300px;background:#0a0e18;aspect-ratio:16/9;pointer-events:none"
+                style="width:100%;height:auto;display:block;object-fit:contain;min-height:280px;background:#0a0e18;aspect-ratio:16/9;pointer-events:none"
                 onloadedmetadata="this.play()"
               >
                 <source src="assets/videos/hero-demo.mp4" type="video/mp4">
@@ -1787,7 +1787,7 @@
                 console.log('Video src:', video.src);
                 console.log('Video readyState:', video.readyState);
 
-                // MOBILE FIX: Force dimensions and visibility
+                // MOBILE FIX: Force dimensions and visibility - MAXIMUM SIZE
                 function forceMobileVideo() {
                   const isMobile = window.innerWidth <= 768;
                   console.log('forceMobileVideo - isMobile:', isMobile, 'width:', window.innerWidth);
@@ -1796,17 +1796,17 @@
                     // Force video container styles
                     const container = video.parentElement;
                     if (container) {
-                      container.style.minHeight = '250px';
+                      container.style.minHeight = '280px';
                       container.style.display = 'block';
                       container.style.visibility = 'visible';
                     }
 
-                    // Force video element styles
+                    // Force video element styles - LARGER for mobile
                     video.style.display = 'block';
                     video.style.visibility = 'visible';
                     video.style.opacity = '1';
-                    video.style.minHeight = '250px';
-                    video.style.maxHeight = '400px';
+                    video.style.minHeight = '280px';
+                    video.style.maxHeight = '500px';
                     video.style.width = '100%';
                     video.style.height = 'auto';
                     video.style.objectFit = 'contain';


### PR DESCRIPTION
Changes for Maximum Mobile Video Real Estate:
- Reduced padding from 0.75rem to 0.35rem on mobile ≤768px (53% less)
- Reduced padding from 0.5rem to 0.25rem on extra small ≤480px (50% less)
- Increased min-height from 250px to 280px (+12%)
- Increased max-height from 400px to 500px on mobile ≤768px (+25%)
- Increased max-height from 350px to 450px on extra small ≤480px (+28%)
- Updated video element inline min-height to 280px
- Updated container min-height to 280px
- Updated JavaScript forceMobileVideo() to use new dimensions

Result: Video now takes up significantly more screen space while maintaining visible edges. More immersive viewing experience on mobile devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)