### PR TITLE
Add visual savings display to yearly pricing plan

### DIFF
--- a/index.html
+++ b/index.html
@@ -4146,9 +4146,26 @@
               $699 <span class="pill">/year</span>
             </div>
 
-            <p style="font-size:.9rem;color:#3ed598;margin:.5rem 0 1rem 0;text-align:center;font-weight:700">
-              Billed annually ($58.25/mo) • Save $489 vs monthly
-            </p>
+            <!-- Visual Savings Display -->
+            <div style="background:linear-gradient(135deg,rgba(62,213,152,.15),rgba(62,213,152,.05));border:2px solid rgba(62,213,152,.3);border-radius:12px;padding:1rem;margin:1rem 0;text-align:center">
+              <div style="display:flex;align-items:center;justify-content:center;gap:.5rem;margin-bottom:.5rem">
+                <div style="flex:1;height:2px;background:linear-gradient(to right,transparent,rgba(62,213,152,.6))"></div>
+                <span style="font-size:.85rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;font-weight:700">You Save</span>
+                <div style="flex:1;height:2px;background:linear-gradient(to left,transparent,rgba(62,213,152,.6))"></div>
+              </div>
+
+              <div style="font-size:1.8rem;font-weight:800;color:#3ed598;margin-bottom:.25rem">
+                $489
+              </div>
+
+              <div style="font-size:.9rem;color:var(--muted);margin-bottom:.5rem">
+                <strong style="color:#3ed598">41% off</strong> • That's <strong style="color:#3ed598">5 months free</strong>
+              </div>
+
+              <div style="font-size:.8rem;color:var(--muted-2);opacity:.8">
+                Billed annually at $699 ($58.25/mo equivalent)
+              </div>
+            </div>
 
             <ul>
 


### PR DESCRIPTION
- Replace simple text savings with prominent visual box
- Show $489 in large 1.8rem bold text (emotional impact)
- Display "41% off" and "5 months free" as key value props
- Add gradient dividers with "You Save" label for emphasis
- Use green gradient background box to draw attention
- Move billing details to smaller footer text
- No mental math required - savings immediately visible
- Increases perceived value and conversion potential