### PR TITLE
Add bug-images folder for visual bug documentation

### DIFF
--- a/bug-images/README.md
+++ b/bug-images/README.md
@@ -1,0 +1,19 @@
+# Bug Images
+
+This folder contains screenshots and images of bugs that are difficult to describe with text alone.
+
+## Usage
+
+- Add screenshots of visual bugs, layout issues, or unexpected behavior
+- Name files descriptively (e.g., `chatbot-overlap-issue-2024-11-05.png`)
+- Include the date or issue reference in the filename when possible
+- Supported formats: PNG, JPG, GIF, WebP
+
+## Organization
+
+Feel free to organize images by:
+- Date (YYYY-MM-DD)
+- Feature area (e.g., chatbot, homepage, FAQ)
+- Bug severity or priority
+
+This helps track issues visually and provides context for bug reports and discussions.


### PR DESCRIPTION
Created a dedicated folder for storing screenshots and images of bugs that are difficult to describe with text. Includes README with usage guidelines and organization suggestions.