### PR TITLE
Remove special background from interactive demo section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3655,7 +3655,7 @@
 
     <!-- BEFORE/AFTER SHOWCASE -->
 
-    <section class="section" style="background:linear-gradient(180deg,rgba(5,7,13,1) 0%,rgba(10,12,20,1) 100%)">
+    <section class="section">
 
       <div class="container stack">
 


### PR DESCRIPTION
Removed the gradient background from the comparison slider section to maintain visual consistency with other sections of the page.

Before: background:linear-gradient(180deg,rgba(5,7,13,1) 0%,rgba(10,12,20,1) 100%)
After: Using default section background (same as rest of page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)