### PR TITLE
Keep only vaporwave, newyear, and epic storm themes

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -263,20 +263,6 @@
           };
         }
 
-      case 'presents':
-        // Falling Christmas presents
-        return {
-          x: Math.random() * W,
-          y: -20 - Math.random() * H * 0.3,
-          vx: (Math.random() * 2 - 1) * 0.3,
-          vy: Math.random() * 1.2 + 0.8, // 0.8-2.0
-          size: Math.random() * 12 + 8, // 8-20px
-          rotation: Math.random() * Math.PI * 2,
-          rotationSpeed: (Math.random() * 2 - 1) * 0.06,
-          color: Math.random() < 0.5 ? 'red' : 'green', // Red or green presents
-          alpha: 0.8 + Math.random() * 0.2
-        };
-
       case 'fireworks':
         // Fireworks that explode
         return {
@@ -293,91 +279,22 @@
           alpha: 1.0
         };
 
-      case 'hearts':
-        // Floating hearts
+      case 'lightning':
+        // Epic lightning bolt
         return {
-          x: Math.random() * W,
-          y: H + 20,
-          vx: (Math.random() * 2 - 1) * 0.4,
-          vy: -(Math.random() * 0.8 + 0.6), // Float up 0.6-1.4
-          size: Math.random() * 8 + 6, // 6-14px
-          rotation: Math.random() * Math.PI * 0.4 - 0.2, // Slight tilt
-          pulse: Math.random() * Math.PI * 2,
-          pulseSpeed: Math.random() * 0.08 + 0.04,
-          sway: Math.random() * Math.PI * 2,
-          swaySpeed: Math.random() * 0.05 + 0.02,
-          alpha: 0.7 + Math.random() * 0.3
-        };
-
-      case 'aurora-stars':
-        // Twinkling stars for aurora theme
-        return {
-          x: Math.random() * W,
-          y: Math.random() * H,
+          x: Math.random() * W * 0.8 + W * 0.1, // Start in middle 80% of screen
+          y: 0,
           vx: 0,
           vy: 0,
-          size: Math.random() * 2.5 + 0.8,
-          twinkle: Math.random() * Math.PI * 2,
-          twinkleSpeed: Math.random() * 0.06 + 0.03,
-          brightness: Math.random(),
-          alpha: 0.5 + Math.random() * 0.5
-        };
-
-      case 'sand-shimmer':
-        // Heat shimmer particles
-        return {
-          x: Math.random() * W,
-          y: Math.random() * H,
-          vx: 0,
-          vy: -(Math.random() * 0.3 + 0.1), // Slow rise 0.1-0.4
-          size: Math.random() * 30 + 20, // 20-50px blur
-          wave: Math.random() * Math.PI * 2,
-          waveSpeed: Math.random() * 0.06 + 0.04,
-          waveAmount: Math.random() * 2 + 1,
-          alpha: 0.15 + Math.random() * 0.15 // Very subtle 0.15-0.3
-        };
-
-      case 'lightning-rain':
-        // Rain with occasional lightning
-        if (Math.random() < 0.05) {
-          // Lightning bolt
-          return {
-            x: Math.random() * W,
-            y: 0,
-            vx: 0,
-            vy: 0,
-            size: Math.random() * 3 + 2,
-            type: 'lightning',
-            life: 0,
-            maxLife: 8, // Short flash
-            alpha: 1.0,
-            branches: Math.floor(Math.random() * 3) + 2 // 2-4 branches
-          };
-        } else {
-          // Regular rain drop
-          return {
-            x: Math.random() * W,
-            y: -10,
-            vx: (Math.random() * 2 - 1) * 0.5,
-            vy: Math.random() * 3 + 4, // Fast rain 4-7
-            size: Math.random() * 2 + 1,
-            type: 'raindrop',
-            alpha: 0.5 + Math.random() * 0.3
-          };
-        }
-
-      case 'pixel-sprites':
-        // 8-bit retro sprites
-        return {
-          x: Math.random() * W,
-          y: Math.random() * H,
-          vx: (Math.random() * 2 - 1) * 0.8,
-          vy: (Math.random() * 2 - 1) * 0.8,
-          size: Math.random() * 8 + 6, // 6-14px
-          sprite: Math.floor(Math.random() * 4), // 4 sprite types
-          blink: Math.random() * Math.PI * 2,
-          blinkSpeed: Math.random() * 0.1 + 0.05,
-          alpha: 0.8 + Math.random() * 0.2
+          targetX: Math.random() * W, // Where it ends
+          size: Math.random() * 4 + 3, // Thickness 3-7
+          life: 0,
+          maxLife: 12 + Math.floor(Math.random() * 8), // Flash duration 12-20 frames
+          alpha: 1.0,
+          segments: [], // Will hold lightning path segments
+          branches: Math.floor(Math.random() * 3) + 2, // 2-4 branch points
+          intensity: Math.random() * 0.3 + 0.7, // Brightness variation 0.7-1.0
+          respawnTime: Math.floor(Math.random() * 60) + 120 // Respawn after 120-180 frames
         };
 
       case 'vaporwave-grid':
