### PR TITLE
Remove blue colors from scrubber timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -3725,9 +3725,9 @@
 
         <!-- Scrubber Timeline -->
         <div style="max-width:1400px;margin:1.5rem auto 0;padding:0 1rem">
-          <div style="position:relative;height:48px;background:rgba(91,138,255,.1);border-radius:24px;border:1px solid rgba(91,138,255,.3);overflow:hidden;cursor:pointer" id="scrubber-track">
+          <div style="position:relative;height:48px;background:rgba(255,255,255,.05);border-radius:24px;border:1px solid rgba(255,255,255,.1);overflow:hidden;cursor:pointer" id="scrubber-track">
             <!-- Progress fill -->
-            <div id="scrubber-fill" style="position:absolute;left:0;top:0;height:100%;width:50%;background:linear-gradient(90deg,rgba(91,138,255,.3),rgba(91,138,255,.15));transition:width 0.3s ease;pointer-events:none"></div>
+            <div id="scrubber-fill" style="position:absolute;left:0;top:0;height:100%;width:50%;background:linear-gradient(90deg,rgba(255,255,255,.1),rgba(255,255,255,.05));transition:width 0.3s ease;pointer-events:none"></div>
             <!-- Position markers -->
             <div style="position:absolute;left:0;top:50%;transform:translateY(-50%);width:100%;height:2px;background:rgba(255,255,255,.1);pointer-events:none">
               <div style="position:absolute;left:25%;top:50%;transform:translate(-50%,-50%);width:2px;height:12px;background:rgba(255,255,255,.2)"></div>


### PR DESCRIPTION
Changed scrubber timeline from blue accent colors to neutral white/gray for visual consistency.

Changes:
- Track background: rgba(91,138,255,.1) → rgba(255,255,255,.05)
- Track border: rgba(91,138,255,.3) → rgba(255,255,255,.1)
- Fill gradient: rgba(91,138,255,.3/.15) → rgba(255,255,255,.1/.05)

The scrubber now blends better with the rest of the interface without the blue highlighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)