### PR TITLE
Fix Resources button alignment to match nav links exactly

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -281,6 +281,7 @@
       margin: 0;
       padding: 0;
       display: flex;
+      align-items: center;
       gap: .8rem;
       min-width: 0;
       flex-shrink: 10;
@@ -344,8 +345,8 @@
       transition: all .2s ease;
       font-size: .95rem;
       white-space: nowrap;
-      margin: 0;
-      vertical-align: middle;
+      min-width: 0;
+      flex-shrink: 1;
     }
 
     .nav-dropdown-toggle:hover {


### PR DESCRIPTION
The Resources dropdown button was still slightly misaligned with other nav links.

Root cause: Flex items without explicit vertical alignment can have baseline issues, especially when mixing button and anchor elements.

Changes:
- Added align-items: center to nav ul to ensure all flex items are vertically centered
- Added min-width: 0 and flex-shrink: 1 to .nav-dropdown-toggle (matches nav a)
- Removed margin: 0 and vertical-align: middle (not needed with flex centering)

The Resources button now aligns perfectly with adjacent navigation links at all viewport sizes.