### PR TITLE
Fix Gugi font loading on manage-subscription page

### DIFF
--- a/manage-subscription.html
+++ b/manage-subscription.html
@@ -12,17 +12,9 @@
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Space+Grotesk:wght@500;700&family=Gugi&display=swap" rel="stylesheet">
 
   <style>
-    /* Gugi Font */
-    @font-face {
-      font-family: 'Gugi';
-      src: url('assets/fonts/Gugi-Regular.ttf') format('truetype');
-      font-weight: normal;
-      font-style: normal;
-      font-display: swap;
-    }
 
     :root {
       color-scheme: dark;


### PR DESCRIPTION
Load Gugi from Google Fonts instead of non-existent local file. Now matches index.html font loading strategy.