### PR TITLE
Fix language dropdown using direct body child architecture

### DIFF
--- a/index.html
+++ b/index.html
@@ -1090,105 +1090,11 @@
     }
 
 
-    /* Language Dropdown */
+    /* Language Dropdown - container only (menu created as body child in JavaScript) */
     .lang-dropdown{
       position:relative;
       flex-shrink:0;
       z-index:9999999 !important;
-    }
-
-    .lang-dropdown-menu{
-      position:fixed !important;
-      top:70px !important;
-      right:20px !important;
-      background:rgba(10,12,20,1) !important;
-      border:2px solid rgba(255,255,255,.4) !important;
-      border-radius:12px;
-      padding:.5rem;
-      min-width:180px;
-      max-height:500px;
-      overflow-y:auto;
-      box-shadow:0 8px 32px rgba(0,0,0,.8) !important;
-      display:none;
-      flex-direction:column;
-      gap:.25rem;
-      z-index:9999998 !important;
-      backdrop-filter:blur(12px);
-      scrollbar-width:thin;
-      scrollbar-color:rgba(91,138,255,.5) rgba(255,255,255,.1);
-    }
-
-    .lang-dropdown-menu.show{
-      display:flex !important;
-      visibility:visible !important;
-      opacity:1 !important;
-    }
-
-    .lang-dropdown-menu::-webkit-scrollbar{
-      width:8px;
-    }
-
-    .lang-dropdown-menu::-webkit-scrollbar-track{
-      background:rgba(255,255,255,.05);
-      border-radius:4px;
-    }
-
-    .lang-dropdown-menu::-webkit-scrollbar-thumb{
-      background:rgba(91,138,255,.5);
-      border-radius:4px;
-    }
-
-    .lang-dropdown-menu::-webkit-scrollbar-thumb:hover{
-      background:rgba(91,138,255,.7);
-    }
-
-    html[data-theme="light"] .lang-dropdown-menu{
-      background:rgba(255,255,255,.98);
-      border-color:rgba(30,41,59,.2);
-      box-shadow:0 8px 24px rgba(0,0,0,.15);
-      scrollbar-color:rgba(59,130,246,.5) rgba(0,0,0,.05);
-    }
-
-    html[data-theme="light"] .lang-dropdown-menu::-webkit-scrollbar-track{
-      background:rgba(0,0,0,.05);
-    }
-
-    html[data-theme="light"] .lang-dropdown-menu::-webkit-scrollbar-thumb{
-      background:rgba(59,130,246,.5);
-    }
-
-    html[data-theme="light"] .lang-dropdown-menu::-webkit-scrollbar-thumb:hover{
-      background:rgba(59,130,246,.7);
-    }
-
-    .lang-dropdown-menu.show{display:flex}
-
-    .lang-dropdown-menu button{
-      padding:.6rem .9rem;
-      background:transparent;
-      border:none;
-      border-radius:8px;
-      color:#b7c2d9;
-      text-align:left;
-      cursor:pointer;
-      transition:all .2s ease;
-      font-size:.9rem;
-      font-family:'Space Grotesk',system-ui,sans-serif;
-      font-weight:500;
-    }
-
-    .lang-dropdown-menu button:hover{
-      background:rgba(91,138,255,.15);
-      color:#fff;
-    }
-
-    html[data-theme="light"] .lang-dropdown-menu button{
-      color:#475569;
-    }
-
-    html[data-theme="light"] .lang-dropdown-menu button:hover{
-      background:rgba(59,130,246,.12);
-      color:#0f172a;
     }
 
 
@@ -1371,11 +1277,49 @@
 
       .cta-header{display:none}
 
