### PR TITLE
Soften absolute language in Why Us section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3028,7 +3028,7 @@
           <!-- The Commitment -->
           <div style="text-align:center;margin-top:1.5rem;padding:2rem;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04));border-radius:12px;border:1px solid rgba(91,138,255,.2)">
             <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.15rem;max-width:60ch;margin:0 auto">
-              <strong style="color:var(--brand)">We're not selling you a dream.</strong> We're giving you tools that work. Clear structure. Real-time signals. Audited performance. And if it doesn't click for you? Seven days, full refund, no questions asked.
+              <strong style="color:var(--brand)">We're not selling you a dream.</strong> We're giving you tools we actually use. Clear structure. Real-time signals. Audited performance. And if it doesn't click for you? Seven days, full refund, no questions asked.
             </p>
             <p style="color:var(--muted);margin-top:1.5rem;font-size:0.95rem;font-style:italic">
               Because the only thing worse than missing a trade is trading on false signals.


### PR DESCRIPTION
Changed 'tools that work' to 'tools we actually use' to be more humble and honest. Implies belief and personal use without making absolute guarantees about outcomes.