### PR TITLE
Remove directive language from documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2946,11 +2946,11 @@
               <div style="margin-bottom:1.5rem">
                 <p style="font-size:.9rem;color:var(--muted);margin-bottom:.5rem;font-weight:700">🎯 The Five Key Moments Pentarch Spots</p>
                 <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                  <li>• <strong style="color:#00FF7F">🟢 TD (Touchdown):</strong> "The selling might be done" — Price has fallen for a while, sellers are getting tired</li>
-                  <li>• <strong style="color:#00FF7F">🟢 IGN (Ignition):</strong> "Buyers are taking control" — Price is breaking up and buyers are stepping in strong</li>
-                  <li>• <strong style="color:#FFD700">🟡 WRN (Warning):</strong> "Something's not right" — Price is still going up but showing early signs of weakness</li>
-                  <li>• <strong style="color:#FF4560">🔴 CAP (Climax):</strong> "The party might be over" — Price pushed too far too fast, buyers might be exhausted</li>
-                  <li>• <strong style="color:#FF4560">🔴 BDN (Breakdown):</strong> "Sellers are taking control" — Price is breaking down and sellers are stepping in strong</li>
+                  <li>• <strong style="color:#00FF7F">🟢 TD (Touchdown):</strong> "Downward momentum may be exhausting" — Price has fallen for a while, downside pressure is weakening</li>
+                  <li>• <strong style="color:#00FF7F">🟢 IGN (Ignition):</strong> "Upward momentum is building" — Price is breaking up and upward pressure is strengthening</li>
+                  <li>• <strong style="color:#FFD700">🟡 WRN (Warning):</strong> "Something's not right" — Price is still rising but showing early signs of weakness</li>
+                  <li>• <strong style="color:#FF4560">🔴 CAP (Climax):</strong> "Upward momentum may be exhausting" — Price pushed too far too fast, upside pressure is weakening</li>
+                  <li>• <strong style="color:#FF4560">🔴 BDN (Breakdown):</strong> "Downward momentum is building" — Price is breaking down and downward pressure is strengthening</li>
                 </ul>
               </div>
 
@@ -2975,8 +2975,8 @@
               <div style="margin-bottom:1.5rem">
                 <p style="font-size:.9rem;color:var(--muted);margin-bottom:.5rem;font-weight:700">⚡ NanoFlow Crosses (Momentum Check)</p>
                 <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                  <li>• Little <strong>green crosses</strong> = Bullish momentum is healthy</li>
-                  <li>• Little <strong>red crosses</strong> = Bearish momentum is healthy</li>
+                  <li>• Little <strong>green crosses</strong> = Upward momentum is healthy</li>
+                  <li>• Little <strong>red crosses</strong> = Downward momentum is healthy</li>
                   <li>• Lots of crosses = Strong trending move. No crosses = Weakening trend</li>
                 </ul>
               </div>
@@ -3014,12 +3014,12 @@
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Imagine having 10 powerful tools in one place</strong> — instead of cluttering your chart with dozens of indicators, OmniDeck combines the best ones into a single, clean view.</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• <strong>TD Sequential:</strong> Spots when buyers or sellers are getting exhausted (helps you catch reversals)</li>
+                <li>• <strong>TD Sequential:</strong> Spots when upward or downward momentum is getting exhausted (helps you catch reversals)</li>
                 <li>• <strong>Squeeze Cloud:</strong> Shows when price is "coiling up" ready to explode in one direction</li>
                 <li>• <strong>Bull Market Support Band:</strong> Shows the "floor" where price tends to bounce during uptrends</li>
                 <li>• <strong>SuperTrend Ensemble:</strong> Multiple trend confirmations that work together (stronger than one alone)</li>
                 <li>• <strong>Regime System:</strong> Tells you if the market is in "bull mode," "bear mode," or "choppy mode"</li>
-                <li>• <strong>Supply/Demand Zones:</strong> Highlights price levels where big traders (institutions) are buying or selling</li>
+                <li>• <strong>Supply/Demand Zones:</strong> Highlights price levels where big traders (institutions) are accumulating or distributing</li>
                 <li>• <strong>Candlestick Patterns:</strong> Automatically spots classic patterns like hammers, engulfing candles, etc.</li>
                 <li>• <strong>Liquidity Sweeps:</strong> Detects when price "fakes out" to trap traders before reversing</li>
                 <li>• <strong>EMA Events:</strong> Alerts you when important moving averages cross (these are key moments)</li>
@@ -3053,16 +3053,16 @@
             <div class="punch">Tracks institutional accumulation/distribution patterns in real-time.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details" style="margin-top:.5rem">Details ▼</button>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Ever wondered if the "smart money" is buying or selling?</strong> Volume Oracle tracks institutional activity patterns in real-time, showing you what the big players are doing.</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Ever wondered if the "smart money" is accumulating or distributing?</strong> Volume Oracle tracks institutional activity patterns in real-time, showing you what the big players are doing.</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• <strong>ACCUMULATION/DISTRIBUTION:</strong> Shows whether institutions are buying (accumulating) or selling (distributing) based on volume patterns</li>
+                <li>• <strong>ACCUMULATION/DISTRIBUTION:</strong> Shows whether institutions are accumulating (demand building) or distributing (supply increasing) based on volume patterns</li>
                 <li>• <strong>Strength Percentage:</strong> How strong the current pattern is (0-100%) — higher numbers mean stronger conviction</li>
                 <li>• <strong>Duration Tracking:</strong> How long the current accumulation or distribution phase has been running</li>
                 <li>• <strong>⚡ Early Warning Flash:</strong> Alerts when the pattern might be weakening and ready to flip</li>
                 <li>• <strong>Position Calculator:</strong> Built-in calculator that suggests risk levels based on the current regime</li>
               </ul>
