### PR TITLE
MAJOR FIX: Rewrite mobile menu and language dropdown with event deleg…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4630,68 +4630,100 @@
 
     /* ======================== Mobile menu ======================== */
 
+    // Use event delegation for Google Translate compatibility
     (function(){
 
-      const menuBtn=document.getElementById('menuToggle');
-
-      const nav=document.getElementById('mainnav');
-
-      const backdrop=document.getElementById('navBackdrop');
-
-      const closeBtn=document.getElementById('mobileNavClose');
-
-      if (!menuBtn || !nav || !backdrop) {
-        console.error('Mobile menu elements not found:', {
-          menuBtn: !!menuBtn,
-          nav: !!nav,
-          backdrop: !!backdrop
-        });
-        return;
-      }
-
-      console.log('Mobile menu initialized successfully');
+      let isMenuOpen = false;
+      console.log('Mobile menu script loading...');
 
       function lockScroll(lock){
-        // Use body overflow only - less aggressive on iOS Safari
         document.body.style.overflow = lock ? 'hidden' : '';
-        // Only disable touch-action on the nav element, not entire body
+        const nav = document.getElementById('mainnav');
         if(nav) nav.style.touchAction = lock ? 'none' : '';
       }
 
-      function open(){
+      function openMenu(){
         console.log('Opening mobile menu');
+        const nav = document.getElementById('mainnav');
+        const backdrop = document.getElementById('navBackdrop');
+        const menuBtn = document.getElementById('menuToggle');
+
+        if (!nav || !backdrop || !menuBtn) {
+          console.error('Cannot open menu - elements not found');
+          return;
+        }
+
         nav.classList.add('open');
         backdrop.classList.add('show');
         menuBtn.setAttribute('aria-expanded','true');
         lockScroll(true);
+        isMenuOpen = true;
       }
 
-      function close(){
+      function closeMenu(){
         console.log('Closing mobile menu');
+        const nav = document.getElementById('mainnav');
+        const backdrop = document.getElementById('navBackdrop');
+        const menuBtn = document.getElementById('menuToggle');
+
+        if (!nav || !backdrop || !menuBtn) {
+          console.error('Cannot close menu - elements not found');
+          return;
+        }
+
         nav.classList.remove('open');
         backdrop.classList.remove('show');
         menuBtn.setAttribute('aria-expanded','false');
         lockScroll(false);
+        isMenuOpen = false;
       }
 
-      menuBtn.addEventListener('click',(e)=>{
-        e.preventDefault();
-        e.stopPropagation();
-        console.log('Menu button clicked, current state:', nav.classList.contains('open') ? 'open' : 'closed');
-        (nav.classList.contains('open') ? close : open)();
+      // Use event delegation on document to handle Google Translate DOM changes
+      document.addEventListener('click', function(e) {
+        // Check if click is on menu toggle button
+        if (e.target.closest('#menuToggle') || e.target.closest('.menu-toggle')) {
+          e.preventDefault();
+          e.stopPropagation();
+          console.log('Menu button clicked via delegation, current state:', isMenuOpen ? 'open' : 'closed');
+          if (isMenuOpen) {
+            closeMenu();
+          } else {
+            openMenu();
+          }
+          return;
+        }
+
+        // Check if click is on backdrop
+        if (e.target.closest('#navBackdrop') || e.target.closest('.nav-backdrop')) {
+          console.log('Backdrop clicked');
+          closeMenu();
+          return;
+        }
+
+        // Check if click is on close button
+        if (e.target.closest('#mobileNavClose') || e.target.closest('.mobile-nav-close')) {
+          console.log('Close button clicked');
+          closeMenu();
+          return;
+        }
+
+        // Check if click is on a menu link
+        if (e.target.closest('#mainnav a')) {
+          console.log('Menu link clicked, closing menu');
+          closeMenu();
+          return;
+        }
       });
 
-      backdrop.addEventListener('click', close);
-
-      if (closeBtn) {
-        closeBtn.addEventListener('click', close);
-      }
-
-      document.addEventListener('keydown', e=>{
-        if(e.key==='Escape' && nav.classList.contains('open')) close();
+      // Escape key handler
+      document.addEventListener('keydown', function(e) {
+        if(e.key === 'Escape' && isMenuOpen) {
+          console.log('Escape pressed, closing menu');
+          closeMenu();
+        }
       });
 
-      document.querySelectorAll('#mainnav a').forEach(a=>a.addEventListener('click', close));
+      console.log('Mobile menu initialized with event delegation');
 
     })();
 
@@ -4754,50 +4786,54 @@
 
     /* ======================== Language Dropdown ======================== */
 
+    // Use event delegation for Google Translate compatibility
     (function(){
-      const langToggle = document.getElementById('langToggle');
-      const langMenu = document.querySelector('.lang-dropdown-menu');
-      const langDropdown = document.querySelector('.lang-dropdown');
-
-      if (!langToggle || !langMenu) return;
+      let isLangOpen = false;
+      console.log('Language dropdown script loading...');
 
       function openLang() {
+        console.log('Opening language dropdown');
+        const langMenu = document.querySelector('.lang-dropdown-menu');
+        const langToggle = document.getElementById('langToggle');
+        if (!langMenu || !langToggle) {
+          console.error('Cannot open lang menu - elements not found');
+          return;
+        }
         langMenu.classList.add('show');
         langToggle.setAttribute('aria-expanded', 'true');
+        isLangOpen = true;
       }
 
       function closeLang() {
+        console.log('Closing language dropdown');
+        const langMenu = document.querySelector('.lang-dropdown-menu');
+        const langToggle = document.getElementById('langToggle');
+        if (!langMenu || !langToggle) return;
         langMenu.classList.remove('show');
         langToggle.setAttribute('aria-expanded', 'false');
+        isLangOpen = false;
       }
 
-      // Toggle on click
-      langToggle.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const isOpen = langMenu.classList.contains('show');
-        if (isOpen) closeLang();
-        else openLang();
-      });
-
-      // Close when clicking outside
-      document.addEventListener('click', (e) => {
-        if (!langDropdown.contains(e.target)) {
-          closeLang();
+      // Use event delegation on document
+      document.addEventListener('click', function(e) {
+        // Check if click is on language toggle button
+        if (e.target.closest('#langToggle')) {
+          e.preventDefault();
+          e.stopPropagation();
+          console.log('Lang button clicked via delegation, current state:', isLangOpen ? 'open' : 'closed');
+          if (isLangOpen) {
+            closeLang();
+          } else {
+            openLang();
+          }
+          return;
         }
-      });
 
-      // Close on escape key
-      document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && langMenu.classList.contains('show')) {
-          closeLang();
-        }
-      });
-
-      // Handle language selection
-      langMenu.querySelectorAll('button').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          const lang = btn.getAttribute('data-lang');
+        // Check if click is on a language button
+        const langBtn = e.target.closest('.lang-dropdown-menu button');
+        if (langBtn) {
+          const lang = langBtn.getAttribute('data-lang');
+          console.log('Language selected:', lang);
 
           // Update hidden select and trigger Google Translate
           const hiddenSelect = document.getElementById('langSel');
@@ -4807,8 +4843,25 @@
           }
 
           closeLang();
-        });
+          return;
+        }
+
+        // Close when clicking outside dropdown
+        if (isLangOpen && !e.target.closest('.lang-dropdown')) {
+          console.log('Clicked outside lang dropdown, closing');
+          closeLang();
+        }
       });
+
+      // Close on escape key
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && isLangOpen) {
+          console.log('Escape pressed, closing lang dropdown');
+          closeLang();
+        }
+      });
+
+      console.log('Language dropdown initialized with event delegation');
     })();
 
 


