### PR TITLE
COMPLETE REDESIGN: Change mobile menu from slide-in panel to simple d…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1261,37 +1261,34 @@
       /* Ensure header buttons have adequate space */
       .nav{padding:.7rem 0}
 
-      .menu-toggle{display:inline-flex}
+      .menu-toggle{
+        display:inline-flex;
+        position:relative;
+        z-index:999999 !important;
+      }
 
+      /* Simple dropdown menu instead of slide-in panel */
       nav[aria-label="Main"]{
-        display:flex !important;
-        position:fixed;
-        right:0;
-        top:0;
-        bottom:0;
-        width:min(92vw,420px);
+        display:none !important;
+        position:fixed !important;
+        top:70px !important;
+        right:20px !important;
+        width:280px !important;
+        max-width:90vw !important;
         background:#1a1d2e !important;
-        border-left:2px solid rgba(255,255,255,.25);
-        border-radius:16px 0 0 16px;
-        padding:1.5rem 1rem;
-        flex-direction:column;
-        gap:.4rem;
-        z-index:99999 !important;
-        transform:translateX(100%);
-        transition:transform .3s cubic-bezier(0.4, 0, 0.2, 1);
-        box-shadow:-4px 0 20px rgba(0,0,0,.5);
-        overflow-y:auto;
-        visibility:visible !important;
-        opacity:1 !important;
-        /* Performance */
-        will-change:transform;
-        backface-visibility:hidden;
-        -webkit-overflow-scrolling:touch;
+        border:2px solid rgba(255,255,255,.4) !important;
+        border-radius:12px !important;
+        padding:1rem !important;
+        flex-direction:column !important;
+        gap:.3rem !important;
+        z-index:999998 !important;
+        box-shadow:0 8px 32px rgba(0,0,0,.8) !important;
+        max-height:80vh !important;
+        overflow-y:auto !important;
       }
 
       nav[aria-label="Main"].open{
-        transform:translateX(0) !important;
-        visibility:visible !important;
+        display:flex !important;
       }
 
       nav ul{
@@ -1312,46 +1309,17 @@
         list-style:none !important;
       }
 
+      /* Hide mobile nav header for simple dropdown */
       .mobile-nav-header{
-        display:flex !important;
-        justify-content:space-between;
-        align-items:center;
-        margin-bottom:1rem;
-        padding-bottom:1rem;
-        border-bottom:1px solid rgba(255,255,255,.15);
-        visibility:visible !important;
-        opacity:1 !important;
+        display:none !important;
       }
 
       .mobile-nav-title{
-        font-size:1.2rem;
-        font-weight:700;
-        color:#fff !important;
-        visibility:visible !important;
-        opacity:1 !important;
+        display:none !important;
       }
 
       .mobile-nav-close{
-        background:rgba(255,255,255,.1);
-        border:1px solid rgba(255,255,255,.2);
-        border-radius:8px;
-        width:36px;
-        height:36px;
-        display:flex !important;
-        align-items:center;
-        justify-content:center;
-        cursor:pointer;
-        color:#fff !important;
-        font-size:1.5rem;
-        line-height:1;
-        transition:all 0.2s ease;
-        visibility:visible !important;
-        opacity:1 !important;
-      }
-
-      .mobile-nav-close:hover{
-        background:rgba(255,255,255,.15);
-        transform:rotate(90deg);
+        display:none !important;
       }
 
       nav a{
@@ -1430,12 +1398,12 @@
       .nav-backdrop{
         position:fixed;
         inset:0;
-        background:rgba(0,0,0,.75);
-        backdrop-filter:blur(4px);
-        z-index:99998 !important;
+        background:rgba(0,0,0,.3);
+        backdrop-filter:blur(2px);
+        z-index:999997 !important;
         display:none;
         opacity:0;
-        transition:opacity .3s ease;
+        transition:opacity .2s ease;
       }
 
       .nav-backdrop.show{
@@ -1448,17 +1416,17 @@
     
     @media (max-width:600px){
       nav[aria-label="Main"]{
-        width:100%;
-        border-radius:0;
-        background:rgba(10,12,20,1);
-        padding:2rem 1.5rem;
+        width:90vw !important;
+        right:5vw !important;
+        left:5vw !important;
+        max-width:none !important;
       }
-      
+
       nav a{
         padding:.9rem 1.2rem;
-        font-size:1.1rem;
+        font-size:1.05rem;
         color:#ffffff !important;
-        font-weight:700;
+        font-weight:600;
         border-bottom:1px solid rgba(255,255,255,.1);
         display:block !important;
         text-align:left;


### PR DESCRIPTION
…ropdown

## The Problem
Slide-in panel was too complex and kept having visibility issues. User suggested trying a different approach - dropdown instead of slide-in.

## The Solution - Simple Dropdown Menu

### Changed from Slide-In Panel to Dropdown
BEFORE: Side panel that slides in from right (transform: translateX) AFTER: Simple dropdown that appears below menu button

### Key Changes
1. **Position**: Changed from `right:0; transform:translateX(100%)` to `position:fixed; top:70px; right:20px`
2. **Display**: Changed from transform-based to simple `display:none/flex`
3. **Size**: Changed from `min(92vw,420px)` full-height to compact `280px` width
4. **Removed**: Mobile nav header (Menu title and X button) - not needed for dropdown
5. **Backdrop**: Lighter (rgba(0,0,0,.3) instead of .75) and less blur
6. **Z-index**: Menu=999998, Backdrop=999997, Button=999999

### How It Works Now
- Click "Menu ☰" button
- Dropdown appears directly below button (like language dropdown)
- Dark panel with white text
- Click outside or backdrop to close
- Much simpler and more reliable

### Mobile Responsive
- < 600px: Dropdown expands to 90vw width, centered
- All screen sizes: Fixed positioning ensures it works

This matches the pattern of the language dropdown which IS working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)