### PR TITLE
Convert site language to observational tone

### DIFF
--- a/404.html
+++ b/404.html
@@ -33,9 +33,9 @@
   <main class="wrap">
     <div class="card">
       <h1>404 — Page not found</h1>
-      <p>We couldn’t find that page. Try the links below or head back to the homepage.</p>
+      <p>This page could not be found. The links below provide navigation to other sections.</p>
       <div class="links">
-        <a class="btn" href="/">Go home</a>
+        <a class="btn" href="/">Homepage</a>
         <a class="ghost" href="/#product">Product</a>
         <a class="ghost" href="/#docs">Docs</a>
         <a class="ghost" href="/resources/">Resources</a>

--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -280,8 +280,8 @@
     const button = document.createElement('button');
     button.className = 'sp-theme-toggle';
     button.innerHTML = '🎨';
-    button.setAttribute('aria-label', 'Change theme');
-    button.setAttribute('title', 'Change theme');
+    button.setAttribute('aria-label', 'Theme selection');
+    button.setAttribute('title', 'Theme selection');
     button.onclick = () => openThemeModal();
     document.body.appendChild(button);
     return button;
@@ -302,8 +302,8 @@
     const header = document.createElement('div');
     header.className = 'sp-theme-modal-header';
     header.innerHTML = `
-      <h2 class="sp-theme-modal-title">Choose Your Theme</h2>
-      <button class="sp-theme-modal-close" aria-label="Close">×</button>
+      <h2 class="sp-theme-modal-title">Theme Selection</h2>
+      <button class="sp-theme-modal-close" aria-label="Close modal">×</button>
     `;
     header.querySelector('.sp-theme-modal-close').onclick = closeThemeModal;
 

--- a/index.html
+++ b/index.html
@@ -2538,7 +2538,7 @@
 <body>
 
 <!-- Skip to content link for accessibility -->
-<a href="#main" class="skip-link">Skip to main content</a>
+<a href="#main" class="skip-link">Main content</a>
 
 <!-- CRITICAL: Force elements visible on mobile IMMEDIATELY -->
 <script>
@@ -2636,7 +2636,7 @@
 
 
       <div class="lang-dropdown">
-        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Select language" aria-expanded="false" aria-haspopup="true" style="font-size:1.3rem;padding:.5rem .7rem">
+        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Language selection" aria-expanded="false" aria-haspopup="true" style="font-size:1.3rem;padding:.5rem .7rem">
           <span>🌐</span>
         </button>
       </div>
@@ -2661,7 +2661,7 @@
         <option value="id">Bahasa Indonesia</option>
       </select>
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Toggle theme" style="font-size:1.3rem;padding:.5rem .7rem">
+      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Theme selection" style="font-size:1.3rem;padding:.5rem .7rem">
         <span id="theme-icon">🌙</span>
       </button>
 
@@ -2671,7 +2671,7 @@
 
 
 
-      <a class="btn btn-primary cta-header" href="#pricing">Try Risk-Free →</a>
+      <a class="btn btn-primary cta-header" href="#pricing">Available Risk-Free →</a>
 
 
 
@@ -2978,11 +2978,11 @@
           <div style="display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;margin-bottom:1.5rem">
 
             <a class="btn btn-primary" href="#pricing" style="position:relative">
-              Try Risk-Free for 7 Days
+              Available Risk-Free for 7 Days
               <span style="position:absolute;top:-8px;right:-8px;background:#f9a23c;color:#fff;font-size:.7rem;padding:.2rem .5rem;border-radius:999px;font-weight:700;box-shadow:0 2px 8px rgba(249,162,60,.4)">Save $489</span>
             </a>
 
-            <a class="btn btn-ghost" href="#inside">See All 7 Indicators</a>
+            <a class="btn btn-ghost" href="#inside">All 7 Indicators</a>
 
           </div>
 
@@ -2997,7 +2997,7 @@
           </div>
 
           <p style="color:var(--muted);font-size:.9rem;margin:0 0 .5rem 0">
-            <strong style="color:#3ed598">✓</strong> Join 500+ traders who trade with complete clarity
+            <strong style="color:#3ed598">✓</strong> 500+ traders trade with complete clarity
           </p>
 
           <p style="color:var(--muted-2);font-size:.8rem;margin:0;opacity:.85">