### PR DESCRIPTION
…ation

## Root Cause
Google Translate was modifying the DOM structure, breaking direct event listeners attached to specific elements via getElementById. The menu button and language dropdown were not responding to clicks.

## Mobile Menu Fix
- Complete rewrite using event delegation on document
- Uses e.target.closest() to find elements dynamically
- Tracks menu state with isMenuOpen variable instead of DOM queries
- Works even when Google Translate wraps elements in <font> or <span> tags
- Comprehensive logging at every step for debugging
- Handles clicks on:
  * Menu toggle button (by ID or class)
  * Backdrop
  * Close button
  * Menu links (auto-closes on click)
- Escape key still works

## Language Dropdown Fix
- Complete rewrite using event delegation on document
- Uses e.target.closest() to find elements dynamically
- Tracks dropdown state with isLangOpen variable
- Works with Google Translate DOM modifications
- Comprehensive logging for debugging
- Handles clicks on:
  * Language toggle button
  * Language selection buttons
  * Outside dropdown (closes)
- Escape key still works

## Technical Details
Event delegation pattern: Instead of attaching listeners to specific elements that might get wrapped by Google Translate, we attach ONE listener to the document and use closest() to check if the click target matches our selectors. This works regardless of DOM structure changes.

Both systems now console.log every action, making debugging easy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)