### PR TITLE
Remove 8 themes to streamline theme selection

### DIFF
--- a/assets/themes.js
+++ b/assets/themes.js
@@ -42,41 +42,6 @@
       }
     },
 
-    halloween: {
-      name: 'Halloween',
-      icon: '🎃',
-      description: 'Spooky season vibes',
-      colors: {
-        bg: '#0d0510',
-        bgElev: '#1a0f1e',
-        bgSoft: '#2a1533',
-        text: '#f4e8ff',
-        muted: '#c4aed4',
-        mutedSoft: '#9178a1',
-        brand: '#8b5cf6',
-        brandGlow: 'rgba(139, 92, 246, 0.6)',
-        accent: '#ff6b35',
-        success: '#10b981',
-        warn: '#fbbf24',
-        border: 'rgba(139, 92, 246, 0.25)'
-      },
-      particles: {
-        type: 'ghosts',
-        color: 'rgba(139, 92, 246, 0.8)',
-        lineColor: 'rgba(255, 107, 53, 0.3)',
-        count: 60,
-        emoji: '👻'
-      },
-      aurora: {
-        colors: [
-          'rgba(139, 92, 246, 0.45)',
-          'rgba(255, 107, 53, 0.35)',
-          'rgba(16, 185, 129, 0.25)',
-          'rgba(251, 191, 36, 0.20)'
-        ]
-      }
-    },
-
     winter: {
       name: 'Winter',
       icon: '❄️',
@@ -181,41 +146,6 @@
       }
     },
 
-    forest: {
-      name: 'Forest',
-      icon: '🌲',
-      description: 'Natural serenity',
-      colors: {
-        bg: '#05120a',
-        bgElev: '#0d1f14',
-        bgSoft: '#1a2e23',
-        text: '#ecfdf5',
-        muted: '#86efac',
-        mutedSoft: '#4ade80',
-        brand: '#10b981',
-        brandGlow: 'rgba(16, 185, 129, 0.6)',
-        accent: '#84cc16',
-        success: '#22c55e',
-        warn: '#f59e0b',
-        border: 'rgba(16, 185, 129, 0.22)'
-      },
-      particles: {
-        type: 'fireflies',
-        color: 'rgba(132, 204, 22, 0.8)',
-        lineColor: 'rgba(16, 185, 129, 0.25)',
-        count: 55,
-        emoji: '✨'
-      },
-      aurora: {
-        colors: [
-          'rgba(16, 185, 129, 0.35)',
-          'rgba(132, 204, 22, 0.30)',
-          'rgba(34, 197, 94, 0.25)',
-          'rgba(20, 184, 166, 0.20)'
-        ]
-      }
-    },
-
     matrix: {
       name: 'Matrix',
       icon: '💚',
@@ -246,40 +176,6 @@
           'rgba(57, 255, 20, 0.30)',
           'rgba(0, 204, 51, 0.25)',
           'rgba(0, 255, 65, 0.20)'
-        ]
-      }
-    },
-
-    midnight: {
-      name: 'Midnight',
-      icon: '🌙',
-      description: 'Moonlit clouds and stars',
-      colors: {
-        bg: '#0f0620',
-        bgElev: '#1a0d33',
-        bgSoft: '#2a1547',
-        text: '#e9d5ff',
-        muted: '#c4b5fd',
-        mutedSoft: '#a78bfa',
-        brand: '#7c3aed',
-        brandGlow: 'rgba(124, 58, 237, 0.6)',
-        accent: '#a78bfa',
-        success: '#34d399',
-        warn: '#fbbf24',
-        border: 'rgba(124, 58, 237, 0.25)'
-      },
-      particles: {
-        type: 'moon-clouds',
-        color: 'rgba(196, 181, 253, 0.25)',
-        lineColor: 'rgba(167, 139, 250, 0.3)',
-        count: 70
-      },
-      aurora: {
-        colors: [
-          'rgba(124, 58, 237, 0.40)',
-          'rgba(167, 139, 250, 0.35)',
-          'rgba(233, 213, 255, 0.25)',
-          'rgba(196, 181, 253, 0.30)'
         ]
       }
     },
@@ -420,40 +316,6 @@
       }
     },
 
