### PR TITLE
Fix mobile menu visibility issue - add explicit CSS rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,13 +606,13 @@
       .menu-toggle{display:inline-flex}
 
       nav[aria-label="Main"]{
-        display:flex;
+        display:flex !important;
         position:fixed;
         right:0;
         top:0;
         bottom:0;
         width:min(92vw,420px);
-        background:rgba(10,12,20,.99);
+        background:rgba(10,12,20,.99) !important;
         border-left:2px solid rgba(255,255,255,.25);
         border-radius:16px 0 0 16px;
         padding:1.5rem 1rem;
@@ -623,27 +623,45 @@
         transition:transform .3s cubic-bezier(0.4, 0, 0.2, 1);
         box-shadow:-4px 0 20px rgba(0,0,0,.5);
         overflow-y:auto;
+        visibility:visible !important;
+        opacity:1 !important;
       }
 
       nav[aria-label="Main"].open{
-        transform:translateX(0);
+        transform:translateX(0) !important;
       }
 
-      nav ul{flex-direction:column;gap:.2rem}
+      nav ul{
+        flex-direction:column;
+        gap:.2rem;
+        display:flex !important;
+        visibility:visible !important;
+        opacity:1 !important;
+      }
+
+      nav li{
+        display:block !important;
+        visibility:visible !important;
+        opacity:1 !important;
+      }
 
       .mobile-nav-header{
-        display:flex;
+        display:flex !important;
         justify-content:space-between;
         align-items:center;
         margin-bottom:1rem;
         padding-bottom:1rem;
         border-bottom:1px solid rgba(255,255,255,.15);
+        visibility:visible !important;
+        opacity:1 !important;
       }
 
       .mobile-nav-title{
         font-size:1.2rem;
         font-weight:700;
-        color:#fff;
+        color:#fff !important;
+        visibility:visible !important;
+        opacity:1 !important;
       }
 
       .mobile-nav-close{
@@ -652,14 +670,16 @@
         border-radius:8px;
         width:36px;
         height:36px;
-        display:flex;
+        display:flex !important;
         align-items:center;
         justify-content:center;
         cursor:pointer;
-        color:#fff;
+        color:#fff !important;
         font-size:1.5rem;
         line-height:1;
         transition:all 0.2s ease;
+        visibility:visible !important;
+        opacity:1 !important;
       }
 
       .mobile-nav-close:hover{
@@ -672,6 +692,15 @@
         font-size:1.05rem;
         color:#fff !important;
         font-weight:600;
+        display:flex !important;
+        visibility:visible !important;
+        opacity:1 !important;
+        background:transparent;
+      }
+
+      nav a:hover, nav a:focus{
+        background:rgba(91,138,255,.2) !important;
+        color:#fff !important;
       }
 
       .lang-wrap{order:2}


### PR DESCRIPTION
PROBLEM:
Mobile menu was moving (sliding in) but content not visible

FIX:
Added explicit !important rules to ensure all mobile menu elements are visible:
- nav panel: display:flex, visibility:visible, opacity:1, background forced
- nav ul: display:flex, visibility:visible, opacity:1
- nav li: display:block, visibility:visible, opacity:1
- nav a: display:flex, visibility:visible, opacity:1, white color
- mobile-nav-header: display:flex, visibility:visible
- mobile-nav-title: white color, visible
- mobile-nav-close: display:flex, white color, visible

This ensures the menu content overrides any conflicting styles from themes or other CSS.

🤖 Generated with Claude Code