### PR TITLE
Add video compression script (not needed - video already optimal)

### DIFF
--- a/convert-videos.js
+++ b/convert-videos.js
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+
+/**
+ * Video to WebM/MP4 Converter
+ * Compresses videos with optimal settings for web delivery
+ * Generates multiple formats (WebM + MP4) for browser compatibility
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const { exec } = require('child_process');
+
+const readdir = promisify(fs.readdir);
+const stat = promisify(fs.stat);
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+const execPromise = promisify(exec);
+
+// Check if ffmpeg is installed
+let ffmpegInstalled = false;
+let useFluentFFmpeg = false;
+
+async function checkFFmpeg() {
+  try {
+    await execPromise('ffmpeg -version');
+    ffmpegInstalled = true;
+    console.log('✅ ffmpeg found (native)');
+    return true;
+  } catch (err) {
+    console.log('⚠️  Native ffmpeg not found, checking fluent-ffmpeg...');
+
+    try {
+      require('fluent-ffmpeg');
+      useFluentFFmpeg = true;
+      console.log('✅ fluent-ffmpeg package found');
+      return true;
+    } catch (err2) {
+      console.error('❌ Neither ffmpeg nor fluent-ffmpeg found.');
+      console.log('\nInstall options:');
+      console.log('  Option 1 (Native): apt-get install ffmpeg');
+      console.log('  Option 2 (Node):   npm install fluent-ffmpeg @ffmpeg-installer/ffmpeg');
+      return false;
+    }
+  }
+}
+
+// Configuration
+const CONFIG = {
+  inputFormats: ['.mp4', '.mov', '.avi', '.webm'],
+  outputFormats: ['webm', 'mp4'], // Generate both for compatibility
+  webm: {
+    videoBitrate: '1000k',    // 1 Mbps (good quality)
+    audioBitrate: '128k',
+    codec: 'libvpx-vp9',      // VP9 codec (better than VP8)
+    audioCodec: 'libopus'
+  },
+  mp4: {
+    videoBitrate: '1000k',
+    audioBitrate: '128k',
+    codec: 'libx264',         // H.264 codec
+    audioCodec: 'aac',
+    preset: 'medium'          // Encoding speed (slow = better quality)
+  },
+  createBackup: true,
+  verbose: true
+};
+
+// Statistics
+const stats = {
+  processed: 0,
+  skipped: 0,
+  errors: 0,
+  totalOriginalSize: 0,
+  totalCompressedSize: 0
+};
+
+/**
+ * Format bytes to human readable
+ */
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+/**
+ * Recursively find all video files
+ */
+async function findVideos(dir, videos = []) {
+  const files = await readdir(dir);
+
+  for (const file of files) {
+    const filepath = path.join(dir, file);
+    const fileStat = await stat(filepath);
+
+    if (fileStat.isDirectory()) {
+      await findVideos(filepath, videos);
+    } else {
+      const ext = path.extname(filepath).toLowerCase();
+      if (CONFIG.inputFormats.includes(ext)) {
+        videos.push(filepath);
+      }
+    }
+  }
+
+  return videos;
+}
+
+/**
+ * Convert video using native ffmpeg
+ */
+async function convertWithNativeFFmpeg(inputPath, outputPath, format) {
+  const config = CONFIG[format];
+
+  let command;
+  if (format === 'webm') {
+    command = `ffmpeg -i "${inputPath}" -c:v ${config.codec} -b:v ${config.videoBitrate} -c:a ${config.audioCodec} -b:a ${config.audioBitrate} -y "${outputPath}"`;
+  } else if (format === 'mp4') {
+    command = `ffmpeg -i "${inputPath}" -c:v ${config.codec} -b:v ${config.videoBitrate} -preset ${config.preset} -c:a ${config.audioCodec} -b:a ${config.audioBitrate} -movflags +faststart -y "${outputPath}"`;
+  }
+
+  await execPromise(command);
+}
+
+/**
+ * Convert video using fluent-ffmpeg
+ */
+async function convertWithFluentFFmpeg(inputPath, outputPath, format) {
+  const ffmpeg = require('fluent-ffmpeg');
+
+  // Try to use bundled ffmpeg
+  try {
+    const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path;
+    ffmpeg.setFfmpegPath(ffmpegPath);
+    console.log('   Using bundled ffmpeg:', ffmpegPath);
+  } catch (err) {
+    console.log('   Using system ffmpeg');
+  }
+
+  const config = CONFIG[format];
+
+  return new Promise((resolve, reject) => {
+    let command = ffmpeg(inputPath);
+
+    if (format === 'webm') {
+      command
+        .videoCodec(config.codec)
+        .videoBitrate(config.videoBitrate)
+        .audioCodec(config.audioCodec)
+        .audioBitrate(config.audioBitrate);
+    } else if (format === 'mp4') {
+      command
+        .videoCodec(config.codec)
+        .videoBitrate(config.videoBitrate)
+        .audioCodec(config.audioCodec)
+        .audioBitrate(config.audioBitrate)
+        .addOption('-preset', config.preset)
+        .addOption('-movflags', '+faststart'); // Enable streaming
+    }
+
+    command
+      .on('start', (cmd) => {
+        if (CONFIG.verbose) {
+          console.log('   Command:', cmd);
+        }
+      })
+      .on('progress', (progress) => {
+        if (CONFIG.verbose && progress.percent) {
+          process.stdout.write(`\r   Progress: ${Math.floor(progress.percent)}%`);
+        }
+      })
+      .on('end', () => {
+        if (CONFIG.verbose) {
+          process.stdout.write('\r   Progress: 100%\n');
+        }
+        resolve();
+      })
+      .on('error', (err) => {
+        reject(err);
+      })
+      .save(outputPath);
+  });
+}
+
+/**
+ * Convert video to optimized format
+ */
+async function convertVideo(inputPath, format) {
+  const ext = path.extname(inputPath);
+  const basename = path.basename(inputPath, ext);
+  const dirname = path.dirname(inputPath);
+  const outputPath = path.join(dirname, `${basename}-optimized.${format}`);
+
+  // Skip if output already exists
+  if (fs.existsSync(outputPath)) {
+    if (CONFIG.verbose) {
+      console.log(`⏭️  Skipped: ${basename}-optimized.${format} (already exists)`);
+    }
+    stats.skipped++;
+    return null;
+  }
+
+  try {
+    const originalStat = await stat(inputPath);
+    stats.totalOriginalSize += originalStat.size;
+
+    console.log(`\n🎬 Converting: ${path.basename(inputPath)} → ${basename}-optimized.${format}`);
+    console.log(`   Original size: ${formatBytes(originalStat.size)}`);
+    console.log(`   Target format: ${format.toUpperCase()}`);
+    console.log(`   Video bitrate: ${CONFIG[format].videoBitrate}`);
+
+    const startTime = Date.now();
+
+    // Convert using available method
+    if (useFluentFFmpeg) {
+      await convertWithFluentFFmpeg(inputPath, outputPath, format);
+    } else {
+      await convertWithNativeFFmpeg(inputPath, outputPath, format);
+    }
+
+    const compressedStat = await stat(outputPath);
+    stats.totalCompressedSize += compressedStat.size;
+
+    const reduction = ((1 - compressedStat.size / originalStat.size) * 100).toFixed(1);
+    const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+
+    console.log(`✅ ${basename}-optimized.${format} created`);
+    console.log(`   Compressed size: ${formatBytes(compressedStat.size)}`);
+    console.log(`   Reduction: ${reduction}% (${formatBytes(originalStat.size - compressedStat.size)} saved)`);
+    console.log(`   Duration: ${duration}s`);
+
+    stats.processed++;
+
+    return {
+      original: inputPath,
+      compressed: outputPath,
+      format: format,
+      originalSize: originalStat.size,
+      compressedSize: compressedStat.size,
+      reduction
+    };
+
+  } catch (err) {
+    console.error(`❌ Error converting ${inputPath} to ${format}:`, err.message);
+    stats.errors++;
+    return null;
+  }
+}
+
+/**
+ * Update HTML files to use optimized videos
+ */
+async function updateHTMLReferences(conversions) {
+  console.log('\n📝 Updating HTML file references...');
+
+  const htmlFiles = [
+    'index.html',
+    'faq.html',
+    'privacy.html',
+    'terms.html',
+    'refund.html',
+    'manage-subscription.html',
+    'roadmap.html'
+  ];
+
+  let totalReplacements = 0;
+
+  for (const htmlFile of htmlFiles) {
+    const filepath = path.join('/home/user/signalpilot.io', htmlFile);
+
+    if (!fs.existsSync(filepath)) continue;
+
+    let content = await readFile(filepath, 'utf8');
+    let replacements = 0;
+
+    // Group conversions by original file
+    const conversionsByOriginal = {};
+    for (const conversion of conversions) {
+      if (!conversion) continue;
+
+      if (!conversionsByOriginal[conversion.original]) {
+        conversionsByOriginal[conversion.original] = [];
+      }
+      conversionsByOriginal[conversion.original].push(conversion);
+    }
+
+    // Update HTML with <video> tag supporting multiple sources
+    for (const [originalPath, formats] of Object.entries(conversionsByOriginal)) {
+      const originalRelative = path.relative('/home/user/signalpilot.io', originalPath);
+
+      // Build source tags for different formats
+      const webmFile = formats.find(f => f.format === 'webm');
+      const mp4File = formats.find(f => f.format === 'mp4');
+
+      // Replace simple src attributes with multi-source <video> tag
+      const srcRegex = new RegExp(`<video[^>]*src=["']/?${originalRelative}["'][^>]*>`, 'g');
+      const matches = content.match(srcRegex);
+
+      if (matches) {
+        for (const match of matches) {
+          // Extract attributes from original video tag
+          const autoplayMatch = match.match(/autoplay/);
+          const loopMatch = match.match(/loop/);
+          const mutedMatch = match.match(/muted/);
+          const playsinlineMatch = match.match(/playsinline/);
+          const controlsMatch = match.match(/controls/);
+          const posterMatch = match.match(/poster=["']([^"']+)["']/);
+
+          const webmRelative = webmFile ? path.relative('/home/user/signalpilot.io', webmFile.compressed) : null;
+          const mp4Relative = mp4File ? path.relative('/home/user/signalpilot.io', mp4File.compressed) : null;
+
+          let newVideoTag = '<video';
+          if (autoplayMatch) newVideoTag += ' autoplay';
+          if (loopMatch) newVideoTag += ' loop';
+          if (mutedMatch) newVideoTag += ' muted';
+          if (playsinlineMatch) newVideoTag += ' playsinline';
+          if (controlsMatch) newVideoTag += ' controls';
+          if (posterMatch) newVideoTag += ` poster="${posterMatch[1]}"`;
+          newVideoTag += '>\n';
+
+          // Add WebM source first (smaller, better compression)
+          if (webmRelative) {
+            newVideoTag += `  <source src="/${webmRelative}" type="video/webm">\n`;
+          }
+
+          // Add MP4 source as fallback
+          if (mp4Relative) {
+            newVideoTag += `  <source src="/${mp4Relative}" type="video/mp4">\n`;
+          }
+
+          newVideoTag += '  Your browser does not support the video tag.\n</video>';
+
+          content = content.replace(match, newVideoTag);
+          replacements++;
+        }
+      }
+    }
+
+    if (replacements > 0) {
+      // Create backup
+      if (CONFIG.createBackup) {
+        await writeFile(`${filepath}.backup`, await readFile(filepath));
+      }
+
+      await writeFile(filepath, content);
+      console.log(`✅ ${htmlFile}: ${replacements} video references updated`);
+      totalReplacements += replacements;
+    }
+  }
+
+  console.log(`\n📊 Total: ${totalReplacements} video references updated across ${htmlFiles.length} files`);
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  console.log('🎬 Signal Pilot Video Converter\n');
+
+  // Check ffmpeg availability
+  const hasFFmpeg = await checkFFmpeg();
+  if (!hasFFmpeg) {
+    process.exit(1);
+  }
+
+  console.log('\nConfiguration:');
+  console.log(`  Output formats: ${CONFIG.outputFormats.join(', ')}`);
+  console.log(`  Video bitrate: ${CONFIG.webm.videoBitrate} (WebM), ${CONFIG.mp4.videoBitrate} (MP4)`);
+  console.log(`  Audio bitrate: ${CONFIG.webm.audioBitrate}`);
+  console.log('');
+
+  // Find all videos
+  console.log('🔍 Finding videos...');
+  const videoDir = '/home/user/signalpilot.io/assets/videos';
+
+  if (!fs.existsSync(videoDir)) {
+    console.error('❌ Videos directory not found:', videoDir);
+    process.exit(1);
+  }
+
+  const videos = await findVideos(videoDir);
+  console.log(`📂 Found ${videos.length} video(s)\n`);
+
+  if (videos.length === 0) {
+    console.log('No videos to convert.');
+    return;
+  }
+
+  // Convert all videos to both formats
+  const conversions = [];
+
+  for (const videoPath of videos) {
+    for (const format of CONFIG.outputFormats) {
+      const result = await convertVideo(videoPath, format);
+      if (result) {
+        conversions.push(result);
+      }
+    }
+  }
+
+  // Print statistics
+  console.log('\n' + '='.repeat(60));
+  console.log('📊 CONVERSION SUMMARY');
+  console.log('='.repeat(60));
+  console.log(`✅ Processed: ${stats.processed} video(s)`);
+  console.log(`⏭️  Skipped: ${stats.skipped} video(s)`);
+  console.log(`❌ Errors: ${stats.errors} video(s)`);
+  console.log('');
+  console.log(`📦 Original size: ${formatBytes(stats.totalOriginalSize)}`);
+  console.log(`📦 Compressed size: ${formatBytes(stats.totalCompressedSize)}`);
+
+  if (stats.totalOriginalSize > 0) {
+    const totalReduction = ((1 - stats.totalCompressedSize / stats.totalOriginalSize) * 100).toFixed(1);
+    const savedBytes = stats.totalOriginalSize - stats.totalCompressedSize;
+    console.log(`💾 Saved: ${formatBytes(savedBytes)} (${totalReduction}% reduction)`);
+  }
+  console.log('='.repeat(60));
+
+  // Update HTML references
+  if (conversions.length > 0) {
+    await updateHTMLReferences(conversions);
+  }
+
+  console.log('\n✨ Done! All videos converted.');
+  console.log('\n💡 Next steps:');
+  console.log('   1. Test videos on your site (check both WebM and MP4 play)');
+  console.log('   2. WebM plays first (better compression), MP4 is fallback');
+  console.log('   3. If everything works, delete original large video files');
+  console.log('   4. Commit: git add . && git commit -m "Compress videos for web"');
+}
+
+// Run the script
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@ffmpeg-installer/ffmpeg": "^1.1.0",
+        "fluent-ffmpeg": "^2.1.3",
         "sharp": "^0.34.4"
       }
     },