-    storm: {
-      name: 'Storm',
-      icon: '⚡',
-      description: 'Epic lightning strikes',
-      colors: {
-        bg: '#05050a',
-        bgElev: '#0a0a14',
-        bgSoft: '#0f0f1f',
-        text: '#e0e7ff',
-        muted: '#a5b4fc',
-        mutedSoft: '#818cf8',
-        brand: '#6366f1',
-        brandGlow: 'rgba(99, 102, 241, 0.7)',
-        accent: '#8b5cf6',
-        success: '#10b981',
-        warn: '#f59e0b',
-        border: 'rgba(99, 102, 241, 0.25)'
-      },
-      particles: {
-        type: 'lightning',
-        color: 'rgba(255, 255, 255, 1.0)',
-        lineColor: 'rgba(165, 180, 252, 0.8)',
-        count: 8  // Few, dramatic lightning strikes
-      },
-      aurora: {
-        colors: [
-          'rgba(99, 102, 241, 0.40)',
-          'rgba(139, 92, 246, 0.35)',
-          'rgba(165, 180, 252, 0.30)',
-          'rgba(129, 140, 248, 0.25)'
-        ]
-      }
-    },
-
     vaporwave: {
       name: 'Vaporwave',
       icon: '🌴',
@@ -484,142 +346,6 @@
           'rgba(6, 182, 212, 0.40)',
           'rgba(251, 146, 60, 0.35)',
           'rgba(236, 72, 153, 0.30)'
-        ]
-      }
-    },
-
-    quantum: {
-      name: 'Quantum',
-      icon: '⚛️',
-      description: 'Particle physics',
-      colors: {
-        bg: '#000508',
-        bgElev: '#0a1018',
-        bgSoft: '#0f1a28',
-        text: '#dbeafe',
-        muted: '#93c5fd',
-        mutedSoft: '#60a5fa',
-        brand: '#3b82f6',
-        brandGlow: 'rgba(59, 130, 246, 0.6)',
-        accent: '#8b5cf6',
-        success: '#10b981',
-        warn: '#f59e0b',
-        border: 'rgba(59, 130, 246, 0.22)'
-      },
-      particles: {
-        type: 'quantum-dots',
-        color: 'rgba(139, 92, 246, 0.85)',
-        lineColor: 'rgba(59, 130, 246, 0.5)',
-        count: 45
-      },
-      aurora: {
-        colors: [
-          'rgba(59, 130, 246, 0.45)',
-          'rgba(139, 92, 246, 0.40)',
-          'rgba(167, 139, 250, 0.35)',
-          'rgba(96, 165, 250, 0.30)'
-        ]
-      }
-    },
-
-    spacewarp: {
-      name: 'Space Warp',
-      icon: '🌠',
-      description: 'Hyperspace jump',
-      colors: {
-        bg: '#000000',
-        bgElev: '#050510',
-        bgSoft: '#0a0a1a',
-        text: '#ffffff',
-        muted: '#e0e7ff',
-        mutedSoft: '#c7d2fe',
-        brand: '#6366f1',
-        brandGlow: 'rgba(99, 102, 241, 0.7)',
-        accent: '#a78bfa',
-        success: '#10b981',
-        warn: '#f59e0b',
-        border: 'rgba(99, 102, 241, 0.25)'
-      },
-      particles: {
-        type: 'warp-stars',
-        color: 'rgba(255, 255, 255, 0.9)',
-        lineColor: 'rgba(165, 180, 252, 0.6)',
-        count: 60
-      },
-      aurora: {
-        colors: [
-          'rgba(99, 102, 241, 0.40)',
-          'rgba(167, 139, 250, 0.35)',
-          'rgba(129, 140, 248, 0.30)',
-          'rgba(165, 180, 252, 0.25)'
-        ]
-      }
-    },
-
-    neural: {
-      name: 'Neural Net',
-      icon: '🧠',
-      description: 'AI consciousness',
-      colors: {
-        bg: '#050a0a',
-        bgElev: '#0a1414',
-        bgSoft: '#0f1f1f',
-        text: '#d1fae5',
-        muted: '#6ee7b7',
-        mutedSoft: '#34d399',
-        brand: '#10b981',
-        brandGlow: 'rgba(16, 185, 129, 0.6)',
-        accent: '#06b6d4',
-        success: '#22c55e',
-        warn: '#f59e0b',
-        border: 'rgba(16, 185, 129, 0.22)'
-      },
-      particles: {
-        type: 'neural-nodes',
-        color: 'rgba(16, 185, 129, 0.8)',
-        lineColor: 'rgba(6, 182, 212, 0.5)',
-        count: 35
-      },
-      aurora: {
-        colors: [
-          'rgba(16, 185, 129, 0.35)',
-          'rgba(6, 182, 212, 0.30)',
-          'rgba(20, 184, 166, 0.25)',
-          'rgba(52, 211, 153, 0.20)'
-        ]
-      }
-    },
-
-    tron: {
-      name: 'Tron',
-      icon: '💿',
-      description: 'Digital frontier',
-      colors: {
-        bg: '#000000',
-        bgElev: '#001a1a',
-        bgSoft: '#002a2a',
-        text: '#e0f2fe',
-        muted: '#67e8f9',
-        mutedSoft: '#22d3ee',
-        brand: '#06b6d4',
-        brandGlow: 'rgba(6, 182, 212, 0.7)',
-        accent: '#0ea5e9',
-        success: '#10b981',
-        warn: '#f59e0b',
-        border: 'rgba(6, 182, 212, 0.28)'
-      },
-      particles: {
-        type: 'light-trails',
-        color: 'rgba(6, 182, 212, 0.9)',
-        lineColor: 'rgba(34, 211, 238, 0.6)',
-        count: 50
-      },
-      aurora: {
-        colors: [
-          'rgba(6, 182, 212, 0.45)',
-          'rgba(34, 211, 238, 0.40)',
-          'rgba(14, 165, 233, 0.35)',
-          'rgba(103, 232, 249, 0.30)'
         ]
       }
     }
@@ -697,9 +423,7 @@
     // Auto-suggest seasonal themes
     const now = new Date();
     const month = now.getMonth();
-    if (month === 9 && savedTheme === 'default') { // October
-      showSeasonalSuggestion('halloween', 'Try our spooky Halloween theme! 🎃');
-    } else if ((month === 11 || month === 0) && savedTheme === 'default') { // Dec/Jan
+    if ((month === 11 || month === 0) && savedTheme === 'default') { // Dec/Jan
       showSeasonalSuggestion('winter', 'Switch to Winter theme for a frosty feel! ❄️');
     }
   }


### PR DESCRIPTION
Removed themes:
- Halloween (🎃) - Spooky season vibes
- Forest (🌲) - Natural serenity
- Midnight (🌙) - Moonlit clouds
- Storm (⚡) - Lightning strikes
- Quantum (⚛️) - Particle physics
- Space Warp (🌠) - Hyperspace jump
- Neural Net (🧠) - AI consciousness
- Tron (💿) - Digital frontier

Also removed Halloween seasonal suggestion from initThemeSystem.

Remaining themes: default, winter, cyberpunk, ocean, matrix, sakura, lava, digitalization, newyear, vaporwave