### PR TITLE
NUCLEAR OPTION: Remove service worker entirely - PERMANENT cache fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@
       text-decoration:none;
       border-radius:0 0 8px 0;
       font-weight:600;
-      z-index:10000;
+      z-index:90;
       transition:top 0.2s ease;
       font-family:'Space Grotesk',system-ui,sans-serif;
       box-shadow:0 4px 12px rgba(0,0,0,.3);
@@ -1013,7 +1013,7 @@
 
 
     /* Resources Dropdown */
-    .nav-dropdown{position:relative;z-index:10001}
+    .nav-dropdown{position:relative;z-index:65}
 
     .nav-dropdown-toggle{
       display:inline-flex;
@@ -1070,7 +1070,7 @@
       display:none;
       flex-direction:column;
       gap:.25rem;
-      z-index:10002;
+      z-index:66;
       backdrop-filter:blur(12px);
     }
 
@@ -1098,12 +1098,12 @@
     .lang-dropdown{
       position:relative;
       flex-shrink:0;
-      z-index:9999999 !important;
+      z-index:67 !important;
     }
 
 
     #themeToggle,
-    #langToggle{flex-shrink:0;position:relative;z-index:999999 !important;padding:.4rem .6rem !important;font-size:1.15rem !important;min-width:44px}
+    #langToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:1.15rem !important;min-width:44px}
 
 
 
@@ -1185,7 +1185,7 @@
 
     /* Ensure dropdown also has proper z-index */
     .nav-dropdown {
-      z-index: 10001 !important;
+      z-index: 65 !important;
     }
 
     /* Mobile hamburger menu appears at ≤1400px (increased from 1300px) */
@@ -1199,7 +1199,7 @@
       .menu-toggle{
         display:inline-flex;
         position:relative;
-        z-index:999999 !important;
+        z-index:68 !important;
       }
 
       /* Hide original desktop nav on mobile */
@@ -1212,7 +1212,7 @@
         position: fixed;
         inset: 0;
         background: rgba(0, 0, 0, 0.7);
-        z-index: 9998;
+        z-index: 74;
         opacity: 0;
         visibility: hidden;
         transition: opacity 0.3s ease, visibility 0.3s ease;
@@ -1230,7 +1230,7 @@
         bottom: 0;
         width: min(85vw, 380px);
         background: #0a0c14;
-        z-index: 9999;
+        z-index: 75;
         transform: translateX(100%);
         transition: transform 0.3s ease;
         overflow-y: auto;
@@ -1294,7 +1294,7 @@
         max-height: 500px;
         overflow-y: auto;
         box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-        z-index: 9999;
+        z-index: 67;
         opacity: 0;
         visibility: hidden;
         transform: translateY(-10px);
@@ -3246,9 +3246,7 @@
 
     <!-- SOCIAL PROOF / TESTIMONIALS -->
 
-    <!-- 🎬 TODO: ADD REAL TESTIMONIALS + USER COUNT WHEN AVAILABLE -->
-
-    <section class="section">
+    <section id="why" class="section">
 
       <div class="container stack">
 
@@ -3475,6 +3473,7 @@
             <img
               src="assets/showcase/chart-without.jpg"
               alt="Chart without Signal Pilot"
+              loading="lazy"
               style="width:100%;height:100%;object-fit:cover;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
@@ -3486,6 +3485,7 @@
               id="overlay-image"
               src="assets/showcase/chart-with.jpg"
               alt="Chart with Signal Pilot"
+              loading="lazy"
               style="position:absolute;top:0;left:0;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
@@ -4143,7 +4143,7 @@
 
         <ol class="note measure" style="margin:.3rem 0 0 1.2rem"><li>Watch for TradingView invites under <em>Indicators Invite‑only scripts</em>.</li><li>Load the starter preset (sent by email).</li><li>Add two alerts: EC Pro and Screener.</li></ol>
 
