### PR TITLE
Fix Google Translate integration with hidden select element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2435,6 +2435,26 @@
         </div>
       </div>
 
+      <!-- Hidden select for Google Translate compatibility -->
+      <select id="langSel" style="display:none;" aria-hidden="true">
+        <option value="en">English</option>
+        <option value="de">Deutsch</option>
+        <option value="fr">Français</option>
+        <option value="es">Español</option>
+        <option value="it">Italiano</option>
+        <option value="zh">中文</option>
+        <option value="ru">Русский</option>
+        <option value="ar">العربية</option>
+        <option value="pt">Português</option>
+        <option value="tr">Türkçe</option>
+        <option value="ja">日本語</option>
+        <option value="ko">한국어</option>
+        <option value="vi">Tiếng Việt</option>
+        <option value="th">ไทย</option>
+        <option value="hi">हिन्दी</option>
+        <option value="id">Bahasa Indonesia</option>
+      </select>
+
       <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Toggle theme" style="font-size:1.3rem;padding:.5rem .7rem">
         <span id="theme-icon">🌙</span>
       </button>
@@ -4034,11 +4054,11 @@
         btn.addEventListener('click', (e) => {
           const lang = btn.getAttribute('data-lang');
 
-          // Use Google Translate
-          const googleTranslateCombo = document.querySelector('.goog-te-combo');
-          if (googleTranslateCombo) {
-            googleTranslateCombo.value = lang;
-            googleTranslateCombo.dispatchEvent(new Event('change'));
+          // Update hidden select and trigger Google Translate
+          const hiddenSelect = document.getElementById('langSel');
+          if (hiddenSelect) {
+            hiddenSelect.value = lang;
+            hiddenSelect.dispatchEvent(new Event('change'));
           }
 
           closeLang();


### PR DESCRIPTION
- Add hidden <select id="langSel"> with all 16 languages for Google Translate compatibility
- Update language dropdown button handlers to sync with hidden select
- Maintain clean globe icon UI while preserving translation functionality
- Fixes issue where translations were completely broken after UI redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)