### PR TITLE
Fix click-to-zoom: add pointer-events:none to caption overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -3073,7 +3073,7 @@
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/1.jpg" alt="Pentarch chart example 1" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
               <!-- Caption Overlay -->
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-1">
                   Apple: Multi-timeframe precision
                 </p>
@@ -3083,7 +3083,7 @@
             <!-- Chart 2 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/2.jpg" alt="Pentarch chart example 2" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-2">
                   Bitcoin: Long-term trend mastery
                 </p>
@@ -3093,7 +3093,7 @@
             <!-- Chart 3 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/3.jpg" alt="Pentarch chart example 3" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-3">
                   Dollar Index: Currency signals
                 </p>
@@ -3103,7 +3103,7 @@
             <!-- Chart 4 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/4.jpg" alt="Pentarch chart example 4" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-4">
                   Ethereum: Crypto momentum alerts
                 </p>
@@ -3113,7 +3113,7 @@
             <!-- Chart 5 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/5.jpg" alt="Pentarch chart example 5" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-5">
                   EUR/USD: Forex trend detection
                 </p>
@@ -3123,7 +3123,7 @@
             <!-- Chart 6 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/6.jpg" alt="Pentarch chart example 6" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-6">
                   MicroStrategy: Volatility tracking
                 </p>
@@ -3133,7 +3133,7 @@
             <!-- Chart 7 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/7.jpg" alt="Pentarch chart example 7" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-7">
                   S&P 500: Index intelligence
                 </p>
@@ -3143,7 +3143,7 @@
             <!-- Chart 8 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/8.jpg" alt="Pentarch chart example 8" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-8">
                   Tesla: Swing trade signals
                 </p>
@@ -3153,7 +3153,7 @@
             <!-- Chart 9 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">
               <img src="assets/images/pentarch/9.jpg" alt="Pentarch chart example 9" loading="lazy" style="width:100%;height:auto;display:block;object-fit:contain">
-              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text)">
+              <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(5,7,13,0.95),transparent);padding:2rem 1.5rem 1.5rem;color:var(--text);pointer-events:none">
                 <p style="margin:0;font-size:1.1rem;font-weight:700;color:var(--brand)" id="caption-9">
                   Gold: Safe haven timing
                 </p>
@@ -3431,21 +3431,26 @@
               updateDots();
 
               // Carousel item click handlers - stop auto-scroll and open lightbox
+              console.log('Setting up click handlers for', items.length, 'carousel items');
               items.forEach((item, index) => {
                 item.style.cursor = 'zoom-in';
                 item.addEventListener('click', (e) => {
+                  console.log('Carousel item clicked:', index);
                   // Don't trigger if clicking on navigation buttons
                   if (e.target.closest('#carousel-prev') || e.target.closest('#carousel-next')) {
+                    console.log('Ignoring click on navigation button');
                     return;
                   }
                   e.stopPropagation();
                   clearInterval(autoScrollInterval);
                   const img = item.querySelector('img');
                   if (img) {
+                    console.log('Opening lightbox for image:', img.src);
                     openLightbox(img.src, img.alt, index);
                   }
                 });
               });
+              console.log('Click handlers setup complete');
 
               // Lightbox functionality
               function openLightbox(imageSrc, imageAlt, imageIndex) {


### PR DESCRIPTION
- Added pointer-events:none to all 9 carousel caption overlays
- This allows clicks to pass through captions to the carousel item
- Previously, caption overlays were blocking click events
- Added console.log debugging to track click handler execution
- Now clicks work on both the image and caption areas

The issue was that the absolutely positioned caption divs were intercepting click events before they could reach the carousel items. Setting pointer-events:none makes them visually present but click-transparent.