-      /* Mobile language dropdown - adjust positioning */
-      .lang-dropdown-menu{
-        right:auto;
-        left:0;
-        min-width:160px;
+      /* Language dropdown - created as direct child of body */
+      .lang-dropdown-menu {
+        position: fixed;
+        top: 70px;
+        right: 20px;
+        background: rgba(10, 12, 20, 0.98);
+        border: 2px solid rgba(255, 255, 255, 0.4);
+        border-radius: 12px;
+        padding: 0.5rem;
+        min-width: 180px;
+        max-height: 500px;
+        overflow-y: auto;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
+        z-index: 9999;
+        opacity: 0;
+        visibility: hidden;
+        transform: translateY(-10px);
+        transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+      .lang-dropdown-menu.active {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
+      }
+      .lang-dropdown-menu button {
+        padding: 0.6rem 0.9rem;
+        background: transparent;
+        border: none;
+        border-radius: 8px;
+        color: #b7c2d9;
+        text-align: left;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        font-size: 0.9rem;
+        font-family: 'Space Grotesk', system-ui, sans-serif;
+        font-weight: 500;
+      }
+      .lang-dropdown-menu button:hover {
+        background: rgba(91, 138, 255, 0.15);
+        color: #fff;
       }
 
     }
@@ -2659,27 +2603,9 @@
 
 
       <div class="lang-dropdown">
-        <button id="langToggle" onclick="toggleLang()" class="btn btn-ghost btn-sm" type="button" aria-label="Select language" aria-expanded="false" aria-haspopup="true" style="font-size:1.3rem;padding:.5rem .7rem">
+        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Select language" aria-expanded="false" aria-haspopup="true" style="font-size:1.3rem;padding:.5rem .7rem">
           <span>🌐</span>
         </button>
-        <div class="lang-dropdown-menu">
-          <button data-lang="en">English</button>
-          <button data-lang="de">Deutsch</button>
-          <button data-lang="fr">Français</button>
-          <button data-lang="es">Español</button>
-          <button data-lang="it">Italiano</button>
-          <button data-lang="zh">中文</button>
-          <button data-lang="ru">Русский</button>
-          <button data-lang="ar">العربية</button>
-          <button data-lang="pt">Português</button>
-          <button data-lang="tr">Türkçe</button>
-          <button data-lang="ja">日本語</button>
-          <button data-lang="ko">한국어</button>
-          <button data-lang="vi">Tiếng Việt</button>
-          <button data-lang="th">ไทย</button>
-          <button data-lang="hi">हिन्दी</button>
-          <button data-lang="id">Bahasa Indonesia</button>
-        </div>
       </div>
 
       <!-- Hidden select for Google Translate compatibility -->
@@ -4773,89 +4699,103 @@
     })();
 
 
-    /* ======================== Language Dropdown - ULTRA SIMPLE ======================== */
+    /* ======================== Language Dropdown - Direct child of body ======================== */
 
