### PR TITLE
Replace text bullets with animated cycle diagram

### DIFF
--- a/index.html
+++ b/index.html
@@ -2959,11 +2959,11 @@
     <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
       <div class="container">
 
-        <div style="max-width:900px;margin:0 auto;text-align:center">
+        <div style="max-width:1000px;margin:0 auto;text-align:center">
 
           <h2 class="headline lg" style="margin-bottom:2rem">The Signal Pilot Difference</h2>
 
-          <div style="background:rgba(0,0,0,.2);border:1px solid rgba(91,138,255,.2);border-radius:16px;padding:2.5rem 2rem;margin-bottom:2rem">
+          <div style="background:rgba(0,0,0,.2);border:1px solid rgba(91,138,255,.2);border-radius:16px;padding:2.5rem 2rem;margin-bottom:3rem">
             <p style="font-size:1.3rem;line-height:1.6;color:var(--text);margin:0 0 1.5rem 0;font-weight:500">
               Most indicators show signals.
             </p>
@@ -2972,41 +2972,120 @@
             </p>
           </div>
 
-          <div style="background:rgba(0,0,0,.15);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:2rem;text-align:left">
-            <p style="font-size:1.05rem;line-height:1.8;color:var(--muted);margin:0 0 1.5rem 0">
-              Five events map every market cycle:
-            </p>
-            <div style="display:grid;gap:1rem;margin-bottom:1.5rem">
-              <div style="display:flex;align-items:center;gap:1rem">
-                <span style="width:8px;height:8px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6);flex-shrink:0"></span>
-                <span style="color:var(--text);font-size:1rem"><strong style="color:#3ed598">Accumulation</strong> — TD Touchdown identifies early-cycle reversals</span>
+          <!-- Cycle Diagram -->
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:3rem;align-items:center;margin-bottom:2rem">
+
+            <!-- SVG Circle Diagram -->
+            <div style="position:relative;aspect-ratio:1;max-width:400px;margin:0 auto">
+              <svg viewBox="0 0 400 400" style="width:100%;height:auto;transform:rotate(-90deg)">
+                <!-- Background circle -->
+                <circle cx="200" cy="200" r="160" fill="none" stroke="rgba(255,255,255,0.05)" stroke-width="40"/>
+
+                <!-- Phase 1: TD + IGN (Accumulation + Markup) - Green - 40% -->
+                <circle cx="200" cy="200" r="160" fill="none" stroke="#3ed598" stroke-width="40"
+                  stroke-dasharray="402 1005"
+                  stroke-dashoffset="0"
+                  style="opacity:0.9;filter:drop-shadow(0 0 12px rgba(62,213,152,0.6));animation:phase-appear 0.8s ease forwards"
+                  stroke-linecap="round"/>
+
+                <!-- Phase 2: WRN (Distribution) - Orange - 20% -->
+                <circle cx="200" cy="200" r="160" fill="none" stroke="#f9a23c" stroke-width="40"
+                  stroke-dasharray="201 1005"
+                  stroke-dashoffset="-402"
+                  style="opacity:0.9;filter:drop-shadow(0 0 12px rgba(249,162,60,0.6));animation:phase-appear 0.8s 0.2s ease forwards;animation-fill-mode:backwards"
+                  stroke-linecap="round"/>
+
+                <!-- Phase 3: CAP (Climax) - Cyan - 20% -->
+                <circle cx="200" cy="200" r="160" fill="none" stroke="#76ddff" stroke-width="40"
+                  stroke-dasharray="201 1005"
+                  stroke-dashoffset="-603"
+                  style="opacity:0.9;filter:drop-shadow(0 0 12px rgba(118,221,255,0.6));animation:phase-appear 0.8s 0.4s ease forwards;animation-fill-mode:backwards"
+                  stroke-linecap="round"/>
+
+                <!-- Phase 4: BDN (Decline) - Pink - 20% -->
+                <circle cx="200" cy="200" r="160" fill="none" stroke="#ff6b9d" stroke-width="40"
+                  stroke-dasharray="201 1005"
+                  stroke-dashoffset="-804"
+                  style="opacity:0.9;filter:drop-shadow(0 0 12px rgba(255,107,157,0.6));animation:phase-appear 0.8s 0.6s ease forwards;animation-fill-mode:backwards"
+                  stroke-linecap="round"/>
+
+                <!-- Center circle -->
+                <circle cx="200" cy="200" r="115" fill="rgba(5,7,13,0.95)" stroke="rgba(91,138,255,0.3)" stroke-width="2"/>
+
+                <!-- Center text -->
+                <text x="200" y="190" text-anchor="middle" fill="#ecf1ff" font-size="18" font-weight="700" font-family="Space Grotesk, sans-serif" transform="rotate(90 200 200)">Complete</text>
+                <text x="200" y="210" text-anchor="middle" fill="#5b8aff" font-size="20" font-weight="700" font-family="Space Grotesk, sans-serif" transform="rotate(90 200 200)">Market Cycle</text>
+              </svg>
+
+              <!-- Phase labels positioned around circle -->
+              <div style="position:absolute;top:8%;left:50%;transform:translateX(-50%);text-align:center">
+                <div style="font-size:0.85rem;font-weight:700;color:#3ed598">TD → IGN</div>
+                <div style="font-size:0.75rem;color:var(--muted)">Accumulation</div>
               </div>
