### PR TITLE
Fix Google Translate not applying on roadmap and FAQ pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1503,11 +1503,25 @@
       document.documentElement.dir = (code === 'ar') ? 'rtl' : 'ltr';
 
       if (code !== 'en' && !window.google && !window.__gte_loading) {
-        window.__gte_loading = true;
-        const script = document.createElement('script');
-        script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        script.async = true;
-        document.head.appendChild(script);
+        // Check if we need to reload for translation to apply
+        const currentCookie = document.cookie.split('; ').find(row => row.startsWith('googtrans='));
+        const isTranslated = window.location.href.includes('#googtrans');
+
+        if (!isTranslated && currentCookie) {
+          // Cookie is set but page isn't translated - reload to apply
+          window.location.reload();
+        } else {
+          // Load the script for first time
+          window.__gte_loading = true;
+          const script = document.createElement('script');
+          script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+          script.async = true;
+          script.onload = function() {
+            // Reload page after script loads to apply translation
+            setTimeout(() => window.location.reload(), 100);
+          };
+          document.head.appendChild(script);
+        }
       }
     })();
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -1283,11 +1283,25 @@
 
       // Load Google Translate if not English
       if (code !== 'en' && !window.google && !window.__gte_loading) {
-        window.__gte_loading = true;
-        const script = document.createElement('script');
-        script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        script.async = true;
-        document.head.appendChild(script);
+        // Check if we need to reload for translation to apply
+        const currentCookie = document.cookie.split('; ').find(row => row.startsWith('googtrans='));
+        const isTranslated = window.location.href.includes('#googtrans');
+
+        if (!isTranslated && currentCookie) {
+          // Cookie is set but page isn't translated - reload to apply
+          window.location.reload();
+        } else {
+          // Load the script for first time
+          window.__gte_loading = true;
+          const script = document.createElement('script');
+          script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+          script.async = true;
+          script.onload = function() {
+            // Reload page after script loads to apply translation
+            setTimeout(() => window.location.reload(), 100);
+          };
+          document.head.appendChild(script);
+        }
       }
     })();
 


### PR DESCRIPTION
Translation Fix:
- Detect when language cookie is set but translation hasn't applied
- Automatically reload page to trigger Google Translate
- Check for #googtrans in URL to verify translation state
- Add script onload reload for first-time language selection

Before: Roadmap and FAQ pages wouldn't translate on load even with saved language preference
After: Pages automatically reload and apply translation when non-English language is detected

This ensures consistent translation behavior across all pages:
- index.html (already working) ✓
- roadmap.html (now fixed) ✓
- faq.html (now fixed) ✓