### PR TITLE
Add GDPR/CCPA compliant cookie consent system

### DIFF
--- a/assets/cookie-consent.css
+++ b/assets/cookie-consent.css
@@ -1,0 +1,332 @@
+/**
+ * Cookie Consent Banner
+ * Simple, clean, GDPR/CCPA compliant
+ */
+
+/* Banner Styles */
+#cookie-consent-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--bg-elev);
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.3);
+  padding: 1.5rem;
+  z-index: 9999;
+  display: none;
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.cookie-consent-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.cookie-consent-text {
+  flex: 1;
+  min-width: 300px;
+}
+
+.cookie-consent-text h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.1rem;
+  color: var(--text);
+}
+
+.cookie-consent-text p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.cookie-consent-text a {
+  color: var(--brand);
+  text-decoration: none;
+}
+
+.cookie-consent-text a:hover {
+  text-decoration: underline;
+}
+
+.cookie-consent-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cookie-consent-btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.cookie-consent-btn-accept {
+  background: var(--brand);
+  color: #fff;
+}
+
+.cookie-consent-btn-accept:hover {
+  background: var(--brand-2);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(91, 138, 255, 0.3);
+}
+
+.cookie-consent-btn-decline {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.cookie-consent-btn-decline:hover {
+  background: var(--bg-soft);
+  color: var(--text);
+}
+
+.cookie-consent-btn-settings {
+  background: transparent;
+  color: var(--brand);
+  border: 1px solid var(--brand);
+}
+
+.cookie-consent-btn-settings:hover {
+  background: rgba(91, 138, 255, 0.1);
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+  #cookie-consent-banner {
+    padding: 1rem;
+  }
+
+  .cookie-consent-container {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: stretch;
+  }
+
+  .cookie-consent-text {
+    min-width: 0;
+  }
+
+  .cookie-consent-actions {
+    flex-direction: column;
+  }
+
+  .cookie-consent-btn {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+/* Preferences Modal */
+#cookie-preferences-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(4px);
+  z-index: 10000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.cookie-preferences-content {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  animation: slideIn 0.3s ease;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.cookie-preferences-header {
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.cookie-preferences-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--text);
+}
+
+.cookie-preferences-close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+}
+
+.cookie-preferences-close:hover {
+  color: var(--text);
+}
+
+.cookie-preferences-body {
+  padding: 1.5rem;
+}
+
+.cookie-category {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.cookie-category:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
+.cookie-category-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.cookie-category-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.cookie-toggle {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 26px;
+}
+
+.cookie-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.cookie-toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--border);
+  transition: 0.3s;
+  border-radius: 26px;
+}
+
+.cookie-toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  bottom: 3px;
+  background: white;
+  transition: 0.3s;
+  border-radius: 50%;
+}
+
+.cookie-toggle input:checked + .cookie-toggle-slider {
+  background: var(--brand);
+}
+
+.cookie-toggle input:checked + .cookie-toggle-slider:before {
+  transform: translateX(24px);
+}
+
+.cookie-toggle input:disabled + .cookie-toggle-slider {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cookie-category-description {
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.cookie-category-badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-left: 0.5rem;
+}
+
+.badge-required {
+  background: rgba(62, 213, 152, 0.2);
+  color: var(--good);
+}
+
+.cookie-preferences-footer {
+  padding: 1.5rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 768px) {
+  .cookie-preferences-footer {
+    flex-direction: column-reverse;
+  }
+
+  .cookie-preferences-footer button {
+    width: 100%;
+  }
+}

--- a/assets/cookie-consent.js
+++ b/assets/cookie-consent.js
@@ -1,0 +1,215 @@
+/**
+ * Cookie Consent Manager
+ * GDPR/CCPA compliant consent management
+ * Blocks Clarity + GA4 until consent is given
+ */
+
+(function() {
+  'use strict';
+
+  const CONSENT_KEY = 'sp_cookie_consent';
+  const CONSENT_VERSION = '1.0';
+
+  // Default consent state
+  const defaultConsent = {
+    version: CONSENT_VERSION,
+    timestamp: null,
+    essential: true, // Always true, no consent needed
+    analytics: false
+  };
+
+  // Get current consent
+  function getConsent() {
+    try {
+      const stored = localStorage.getItem(CONSENT_KEY);
+      if (stored) {
+        const consent = JSON.parse(stored);
+        // Check if version matches
+        if (consent.version === CONSENT_VERSION) {
+          return consent;
+        }
+      }
+    } catch (e) {
+      console.error('Error reading consent:', e);
+    }
+    return null;
+  }
+
+  // Save consent
+  function saveConsent(consent) {
+    try {
+      consent.timestamp = new Date().toISOString();
+      consent.version = CONSENT_VERSION;
+      localStorage.setItem(CONSENT_KEY, JSON.stringify(consent));
+      console.log('✅ Cookie consent saved:', consent);
+    } catch (e) {
+      console.error('Error saving consent:', e);
+    }
+  }
+
+  // Load analytics scripts
+  function loadAnalytics() {
+    console.log('📊 Loading analytics with consent...');
+
+    // Load Microsoft Clarity
+    (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "txh7b3h2ja");
+
+    // Load Google Analytics 4
+    const gaScript = document.createElement('script');
+    gaScript.async = true;
+    gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-3RCZ0JBB0V';
+    document.head.appendChild(gaScript);
+
+    gaScript.onload = function() {
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-3RCZ0JBB0V', {
+        'anonymize_ip': true
+      });
+      window.gtag = gtag;
+    };
+
+    console.log('✅ Analytics loaded');
+  }
+
+  // Show banner
+  function showBanner() {
+    const banner = document.getElementById('cookie-consent-banner');
+    if (banner) {
+      banner.style.display = 'block';
+    }
+  }
+
+  // Hide banner
+  function hideBanner() {
+    const banner = document.getElementById('cookie-consent-banner');
+    if (banner) {
+      banner.style.display = 'none';
+    }
+  }
+
+  // Accept all cookies
+  function acceptAll() {
+    const consent = {
+      essential: true,
+      analytics: true
+    };
+    saveConsent(consent);
+    hideBanner();
+    loadAnalytics();
+  }
+
+  // Decline optional cookies
+  function declineAll() {
+    const consent = {
+      essential: true,
+      analytics: false
+    };
+    saveConsent(consent);
+    hideBanner();
+    console.log('❌ Analytics declined');
+  }
+
+  // Show preferences modal
+  function showPreferences() {
+    const modal = document.getElementById('cookie-preferences-modal');
+    if (modal) {
+      modal.style.display = 'flex';
+      
+      // Load current preferences
+      const consent = getConsent() || defaultConsent;
+      document.getElementById('analytics-toggle').checked = consent.analytics;
+    }
+  }
+
+  // Hide preferences modal
+  function hidePreferences() {
+    const modal = document.getElementById('cookie-preferences-modal');
+    if (modal) {
+      modal.style.display = 'none';
+    }
+  }
+
+  // Save preferences from modal
+  function savePreferences() {
+    const analyticsEnabled = document.getElementById('analytics-toggle').checked;
+    
+    const consent = {
+      essential: true,
+      analytics: analyticsEnabled
+    };
+    
+    saveConsent(consent);
+    hidePreferences();
+    hideBanner();
+
+    if (analyticsEnabled) {
+      loadAnalytics();
+    }
+
+    // Show confirmation
+    console.log('✅ Preferences saved:', consent);
+  }
+
+  // Initialize consent system
+  function init() {
+    // Check if consent already given
+    const consent = getConsent();
+
+    if (consent) {
+      console.log('📋 Existing consent found:', consent);
+      
+      // Load analytics if consented
+      if (consent.analytics) {
+        loadAnalytics();
+      }
+    } else {
+      // No consent yet, show banner
+      console.log('🍪 No consent found, showing banner');
+      showBanner();
+    }
+
+    // Setup event listeners
+    const acceptBtn = document.getElementById('cookie-accept-all');
+    const declineBtn = document.getElementById('cookie-decline-all');
+    const settingsBtn = document.getElementById('cookie-settings');
+    const closeModalBtn = document.getElementById('cookie-preferences-close');
+    const savePrefsBtn = document.getElementById('cookie-save-preferences');
+    const cancelPrefsBtn = document.getElementById('cookie-cancel-preferences');
+
+    if (acceptBtn) acceptBtn.addEventListener('click', acceptAll);
+    if (declineBtn) declineBtn.addEventListener('click', declineAll);
+    if (settingsBtn) settingsBtn.addEventListener('click', showPreferences);
+    if (closeModalBtn) closeModalBtn.addEventListener('click', hidePreferences);
+    if (savePrefsBtn) savePrefsBtn.addEventListener('click', savePreferences);
+    if (cancelPrefsBtn) cancelPrefsBtn.addEventListener('click', hidePreferences);
+
+    // Close modal on background click
+    const modal = document.getElementById('cookie-preferences-modal');
+    if (modal) {
+      modal.addEventListener('click', function(e) {
+        if (e.target === modal) {
+          hidePreferences();
+        }
+      });
+    }
+
+    // Expose global function for "Manage Cookies" links
+    window.manageCookiePreferences = showPreferences;
+
+    console.log('🍪 Cookie consent system initialized');
+  }
+
+  // Start when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();

--- a/index.html
+++ b/index.html
@@ -103,30 +103,8 @@
 
   <script defer data-domain="signalpilot.io" src="https://plausible.io/js/script.js"></script>
 
-  <!-- Microsoft Clarity (deferred for performance) -->
-  <script type="text/javascript">
-    window.addEventListener('load', function() {
-      setTimeout(function() {
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "txh7b3h2ja");
-      }, 1000);
-    });
-  </script>
-
-  <!-- Google Analytics (GA4) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3RCZ0JBB0V"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-3RCZ0JBB0V');
-  </script>
-
-
+  <!-- Microsoft Clarity & GA4 loaded via consent manager -->
+  <!-- See: assets/cookie-consent.js -->
 
   <!-- Fonts: Space Grotesk (body/UI) + EB Garamond (headlines) + Gugi (brand) -->
 
