### PR TITLE
Fix Resources button alignment in roadmap header

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -335,15 +335,17 @@
       gap: .3rem;
       padding: .5rem .9rem;
       border-radius: 999px;
-      background: none;
-      border: none;
       color: #b7c2d9;
       font-weight: 600;
-      font-size: .95rem;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      background: transparent;
+      border: none;
       cursor: pointer;
       transition: all .2s ease;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
+      font-size: .95rem;
       white-space: nowrap;
+      margin: 0;
+      vertical-align: middle;
     }
 
     .nav-dropdown-toggle:hover {
@@ -362,8 +364,8 @@
     }
 
     .dropdown-arrow {
-      font-size: 0.7rem;
-      transition: transform 0.2s;
+      font-size: .7em;
+      transition: transform .2s ease;
     }
 
     .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow {


### PR DESCRIPTION
The Resources button was not vertically aligned with the other nav links.

Changes to .nav-dropdown-toggle:
- Added margin: 0 to override default button margins
- Added vertical-align: middle for proper alignment with inline elements
- Changed background: none to background: transparent (matches main site exactly)
- Reordered properties to match main site CSS order

Changes to .dropdown-arrow:
- Changed font-size from 0.7rem to .7em (relative to parent, not root)
- Changed transition from 0.2s to .2s ease (matches main site)

These changes ensure the Resources button aligns perfectly with adjacent nav links.