### PR TITLE
Fix header button overlap by hiding CTA at higher breakpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -809,8 +809,8 @@
 
     .cta-header{margin-left:.25rem;flex-shrink:0;padding:.5rem .9rem !important;font-size:.88rem !important}
 
-    /* Hide CTA earlier on smaller screens to prevent overlap */
-    @media (max-width:1200px){
+    /* Hide CTA earlier on smaller screens to prevent overlap with lang/theme buttons */
+    @media (max-width:1350px){
       .cta-header{display:none !important}
     }
 
@@ -835,6 +835,24 @@
     }
 
     /* Reduce nav width on medium screens to prevent overlap */
+    /* Upper range: CTA hidden, give nav more room but still constrain */
+    @media (max-width:1350px) and (min-width:1201px){
+      nav[aria-label="Main"]{
+        max-width:500px;
+        overflow:hidden;
+      }
+      nav ul{
+        flex-wrap:nowrap;
+        overflow:hidden;
+      }
+    }
+
+    @media (max-width:1300px) and (min-width:1201px){
+      nav[aria-label="Main"]{
+        max-width:450px;
+      }
+    }
+
     @media (max-width:1200px) and (min-width:1061px){
       nav[aria-label="Main"]{
         max-width:400px;


### PR DESCRIPTION
ISSUE: Language selector (🌐) and theme toggle (🌙/☀️) buttons were being overlapped by navigation menu items on medium screens, making them unreadable.

ROOT CAUSE: CTA button ("Try Risk-Free") was visible up to 1200px, but nav compression started at 1300px, creating overlap in the 1201px-1300px range.

SOLUTION:
1. Hide CTA button earlier (≤1350px instead of ≤1200px)
2. Add nav width constraints for 1201px-1350px range:
   - 1201px-1350px: max-width 500px
   - 1201px-1300px: max-width 450px

RESULT: Language selector and theme toggle buttons now have adequate space at all screen sizes. Progressive nav width constraints prevent any overlap while maintaining readability.

🤖 Generated with Claude Code