### PR TITLE
Add screenshot boxes to all Elite Seven indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -3123,6 +3123,19 @@
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
+
+            <!-- Screenshot Box -->
+            <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
+              <img src="assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover" loading="lazy">
+              <!-- Placeholder overlay (remove when you add real image) -->
+              <div style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.8);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="width:48px;height:48px;margin:0 auto .5rem;opacity:.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.8rem;color:var(--muted);margin:0">Screenshot placeholder</p>
+                </div>
+              </div>
+            </div>
+
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
@@ -3182,6 +3195,18 @@
 
           <!-- INDICATOR 2: OMNIDECK -->
           <article class="card product">
+
+            <!-- Screenshot Box -->
+            <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
+              <img src="assets/screenshots/omnideck-screenshot.jpg" alt="Omnideck all-in-one indicator" style="width:100%;height:100%;object-fit:cover" loading="lazy">
+              <div style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.8);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="width:48px;height:48px;margin:0 auto .5rem;opacity:.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.8rem;color:var(--muted);margin:0">Screenshot placeholder</p>
+                </div>
+              </div>
+            </div>
+
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/><circle cx="7" cy="7" r="1" fill="currentColor"/><circle cx="17" cy="7" r="1" fill="currentColor"/><circle cx="7" cy="17" r="1" fill="currentColor"/><circle cx="17" cy="17" r="1" fill="currentColor"/></svg>
               <h3 style="white-space:nowrap">SP — Omnideck</h3>
@@ -3210,6 +3235,18 @@
 
           <!-- INDICATOR 3: VOLUME ORACLE -->
           <article class="card product">
+
+            <!-- Screenshot Box -->
+            <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
+              <img src="assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle institutional flow tracking" style="width:100%;height:100%;object-fit:cover" loading="lazy">
+              <div style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.8);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="width:48px;height:48px;margin:0 auto .5rem;opacity:.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.8rem;color:var(--muted);margin:0">Screenshot placeholder</p>
+                </div>
+              </div>
+            </div>
+
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s4-8 10-8 10 8 10 8-4 8-10 8-10-8-10-8z"/><circle cx="12" cy="12" r="2.5"/><rect x="8" y="17" width="1.2" height="4" opacity=".3"/><rect x="11.4" y="16" width="1.2" height="5" opacity=".3"/><rect x="14.8" y="17" width="1.2" height="4" opacity=".3"/></svg>
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
@@ -3233,6 +3270,18 @@
 
           <!-- INDICATOR 4: PLUTUS FLOW -->
           <article class="card product">
+
+            <!-- Screenshot Box -->
+            <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
+              <img src="assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow cumulative delta tracking" style="width:100%;height:100%;object-fit:cover" loading="lazy">
+              <div style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.8);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="width:48px;height:48px;margin:0 auto .5rem;opacity:.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.8rem;color:var(--muted);margin:0">Screenshot placeholder</p>
+                </div>
+              </div>
+            </div>
+
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 17l6-6 4 4 8-8"/><path d="M21 7v6h-6"/><path d="M3 22h18" opacity=".3"/><rect x="5" y="18" width="2" height="4" opacity=".4"/><rect x="11" y="14" width="2" height="8" opacity=".4"/><rect x="17" y="10" width="2" height="12" opacity=".4"/></svg>
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
@@ -3256,6 +3305,18 @@
 
           <!-- INDICATOR 5: JANUS ATLAS -->
           <article class="card product">
+
+            <!-- Screenshot Box -->
+            <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
+              <img src="assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover" loading="lazy">
+              <div style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.8);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="width:48px;height:48px;margin:0 auto .5rem;opacity:.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.8rem;color:var(--muted);margin:0">Screenshot placeholder</p>
+                </div>
+              </div>
+            </div>
+
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 12h18M3 18h18"/><circle cx="7" cy="6" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="17" cy="18" r="1.5" fill="currentColor"/><path d="M21 6v12" opacity=".3" stroke-width="1.5"/></svg>
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
@@ -3280,6 +3341,18 @@
 
           <!-- INDICATOR 6: AUGURY GRID -->
           <article class="card product">
+
+            <!-- Screenshot Box -->
+            <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
+              <img src="assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover" loading="lazy">
+              <div style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.8);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="width:48px;height:48px;margin:0 auto .5rem;opacity:.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.8rem;color:var(--muted);margin:0">Screenshot placeholder</p>
+                </div>
+              </div>
+            </div>
+
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="10" r="7"/><path d="M7 10h10M12 3v14M9 6l6 8M15 6l-6 8" opacity=".25" stroke-width="1.5"/><ellipse cx="12" cy="17.5" rx="5" ry="1.8"/><path d="M7 17.5c0 1 2.2 1.8 5 1.8s5-.8 5-1.8"/></svg>
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
@@ -3304,6 +3377,18 @@
 
           <!-- INDICATOR 7: HARMONIC OSCILLATOR -->
           <article class="card product">
+
+            <!-- Screenshot Box -->
+            <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
+              <img src="assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover" loading="lazy">
+              <div style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.8);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="width:48px;height:48px;margin:0 auto .5rem;opacity:.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.8rem;color:var(--muted);margin:0">Screenshot placeholder</p>
+                </div>
+              </div>
+            </div>
+
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 13c2-4 6-4 8 0s6 4 10-2"/><circle cx="7" cy="13" r="1.2"/><circle cx="15" cy="13" r="1.2"/></svg>
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>


### PR DESCRIPTION
Design Features:
- Small branded boxes (max 280px wide, 16:9 aspect ratio)
- Positioned at top of each indicator card
- Rounded corners (8px) with brand blue border & subtle glow
- Gradient background (brand blue tones)
- Fully responsive - scales to container width on mobile
- Lazy loading for performance

Implementation:
- Added to all 7 indicators: Pentarch, Omnideck, Volume Oracle, Plutus Flow, Janus Atlas, Augury Grid, Harmonic Oscillator
- Each has placeholder overlay with image icon & "Screenshot placeholder" text
- Created assets/screenshots/ directory structure
- Ready for real TradingView screenshots

To Add Real Screenshots:
1. Take TradingView screenshots (1920x1080 or 16:9 ratio)
2. Optimize to <150kb (use WebP or optimized JPG)
3. Save to assets/screenshots/ with these names:
   - pentarch-screenshot.jpg
   - omnideck-screenshot.jpg
   - volume-oracle-screenshot.jpg
   - plutus-flow-screenshot.jpg
   - janus-atlas-screenshot.jpg
   - augury-grid-screenshot.jpg
   - harmonic-oscillator-screenshot.jpg
4. Remove placeholder overlay div from each box

Elevates Elite Seven section from text-only to visual teaching moment.