### PR TITLE
Update interactive demo button labels for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -3587,10 +3587,10 @@
         <!-- Demo Controls -->
         <div style="display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;margin-bottom:1.5rem">
           <button id="toggle-before" class="btn btn-ghost btn-sm" style="min-width:120px">
-            <span>Before View</span>
+            <span>Before Signal Pilot</span>
           </button>
           <button id="toggle-after" class="btn btn-ghost btn-sm" style="min-width:120px">
-            <span>After View</span>
+            <span>After Signal Pilot</span>
           </button>
           <button id="autoplay-toggle" class="btn btn-ghost btn-sm" style="min-width:140px">
             <span>▶ Auto-Play</span>


### PR DESCRIPTION
- Change "Before View" → "Before Signal Pilot"
- Change "After View" → "After Signal Pilot"
- More explicit about what the comparison shows
- Better brand consistency throughout demo section
- Clearer user understanding of toggle functionality