### PR TITLE
CRITICAL FIX: Force menu visibility and clicks through Google Transla…

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,6 +383,60 @@
       color: inherit !important;
     }
 
+    /* CRITICAL: Force Google Translate font/span wrappers to not block clicks */
+    nav[aria-label="Main"] font,
+    nav[aria-label="Main"] span:not(.mobile-nav-title),
+    .lang-dropdown font,
+    .lang-dropdown span,
+    .lang-dropdown-menu font,
+    .lang-dropdown-menu span,
+    .menu-toggle font,
+    .menu-toggle span,
+    #langToggle font,
+    #langToggle span,
+    .nav-dropdown font,
+    .nav-dropdown span {
+      pointer-events: none !important;
+      color: inherit !important;
+      background: transparent !important;
+      font-family: inherit !important;
+      font-size: inherit !important;
+      font-weight: inherit !important;
+      line-height: inherit !important;
+      display: inline !important;
+      opacity: 1 !important;
+      visibility: visible !important;
+    }
+
+    /* Force mobile menu text to be white */
+    @media (max-width:1400px){
+      nav[aria-label="Main"] *,
+      nav[aria-label="Main"] font,
+      nav[aria-label="Main"] span,
+      .mobile-nav-header *,
+      .mobile-nav-title,
+      #mainnav *,
+      #mainnav font,
+      #mainnav span {
+        color: #ffffff !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+      }
+    }
+
+    /* Ensure clickable elements always work */
+    nav[aria-label="Main"] a,
+    nav[aria-label="Main"] button,
+    .lang-dropdown button,
+    .lang-dropdown-menu button,
+    .menu-toggle,
+    #langToggle,
+    #menuToggle,
+    .mobile-nav-close {
+      pointer-events: auto !important;
+      cursor: pointer !important;
+    }
+
     /* Fix header squeezing when Google Translate is active */
     header .container,
     header .nav {


### PR DESCRIPTION
…te wrappers

## The Problem
1. Mobile menu was sliding in but appeared black/invisible
2. Language dropdown (globe icon) wasn't responding to clicks
3. Google Translate wraps all text in <font> and <span> tags
4. These wrapper tags were blocking pointer-events and hiding content

## The Fix

### Force Google Translate wrappers to be transparent
- Set pointer-events: none on ALL font/span tags inside:
  * Mobile menu (nav[aria-label="Main"])
  * Language dropdown
  * Menu toggle button
  * Language toggle button
- Makes wrapper tags invisible to clicks so clicks pass through

### Force mobile menu text to be white
- Added aggressive media query for mobile (< 1400px)
- Forces ALL elements inside mobile menu to:
  * color: #ffffff !important (white text)
  * visibility: visible !important
  * opacity: 1 !important
- Applies to all *, font, span tags inside menu

### Force clickable elements to work
- Set pointer-events: auto on actual buttons/links:
  * nav links
  * menu buttons
  * language buttons
  * toggle buttons
- Added cursor: pointer for visual feedback

## Result
- Mobile menu now visible with white text on dark background
- All menu items are clickable
- Language dropdown now responds to clicks
- Works perfectly with Google Translate active

🤖 Generated with [Claude Code](https://claude.com/claude-code)