@@ -419,29 +336,6 @@
             alpha: 0.4 + Math.random() * 0.3
           };
         }
-
-      case 'binary-rain':
-        // Binary code rain (lighter matrix)
-        if (!createParticle.binaryIndex) createParticle.binaryIndex = 0;
-
-        const binColumnSpacing = W / 55;
-        const binX = (createParticle.binaryIndex % 55) * binColumnSpacing + (binColumnSpacing / 2);
-        const binY = Math.random() * H - 150;
-
-        createParticle.binaryIndex++;
-
-        return {
-          x: binX,
-          y: binY,
-          vx: 0,
-          vy: 1.8, // Slower than matrix
-          size: 16,
-          chars: [], // Will hold 0s and 1s
-          trailLength: Math.floor(Math.random() * 3) + 10, // 10-12 chars
-          speed: 0.1,
-          frame: 0,
-          alpha: 1.0
-        };
 
       default: // stars
         return {
@@ -843,35 +737,6 @@
         }
         break;
 
-      case 'presents':
-        // Christmas present falling
-        p.rotation += p.rotationSpeed;
-
-        ctx.translate(p.x, p.y);
-        ctx.rotate(p.rotation);
-
-        ctx.globalAlpha = p.alpha;
-
-        // Present box
-        const boxColor = p.color === 'red' ? '#dc2626' : '#22c55e';
-        ctx.fillStyle = boxColor;
-        ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size);
-
-        // Ribbon
-        const ribbonColor = p.color === 'red' ? '#fbbf24' : '#dc2626';
-        ctx.fillStyle = ribbonColor;
-        ctx.fillRect(-p.size / 2, -p.size * 0.1, p.size, p.size * 0.2);
-        ctx.fillRect(-p.size * 0.1, -p.size / 2, p.size * 0.2, p.size);
-
-        // Bow on top
-        ctx.beginPath();
-        ctx.arc(-p.size * 0.15, -p.size / 2, p.size * 0.15, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.beginPath();
-        ctx.arc(p.size * 0.15, -p.size / 2, p.size * 0.15, 0, Math.PI * 2);
-        ctx.fill();
-        break;
-
       case 'fireworks':
         // Fireworks animation
         p.life++;
@@ -934,158 +799,82 @@
         }
         break;
 
-      case 'hearts':
-        // Floating heart
-        p.pulse += p.pulseSpeed;
-        p.sway += p.swaySpeed;
+      case 'lightning':
+        // Epic lightning bolt effect
+        p.life++;
 
