### PR TITLE
Enforce 'The Elite Seven' branding consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -3028,7 +3028,7 @@
               <span style="position:absolute;top:-8px;right:-8px;background:#f9a23c;color:#fff;font-size:.7rem;padding:.2rem .5rem;border-radius:999px;font-weight:700;box-shadow:0 2px 8px rgba(249,162,60,.4)">Save $489</span>
             </a>
 
-            <a class="btn btn-ghost" href="#inside">All 7 Indicators</a>
+            <a class="btn btn-ghost" href="#inside">The Elite Seven</a>
 
           </div>
 
@@ -4558,7 +4558,7 @@
 
       <div class="card">
         <strong style="color:var(--warn)">💎 What's included in my plan?</strong>
-        <p class="note">Every plan includes: <strong>All 7 indicators</strong> (The Elite Seven), all future updates, ongoing support, documentation, presets, and access to new indicators as they launch. Lifetime includes everything, forever.</p>
+        <p class="note">Every plan includes: <strong>The Elite Seven</strong>, all future updates, ongoing support, documentation, presets, and access to new indicators as they launch. Lifetime includes everything, forever.</p>
       </div>
 
       <div class="card">


### PR DESCRIPTION
Marketing contexts now always use 'The Elite Seven':
- Hero CTA button: 'All 7 Indicators' → 'The Elite Seven'
- FAQ: 'All 7 indicators (The Elite Seven)' → 'The Elite Seven' (removed redundancy)

Functional contexts still use '7 indicators':
- Comparison table: '7 indicators, one overlay' (kept - technical description)

Result: Cleaner, more consistent brand messaging.