@@ -18,6 +20,141 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@ffmpeg-installer/darwin-arm64": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-arm64/-/darwin-arm64-4.1.5.tgz",
+      "integrity": "sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/HEAD:/LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/darwin-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-x64/-/darwin-x64-4.1.0.tgz",
+      "integrity": "sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "LGPL-2.1",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/ffmpeg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.1.0.tgz",
+      "integrity": "sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==",
+      "dev": true,
+      "license": "LGPL-2.1",
+      "optionalDependencies": {
+        "@ffmpeg-installer/darwin-arm64": "4.1.5",
+        "@ffmpeg-installer/darwin-x64": "4.1.0",
+        "@ffmpeg-installer/linux-arm": "4.1.3",
+        "@ffmpeg-installer/linux-arm64": "4.1.4",
+        "@ffmpeg-installer/linux-ia32": "4.1.0",
+        "@ffmpeg-installer/linux-x64": "4.1.0",
+        "@ffmpeg-installer/win32-ia32": "4.1.0",
+        "@ffmpeg-installer/win32-x64": "4.1.0"
+      }
+    },
+    "node_modules/@ffmpeg-installer/linux-arm": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm/-/linux-arm-4.1.3.tgz",
+      "integrity": "sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPLv3",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-arm64": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm64/-/linux-arm64-4.1.4.tgz",
+      "integrity": "sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPLv3",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-ia32": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-ia32/-/linux-ia32-4.1.0.tgz",
+      "integrity": "sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPLv3",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-x64/-/linux-x64-4.1.0.tgz",
+      "integrity": "sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPLv3",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/win32-ia32": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-ia32/-/win32-ia32-4.1.0.tgz",
+      "integrity": "sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "GPLv3",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/win32-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz",
+      "integrity": "sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "GPLv3",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
@@ -469,6 +606,12 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -478,6 +621,28 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/fluent-ffmpeg": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
+      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^0.2.9",
+        "which": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -542,6 +707,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "devDependencies": {
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "fluent-ffmpeg": "^2.1.3",
     "sharp": "^0.34.4"
   }
 }


### PR DESCRIPTION
Created: convert-videos.js
- Converts videos to WebM + MP4 formats
- Multi-format output for browser compatibility
- Automatic HTML reference updates
- Quality settings: 500-1000k bitrate

Testing result:
- Original hero-demo.mp4: 1.59 MB @ 565 kb/s (ALREADY OPTIMAL)
- WebM attempts: 2.0-3.1 MB (larger than original)
- Conclusion: Keep original video as-is

Script preserved for future videos that may need compression. Uses fluent-ffmpeg + bundled ffmpeg binary.