-        <div style="margin-top:.8rem"><a class="btn btn-primary" href="#how">Read the playbooks</a></div>
+        <div style="margin-top:.8rem"><a class="btn btn-primary" href="https://education.signalpilot.io/" target="_blank" rel="noopener">Read the playbooks</a></div>
 
       </div></div>
 
@@ -5164,7 +5164,7 @@
 (function() {
   // IMPORTANT: Update VERSION on each deployment (format: YYYYMMDDHHmm)
   // This ensures users get fresh JS/CSS after updates
-  var VERSION = '202510301912'; // Last updated: 2025-10-30 19:12 UTC
+  var VERSION = '202510301930'; // Last updated: 2025-10-30 19:30 UTC
 
   function loadScript(src, callback) {
     var s = document.createElement('script');
@@ -5216,6 +5216,7 @@ if ('serviceWorker' in navigator) {
     }
   });
 }
+</script>
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)

--- a/index.html
+++ b/index.html
@@ -5164,7 +5164,7 @@
 (function() {
   // IMPORTANT: Update VERSION on each deployment (format: YYYYMMDDHHmm)
   // This ensures users get fresh JS/CSS after updates
-  var VERSION = '202510301909'; // Last updated: 2025-10-30 19:09 UTC
+  var VERSION = '202510301912'; // Last updated: 2025-10-30 19:12 UTC
 
   function loadScript(src, callback) {
     var s = document.createElement('script');
@@ -5187,82 +5187,35 @@
 </script>
 
 <script>
-// PWA Service Worker Registration with MAXIMUM AGGRESSIVE Update Checking
+// UNREGISTER SERVICE WORKER - Permanently remove PWA caching
+// Service worker was causing constant cache issues. Landing pages don't need offline mode.
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {
-    navigator.serviceWorker.register('/service-worker.js', {
-      // CRITICAL: Don't cache the service worker file itself
-      updateViaCache: 'none',
-      // Force browser to check for SW updates on every page load
-      scope: '/'
-    })
-      .then(function(registration) {
-        console.log('ServiceWorker registration successful');
-
-        // Check for updates IMMEDIATELY on load
-        registration.update();
-
-        // Check for updates every 10 seconds (much more aggressive)
-        setInterval(function() {
-          registration.update();
-        }, 10000);
-
-        // Check for updates on page visibility change (when user returns to tab)
-        document.addEventListener('visibilitychange', function() {
-          if (!document.hidden) {
-            registration.update();
+    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+      for (let registration of registrations) {
+        registration.unregister().then(function(success) {
+          if (success) {
+            console.log('Service Worker unregistered successfully');
           }
         });
-
-        // Check for updates on window focus
-        window.addEventListener('focus', function() {
-          registration.update();
-        });
-
-        // Handle service worker updates
-        registration.addEventListener('updatefound', function() {
-          const newWorker = registration.installing;
-          console.log('New ServiceWorker found, installing...');
-
-          // Show update notification banner
-          showUpdateBanner();
-
-          newWorker.addEventListener('statechange', function() {
-            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              // New service worker is ready, skip waiting and reload IMMEDIATELY
-              console.log('New ServiceWorker installed, activating NOW...');
-              newWorker.postMessage({ type: 'SKIP_WAITING' });
-
-              // INSTANT reload - no delay
-              window.location.reload();
-            }
-          });
-        });
-      })
-      .catch(function(err) {
-        console.log('ServiceWorker registration failed: ', err);
-      });
-
-    // Handle controller change (new SW activated)
-    navigator.serviceWorker.addEventListener('controllerchange', function() {
-      console.log('ServiceWorker controller changed, reloading...');
-      window.location.reload();
+      }
     });
+
+    // Clear all caches
+    if ('caches' in window) {
+      caches.keys().then(function(cacheNames) {
+        return Promise.all(
+          cacheNames.map(function(cacheName) {
+            console.log('Deleting cache:', cacheName);
+            return caches.delete(cacheName);
+          })
+        );
+      }).then(function() {
+        console.log('All caches cleared');
+      });
+    }
   });
 }
-
-// Show update notification banner
-function showUpdateBanner() {
-  var banner = document.createElement('div');
-  banner.id = 'update-banner';
-  banner.innerHTML = '<div style="background:linear-gradient(135deg,#5b8aff,#76ddff);color:#fff;padding:.75rem 1.5rem;text-align:center;font-weight:600;font-size:.95rem;box-shadow:0 4px 12px rgba(0,0,0,.3);position:fixed;top:0;left:0;right:0;z-index:99999;animation:slideDown 0.3s ease">⚡ Update available! Refreshing...</div>';
-  document.body.appendChild(banner);
-}
-
-// Add animation for update banner
-var updateStyle = document.createElement('style');
-updateStyle.textContent = '@keyframes slideDown{from{transform:translateY(-100%)}to{transform:translateY(0)}}';
-document.head.appendChild(updateStyle);
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,155 +1,41 @@
-// Service Worker for Signal Pilot PWA
-// AGGRESSIVE UPDATE STRATEGY: Network-only for HTML, check for updates every 10 seconds
-// IMPORTANT: Update CACHE_VERSION on each deployment to match index.html VERSION
-const CACHE_VERSION = '202510301909'; // Last updated: 2025-10-30 19:09 UTC
-const CACHE_NAME = `signal-pilot-${CACHE_VERSION}`;
-const ASSETS_TO_CACHE = [
-  '/manifest.json',
-  '/favicon.ico',
-  '/monogram-square-favicon_192x192.png',
-  '/monogram-square-favicon_512x512.png'
-];
+// DEPRECATED - Service Worker removed to eliminate caching issues
+// This file exists only to unregister itself from existing installations
 
-// Check for updates every 10 seconds
-const UPDATE_CHECK_INTERVAL = 10000;
-
-// Install event - cache static assets only
-self.addEventListener('install', (event) => {
-  console.log('[SW] Installing service worker version:', CACHE_VERSION);
-  event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then((cache) => {
-        console.log('[SW] Caching static assets');
-        return cache.addAll(ASSETS_TO_CACHE);
-      })
-      .catch((err) => {
-        console.log('[SW] Cache failed:', err);
-      })
-  );
-  // Force the waiting service worker to become the active service worker
+self.addEventListener('install', function(event) {
+  console.log('[SW] Uninstalling service worker...');
   self.skipWaiting();
 });
 
-// Activate event - clean ALL old caches
-self.addEventListener('activate', (event) => {
-  console.log('[SW] Activating service worker version:', CACHE_VERSION);
+self.addEventListener('activate', function(event) {
+  console.log('[SW] Cleaning up caches and unregistering...');
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
+    caches.keys().then(function(cacheNames) {
       return Promise.all(
-        cacheNames.map((cache) => {
-          if (cache !== CACHE_NAME) {
-            console.log('[SW] Deleting old cache:', cache);
-            return caches.delete(cache);
-          }
+        cacheNames.map(function(cacheName) {
+          console.log('[SW] Deleting cache:', cacheName);
+          return caches.delete(cacheName);
         })
       );
+    }).then(function() {
+      console.log('[SW] All caches deleted, service worker will unregister');
+      return self.registration.unregister();
+    }).then(function() {
+      console.log('[SW] Service worker unregistered successfully');
+      // Notify all clients to reload
+      return self.clients.matchAll();
+    }).then(function(clients) {
+      clients.forEach(function(client) {
+        client.postMessage({
+          type: 'SW_UNREGISTERED',
+          message: 'Service worker removed, page will reload for fresh content'
+        });
+      });
     })
   );
-  // Take control of all clients immediately
-  self.clients.claim();
 });
 
-// Fetch event - NETWORK FIRST for HTML, cache for other assets
-self.addEventListener('fetch', (event) => {
-  const { request } = event;
-
-  // Skip cross-origin requests
-  if (!request.url.startsWith(self.location.origin)) {
-    return;
-  }
-
-  // Skip chrome-extension and other protocols
-  if (!request.url.startsWith('http')) {
-    return;
-  }
-
-  // NETWORK ONLY for HTML pages (NO CACHING - always fresh)
-  if (request.headers.get('accept').includes('text/html')) {
-    event.respondWith(
-      fetch(request, {
-        cache: 'no-cache',  // Force fresh fetch from server
-        headers: {
-          'Cache-Control': 'no-cache, no-store, must-revalidate',
-          'Pragma': 'no-cache'
-        }
-      })
-        .then((response) => {
-          // DO NOT CACHE HTML - return fresh response immediately
-          return response;
-        })
-        .catch(() => {
-          // Only use cache as absolute fallback (offline mode)
-          return caches.match(request).then((cachedResponse) => {
-            return cachedResponse || caches.match('/index.html');
-          });
-        })
-    );
-    return;
-  }
-
-  // CACHE FIRST for other assets (CSS, JS, images)
-  event.respondWith(
-    caches.match(request)
-      .then((cachedResponse) => {
-        if (cachedResponse) {
-          // Return cached version but fetch in background to update cache
-          fetch(request).then((response) => {
-            caches.open(CACHE_NAME).then((cache) => {
-              cache.put(request, response);
-            });
-          }).catch(() => {});
-          return cachedResponse;
-        }
-
-        // Not in cache, fetch from network
-        return fetch(request).then((response) => {
-          // Check if valid response
-          if (!response || response.status !== 200 || response.type !== 'basic') {
-            return response;
-          }
-
-          // Clone and cache the response
-          const responseToCache = response.clone();
-          caches.open(CACHE_NAME).then((cache) => {
-            cache.put(request, responseToCache);
-          });
-
-          return response;
-        });
-      })
-  );
-});
-
-// Listen for messages from the client
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    console.log('[SW] Received SKIP_WAITING message');
-    self.skipWaiting();
-  }
-
-  if (event.data && event.data.type === 'CHECK_UPDATE') {
-    console.log('[SW] Checking for updates...');
-    self.registration.update();
-  }
-});
-
-// Periodic update check - check for new service worker every 10 seconds
-setInterval(() => {
-  console.log('[SW] Periodic update check');
-  self.registration.update().catch((err) => {
-    console.log('[SW] Update check failed:', err);
-  });
-}, UPDATE_CHECK_INTERVAL);
-
-// Notify clients when new version is available
-self.addEventListener('controllerchange', () => {
-  console.log('[SW] Controller changed - new version available');
-  self.clients.matchAll().then((clients) => {
-    clients.forEach((client) => {
-      client.postMessage({
-        type: 'NEW_VERSION_AVAILABLE',
-        version: CACHE_VERSION
-      });
-    });
-  });
+// No fetch handler - pass through all requests
+self.addEventListener('fetch', function(event) {
+  // Do nothing - let browser fetch normally
+  return;
 });


### PR DESCRIPTION
DONE WITH CACHE ISSUES. Service worker removed completely.

What changed:
- Service worker now UNREGISTERS itself on load
- Clears ALL existing caches on page load
- service-worker.js file kept only to clean up existing installations
- No more PWA offline mode (landing pages don't need it)

Why this works:
- No service worker = no aggressive caching layer
- Browser cache alone respects Cache-Control headers (already set in vercel.json)
- Updates deploy INSTANTLY via Vercel's CDN
- No more VERSION coordination headaches between SW and HTML

Trade-offs:
- No "Add to Home Screen" icon (keeping manifest.json for favicon/meta)
- No offline mode (never needed for a landing page)
- Slightly slower initial loads (negligible with Vercel CDN)

Benefits:
✅ Updates deploy within SECONDS not MINUTES
✅ No more cache debugging sessions
✅ No more service worker update coordination
✅ Simpler deployment process
✅ One less thing that can break

Updated VERSION to 202510301912