### PR TITLE
Fix language dropdown appearing at bottom instead of as overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1101,6 +1101,51 @@
       z-index:67 !important;
     }
 
+    /* Language dropdown menu - created as direct child of body, needs to work on ALL screen sizes */
+    .lang-dropdown-menu {
+      position: fixed !important;
+      top: 70px;
+      right: 20px;
+      background: rgba(10, 12, 20, 0.98);
+      border: 2px solid rgba(255, 255, 255, 0.4);
+      border-radius: 12px;
+      padding: 0.5rem;
+      min-width: 180px;
+      max-height: 500px;
+      overflow-y: auto;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
+      z-index: 76 !important;
+      opacity: 0 !important;
+      visibility: hidden !important;
+      transform: translateY(-10px);
+      transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+      display: flex !important;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+    .lang-dropdown-menu.active {
+      opacity: 1 !important;
+      visibility: visible !important;
+      transform: translateY(0) !important;
+    }
+    .lang-dropdown-menu button {
+      padding: 0.6rem 0.9rem;
+      background: transparent;
+      border: none;
+      border-radius: 8px;
+      color: #b7c2d9;
+      text-align: left;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      font-size: 0.9rem;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      font-weight: 500;
+    }
+    .lang-dropdown-menu button:hover {
+      background: rgba(91, 138, 255, 0.15);
+      color: #fff;
+    }
+
 
     #themeToggle,
     #langToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:1.15rem !important;min-width:44px}
@@ -1281,53 +1326,8 @@
 
       .cta-header{display:none}
 
-      /* Language dropdown - created as direct child of body */
-      .lang-dropdown-menu {
-        position: fixed;
-        top: 70px;
-        right: 20px;
-        background: rgba(10, 12, 20, 0.98);
-        border: 2px solid rgba(255, 255, 255, 0.4);
-        border-radius: 12px;
-        padding: 0.5rem;
-        min-width: 180px;
-        max-height: 500px;
-        overflow-y: auto;
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-        z-index: 67;
-        opacity: 0;
-        visibility: hidden;
-        transform: translateY(-10px);
-        transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-      }
-      .lang-dropdown-menu.active {
-        opacity: 1;
-        visibility: visible;
-        transform: translateY(0);
-      }
-      .lang-dropdown-menu button {
-        padding: 0.6rem 0.9rem;
-        background: transparent;
-        border: none;
-        border-radius: 8px;
-        color: #b7c2d9;
-        text-align: left;
-        cursor: pointer;
-        transition: all 0.2s ease;
-        font-size: 0.9rem;
-        font-family: 'Space Grotesk', system-ui, sans-serif;
-        font-weight: 500;
-      }
-      .lang-dropdown-menu button:hover {
-        background: rgba(91, 138, 255, 0.15);
-        color: #fff;
-      }
-
     }
-    
+
     @media (max-width:600px){
       nav[aria-label="Main"]{
         width:90vw !important;
@@ -5164,7 +5164,7 @@
 (function() {
   // IMPORTANT: Update VERSION on each deployment (format: YYYYMMDDHHmm)
   // This ensures users get fresh JS/CSS after updates
-  var VERSION = '202510301930'; // Last updated: 2025-10-30 19:30 UTC
+  var VERSION = '202510301943'; // Last updated: 2025-10-30 19:43 UTC
 
   function loadScript(src, callback) {
     var s = document.createElement('script');


### PR DESCRIPTION
ROOT CAUSE:
.lang-dropdown-menu CSS was ONLY defined inside @media (max-width:1400px) On desktop (>1400px), the dropdown had NO positioning CSS at all, so it appeared in document flow at bottom of page.

FIXES:
- Moved .lang-dropdown-menu CSS OUTSIDE media query (applies to all screen sizes)
- Added !important to critical properties (position, opacity, visibility, display)
- Increased z-index from 67 to 76 (above sticky CTA bar which is z-index:50)
- Removed duplicate CSS from inside @media query
- Language dropdown now works correctly on ALL screen sizes

TESTING:
- Click globe button -> dropdown appears below button
- Language buttons no longer visible at bottom of page
- Dropdown appears above sticky CTA bar
- Works on both desktop and mobile

Updated VERSION to 202510301943