@@ -2613,6 +2591,9 @@
 
   <!-- Performance & Utilities -->
   <link rel="stylesheet" href="/assets/performance.css">
+
+  <!-- Cookie Consent -->
+  <link rel="stylesheet" href="/assets/cookie-consent.css">
 
   <!-- AI Chatbot -->
   <link rel="stylesheet" href="/assets/chatbot.css">
@@ -5135,6 +5116,8 @@
 
             <li style="margin-bottom:.5rem"><a href="manage-subscription.html" style="color:var(--muted);text-decoration:none;font-size:.9rem">Manage Subscription</a></li>
 
+            <li style="margin-bottom:.5rem"><a href="#" onclick="manageCookiePreferences();return false;" style="color:var(--muted);text-decoration:none;font-size:.9rem">Manage Cookies</a></li>
+
           </ul>
 
         </div>
@@ -6565,6 +6548,9 @@ if ('serviceWorker' in navigator) {
 })();
 </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js"></script>
+
 <!-- AI Chatbot -->
 <script src="/assets/chatbot.js" defer></script>
 
@@ -6617,6 +6603,70 @@ if ('serviceWorker' in navigator) {
   console.log('💻 Desktop: Section lazy loading initialized for', lazyLoadSections.length, 'sections');
 })();
 </script>
