### PR TITLE
Remove With/Without Signal Pilot labels from comparison slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -3691,9 +3691,6 @@
               style="width:100%;height:100%;object-fit:cover;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
-            <div style="position:absolute;top:50%;right:20px;transform:translateY(-50%);background:rgba(255,107,157,.15);border:1px solid rgba(255,107,157,.3);padding:.75rem 1.25rem;border-radius:8px;backdrop-filter:blur(8px);user-select:none;pointer-events:none">
-              <span style="color:#ff6b9d;font-weight:700;font-size:.95rem">❌ Without <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em">Signal Pilot</span></span>
-            </div>
           </div>
 
           <!-- With Signal Pilot (Overlay - slides over) -->
@@ -3705,9 +3702,6 @@
               style="position:absolute;top:0;left:0;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
-            <div style="position:absolute;top:50%;right:20px;transform:translateY(-50%);background:rgba(62,213,152,.15);border:1px solid rgba(62,213,152,.3);padding:.75rem 1.25rem;border-radius:8px;backdrop-filter:blur(8px);user-select:none;pointer-events:none">
-              <span style="color:#3ed598;font-weight:700;font-size:.95rem">✓ With <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em">Signal Pilot</span></span>
-            </div>
           </div>
 
           <!-- Slider Handle with Pulse Animation -->


### PR DESCRIPTION
Removed overlay labels that were blocking important chart information:
- Deleted "❌ Without Signal Pilot" label from background image
- Deleted "✓ With Signal Pilot" label from overlay image

The scrubber timeline below still clearly indicates "Without" (left) and "With" (right), so users understand the comparison without on-screen labels blocking chart data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)