### PR TITLE
Remove comparison stats percentages from slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -3742,18 +3742,6 @@
           </div>
         </div>
 
-        <!-- Comparison Stats -->
-        <div id="comparison-stats" style="display:flex;justify-content:center;gap:2rem;margin-top:1.5rem;flex-wrap:wrap">
-          <div style="text-align:center">
-            <div style="font-size:2rem;font-weight:800;color:#ff6b9d" id="stat-without">0%</div>
-            <div style="font-size:.85rem;color:var(--muted);margin-top:.25rem">Without Signal Pilot</div>
-          </div>
-          <div style="text-align:center">
-            <div style="font-size:2rem;font-weight:800;color:#3ed598" id="stat-with">50%</div>
-            <div style="font-size:.85rem;color:var(--muted);margin-top:.25rem">With Signal Pilot</div>
-          </div>
-        </div>
-
       </div>
 
     </section>
@@ -3785,8 +3773,6 @@
       const scrubberTrack = document.getElementById('scrubber-track');
       const scrubberThumb = document.getElementById('scrubber-thumb');
       const scrubberFill = document.getElementById('scrubber-fill');
-      const statWithout = document.getElementById('stat-without');
-      const statWith = document.getElementById('stat-with');
       const toggleBefore = document.getElementById('toggle-before');
       const toggleAfter = document.getElementById('toggle-after');
       const autoplayToggle = document.getElementById('autoplay-toggle');
@@ -3852,10 +3838,6 @@
         // Update scrubber
         scrubberThumb.style.left = percentage + '%';
         scrubberFill.style.width = percentage + '%';
-
-        // Feature 15: Update comparison stats
-        statWithout.textContent = Math.round(100 - percentage) + '%';
-        statWith.textContent = Math.round(percentage) + '%';
       }
 
       // Update overlay image width to match slider container


### PR DESCRIPTION
Removed the percentage display below the comparison slider that showed "100% Without Signal Pilot / 0% With Signal Pilot" as it provided no meaningful value.

Changes:
- Removed comparison-stats div and all percentage displays
- Removed statWithout and statWith variable declarations
- Removed JavaScript code that updated these stats

The scrubber timeline labels ("Without" / "With") and control buttons provide sufficient context for the comparison without cluttering the interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)