### PR TITLE
Reduce chatbot size on desktop - make it more compact

### DIFF
--- a/assets/chatbot.css
+++ b/assets/chatbot.css
@@ -78,8 +78,8 @@
   position: fixed;
   bottom: 6rem;
   right: 2rem;
-  width: min(90vw, 380px);
-  height: min(75vh, 550px);
+  width: min(90vw, 340px);
+  height: min(70vh, 480px);
   background: #0c111c;
   border: 1px solid rgba(91, 138, 255, 0.3);
   border-radius: 16px;


### PR DESCRIPTION
Desktop chatbot container:
- Width: 380px → 340px (40px smaller)
- Height: 550px → 480px (70px smaller)
- Max height: 75vh → 70vh

Result: Much more compact chatbot on desktop, takes less screen space