### PR TITLE
Create assets/showcase folder for interactive demo images

### DIFF
--- a/assets/showcase/.gitkeep
+++ b/assets/showcase/.gitkeep
@@ -1,0 +1,1 @@
+# This folder contains comparison slider images for the interactive demo section

--- a/assets/showcase/README.md
+++ b/assets/showcase/README.md
@@ -1,0 +1,28 @@
+# Showcase Images
+
+This folder contains images for the interactive comparison slider demo on the main site.
+
+## Required Images
+
+### chart-without.jpg
+- Screenshot of a trading chart **without** Signal Pilot indicators
+- Shows the "before" state - cluttered or confusing chart
+- Recommended size: 1400px × 787px (16:9 aspect ratio)
+- Format: JPG (optimized for web)
+
+### chart-with.jpg
+- Screenshot of the same trading chart **with** Signal Pilot indicators
+- Shows the "after" state - clear signals and structure
+- Recommended size: 1400px × 787px (16:9 aspect ratio)
+- Format: JPG (optimized for web)
+
+## Tips
+
+- Use the same chart/timeframe for both images to show true before/after comparison
+- Ensure both images have identical dimensions for smooth slider interaction
+- Optimize images for web (use tools like TinyJPG or ImageOptim)
+- Keep file sizes under 500KB each for fast loading
+
+## Fallback
+
+If images are not present, the site will show placeholder messages with instructions for where to add them.


### PR DESCRIPTION
Added assets/showcase directory structure with documentation for the before/after comparison slider images.

Files added:
- .gitkeep - Ensures folder is tracked in git
- README.md - Instructions for required images and specifications

Required images (not included):
- chart-without.jpg - Trading chart without Signal Pilot indicators
- chart-with.jpg - Trading chart with Signal Pilot indicators

Recommended specs:
- Size: 1400px × 787px (16:9 aspect ratio)
- Format: JPG optimized for web
- File size: <500KB each

The HTML already has proper fallback handling with helpful placeholder messages if images are not present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)