-              <p style="font-size:.85rem;margin-top:1rem;color:var(--muted)"><strong>What it means:</strong> When you see "ACCUMULATION 82%", it means the indicator detects strong institutional buying pressure (82% confidence). When the ⚡ warning flashes, the current phase may be losing strength.</p>
-              <p style="font-size:.85rem;margin-top:1rem;color:var(--muted);font-style:italic"><strong>Bottom line:</strong> Volume Oracle helps you see if institutions are buying or selling, which can be useful context for understanding market moves. Think of it as "following the money."</p>
+              <p style="font-size:.85rem;margin-top:1rem;color:var(--muted)"><strong>What it means:</strong> When you see "ACCUMULATION 82%", it means the indicator detects strong institutional demand pressure (82% confidence). When the ⚡ warning flashes, the current phase may be losing strength.</p>
+              <p style="font-size:.85rem;margin-top:1rem;color:var(--muted);font-style:italic"><strong>Bottom line:</strong> Volume Oracle helps you see if institutions are accumulating or distributing, which can be useful context for understanding market moves. Think of it as "following the money."</p>
             </div>
             <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" style="margin-top:.5rem">Docs</a>
           </article>
@@ -3086,19 +3086,19 @@
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
               <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">ACCUMULATION</span>
             </div>
-            <div class="punch">Cumulative delta tracking shows buyer/seller pressure over time.</div>
+            <div class="punch">Cumulative delta tracking shows demand/supply pressure over time.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details" style="margin-top:.5rem">Details ▼</button>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Think of Plutus Flow like a tug-of-war meter</strong> — it keeps score of whether buyers or sellers are winning the battle over time.</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Think of Plutus Flow like a tug-of-war meter</strong> — it keeps score of whether demand or supply pressure is winning the battle over time.</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• <strong>Green Ribbon:</strong> Buyers are winning — cumulative buying pressure is higher than selling pressure</li>
-                <li>• <strong>Red Ribbon:</strong> Sellers are winning — cumulative selling pressure is higher than buying pressure</li>
+                <li>• <strong>Green Ribbon:</strong> Demand is winning — cumulative upward pressure is higher than downward pressure</li>
+                <li>• <strong>Red Ribbon:</strong> Supply is winning — cumulative downward pressure is higher than upward pressure</li>
                 <li>• <strong>Centerline Crosses (dots):</strong> The battle is shifting sides — momentum is changing direction</li>
-                <li>• <strong>White Dots:</strong> Extreme levels reached — the buying or selling pressure is getting very strong</li>
+                <li>• <strong>White Dots:</strong> Extreme levels reached — the demand or supply pressure is getting very strong</li>
                 <li>• <strong>Divergence Marks:</strong> Price and flow disagree — price makes a new high but flow doesn't, which signals hidden weakness</li>
               </ul>
-              <p style="font-size:.85rem;margin-top:1rem;color:var(--muted)"><strong>Why it matters:</strong> Price can make deceptive moves, but volume flow tells a more honest story. When the ribbon turns green and climbs, it shows consistent buying. When price hits a new high but the ribbon stays flat (divergence), it suggests the move lacks real support.</p>
-              <p style="font-size:.85rem;margin-top:1rem;color:var(--muted);font-style:italic"><strong>Bottom line:</strong> Plutus Flow tracks the cumulative balance of buying vs selling pressure. It helps you see if a price move has real volume behind it or if it's just noise.</p>
+              <p style="font-size:.85rem;margin-top:1rem;color:var(--muted)"><strong>Why it matters:</strong> Price can make deceptive moves, but volume flow tells a more honest story. When the ribbon turns green and climbs, it shows consistent demand. When price hits a new high but the ribbon stays flat (divergence), it suggests the move lacks real support.</p>
+              <p style="font-size:.85rem;margin-top:1rem;color:var(--muted);font-style:italic"><strong>Bottom line:</strong> Plutus Flow tracks the cumulative balance of demand vs supply pressure. It helps you see if a price move has real volume behind it or if it's just noise.</p>
             </div>
             <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" style="margin-top:.5rem">Docs</a>
           </article>
@@ -3199,7 +3199,7 @@
             <div class="punch">Four oscillators vote on every bar. Multi-confirmation timing system.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details" style="margin-top:.5rem">Details ▼</button>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Ever had one indicator say "buy" and another say "sell"?</strong> Harmonic Oscillator solves this by combining 4 different momentum indicators and showing you when they all agree.</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Ever had one indicator say "bullish" and another say "bearish"?</strong> Harmonic Oscillator solves this by combining 4 different momentum indicators and showing you when they all agree.</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
                 <li>• <strong>4 Oscillators Vote:</strong> Four different momentum indicators each vote "Bullish," "Bearish," or "Neutral" on every candle</li>
                 <li>• <strong>Live Vote Count:</strong> A table shows the real-time vote breakdown (e.g., "3 Bulls, 1 Neutral")</li>


### PR DESCRIPTION
Replaced all buy/sell language with neutral terminology:
- "buyers/sellers" → "upward/downward momentum" or "demand/supply pressure"
- "buying/selling pressure" → "demand/supply pressure" or "accumulation/distribution"
- Removed "buy and sell" references in favor of "bullish and bearish"

Changes across all 7 indicators (Pentarch, OmniDeck, Volume Oracle, Plutus Flow, Harmonic Oscillator) to make descriptions purely informational and non-directive.