@@ -3040,7 +3040,7 @@
               <span class="badge" style="font-size:.75rem;margin-left:.5rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;padding:.3rem .7rem;text-transform:uppercase;letter-spacing:.5px;white-space:nowrap">★ FLAGSHIP</span>
             </div>
             <div class="punch" style="font-size:1.1rem;line-height:1.4">Complete trend regime detection system. Not just isolated signals—the full market cycle.</div>
-            <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details" style="margin-top:.5rem">Learn More ▼</button>
+            <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details" style="margin-top:.5rem">Details ▼</button>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Four integrated layers:</strong></p>
 
@@ -3099,7 +3099,7 @@
               <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(91,138,255,.15);color:var(--brand);white-space:nowrap">ALL-IN-ONE</span>
             </div>
             <div class="punch">Comprehensive overlay—everything you need on the chart.</div>
-            <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details" style="margin-top:.5rem">Learn More ▼</button>
+            <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details" style="margin-top:.5rem">Details ▼</button>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>10 premium systems unified on one chart</strong></p>
               <ul style="font-size:.9rem;line-height:1.8;color:var(--muted-2);list-style:none;padding:0">
@@ -3127,7 +3127,7 @@
               <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(62,213,152,.15);color:var(--good);white-space:nowrap">INSTITUTIONAL</span>
             </div>
             <div class="punch">See when smart money is moving—before retail notices.</div>
-            <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details" style="margin-top:.5rem">Learn More ▼</button>
+            <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details" style="margin-top:.5rem">Details ▼</button>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Shows institutional activity patterns:</strong></p>
               <ul style="font-size:.9rem;line-height:1.8;color:var(--muted-2);list-style:none;padding:0">
@@ -3150,7 +3150,7 @@
               <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">ACCUMULATION</span>
             </div>
             <div class="punch">Follow the money. Cumulative delta reveals hidden accumulation.</div>
-            <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details" style="margin-top:.5rem">Learn More ▼</button>
+            <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details" style="margin-top:.5rem">Details ▼</button>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>The ribbon shows cumulative buying vs selling:</strong></p>
               <ul style="font-size:.9rem;line-height:1.8;color:var(--muted-2);list-style:none;padding:0">
@@ -3173,7 +3173,7 @@
               <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(118,221,255,.15);color:var(--accent);white-space:nowrap">KEY LEVELS</span>
             </div>
             <div class="punch">HTF levels, D/W/M pivots, VWAP, VAL/POC—all key zones in one view.</div>
-            <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details" style="margin-top:.5rem">Learn More ▼</button>
+            <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details" style="margin-top:.5rem">Details ▼</button>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Shows you every institutional reference point automatically:</strong></p>
               <ul style="font-size:.9rem;line-height:1.8;color:var(--muted-2);list-style:none;padding:0">
@@ -3197,7 +3197,7 @@
               <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">S/R MATRIX</span>
             </div>
             <div class="punch">Support/resistance matrix with probability‑weighted breakout zones.</div>
-            <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details" style="margin-top:.5rem">Learn More ▼</button>
+            <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details" style="margin-top:.5rem">Details ▼</button>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>A live table that tracks your entire watchlist:</strong></p>
               <ul style="font-size:.9rem;line-height:1.8;color:var(--muted-2);list-style:none;padding:0">
@@ -3221,7 +3221,7 @@
               <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">TIMING</span>
             </div>
             <div class="punch">Optimized entry timing through phase‑aligned momentum synthesis.</div>
-            <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details" style="margin-top:.5rem">Learn More ▼</button>
+            <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details" style="margin-top:.5rem">Details ▼</button>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Four momentum oscillators vote on every bar:</strong></p>
               <ul style="font-size:.9rem;line-height:1.8;color:var(--muted-2);list-style:none;padding:0">
@@ -3256,7 +3256,7 @@
 
           <p class="note" style="max-width:52ch;margin:1rem auto 0">
 
-            Join the growing community of traders who refuse to trade on repainting signals.
+            A growing community of traders refuses to trade on repainting signals.
 
           </p>
 
@@ -3426,12 +3426,12 @@
 
         <div style="text-align:center;margin-top:3rem;padding:2rem;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04));border:1px solid rgba(91,138,255,.2);border-radius:16px;max-width:700px;margin-left:auto;margin-right:auto">
           <p style="font-size:1.2rem;color:#fff;margin:0 0 1rem 0;font-weight:700">
