### PR TITLE
Reduce carousel caption size on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1523,6 +1523,35 @@
       }
     }
 
+    /* Carousel caption mobile styles */
+    @media (max-width:768px){
+      /* Reduce caption text size on tablets and mobile */
+      .carousel-item > div[style*="position:absolute"] > p:first-child{
+        font-size:0.9rem !important;
+      }
+      .carousel-item > div[style*="position:absolute"] > p:last-child{
+        font-size:0.7rem !important;
+      }
+      /* Reduce padding to save space */
+      .carousel-item > div[style*="position:absolute"]{
+        padding:1.2rem 1rem 1rem !important;
+      }
+    }
+
+    @media (max-width:480px){
+      /* Further reduce caption text on small mobile */
+      .carousel-item > div[style*="position:absolute"] > p:first-child{
+        font-size:0.85rem !important;
+      }
+      .carousel-item > div[style*="position:absolute"] > p:last-child{
+        font-size:0.65rem !important;
+      }
+      /* Reduce padding more on small screens */
+      .carousel-item > div[style*="position:absolute"]{
+        padding:1rem 0.75rem 0.75rem !important;
+      }
+    }
+
     .hero-ctas{display:flex;flex-wrap:wrap;gap:.9rem;align-items:center}
 
     .proof-bar{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.2rem}


### PR DESCRIPTION
- Reduce main caption from 1.1rem to 0.9rem on mobile (768px)
- Reduce timeframe from 0.85rem to 0.7rem on mobile
- Further reduce to 0.85rem/0.65rem on small mobile (480px)
- Decrease padding to maximize visible chart area
- Improves readability while covering less screen space