-        const heartSize = p.size * (1 + Math.sin(p.pulse) * 0.15);
-        const swayX = Math.sin(p.sway) * 10;
-
-        ctx.translate(p.x + swayX, p.y);
-        ctx.rotate(p.rotation);
-
-        ctx.globalAlpha = p.alpha;
-        ctx.fillStyle = config.color;
-
-        // Draw heart shape
-        ctx.beginPath();
-        ctx.moveTo(0, heartSize * 0.3);
-        // Left curve
-        ctx.bezierCurveTo(-heartSize * 0.5, -heartSize * 0.2, -heartSize * 0.5, heartSize * 0.3, 0, heartSize * 0.7);
-        // Right curve
-        ctx.bezierCurveTo(heartSize * 0.5, heartSize * 0.3, heartSize * 0.5, -heartSize * 0.2, 0, heartSize * 0.3);
-        ctx.fill();
-
-        // Glow
-        ctx.globalAlpha = p.alpha * 0.3;
-        ctx.beginPath();
-        ctx.moveTo(0, heartSize * 0.35);
-        ctx.bezierCurveTo(-heartSize * 0.6, -heartSize * 0.25, -heartSize * 0.6, heartSize * 0.35, 0, heartSize * 0.8);
-        ctx.bezierCurveTo(heartSize * 0.6, heartSize * 0.35, heartSize * 0.6, -heartSize * 0.25, 0, heartSize * 0.35);
-        ctx.fill();
-        break;
-
-      case 'aurora-stars':
-        // Bright twinkling stars
-        p.twinkle += p.twinkleSpeed;
-        p.brightness = (Math.sin(p.twinkle) + 1) / 2;
-
-        const auroraAlpha = p.alpha * (0.5 + p.brightness * 0.5);
-
-        // Outer glow
-        const auroraGrad = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, p.size * 3);
-        auroraGrad.addColorStop(0, config.color.replace(/[\d.]+\)/, `${auroraAlpha})`));
-        auroraGrad.addColorStop(0.5, config.color.replace(/[\d.]+\)/, `${auroraAlpha * 0.3})`));
-        auroraGrad.addColorStop(1, 'transparent');
-
-        ctx.globalAlpha = 1;
-        ctx.fillStyle = auroraGrad;
-        ctx.beginPath();
-        ctx.arc(p.x, p.y, p.size * 3, 0, Math.PI * 2);
-        ctx.fill();
-
-        // Core star
-        ctx.fillStyle = '#ffffff';
-        ctx.globalAlpha = auroraAlpha;
-        ctx.beginPath();
-        ctx.arc(p.x, p.y, p.size * 0.5, 0, Math.PI * 2);
-        ctx.fill();
-        break;
-
-      case 'sand-shimmer':
-        // Heat shimmer effect
-        p.wave += p.waveSpeed;
-        const shimmerX = Math.sin(p.wave) * p.waveAmount;
-
-        ctx.globalAlpha = p.alpha;
-        const shimmerGrad = ctx.createRadialGradient(p.x + shimmerX, p.y, 0, p.x + shimmerX, p.y, p.size);
-        shimmerGrad.addColorStop(0, config.color.replace(/[\d.]+\)/, `${p.alpha * 0.8})`));
-        shimmerGrad.addColorStop(0.5, config.color.replace(/[\d.]+\)/, `${p.alpha * 0.4})`));
-        shimmerGrad.addColorStop(1, 'transparent');
-
-        ctx.fillStyle = shimmerGrad;
-        ctx.beginPath();
-        ctx.ellipse(p.x + shimmerX, p.y, p.size * 1.5, p.size * 0.5, 0, 0, Math.PI * 2);
-        ctx.fill();
-        break;
-
-      case 'lightning-rain':
-        // Lightning and rain
-        if (p.type === 'lightning') {
-          p.life++;
-          if (p.life > p.maxLife) {
-            p.alpha = 0; // Remove
-            break;
-          }
-
-          // Flash effect
-          const flashAlpha = 1 - (p.life / p.maxLife);
-          ctx.globalAlpha = flashAlpha;
-          ctx.strokeStyle = '#ffffff';
-          ctx.lineWidth = 3;
-          ctx.shadowColor = '#a5b4fc';
-          ctx.shadowBlur = 10;
-
-          // Draw jagged lightning bolt
-          ctx.beginPath();
-          ctx.moveTo(p.x, p.y);
+        // Generate lightning path on first frame
+        if (p.segments.length === 0) {
           let currentX = p.x;
-          let currentY = p.y;
-          for (let i = 0; i < p.branches; i++) {
-            currentX += (Math.random() * 40 - 20);
-            currentY += H / (p.branches * 1.5);
-            ctx.lineTo(currentX, currentY);
-          }
-          ctx.stroke();
-          ctx.shadowBlur = 0;
+          let currentY = 0;
+          const segments = Math.floor(Math.random() * 8) + 12; // 12-20 segments
 
-        } else {
-          // Raindrop
-          ctx.globalAlpha = p.alpha;
-          ctx.strokeStyle = config.color;
-          ctx.lineWidth = p.size;
-          ctx.beginPath();
-          ctx.moveTo(p.x, p.y);
-          ctx.lineTo(p.x, p.y + 10);
-          ctx.stroke();
-        }
-        break;
+          for (let i = 0; i < segments; i++) {
+            const nextX = currentX + (Math.random() * 80 - 40);
+            const nextY = currentY + (H / segments);
+            p.segments.push({ x: currentX, y: currentY, endX: nextX, endY: nextY });
 
-      case 'pixel-sprites':
-        // 8-bit retro sprites
-        p.blink += p.blinkSpeed;
-        const blinkAlpha = p.alpha * (0.7 + Math.sin(p.blink) * 0.3);
+            // Add random branches
+            if (Math.random() < 0.3 && p.segments.length < 30) {
+              const branchSegments = Math.floor(Math.random() * 3) + 2;
+              let branchX = currentX;
+              let branchY = currentY;
 
-        ctx.globalAlpha = blinkAlpha;
-
-        // Draw pixelated sprite based on type
-        const pixelSize = p.size / 6;
-        const sprites = [
-          // Space invader
-          [[0,1,0,0,0,1,0],[0,0,1,1,1,0,0],[0,1,1,1,1,1,0],[1,1,0,1,0,1,1],[1,1,1,1,1,1,1],[0,0,1,0,1,0,0]],
-          // Pacman
-          [[0,1,1,1,1,0,0],[1,1,1,1,0,0,0],[1,1,1,0,0,0,0],[1,1,1,1,0,0,0],[0,1,1,1,1,0,0]],
-          // Ghost
-          [[0,1,1,1,1,1,0],[1,1,1,1,1,1,1],[1,0,1,1,0,1,1],[1,1,1,1,1,1,1],[1,1,1,1,1,1,1],[1,0,1,1,1,0,1]],
-          // Diamond
-          [[0,0,1,0,0],[0,1,1,1,0],[1,1,1,1,1],[0,1,1,1,0],[0,0,1,0,0]]
-        ];
-
-        ctx.fillStyle = config.color;
-        const sprite = sprites[p.sprite];
-        sprite.forEach((row, y) => {
-          row.forEach((pixel, x) => {
-            if (pixel) {
-              ctx.fillRect(
-                p.x - (row.length * pixelSize) / 2 + x * pixelSize,
-                p.y - (sprite.length * pixelSize) / 2 + y * pixelSize,
-                pixelSize,
-                pixelSize
-              );
+              for (let j = 0; j < branchSegments; j++) {
+                const bNextX = branchX + (Math.random() * 60 - 30) * (Math.random() < 0.5 ? 1 : -1);
+                const bNextY = branchY + (H / segments) * 0.8;
+                p.segments.push({ x: branchX, y: branchY, endX: bNextX, endY: bNextY });
+                branchX = bNextX;
+                branchY = bNextY;
+              }
             }
-          });
+
+            currentX = nextX;
+            currentY = nextY;
+          }
+        }
+
+        // Fade out effect
+        const lifeRatio = 1 - (p.life / p.maxLife);
+        const flashAlpha = p.intensity * lifeRatio;
+
+        // Draw dramatic lightning
+        ctx.globalAlpha = flashAlpha;
+        ctx.shadowColor = config.lineColor;
+        ctx.shadowBlur = 25;
+
+        // Main lightning bolt - thick white core
+        ctx.strokeStyle = '#ffffff';
+        ctx.lineWidth = p.size;
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'miter';
+
+        p.segments.forEach(seg => {
+          ctx.beginPath();
+          ctx.moveTo(seg.x, seg.y);
+          ctx.lineTo(seg.endX, seg.endY);
+          ctx.stroke();
         });
+
+        // Outer glow - purple/blue aura
+        ctx.globalAlpha = flashAlpha * 0.6;
+        ctx.strokeStyle = config.lineColor;
+        ctx.lineWidth = p.size * 2.5;
+        ctx.shadowBlur = 40;
+
+        p.segments.forEach(seg => {
+          ctx.beginPath();
+          ctx.moveTo(seg.x, seg.y);
+          ctx.lineTo(seg.endX, seg.endY);
+          ctx.stroke();
+        });
+
+        ctx.shadowBlur = 0;
+
+        // Mark for removal when done
+        if (p.life > p.maxLife) {
+          p.alpha = 0;
+        }
         break;
 
       case 'vaporwave-grid':
@@ -1135,49 +924,6 @@
             ctx.beginPath();
             ctx.arc(0, 0, p.size / 2, 0, Math.PI * 2);
             ctx.stroke();
-          }
-        }
-        break;
-
-      case 'binary-rain':
-        // Binary code rain (0s and 1s)
-        ctx.font = `${p.size}px monospace`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'top';
-
-        // Initialize chars array if empty
-        if (p.chars.length === 0) {
-          for (let i = 0; i < p.trailLength; i++) {
-            p.chars.push(Math.random() < 0.5 ? '0' : '1');
-          }
-        }
-
-        // Randomly change characters
-        p.frame += p.speed;
-        if (p.frame > 1) {
-          p.frame = 0;
-          const idx = Math.floor(Math.random() * p.chars.length);
-          p.chars[idx] = Math.random() < 0.5 ? '0' : '1';
-        }
-
-        // Draw trail of binary digits - very subtle
-        for (let i = 0; i < p.trailLength; i++) {
-          const charY = p.y + (i * p.size);
-
-          if (i === 0) {
-            // Head character - subtle
-            ctx.fillStyle = 'rgba(134, 239, 172, 0.6)';
-            ctx.fillText(p.chars[i], p.x, charY);
-          } else if (i < 3) {
-            // Near-head characters
-            const alpha = 0.5 - (i * 0.1);
-            ctx.fillStyle = `rgba(34, 197, 94, ${alpha})`;
-            ctx.fillText(p.chars[i], p.x, charY);
-          } else {
-            // Trail - very subtle
-            const alpha = Math.max(0.15, (1 - i / p.trailLength) * p.alpha * 0.45);
-            ctx.fillStyle = `rgba(34, 197, 94, ${alpha})`;
-            ctx.fillText(p.chars[i], p.x, charY);
           }
         }
         break;

--- a/assets/themes.js
+++ b/assets/themes.js
@@ -386,40 +386,6 @@
       }
     },
 