-            Stop guessing. Start knowing.
+            Guessing ends. Knowledge begins.
           </p>
           <p style="font-size:1rem;color:var(--muted);margin:0 0 1.5rem 0">
-            Join 500+ traders who trade with complete clarity
+            500+ traders trade with complete clarity
           </p>
-          <a class="btn btn-primary" href="#pricing">Try Risk-Free for 7 Days</a>
+          <a class="btn btn-primary" href="#pricing">Available Risk-Free for 7 Days</a>
         </div>
 
       </div>
@@ -3879,7 +3879,7 @@
             <strong>The only difference? Billing frequency.</strong> Plus every feature update and new indicator we launch—included automatically, forever.
           </p>
 
-          <span class="note" style="font-size:.85rem">Choose Monthly for flexibility, Yearly for savings (save $489/year), or Lifetime for unlimited access forever.</span>
+          <span class="note" style="font-size:.85rem">Monthly offers flexibility, Yearly provides savings (save $489/year), and Lifetime gives unlimited access forever.</span>
 
         </div>
 
@@ -3927,7 +3927,7 @@
 
               <div class="pp-slot" id="paypal-button-container-P-1WW85539FH424981JND52S7A"></div>
 
-              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/272cee92-d8d5-4259-866b-e7cf95f5d7ee" class="btn btn-primary" target="_blank">Pay by Card</a>
+              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/272cee92-d8d5-4259-866b-e7cf95f5d7ee" class="btn btn-primary" target="_blank">Card Payment</a>
 
             </div>
 
@@ -3979,7 +3979,7 @@
 
               <div class="pp-slot" id="paypal-button-container-P-1S895034P48824141ND52VBA"></div>
 
-              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/bb59d34b-20bb-478d-9db3-533b7e84930b" class="btn btn-primary" target="_blank">Pay by Card</a>
+              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/bb59d34b-20bb-478d-9db3-533b7e84930b" class="btn btn-primary" target="_blank">Card Payment</a>
 
             </div>
 
@@ -4044,7 +4044,7 @@
                 <div style="font-size:0.75rem;text-align:center;opacity:0.7;">Powered by PayPal</div>
               </form>
 
-              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/81822d54-6e08-4c26-b2f0-d5d5e3cdd25e" class="btn btn-primary" target="_blank">Pay by Card (Alternative)</a>
+              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/81822d54-6e08-4c26-b2f0-d5d5e3cdd25e" class="btn btn-primary" target="_blank">Card Payment (Alternative)</a>
 
               <button class="btn btn-disabled" id="lt-soldout" type="button" style="display:none">Sold out — join waitlist below</button>
 
@@ -4141,9 +4141,9 @@
 
         <p class="note measure">We'll activate your TradingView invites: <strong>PayPal/Card 1–8 hours</strong>. If you don't see invites after that, email <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> with your transaction and TradingView username.</p>
 
-        <ol class="note measure" style="margin:.3rem 0 0 1.2rem"><li>Watch for TradingView invites under <em>Indicators Invite‑only scripts</em>.</li><li>Load the starter preset (sent by email).</li><li>Add two alerts: EC Pro and Screener.</li></ol>
+        <ol class="note measure" style="margin:.3rem 0 0 1.2rem"><li>TradingView invites appear under <em>Indicators Invite‑only scripts</em>.</li><li>The starter preset loads (sent by email).</li><li>Two alerts are added: EC Pro and Screener.</li></ol>
 
-        <div style="margin-top:.8rem"><a class="btn btn-primary" href="https://education.signalpilot.io/" target="_blank" rel="noopener">Read the playbooks</a></div>
+        <div style="margin-top:.8rem"><a class="btn btn-primary" href="https://education.signalpilot.io/" target="_blank" rel="noopener">Playbooks</a></div>
 
       </div></div>
 
@@ -4165,7 +4165,7 @@
         <strong style="color:#3ed598">✓</strong> 500+ traders use <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>
       </div>
 
-      <a class="btn btn-primary btn-sm" href="#pricing">Start Trading with Clarity</a>
+      <a class="btn btn-primary btn-sm" href="#pricing">Trading with Clarity</a>
 
       <button class="cta-close" id="ctaClose" aria-label="Close">✕</button>
 
@@ -4291,7 +4291,7 @@
 
     <div class="modal-card">
 
