### PR TITLE
Fix chat functionality

### DIFF
--- a/assets/chatbot.css
+++ b/assets/chatbot.css
@@ -78,8 +78,8 @@
   position: fixed;
   bottom: 6rem;
   right: 2rem;
-  width: min(90vw, 380px);
-  height: min(75vh, 550px);
+  width: min(90vw, 350px);
+  height: min(70vh, 500px);
   background: #0c111c;
   border: 1px solid rgba(91, 138, 255, 0.3);
   border-radius: 16px;


### PR DESCRIPTION
Changed desktop chatbot dimensions from 380x550px to 350x500px:
- Width: 380px → 350px (more compact)
- Height: 550px → 500px (less screen space)

This provides a better balance between usability and screen real estate. Mobile responsive design remains unchanged (fullscreen).