### PR TITLE
Compact Elite Seven headline + add INSTITUTIONAL badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -3130,10 +3130,15 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">The Elite Seven — Built to Work Together</h2>
+        <!-- Badge for additional labels -->
+        <div style="text-align:center;margin-bottom:1rem">
+          <span class="badge" style="display:inline-block">INSTITUTIONAL-GRADE SYSTEM</span>
+        </div>
+
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto">The Elite Seven</h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 3rem">
-          Seven non-repainting indicators. One complete system.
+          Seven non-repainting indicators. Built to work together. One complete system.
         </p>
 
         <div class="grid auto-300">
@@ -4018,7 +4023,7 @@
         <p style="color:var(--muted-2);font-size:.85rem;margin:0">
 
           © 2025 Signal Pilot Labs. All rights reserved. Educational tools only—not financial advice.
-          <br><span style="color:var(--muted-2);font-size:.75rem;opacity:.6">v202510300050</span>
+          <br><span style="color:var(--muted-2);font-size:.75rem;opacity:.6">v202510300055</span>
 
 
         </p>
@@ -4782,7 +4787,7 @@
 (function() {
   // IMPORTANT: Update VERSION on each deployment (format: YYYYMMDDHHmm)
   // This ensures users get fresh JS/CSS after updates
-  var VERSION = '202510300050'; // Last updated: 2025-10-30 00:50 UTC
+  var VERSION = '202510300055'; // Last updated: 2025-10-30 00:55 UTC
 
   function loadScript(src, callback) {
     var s = document.createElement('script');

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 // Service Worker for Signal Pilot PWA
 // Updated cache strategy: Network first for HTML, cache for assets
 // IMPORTANT: Update CACHE_VERSION on each deployment to match index.html VERSION
-const CACHE_VERSION = '202510300050'; // Last updated: 2025-10-30 00:50 UTC
+const CACHE_VERSION = '202510300055'; // Last updated: 2025-10-30 00:55 UTC
 const CACHE_NAME = `signal-pilot-${CACHE_VERSION}`;
 const ASSETS_TO_CACHE = [
   '/manifest.json',


### PR DESCRIPTION
Changes:
- Shorten headline: "The Elite Seven — Built to Work Together" → "The Elite Seven"
- Add badge above: "INSTITUTIONAL-GRADE SYSTEM"
- Add max-width:20ch to headline (prevents 3-row wrap)
- Move "Built to work together" to subtitle
- Provides space for additional badges/labels

Now headline is concise and won't span multiple rows on mobile. Badge area allows for labels like INSTITUTIONAL, PROFESSIONAL, etc.

Update VERSION to 202510300055

🤖 Generated with [Claude Code](https://claude.com/claude-code)