-    function toggleLang() {
-      console.log('=== toggleLang called ===');
+    // Language dropdown - create as direct child of body to escape stacking context
+    (function() {
+      const langBtn = document.getElementById('langToggle');
+      if (!langBtn) return;
 
-      var langMenu = document.querySelector('.lang-dropdown-menu');
+      // Create language dropdown menu
+      const langMenu = document.createElement('div');
+      langMenu.className = 'lang-dropdown-menu';
 
-      if (!langMenu) {
-        alert('Language menu not found!');
-        console.error('.lang-dropdown-menu not found');
-        return;
+      // Create language buttons
+      const languages = [
+        { code: 'en', name: 'English' },
+        { code: 'de', name: 'Deutsch' },
+        { code: 'fr', name: 'Français' },
+        { code: 'es', name: 'Español' },
+        { code: 'it', name: 'Italiano' },
+        { code: 'zh', name: '中文' },
+        { code: 'ru', name: 'Русский' },
+        { code: 'ar', name: 'العربية' },
+        { code: 'pt', name: 'Português' },
+        { code: 'tr', name: 'Türkçe' },
+        { code: 'ja', name: '日本語' },
+        { code: 'ko', name: '한국어' },
+        { code: 'vi', name: 'Tiếng Việt' },
+        { code: 'th', name: 'ไทย' },
+        { code: 'hi', name: 'हिन्दी' },
+        { code: 'id', name: 'Bahasa Indonesia' }
+      ];
+
+      languages.forEach(lang => {
+        const btn = document.createElement('button');
+        btn.setAttribute('data-lang', lang.code);
+        btn.textContent = lang.name;
+        btn.addEventListener('click', function() {
+          console.log('Language selected:', lang.code);
+
+          // Update hidden select and trigger Google Translate
+          const hiddenSelect = document.getElementById('langSel');
+          if (hiddenSelect) {
+            hiddenSelect.value = lang.code;
+            hiddenSelect.dispatchEvent(new Event('change'));
+          }
+
+          // Track event if analytics available
+          if (typeof trackEvent === 'function') {
+            trackEvent('language_change', {
+              language: lang.code,
+              language_name: lang.name
+            });
+          }
+
+          // Close dropdown
+          close();
+        });
+        langMenu.appendChild(btn);
+      });
+
+      // CRITICAL: Append directly to body (escapes header's stacking context)
+      document.body.appendChild(langMenu);
+
+      // Open/close functions
+      function open() {
+        console.log('Opening language dropdown');
+        langMenu.classList.add('active');
+        langBtn.setAttribute('aria-expanded', 'true');
       }
 
-      // Check current state by looking at the actual style
-      var isOpen = (langMenu.style.display === 'flex');
-      console.log('Current state:', isOpen ? 'OPEN' : 'CLOSED');
-      console.log('Current langMenu.style.display:', langMenu.style.display);
-
-      if (isOpen) {
-        // Close dropdown
-        langMenu.style.display = 'none';
-        console.log('>>> Lang dropdown CLOSED <<<');
-      } else {
-        // Open dropdown - set ALL positioning and display properties via inline styles
-        langMenu.style.display = 'flex';
-        langMenu.style.position = 'fixed';
-        langMenu.style.top = '70px';
-        langMenu.style.right = '20px';
-        langMenu.style.background = 'rgba(10,12,20,1)';
-        langMenu.style.border = '2px solid rgba(255,255,255,0.4)';
-        langMenu.style.borderRadius = '12px';
-        langMenu.style.padding = '0.5rem';
-        langMenu.style.minWidth = '180px';
-        langMenu.style.maxHeight = '500px';
-        langMenu.style.overflowY = 'auto';
-        langMenu.style.boxShadow = '0 8px 32px rgba(0,0,0,0.8)';
-        langMenu.style.flexDirection = 'column';
-        langMenu.style.gap = '0.25rem';
-        langMenu.style.zIndex = '9999998';
-        langMenu.style.backdropFilter = 'blur(12px)';
-        langMenu.style.visibility = 'visible';
-        langMenu.style.opacity = '1';
-
-        console.log('>>> Lang dropdown OPENED <<<');
+      function close() {
+        console.log('Closing language dropdown');
+        langMenu.classList.remove('active');
+        langBtn.setAttribute('aria-expanded', 'false');
       }
-    }
 
-    // Close language dropdown when clicking outside
-    document.addEventListener('click', function(e) {
-      var langMenu = document.querySelector('.lang-dropdown-menu');
-      var langBtn = document.getElementById('langToggle');
-
-      if (langMenu && langBtn && langMenu.style.display === 'flex') {
-        if (!langMenu.contains(e.target) && !langBtn.contains(e.target)) {
-          langMenu.style.display = 'none';
-          console.log('Lang dropdown closed (clicked outside)');
+      function toggle() {
+        if (langMenu.classList.contains('active')) {
+          close();
+        } else {
+          open();
         }
       }
-    });
 
-    // Handle language selection
-    document.addEventListener('click', function(e) {
-      if (e.target.closest('.lang-dropdown-menu button')) {
-        var btn = e.target.closest('.lang-dropdown-menu button');
-        var lang = btn.getAttribute('data-lang');
+      // Event listeners
+      langBtn.addEventListener('click', toggle);
 
-        console.log('Language selected:', lang);
-
-        // Update hidden select and trigger Google Translate
-        var hiddenSelect = document.getElementById('langSel');
-        if (hiddenSelect) {
-          hiddenSelect.value = lang;
-          hiddenSelect.dispatchEvent(new Event('change'));
+      // Close when clicking outside
+      document.addEventListener('click', function(e) {
+        if (langMenu.classList.contains('active')) {
+          if (!langMenu.contains(e.target) && !langBtn.contains(e.target)) {
+            close();
+          }
         }
+      });
 
-        // Close dropdown
-        var langMenu = document.querySelector('.lang-dropdown-menu');
-        if (langMenu) {
-          langMenu.classList.remove('show');
-          console.log('Lang dropdown closed (language selected)');
-        }
-      }
-    });
+      console.log('Language dropdown initialized as direct child of body');
+    })();
 
 
 
@@ -5600,14 +5540,7 @@ document.head.appendChild(updateStyle);
       });
     }
 
-    document.querySelectorAll('.lang-dropdown-menu button').forEach(function(btn) {
-      btn.addEventListener('click', function() {
-        trackEvent('language_change', {
-          language: this.getAttribute('data-lang'),
-          language_name: this.textContent.trim()
-        });
-      });
-    });
+    // Language dropdown analytics now integrated into the language dropdown JavaScript above
 
     // 7. TRACK THEME TOGGLE
     const themeToggle = document.getElementById('themeToggle');


### PR DESCRIPTION
Applied same architectural fix that worked for mobile menu to the language dropdown.

Root Problem: Language dropdown was trapped in header's stacking context, just like the mobile menu was before.

Solution: Create language dropdown as direct child of <body>, completely independent from header.

Changes:
- Removed onclick handler and menu HTML from lang-dropdown div
- Removed old CSS rules for .lang-dropdown-menu
- New CSS in media query for .lang-dropdown-menu with transform animation
- JavaScript dynamically creates dropdown and appends to document.body
- Uses .active class with opacity/visibility/transform transitions
- Smooth fade-in animation
- Click-outside to close
- Auto-close on language selection
- Integrated analytics tracking into the new JavaScript

Technical Benefits:
- Escapes header's stacking context completely
- True fixed positioning works properly
- Z-index 9999 is effective and reliable
- Clean CSS transitions for smooth UX
- No CSS specificity battles

Both mobile menu and language dropdown now use the same battle-tested architecture as direct children of body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)