### PR TITLE
Fix Safari iOS aurora video playback and all dropdown z-index issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,11 +472,23 @@
     header .brand {
       flex-shrink: 0 !important;
       min-width: auto !important;
+      white-space:nowrap !important;
     }
 
     header nav[aria-label="Main"] {
       flex-shrink: 1 !important;
       min-width: 0 !important;
+    }
+
+    /* Prevent all header buttons and text from wrapping */
+    header button,
+    header a,
+    .menu-toggle,
+    #langToggle,
+    #themeToggle,
+    .btn {
+      white-space:nowrap !important;
+      flex-shrink:0 !important;
     }
 
     /* Prevent horizontal scroll */
@@ -909,6 +921,11 @@
 
       overflow:visible;
 
+      /* CRITICAL: Fixed height to prevent vertical shifting when translated */
+      min-height:64px !important;
+      max-height:64px !important;
+      height:64px !important;
+
     }
 
     html[data-theme="light"] header{
@@ -923,11 +940,14 @@
       align-items:center;
       gap:.6rem;
       padding:.5rem 0;
-      flex-wrap:nowrap;
+      flex-wrap:nowrap !important;
       width:100%;
       min-width:0;
       position:relative;
       overflow:visible;
+      /* CRITICAL: Prevent vertical expansion when translated */
+      height:100% !important;
+      max-height:64px !important;
     }
 
 
@@ -1079,15 +1099,14 @@
 
     .lang-dropdown-menu{
       position:fixed !important;
-      top:auto !important;
-      right:20px !important;
-      margin-top:.5rem;
+      top:70px !important;
+      right:100px !important;
       background:rgba(10,12,20,1) !important;
       border:2px solid rgba(255,255,255,.4) !important;
       border-radius:12px;
       padding:.5rem;
-      min-width:180px;
-      max-height:500px;
+      min-width:200px;
+      max-height:70vh;
       overflow-y:auto;
       box-shadow:0 8px 32px rgba(0,0,0,.8) !important;
       display:none;
@@ -1097,6 +1116,10 @@
       backdrop-filter:blur(12px);
       scrollbar-width:thin;
       scrollbar-color:rgba(91,138,255,.5) rgba(255,255,255,.1);
+    }
+
+    .lang-dropdown-menu.show{
+      display:flex !important;
     }
 
     .lang-dropdown-menu::-webkit-scrollbar{


### PR DESCRIPTION
## Language Dropdown Fixed
1. Changed position to fixed with explicit top:70px, right:100px
2. Changed max-height to 70vh instead of 500px for better mobile support
3. Added explicit .show class rule: display:flex !important
4. Increased min-width to 200px for better readability
5. Z-index: 9999998 ensures it appears above everything

## Header Vertical Shift Fixed - CRITICAL
Problem: When Google Translate translates to longer languages (German, Spanish, etc.), the header would expand vertically to accommodate wrapped text, causing the entire page to shift down. This was jarring and unprofessional.

Solution:
1. Fixed header height: 64px (min, max, and height all set to 64px !important)
2. Fixed .nav height: 100% with max-height:64px
3. Added white-space:nowrap to ALL header elements:
   - header .brand
   - header buttons
   - header links
   - .menu-toggle, #langToggle, #themeToggle
4. Added flex-shrink:0 to all header buttons to prevent compression
5. Enforced flex-wrap:nowrap on .nav container

Now the header STAYS at 64px height no matter what language is selected. Text will clip or compress rather than wrap to a new line.

This ensures a stable, professional header that doesn't bounce around when translating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)