### PR TITLE
Fix Resources dropdown menu layout in roadmap header

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -374,39 +374,52 @@
       position: absolute;
       top: 100%;
       left: 0;
-      margin-top: 0.5rem;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 0.5rem;
+      margin-top: .5rem;
+      background: rgba(10,12,20,.98);
+      border: 1px solid rgba(255,255,255,.2);
+      border-radius: 12px;
+      padding: .5rem;
       min-width: 200px;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 100;
-      list-style: none;
+      box-shadow: 0 8px 24px rgba(0,0,0,.4);
+      display: none;
+      flex-direction: column;
+      gap: .25rem;
+      z-index: 66;
+      backdrop-filter: blur(12px);
+    }
+
+    html[data-theme="light"] .nav-dropdown-menu {
+      background: rgba(255,255,255,.98);
+      border-color: rgba(30,41,59,.2);
+      box-shadow: 0 8px 24px rgba(0,0,0,.15);
     }
 
     .nav-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
+      display: flex;
     }
 
     .nav-dropdown-menu li {
-      margin: 0;
+      display: block;
     }
 
     .nav-dropdown-menu a {
-      padding: 0.6rem 1rem;
-      border-radius: 6px;
-      transition: all 0.2s;
+      padding: .6rem .9rem;
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+      border-radius: 8px;
+      width: 100%;
+      transform: none !important;
     }
 
     .nav-dropdown-menu a:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
+      background: rgba(91,138,255,.15);
+      color: #fff;
+    }
+
+    html[data-theme="light"] .nav-dropdown-menu a:hover {
+      background: rgba(59,130,246,.12);
+      color: #0f172a;
     }
 
     /* Language Dropdown */


### PR DESCRIPTION
The Resources dropdown was displaying horizontally instead of vertically as a list.

Changes:
- Updated .nav-dropdown-menu to use display: none (default) and display: flex when .show is active
- Added flex-direction: column to make menu items stack vertically
- Added gap: .25rem for proper spacing between items
- Updated background to match main site: rgba(10,12,20,.98)
- Added backdrop-filter: blur(12px) for visual consistency
- Added box-shadow for depth
- Fixed .nav-dropdown-menu li to display: block
- Updated .nav-dropdown-menu a styling to match main site
- Added transform: none !important to prevent hover translateY on dropdown items
- Added light theme support for dropdown menu
- Changed border-radius from 8px to 12px to match main site

The dropdown now displays as a proper vertical list with correct styling.