-              <div style="display:flex;align-items:center;gap:1rem">
-                <span style="width:8px;height:8px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6);flex-shrink:0"></span>
-                <span style="color:var(--text);font-size:1rem"><strong style="color:#3ed598">Markup</strong> — IGN Ignition confirms momentum breakouts</span>
+              <div style="position:absolute;top:50%;right:8%;transform:translateY(-50%);text-align:right">
+                <div style="font-size:0.85rem;font-weight:700;color:#f9a23c">WRN</div>
+                <div style="font-size:0.75rem;color:var(--muted)">Distribution</div>
               </div>
-              <div style="display:flex;align-items:center;gap:1rem">
-                <span style="width:8px;height:8px;border-radius:50%;background:#f9a23c;box-shadow:0 0 8px rgba(249,162,60,.6);flex-shrink:0"></span>
-                <span style="color:var(--text);font-size:1rem"><strong style="color:#f9a23c">Distribution</strong> — WRN Warning detects weakening conditions</span>
+              <div style="position:absolute;bottom:8%;left:50%;transform:translateX(-50%);text-align:center">
+                <div style="font-size:0.85rem;font-weight:700;color:#76ddff">CAP</div>
+                <div style="font-size:0.75rem;color:var(--muted)">Climax</div>
               </div>
-              <div style="display:flex;align-items:center;gap:1rem">
-                <span style="width:8px;height:8px;border-radius:50%;background:#76ddff;box-shadow:0 0 8px rgba(118,221,255,.6);flex-shrink:0"></span>
-                <span style="color:var(--text);font-size:1rem"><strong style="color:#76ddff">Climax</strong> — CAP Climax marks late-cycle exhaustion</span>
-              </div>
-              <div style="display:flex;align-items:center;gap:1rem">
-                <span style="width:8px;height:8px;border-radius:50%;background:#ff6b9d;box-shadow:0 0 8px rgba(255,107,157,.6);flex-shrink:0"></span>
-                <span style="color:var(--text);font-size:1rem"><strong style="color:#ff6b9d">Decline</strong> — BDN Breakdown confirms bearish structure</span>
+              <div style="position:absolute;top:50%;left:8%;transform:translateY(-50%);text-align:left">
+                <div style="font-size:0.85rem;font-weight:700;color:#ff6b9d">BDN</div>
+                <div style="font-size:0.75rem;color:var(--muted)">Decline</div>
               </div>
             </div>
-            <p style="font-size:1.05rem;line-height:1.8;color:var(--text);margin:0;font-weight:600">
-              You see where you are. Not just what happened.
-            </p>
+
+            <!-- Phase Descriptions -->
+            <div style="display:grid;gap:1rem;text-align:left">
+              <div style="padding:1rem;background:rgba(62,213,152,0.08);border-left:3px solid #3ed598;border-radius:8px">
+                <div style="font-weight:700;color:#3ed598;margin-bottom:0.25rem">TD Touchdown → IGN Ignition</div>
+                <div style="font-size:0.9rem;color:var(--muted);line-height:1.5">Early-cycle reversals and momentum breakouts</div>
+              </div>
+              <div style="padding:1rem;background:rgba(249,162,60,0.08);border-left:3px solid #f9a23c;border-radius:8px">
+                <div style="font-weight:700;color:#f9a23c;margin-bottom:0.25rem">WRN Warning</div>
+                <div style="font-size:0.9rem;color:var(--muted);line-height:1.5">Weakening conditions detected</div>
+              </div>
+              <div style="padding:1rem;background:rgba(118,221,255,0.08);border-left:3px solid #76ddff;border-radius:8px">
+                <div style="font-weight:700;color:#76ddff;margin-bottom:0.25rem">CAP Climax</div>
+                <div style="font-size:0.9rem;color:var(--muted);line-height:1.5">Late-cycle exhaustion marks</div>
+              </div>
+              <div style="padding:1rem;background:rgba(255,107,157,0.08);border-left:3px solid #ff6b9d;border-radius:8px">
+                <div style="font-weight:700;color:#ff6b9d;margin-bottom:0.25rem">BDN Breakdown</div>
+                <div style="font-size:0.9rem;color:var(--muted);line-height:1.5">Bearish structure confirmed</div>
+              </div>
+            </div>
+
           </div>
+
+          <p style="font-size:1.15rem;line-height:1.8;color:var(--text);margin:2rem 0 0 0;font-weight:600">
+            You see where you are. Not just what happened.
+          </p>
 
         </div>
 
       </div>
     </section>
+
+    <style>
+      @keyframes phase-appear {
+        from {
+          stroke-dasharray: 0 1005;
+          opacity: 0;
+        }
+        to {
+          opacity: 0.9;
+        }
+      }
+
+      /* Mobile responsive */
+      @media (max-width: 768px) {
+        section div[style*="grid-template-columns:1fr 1fr"] {
+          grid-template-columns: 1fr !important;
+          gap: 2rem !important;
+        }
+      }
+    </style>
 
     <!-- WHAT'S INSIDE -->
 


### PR DESCRIPTION
Transformed 'Signal Pilot Difference' from text-heavy to visual:

✅ Animated SVG circular diagram showing complete market cycle
- 4 colored phases appearing sequentially with animations
- Green (TD→IGN): 40% - Accumulation/Markup
- Orange (WRN): 20% - Distribution
- Cyan (CAP): 20% - Climax
- Pink (BDN): 20% - Decline

✅ Phase labels positioned around circle
✅ Clean description cards with color-coded borders ✅ Smooth CSS animations (phases draw in with staggered delays) ✅ Mobile responsive (2-col → 1-col on mobile)
✅ Glowing effects on each phase

Much more engaging than text bullets. Shows the cycle visually instead of just describing it.