### PR TITLE
Fix critical mobile loading issue caused by expensive CSS selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -2114,12 +2114,14 @@
         opacity: 0 !important;
       }
 
-      /* Remove expensive filters and blend modes - but preserve critical UI blur */
+      /* Remove expensive filters and blend modes on mobile */
       * {
         mix-blend-mode: normal !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
       }
 
-      /* Preserve header blur for visual depth (reduced complexity) */
+      /* Preserve header blur for visual depth */
       header {
         backdrop-filter: blur(8px) !important;
         -webkit-backdrop-filter: blur(8px) !important;
@@ -2129,12 +2131,6 @@
       .modal {
         backdrop-filter: blur(2px) !important;
         -webkit-backdrop-filter: blur(2px) !important;
-      }
-
-      /* Remove all other backdrop filters */
-      *:not(header):not(.modal) {
-        backdrop-filter: none !important;
-        -webkit-backdrop-filter: none !important;
       }
 
       /* Safari-specific: Keep GPU acceleration for smooth scrolling */


### PR DESCRIPTION
CRITICAL FIX: Page was stopping at pricing section on mobile due to expensive *:not(header):not(.modal) selector causing browser hang.

Changed approach:
- Set backdrop-filter: none on universal selector first
- Override with specific selectors for header and modal
- Eliminates expensive :not() pseudo-class evaluation on every element

This fixes the mobile page freeze/stop loading issue while maintaining the intended visual effects on header and modals.