### PR TITLE
Simplify navigation menu text from 'Why Signal Pilot?' to 'Why Us?'

### DIFF
--- a/index.html
+++ b/index.html
@@ -2477,7 +2477,7 @@
 
         <ul>
 
-          <li><a href="#why">Why <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>?</a></li>
+          <li><a href="#why">Why Us?</a></li>
 
           <li><a href="#inside">What's inside</a></li>
 


### PR DESCRIPTION
Changed the main navigation menu link text for better clarity and conciseness.

Before: "Why Signal Pilot?"
After: "Why Us?"

This makes the navigation cleaner and more conventional while maintaining the same anchor link (#why) to the comparison section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)