### PR TITLE
Add PWA safe-area support for add-to-home-screen mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -922,9 +922,13 @@
       overflow:visible;
 
       /* CRITICAL: Fixed height to prevent vertical shifting when translated */
-      min-height:64px !important;
-      max-height:64px !important;
-      height:64px !important;
+      /* Adjusted for PWA safe area */
+      min-height: calc(64px + env(safe-area-inset-top, 0px)) !important;
+      max-height: calc(64px + env(safe-area-inset-top, 0px)) !important;
+      height: calc(64px + env(safe-area-inset-top, 0px)) !important;
+
+      /* PWA mode: Add safe area padding for device notch/status bar */
+      padding-top: env(safe-area-inset-top, 0px);
 
     }
 
@@ -5160,7 +5164,7 @@
 (function() {
   // IMPORTANT: Update VERSION on each deployment (format: YYYYMMDDHHmm)
   // This ensures users get fresh JS/CSS after updates
-  var VERSION = '202510301830'; // Last updated: 2025-10-30 18:30 UTC
+  var VERSION = '202510301905'; // Last updated: 2025-10-30 19:05 UTC
 
   function loadScript(src, callback) {
     var s = document.createElement('script');

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 // Service Worker for Signal Pilot PWA
 // Updated cache strategy: Network first for HTML, cache for assets
 // IMPORTANT: Update CACHE_VERSION on each deployment to match index.html VERSION
-const CACHE_VERSION = '202510301830'; // Last updated: 2025-10-30 18:30 UTC
+const CACHE_VERSION = '202510301905'; // Last updated: 2025-10-30 19:05 UTC
 const CACHE_NAME = `signal-pilot-${CACHE_VERSION}`;
 const ASSETS_TO_CACHE = [
   '/manifest.json',


### PR DESCRIPTION
Fixed header appearing too high in PWA mode by:
- Adding safe-area-inset-top padding to header
- Adjusting header height calculation to include safe area
- This prevents header from overlapping with device status bar

Updated VERSION to 202510301905 for cache busting