-    christmas: {
-      name: 'Christmas',
-      icon: '🎅',
-      description: 'Santa is coming to town',
-      colors: {
-        bg: '#0a1a0a',
-        bgElev: '#14291a',
-        bgSoft: '#1f3b2b',
-        text: '#fef2f2',
-        muted: '#fca5a5',
-        mutedSoft: '#f87171',
-        brand: '#dc2626',
-        brandGlow: 'rgba(220, 38, 38, 0.6)',
-        accent: '#22c55e',
-        success: '#10b981',
-        warn: '#fbbf24',
-        border: 'rgba(34, 197, 94, 0.25)'
-      },
-      particles: {
-        type: 'presents',
-        color: 'rgba(220, 38, 38, 0.85)',
-        lineColor: 'rgba(34, 197, 94, 0.4)',
-        count: 50
-      },
-      aurora: {
-        colors: [
-          'rgba(220, 38, 38, 0.40)',
-          'rgba(34, 197, 94, 0.35)',
-          'rgba(251, 191, 36, 0.30)',
-          'rgba(239, 68, 68, 0.25)'
-        ]
-      }
-    },
-
     newyear: {
       name: 'New Year',
       icon: '🎆',
@@ -454,116 +420,14 @@
       }
     },
 
-    valentine: {
-      name: 'Valentine',
-      icon: '💝',
-      description: 'Love is in the air',
-      colors: {
-        bg: '#1a0510',
-        bgElev: '#2d0f1f',
-        bgSoft: '#3d1a2d',
-        text: '#fdf2f8',
-        muted: '#f9a8d4',
-        mutedSoft: '#f472b6',
-        brand: '#ec4899',
-        brandGlow: 'rgba(236, 72, 153, 0.7)',
-        accent: '#f43f5e',
-        success: '#10b981',
-        warn: '#f59e0b',
-        border: 'rgba(236, 72, 153, 0.28)'
-      },
-      particles: {
-        type: 'hearts',
-        color: 'rgba(244, 63, 94, 0.8)',
-        lineColor: 'rgba(236, 72, 153, 0.4)',
-        count: 55
-      },
-      aurora: {
-        colors: [
-          'rgba(236, 72, 153, 0.45)',
-          'rgba(244, 63, 94, 0.40)',
-          'rgba(249, 168, 212, 0.30)',
-          'rgba(251, 207, 232, 0.25)'
-        ]
-      }
-    },
-
-    aurora: {
-      name: 'Aurora',
-      icon: '🌌',
-      description: 'Northern lights spectacular',
-      colors: {
-        bg: '#020818',
-        bgElev: '#0a1428',
-        bgSoft: '#142038',
-        text: '#dbeafe',
-        muted: '#93c5fd',
-        mutedSoft: '#60a5fa',
-        brand: '#3b82f6',
-        brandGlow: 'rgba(59, 130, 246, 0.6)',
-        accent: '#06b6d4',
-        success: '#10b981',
-        warn: '#f59e0b',
-        border: 'rgba(59, 130, 246, 0.22)'
-      },
-      particles: {
-        type: 'aurora-stars',
-        color: 'rgba(147, 197, 253, 0.85)',
-        lineColor: 'rgba(96, 165, 250, 0.4)',
-        count: 80
-      },
-      aurora: {
-        colors: [
-          'rgba(59, 130, 246, 0.50)',
-          'rgba(139, 92, 246, 0.45)',
-          'rgba(34, 211, 238, 0.40)',
-          'rgba(16, 185, 129, 0.35)'
-        ]
-      }
-    },
-
-    desert: {
-      name: 'Desert',
-      icon: '🏜️',
-      description: 'Sandy heat waves',
-      colors: {
-        bg: '#1a1008',
-        bgElev: '#2d1f14',
-        bgSoft: '#3d2f24',
-        text: '#fef3c7',
-        muted: '#fcd34d',
-        mutedSoft: '#fbbf24',
-        brand: '#f59e0b',
-        brandGlow: 'rgba(245, 158, 11, 0.6)',
-        accent: '#fb923c',
-        success: '#84cc16',
-        warn: '#ef4444',
-        border: 'rgba(245, 158, 11, 0.22)'
-      },
-      particles: {
-        type: 'sand-shimmer',
-        color: 'rgba(251, 191, 36, 0.6)',
-        lineColor: 'rgba(245, 158, 11, 0.3)',
-        count: 60
-      },
-      aurora: {
-        colors: [
-          'rgba(245, 158, 11, 0.35)',
-          'rgba(251, 146, 60, 0.30)',
-          'rgba(251, 191, 36, 0.25)',
-          'rgba(253, 224, 71, 0.20)'
-        ]
-      }
-    },
-
     storm: {
       name: 'Storm',
       icon: '⚡',
-      description: 'Thunder and lightning',
+      description: 'Epic lightning strikes',
       colors: {
-        bg: '#0a0a14',
-        bgElev: '#141428',
-        bgSoft: '#1f1f3d',
+        bg: '#05050a',
+        bgElev: '#0a0a14',
+        bgSoft: '#0f0f1f',
         text: '#e0e7ff',
         muted: '#a5b4fc',
         mutedSoft: '#818cf8',
@@ -575,10 +439,10 @@
         border: 'rgba(99, 102, 241, 0.25)'
       },
       particles: {
-        type: 'lightning-rain',
-        color: 'rgba(165, 180, 252, 0.7)',
-        lineColor: 'rgba(129, 140, 248, 0.4)',
-        count: 70
+        type: 'lightning',
+        color: 'rgba(255, 255, 255, 1.0)',
+        lineColor: 'rgba(165, 180, 252, 0.8)',
+        count: 8  // Few, dramatic lightning strikes
       },
       aurora: {
         colors: [
@@ -586,40 +450,6 @@
           'rgba(139, 92, 246, 0.35)',
           'rgba(165, 180, 252, 0.30)',
           'rgba(129, 140, 248, 0.25)'
-        ]
-      }
-    },
-
-    arcade: {
-      name: 'Arcade',
-      icon: '👾',
-      description: 'Retro 8-bit vibes',
-      colors: {
-        bg: '#0a0014',
-        bgElev: '#1a0028',
-        bgSoft: '#2a0f3d',
-        text: '#fdf4ff',
-        muted: '#f0abfc',
-        mutedSoft: '#e879f9',
-        brand: '#d946ef',
-        brandGlow: 'rgba(217, 70, 239, 0.7)',
-        accent: '#06b6d4',
-        success: '#22c55e',
-        warn: '#eab308',
-        border: 'rgba(217, 70, 239, 0.28)'
-      },
-      particles: {
-        type: 'pixel-sprites',
-        color: 'rgba(217, 70, 239, 0.9)',
-        lineColor: 'rgba(6, 182, 212, 0.5)',
-        count: 45
-      },
-      aurora: {
-        colors: [
-          'rgba(217, 70, 239, 0.45)',
-          'rgba(6, 182, 212, 0.40)',
-          'rgba(251, 191, 36, 0.35)',
-          'rgba(34, 197, 94, 0.30)'
         ]
       }
     },