+
+<!-- Cookie Consent Banner -->
+<div id="cookie-consent-banner">
+  <div class="cookie-consent-container">
+    <div class="cookie-consent-text">
+      <h3>🍪 We use cookies</h3>
+      <p>
+        We use essential cookies for the site to work and analytics cookies (Microsoft Clarity & Google Analytics) to understand how you use our site and improve your experience.
+        <a href="/privacy.html">Privacy Policy</a>
+      </p>
+    </div>
+    <div class="cookie-consent-actions">
+      <button id="cookie-accept-all" class="cookie-consent-btn cookie-consent-btn-accept">Accept All</button>
+      <button id="cookie-decline-all" class="cookie-consent-btn cookie-consent-btn-decline">Decline</button>
+      <button id="cookie-settings" class="cookie-consent-btn cookie-consent-btn-settings">Manage Preferences</button>
+    </div>
+  </div>
+</div>
+
+<!-- Cookie Preferences Modal -->
+<div id="cookie-preferences-modal">
+  <div class="cookie-preferences-content">
+    <div class="cookie-preferences-header">
+      <h2>Cookie Preferences</h2>
+      <button id="cookie-preferences-close" class="cookie-preferences-close" aria-label="Close">&times;</button>
+    </div>
+
+    <div class="cookie-preferences-body">
+      <div class="cookie-category">
+        <div class="cookie-category-header">
+          <h3 class="cookie-category-title">
+            Essential Cookies
+            <span class="cookie-category-badge badge-required">Required</span>
+          </h3>
+          <label class="cookie-toggle">
+            <input type="checkbox" checked disabled>
+            <span class="cookie-toggle-slider"></span>
+          </label>
+        </div>
+        <p class="cookie-category-description">
+          These cookies are necessary for the website to function and cannot be disabled. They include session management, payment processing, and security features.
+        </p>
+      </div>
+
+      <div class="cookie-category">
+        <div class="cookie-category-header">
+          <h3 class="cookie-category-title">Analytics Cookies</h3>
+          <label class="cookie-toggle">
+            <input type="checkbox" id="analytics-toggle">
+            <span class="cookie-toggle-slider"></span>
+          </label>
+        </div>
+        <p class="cookie-category-description">
+          We use Microsoft Clarity and Google Analytics to understand how visitors interact with our site. This helps us improve your experience. These cookies collect anonymized data including page views, time spent, and navigation patterns.
+        </p>
+      </div>
+    </div>
+
+    <div class="cookie-preferences-footer">
+      <button id="cookie-cancel-preferences" class="cookie-consent-btn cookie-consent-btn-decline">Cancel</button>
+      <button id="cookie-save-preferences" class="cookie-consent-btn cookie-consent-btn-accept">Save Preferences</button>
+    </div>
+  </div>
+</div>
 
 </body>
 


### PR DESCRIPTION
Implemented simple, professional cookie consent for Clarity + GA4:

FEATURES:
- Clean banner with Accept/Decline/Settings options
- Granular preferences modal (Essential + Analytics)
- Blocks Clarity + GA4 until consent given
- Stores consent in localStorage
- "Manage Cookies" link in footer
- Respects user choices

COMPLIANCE:
- GDPR compliant (EU users)
- CCPA compliant (California users)
- 2 categories: Essential (always on) + Analytics (opt-in)
- Clear descriptions of what each category does
- Easy to decline or customize

UX:
- Clean, modern design matching site theme
- Mobile responsive (full-width buttons on mobile)
- Smooth animations
- Dark/light theme support
- Non-intrusive placement

TECHNICAL:
- Consent versioning system
- Analytics load only after consent
- Fallback for localStorage errors
- Console logging for debugging
- Keyboard accessible

FILES:
- assets/cookie-consent.css (5.5KB) - Banner and modal styles
- assets/cookie-consent.js (5.9KB) - Consent management logic
- index.html - Removed inline Clarity/GA4, added consent system

This is a SIMPLE 2-category banner (not the complex "1063 partners" type). Perfect for SaaS with just analytics, no advertising.