### PR TITLE
Remove '$100 Guarantee' from title and meta tags for cleaner branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
   <meta http-equiv="Pragma" content="no-cache" />
   <meta http-equiv="Expires" content="0" />
 
-  <title>Signal Pilot — Non-Repainting TradingView Indicators | $100 Guarantee</title>
+  <title>Signal Pilot — Non-Repainting TradingView Indicators</title>
 
-  <meta name="description" content="7 non-repainting TradingView indicators with $100 guarantee. Pentarch™ maps complete market cycles (TD→IGN→WRN→CAP→BDN). Zero repaint, audited. 7-day money-back guarantee. 500+ traders.">
+  <meta name="description" content="Professional cycle detection for TradingView. Pentarch™ maps complete market cycles (TD→IGN→WRN→CAP→BDN). Zero repaint, audited. 7-day money-back guarantee.">
 
   <!-- Enhanced SEO -->
   <meta name="keywords" content="TradingView indicators, non-repainting indicators, Pentarch, market cycle indicators, TD Sequential, trading signals, stock indicators">
@@ -65,9 +65,9 @@
 
   <meta property="og:type" content="website">
 
-  <meta property="og:title" content="Signal Pilot — Non-Repainting TradingView Indicators | $100 Guarantee">
+  <meta property="og:title" content="Signal Pilot — Non-Repainting TradingView Indicators">
 
-  <meta property="og:description" content="7 non-repainting TradingView indicators with $100 guarantee. Pentarch™ maps complete market cycles. Zero repaint, audited. 500+ traders.">
+  <meta property="og:description" content="Professional cycle detection for TradingView. Pentarch™ maps complete market cycles. Zero repaint, audited. 7-day money-back guarantee.">
 
   <meta property="og:url" content="https://www.signalpilot.io/">
 
@@ -82,7 +82,7 @@
   <meta name="twitter:site" content="@signalpilot">
   <meta name="twitter:creator" content="@signalpilot">
   <meta name="twitter:title" content="Signal Pilot — Non-Repainting TradingView Indicators">
-  <meta name="twitter:description" content="7 non-repainting indicators with $100 guarantee. Map complete market cycles. 500+ traders.">
+  <meta name="twitter:description" content="Professional cycle detection for TradingView. Pentarch™ maps complete market cycles. Zero repaint, audited.">
   <meta name="twitter:image" content="https://www.signalpilot.io/preview.png">
   <meta name="twitter:image:alt" content="Signal Pilot Dashboard">
 


### PR DESCRIPTION
Updated SEO tags to be more professional and less promotional:
- Title: "Non-Repainting TradingView Indicators" (removed $100 Guarantee)
- Meta description: Focus on "Professional cycle detection"
- OpenGraph and Twitter tags updated for consistency
- Kept $100 repaint guarantee in FAQ where it can be properly explained

This maintains credibility in search results while keeping the guarantee visible on-page.