@@ -654,40 +484,6 @@
           'rgba(6, 182, 212, 0.40)',
           'rgba(251, 146, 60, 0.35)',
           'rgba(236, 72, 153, 0.30)'
-        ]
-      }
-    },
-
-    terminal: {
-      name: 'Terminal',
-      icon: '💻',
-      description: 'Hacker vibes',
-      colors: {
-        bg: '#0a0f0a',
-        bgElev: '#141f14',
-        bgSoft: '#1f2e1f',
-        text: '#d1fae5',
-        muted: '#86efac',
-        mutedSoft: '#4ade80',
-        brand: '#22c55e',
-        brandGlow: 'rgba(34, 197, 94, 0.6)',
-        accent: '#10b981',
-        success: '#16a34a',
-        warn: '#f59e0b',
-        border: 'rgba(34, 197, 94, 0.22)'
-      },
-      particles: {
-        type: 'binary-rain',
-        color: 'rgba(34, 197, 94, 0.7)',
-        lineColor: 'rgba(16, 185, 129, 0.3)',
-        count: 55
-      },
-      aurora: {
-        colors: [
-          'rgba(34, 197, 94, 0.35)',
-          'rgba(16, 185, 129, 0.30)',
-          'rgba(20, 184, 166, 0.25)',
-          'rgba(52, 211, 153, 0.20)'
         ]
       }
     }


### PR DESCRIPTION
Removed 6 themes (keeping only 3 of the new ones):
- Removed: Christmas, Valentine, Aurora, Desert, Arcade, Terminal
- Kept: New Year (fireworks), Vaporwave, Storm

Storm theme completely redesigned:
- ONLY lightning bolts (no rain)
- Epic lightning effect with jagged bolts
- 12-20 segments per bolt with random branches
- White core with purple/blue outer glow
- Dramatic shadow blur effects (25-40px)
- Fewer particles (8 instead of 70) for impact
- Each lightning lasts 12-20 frames then fades
- Much darker background for better contrast

Removed unused particle code:
- presents, hearts, aurora-stars, sand-shimmer
- pixel-sprites, binary-rain, lightning-rain
- Kept only: fireworks, vaporwave-grid, lightning

Result: Clean theme set with 3 spectacular effects