### PR TITLE
Fix product label text wrapping issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -3148,7 +3148,7 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
               <h3>SP — Pentarch</h3>
-              <span class="badge" style="font-size:.75rem;margin-left:.5rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;padding:.3rem .7rem;text-transform:uppercase;letter-spacing:.5px">★ FLAGSHIP</span>
+              <span class="badge" style="font-size:.75rem;margin-left:.5rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;padding:.3rem .7rem;text-transform:uppercase;letter-spacing:.5px;white-space:nowrap">★ FLAGSHIP</span>
             </div>
             <div class="punch" style="font-size:1.1rem;line-height:1.4">Complete trend regime detection system. Not just isolated signals—the full market cycle.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details" style="margin-top:.5rem">Learn More ▼</button>
@@ -3216,7 +3216,7 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/><circle cx="7" cy="7" r="1" fill="currentColor"/><circle cx="17" cy="7" r="1" fill="currentColor"/><circle cx="7" cy="17" r="1" fill="currentColor"/><circle cx="17" cy="17" r="1" fill="currentColor"/></svg>
               <h3>SP — Omnideck</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(91,138,255,.15);color:var(--brand)">ALL-IN-ONE</span>
+              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(91,138,255,.15);color:var(--brand);white-space:nowrap">ALL-IN-ONE</span>
             </div>
             <div class="punch">Comprehensive overlay—everything you need on the chart.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details" style="margin-top:.5rem">Learn More ▼</button>
@@ -3244,7 +3244,7 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s4-8 10-8 10 8 10 8-4 8-10 8-10-8-10-8z"/><circle cx="12" cy="12" r="2.5"/><rect x="8" y="17" width="1.2" height="4" opacity=".3"/><rect x="11.4" y="16" width="1.2" height="5" opacity=".3"/><rect x="14.8" y="17" width="1.2" height="4" opacity=".3"/></svg>
               <h3>SP — Volume Oracle</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(62,213,152,.15);color:var(--good)">INSTITUTIONAL</span>
+              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(62,213,152,.15);color:var(--good);white-space:nowrap">INSTITUTIONAL</span>
             </div>
             <div class="punch">See when smart money is moving—before retail notices.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details" style="margin-top:.5rem">Learn More ▼</button>
@@ -3267,7 +3267,7 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 17l6-6 4 4 8-8"/><path d="M21 7v6h-6"/><path d="M3 22h18" opacity=".3"/><rect x="5" y="18" width="2" height="4" opacity=".4"/><rect x="11" y="14" width="2" height="8" opacity=".4"/><rect x="17" y="10" width="2" height="12" opacity=".4"/></svg>
               <h3>SP — Plutus Flow</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem">ACCUMULATION</span>
+              <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">ACCUMULATION</span>
             </div>
             <div class="punch">Follow the money. Cumulative delta reveals hidden accumulation.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details" style="margin-top:.5rem">Learn More ▼</button>
@@ -3290,7 +3290,7 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 12h18M3 18h18"/><circle cx="7" cy="6" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="17" cy="18" r="1.5" fill="currentColor"/><path d="M21 6v12" opacity=".3" stroke-width="1.5"/></svg>
               <h3>SP — Janus Atlas</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(118,221,255,.15);color:var(--accent)">KEY LEVELS</span>
+              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(118,221,255,.15);color:var(--accent);white-space:nowrap">KEY LEVELS</span>
             </div>
             <div class="punch">HTF levels, D/W/M pivots, VWAP, VAL/POC—all key zones in one view.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details" style="margin-top:.5rem">Learn More ▼</button>
@@ -3314,7 +3314,7 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="10" r="7"/><path d="M7 10h10M12 3v14M9 6l6 8M15 6l-6 8" opacity=".25" stroke-width="1.5"/><ellipse cx="12" cy="17.5" rx="5" ry="1.8"/><path d="M7 17.5c0 1 2.2 1.8 5 1.8s5-.8 5-1.8"/></svg>
               <h3>SP — Augury Grid</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem">S/R MATRIX</span>
+              <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">S/R MATRIX</span>
             </div>
             <div class="punch">Support/resistance matrix with probability‑weighted breakout zones.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details" style="margin-top:.5rem">Learn More ▼</button>
@@ -3338,7 +3338,7 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 13c2-4 6-4 8 0s6 4 10-2"/><circle cx="7" cy="13" r="1.2"/><circle cx="15" cy="13" r="1.2"/></svg>
               <h3>SP — Harmonic Oscillator</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem">TIMING</span>
+              <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">TIMING</span>
             </div>
             <div class="punch">Optimized entry timing through phase‑aligned momentum synthesis.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details" style="margin-top:.5rem">Learn More ▼</button>


### PR DESCRIPTION
Added white-space:nowrap CSS property to all Elite Seven product badges to prevent labels from wrapping across multiple lines. This ensures labels like "INSTITUTIONAL", "ACCUMULATION", "KEY LEVELS", etc. display cleanly on a single line.

Labels fixed:
- ★ FLAGSHIP
- ALL-IN-ONE
- INSTITUTIONAL
- ACCUMULATION
- KEY LEVELS
- S/R MATRIX
- TIMING

🤖 Generated with [Claude Code](https://claude.com/claude-code)