-      <header><h3 id="cardNotifyTitle">Notify me when card checkout opens</h3><button class="modal-close" data-close aria-label="Close">✕</button></header>
+      <header><h3 id="cardNotifyTitle">Card checkout notification</h3><button class="modal-close" data-close aria-label="Close">✕</button></header>
 
       <form id="card-notify-form" action="https://formspree.io/f/mldpnrop" method="POST">
 
@@ -4301,7 +4301,7 @@
 
         <label>TradingView username<input id="cn-tv" name="tradingview" placeholder="@your.tradingview" required></label>
 
-        <button class="btn btn-primary" type="submit">Notify me</button><a class="btn btn-ghost" href="#waitlist" style="margin-left:.4rem">Go to waitlist</a>
+        <button class="btn btn-primary" type="submit">Notification signup</button><a class="btn btn-ghost" href="#waitlist" style="margin-left:.4rem">Waitlist</a>
 
       </form>
 
@@ -5255,7 +5255,7 @@ if ('serviceWorker' in navigator) {
           
           if (isVisible) {
             targetDiv.style.display = 'none';
-            this.textContent = 'Learn More ▼';
+            this.textContent = 'Details ▼';
           } else {
             targetDiv.style.display = 'block';
             this.textContent = 'Hide Details ▲';

--- a/privacy.html
+++ b/privacy.html
@@ -299,7 +299,7 @@
         <li><strong>Opt-Out:</strong> Unsubscribe from marketing emails (service-related emails cannot be opted out)</li>
       </ul>
 
-      <p>To exercise these rights, contact us at <a href="mailto:privacy@signalpilot.io">privacy@signalpilot.io</a></p>
+      <p>These rights can be exercised by emailing <a href="mailto:privacy@signalpilot.io">privacy@signalpilot.io</a></p>
 
       <h2>7. Cookies and Tracking</h2>
 
@@ -324,7 +324,7 @@
 
       <h2>9. Children's Privacy</h2>
 
-      <p>Our service is not intended for individuals under 18 years of age. We do not knowingly collect personal information from children. If you believe a child has provided us with personal data, contact us immediately at <a href="mailto:privacy@signalpilot.io">privacy@signalpilot.io</a></p>
+      <p>Our service is not intended for individuals under 18 years of age. We do not knowingly collect personal information from children. Reports regarding children providing personal data can be sent to <a href="mailto:privacy@signalpilot.io">privacy@signalpilot.io</a></p>
 
       <h2>10. Changes to This Policy</h2>
 
@@ -348,7 +348,7 @@
       </p>
 
       <p style="font-size: 0.9rem; color: var(--muted-2)">
-        <strong>CCPA Compliance:</strong> California residents have additional rights under the California Consumer Privacy Act. Contact us at <a href="mailto:privacy@signalpilot.io">privacy@signalpilot.io</a> for details.
+        <strong>CCPA Compliance:</strong> California residents have additional rights under the California Consumer Privacy Act. Details are available at <a href="mailto:privacy@signalpilot.io">privacy@signalpilot.io</a>.
       </p>
 
     </div>

--- a/refund.html
+++ b/refund.html
@@ -290,12 +290,12 @@
       
       <h1>Refund Policy</h1>
       
-      <p class="subtitle">Simple, fair refund terms. Try risk-free for 7 days.</p>
+      <p class="subtitle">Simple, fair refund terms. Available risk-free for 7 days.</p>
       
       <div class="updated">Last Updated: October 23, 2025</div>
 
       <div class="success-box">
-        <p><strong>✓ 7-Day Money-Back Guarantee</strong> — Not satisfied? Get a full refund within 7 days of purchase (first-time buyers only).</p>
+        <p><strong>✓ 7-Day Money-Back Guarantee</strong> — A full refund is available within 7 days of purchase for first-time buyers.</p>
       </div>
 
       <h2>1. Overview</h2>
@@ -367,7 +367,7 @@
 
       <h2>3. How to Request a Refund</h2>
 
-      <h3>Step 1: Contact Us</h3>
+      <h3>Step 1: Contacting Support</h3>
       <p>Email <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> with:</p>
       <ul>
         <li>Subject: "Refund Request"</li>
@@ -376,13 +376,13 @@
         <li>Purchase date (if you have it)</li>
       </ul>
 
-      <h3>Step 2: Confirmation</h3>
+      <h3>Step 2: Confirmation Process</h3>
       <p>We'll confirm your refund request within 24-48 hours (usually faster). No lengthy justification needed — we trust you.</p>
 
-      <h3>Step 3: Access Revoked</h3>
+      <h3>Step 3: Access Revocation</h3>
       <p>Once confirmed, your indicator access will be immediately revoked to prevent abuse.</p>
 
-      <h3>Step 4: Refund Processed</h3>
+      <h3>Step 4: Refund Processing</h3>
       <p>Refunds are issued via your original payment method:</p>
       <ul>
         <li><strong>PayPal:</strong> 3-5 business days</li>
@@ -395,7 +395,7 @@
 
       <h2>4. What Happens After 7 Days?</h2>
 
-      <h3>4.1 No Refunds (But You Can Cancel)</h3>
+      <h3>4.1 No Refunds (Cancellation Available)</h3>
       <p>After 7 days, we do NOT offer refunds. However:</p>
       <ul>
         <li>You can <strong>cancel your subscription</strong> anytime to prevent future charges</li>
@@ -409,21 +409,21 @@
       <h3>4.3 Cancellation Process</h3>
       <p><strong>PayPal Subscriptions:</strong></p>
       <ul>
-        <li>Log into PayPal → Settings → Payments → Manage automatic payments</li>
-        <li>Find "Signal Pilot Labs" → Cancel</li>
-        <li>OR email us at <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> and we'll cancel for you</li>
+        <li>Accessible through PayPal → Settings → Payments → Manage automatic payments</li>
+        <li>Located under "Signal Pilot Labs" with cancellation option</li>
+        <li>Cancellation requests can be sent to <a href="mailto:support@signalpilot.io">support@signalpilot.io</a></li>
       </ul>
 
       <p><strong>Cryptocurrency Subscriptions:</strong></p>
       <ul>
-        <li>Email <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> to cancel</li>
-        <li>Simply don't renew (no auto-renewal for crypto)</li>
+        <li>Cancellation requests can be sent to <a href="mailto:support@signalpilot.io">support@signalpilot.io</a></li>
+        <li>No auto-renewal for crypto subscriptions</li>
       </ul>
 
       <h2>5. Special Circumstances</h2>
 
       <h3>5.1 Technical Issues</h3>
-      <p>If you experience technical problems (indicators not loading, access issues, bugs), contact support FIRST. We'll troubleshoot and resolve issues rather than issue refunds.</p>
+      <p>Technical problems (indicators not loading, access issues, bugs) can be reported to support for troubleshooting and resolution before considering refunds.</p>
 
       <p><strong>Common issues we can fix:</strong></p>
       <ul>
@@ -435,10 +435,10 @@
       <p>If we can't resolve a legitimate technical issue, we may offer a refund outside the 7-day window at our discretion.</p>
 
       <h3>5.2 Billing Errors</h3>
-      <p>If you're charged incorrectly (duplicate charges, wrong amount, etc.), contact us immediately. We'll issue a refund or correction regardless of the 7-day window.</p>
+      <p>Incorrect charges (duplicate charges, wrong amount, etc.) can be reported immediately for refunds or corrections regardless of the 7-day window.</p>
 
       <h3>5.3 Extenuating Circumstances</h3>
-      <p>In rare cases (medical emergencies, serious financial hardship), we may consider refund requests outside the 7-day window on a case-by-case basis. Email <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> with details.</p>
+      <p>In rare cases (medical emergencies, serious financial hardship), refund requests outside the 7-day window may be considered on a case-by-case basis. Details can be sent to <a href="mailto:support@signalpilot.io">support@signalpilot.io</a>.</p>
 
       <h2>6. Lifetime Access Refunds</h2>
 
@@ -446,7 +446,7 @@
         <p><strong>⚠️ Important for Lifetime Buyers:</strong> Lifetime access is a one-time purchase with limited availability. After the 7-day window, NO refunds are provided. Treat this as a final purchase decision.</p>
       </div>
 
-      <p>Because Lifetime Access is significantly discounted and capped at 100 licenses, we enforce the 7-day policy strictly. Use the trial period wisely to evaluate if Signal Pilot is right for you.</p>
+      <p>Because Lifetime Access is significantly discounted and capped at 100 licenses, the 7-day policy is strictly enforced. The trial period allows evaluation of whether Signal Pilot meets individual needs.</p>
 
       <h2>7. Subscription Auto-Renewal</h2>
 

--- a/resources/faq/index.html
+++ b/resources/faq/index.html
@@ -59,7 +59,7 @@
         <div class="muted">We keep minimal operational data (e.g., server logs). See <a href="/privacy.html">Privacy Policy</a>.</div>
       </details>
 
-      <p style="margin-top:1rem;">Still stuck? <a href="mailto:support@signalpilot.io">Contact support</a>.</p>
+      <p style="margin-top:1rem;">Additional questions can be sent to <a href="mailto:support@signalpilot.io">support@signalpilot.io</a>.</p>
     </div>
   </main>
 </body>

--- a/resources/index.html
+++ b/resources/index.html
@@ -31,22 +31,22 @@
   <main>
     <div class="wrap">
       <h1>Resources</h1>
-      <p>Grab templates, watch webinars, and browse FAQs while we finish the full documentation.</p>
+      <p>Templates, webinars, and FAQs are available while full documentation is being completed.</p>
       <div class="grid">
         <div class="card">
           <h2 style="margin:.2rem 0 .2rem;font-size:1.15rem;">Trading Journal Template</h2>
           <p>CSV template plus tips for journaling your trades and confidence multipliers.</p>
-          <a href="/resources/journal/">Open &raquo;</a>
+          <a href="/resources/journal/">View &raquo;</a>
         </div>
         <div class="card">
           <h2 style="margin:.2rem 0 .2rem;font-size:1.15rem;">Upcoming Webinars</h2>
-          <p>See what’s scheduled and join live sessions.</p>
-          <a href="/resources/webinars/">Open &raquo;</a>
+          <p>Scheduled sessions and live webinar information.</p>
+          <a href="/resources/webinars/">View &raquo;</a>
         </div>
         <div class="card">
           <h2 style="margin:.2rem 0 .2rem;font-size:1.15rem;">FAQ</h2>
           <p>Answers to the most common questions about Lite and Pro.</p>
-          <a href="/resources/faq/">Open &raquo;</a>
+          <a href="/resources/faq/">View &raquo;</a>
         </div>
       </div>
     </div>

--- a/resources/journal/index.html
+++ b/resources/journal/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Trading Journal Template · SignalPilot</title>
-  <meta name="description" content="Download a simple CSV trading journal template tailored for SignalPilot confidence multipliers." />
+  <meta name="description" content="A simple CSV trading journal template tailored for SignalPilot confidence multipliers." />
   <link rel="canonical" href="https://www.signalpilot.io/resources/journal">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d" />
@@ -35,11 +35,11 @@
   <main>
     <div class="wrap">
       <h1>Trading Journal Template</h1>
-      <p>Keep a simple source of truth for each trade. This CSV includes columns to log <em>confidence multipliers</em>, risk, and outcomes.</p>
+      <p>A simple source of truth for each trade. This CSV includes columns to log <em>confidence multipliers</em>, risk, and outcomes.</p>
 
       <div class="panel">
         <div class="btns">
-          <a class="btn" href="/resources/journal/journal-template.csv" download>Download CSV</a>
+          <a class="btn" href="/resources/journal/journal-template.csv" download>CSV Template</a>
         </div>
         <p><strong>Columns included:</strong></p>
         <ul>
@@ -47,7 +47,7 @@
           <li><code>Session</code>, <code>Setup</code>, <code>ConfidenceScore</code>, <code>Reason</code>, <code>Tags</code></li>
           <li><code>Exit</code>, <code>PnL</code>, <code>RMultiple</code>, <code>Outcome</code>, <code>Notes</code>, <code>ScreenshotURL</code></li>
         </ul>
-        <p>Open the CSV in Excel/Sheets or import to your journaling tool. Use <code>ConfidenceScore</code> to reflect module confluence from SignalPilot.</p>
+        <p>The CSV can be opened in Excel/Sheets or imported to journaling tools. <code>ConfidenceScore</code> reflects module confluence from SignalPilot.</p>
       </div>
     </div>
   </main>

--- a/resources/webinars/index.html
+++ b/resources/webinars/index.html
@@ -35,8 +35,8 @@
       <div class="card">
         <p>No sessions scheduled yet.</p>
         <div class="btns">
-          <a class="btn" href="mailto:support@signalpilot.io?subject=Webinar%20Signup">Join the list</a>
-          <a class="ghost" href="/resources/">Back to resources</a>
+          <a class="btn" href="mailto:support@signalpilot.io?subject=Webinar%20Signup">Webinar signup</a>
+          <a class="ghost" href="/resources/">Resources</a>
         </div>
       </div>
     </div>

--- a/terms.html
+++ b/terms.html
@@ -252,16 +252,16 @@
       <h2>2. Eligibility and Account</h2>
 
       <h3>2.1 Age Requirement</h3>
-      <p>You must be at least 18 years old (or the age of majority in your jurisdiction) to use Signal Pilot.</p>
+      <p>Users must be at least 18 years old (or the age of majority in their jurisdiction) to use Signal Pilot.</p>
 
       <h3>2.2 TradingView Account</h3>
-      <p>You must have a valid TradingView account to use our indicators. Signal Pilot is an independent third-party provider and is not affiliated with TradingView.</p>
+      <p>A valid TradingView account is required to use our indicators. Signal Pilot is an independent third-party provider and is not affiliated with TradingView.</p>
 
       <h3>2.3 Account Security</h3>
       <ul>
-        <li>You are responsible for maintaining the confidentiality of your account</li>
+        <li>Users are responsible for maintaining the confidentiality of their accounts</li>
         <li>One subscription = one TradingView username (account sharing is prohibited)</li>
-        <li>Notify us immediately of any unauthorized access</li>
+        <li>Immediate notification is required for any unauthorized access</li>
       </ul>
 
       <h2>3. Subscription Plans and Payments</h2>
@@ -277,7 +277,7 @@
       <h3>3.2 Billing and Renewal</h3>
       <ul>
         <li>Subscriptions auto-renew unless cancelled</li>
-        <li>You will be charged at the beginning of each billing cycle</li>
+        <li>Charges occur at the beginning of each billing cycle</li>
         <li>Price changes will be communicated 30 days in advance</li>
         <li>No refunds for partial periods (see Refund Policy for details)</li>
       </ul>
@@ -353,10 +353,10 @@
       <h3>7.2 Trading Risks</h3>
       <p>Trading financial instruments involves substantial risk of loss. You acknowledge:</p>
       <ul>
-        <li>You may lose more than your initial investment</li>
+        <li>Losses may exceed initial investment</li>
         <li>Past performance does not guarantee future results</li>
         <li>No indicator can predict market movements with certainty</li>
-        <li>You are solely responsible for your trading decisions</li>
+        <li>Users are solely responsible for their trading decisions</li>
       </ul>
 
       <h3>7.3 No Guarantees</h3>
@@ -368,7 +368,7 @@
       </ul>
 
       <h3>7.4 Independent Research Required</h3>
-      <p>Always conduct your own research, risk assessment, and due diligence. Consult a licensed financial advisor before making investment decisions.</p>
+      <p>Independent research, risk assessment, and due diligence are recommended. Consultation with a licensed financial advisor is advised before making investment decisions.</p>
 
       <h2>8. Limitation of Liability</h2>
 

--- a/thanks.html
+++ b/thanks.html
@@ -20,8 +20,8 @@
     <h1>Order received 🎉</h1>
     <p>Thanks for supporting <strong>SignalPilot Pro</strong>. We’re processing your checkout.</p>
     <p id="emailRow" hidden>We’ll email <code id="custEmail"></code> with onboarding steps and your invite.</p>
-    <p>If you don’t see an email soon, forward your receipt to <a href="mailto:support@signalpilot.io">support@signalpilot.io</a>.</p>
-    <p><a href="/">Return to homepage</a></p>
+    <p>If an email is not received soon, receipts can be forwarded to <a href="mailto:support@signalpilot.io">support@signalpilot.io</a>.</p>
+    <p><a href="/">Homepage</a></p>
   </main>
   <script>
     // Optional: If you later expand the success page using the session_id,


### PR DESCRIPTION
- Changed all CTAs from imperative to observational (e.g., 'Try Risk-Free' → 'Available Risk-Free')
- Updated button text across all pages (e.g., 'Learn More' → 'Details', 'Join' → 'Webinar signup')
- Refactored instructional text to observational (e.g., 'Watch for invites' → 'Invites appear')
- Updated social proof language (e.g., 'Join 500+ traders' → '500+ traders trade')
- Changed navigation and accessibility labels to observational
- Updated all policy pages (terms, privacy, refund) to observational language
- Refactored resource pages and form labels
- Updated theme switcher UI text to observational

All user-facing language is now purely observational with no directive verbs.