### PR TITLE
Align theme toggle and chatbot buttons, optimize for mobile

### DIFF
--- a/assets/chatbot.css
+++ b/assets/chatbot.css
@@ -534,19 +534,40 @@
    MOBILE RESPONSIVE
    ======================================== */
 
-@media (max-width: 480px) {
+/* Tablet - align with theme toggle */
+@media (max-width: 768px) {
   .sp-chatbot-toggle {
-    width: 56px;
-    height: 56px;
-    bottom: 1.25rem;
-    right: 1.25rem;
+    width: 52px;
+    height: 52px;
+    bottom: 1rem;
+    right: 1rem;
+    position: fixed; /* Ensure sticky on mobile */
   }
 
   .sp-chatbot-toggle svg {
     width: 24px;
     height: 24px;
   }
+}
 
+/* Small mobile screens - make smaller to save space */
+@media (max-width: 480px) {
+  .sp-chatbot-toggle {
+    width: 48px;
+    height: 48px;
+    bottom: 1rem;
+    right: 1rem;
+    position: fixed; /* Ensure sticky on mobile */
+  }
+
+  .sp-chatbot-toggle svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+/* Small mobile screens - adjust chatbot window */
+@media (max-width: 480px) {
   .sp-chatbot-window {
     position: fixed;
     inset: 0;
@@ -587,6 +608,22 @@
 
   .sp-chatbot-input {
     font-size: 16px; /* Prevent iOS zoom on focus */
+  }
+}
+
+/* Ultra-small screens - even smaller buttons */
+@media (max-width: 380px) {
+  .sp-chatbot-toggle {
+    width: 44px;
+    height: 44px;
+    bottom: 1rem;
+    right: 1rem;
+    position: fixed; /* Ensure sticky on mobile */
+  }
+
+  .sp-chatbot-toggle svg {
+    width: 18px;
+    height: 18px;
   }
 }
 

--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -48,44 +48,41 @@
       }
     }
 
-    /* Tablet and Mobile - make prominent like chatbot */
+    /* Tablet - align with chatbot */
     @media (max-width: 768px) {
       .sp-theme-toggle {
-        bottom: max(5.75rem, calc(5.5rem + env(safe-area-inset-bottom)));
-        right: 1.25rem;
-        width: 60px;
-        height: 60px;
-        font-size: 1.5rem;
+        bottom: max(5.5rem, calc(5.25rem + env(safe-area-inset-bottom)));
+        right: 1rem;
+        width: 52px;
+        height: 52px;
+        font-size: 1.4rem;
         box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4), 0 0 16px var(--brand-glow);
-        animation: sp-theme-pulse 3s ease-in-out infinite;
         -webkit-tap-highlight-color: transparent;
-      }
-
-      .sp-theme-toggle:hover,
-      .sp-theme-toggle:active {
-        animation: none;
+        position: fixed; /* Ensure sticky on mobile */
       }
     }
 
-    /* Small mobile screens */
+    /* Small mobile screens - make smaller to save space */
     @media (max-width: 480px) {
       .sp-theme-toggle {
         bottom: max(5.5rem, calc(5.25rem + env(safe-area-inset-bottom)));
-        right: 1.25rem;
-        width: 56px;
-        height: 56px;
-        font-size: 1.4rem;
+        right: 1rem;
+        width: 48px;
+        height: 48px;
+        font-size: 1.2rem;
+        position: fixed; /* Ensure sticky on mobile */
       }
     }
 
-    /* Ultra-small screens */
+    /* Ultra-small screens - even smaller */
     @media (max-width: 380px) {
       .sp-theme-toggle {
         bottom: max(5.25rem, calc(5rem + env(safe-area-inset-bottom)));
         right: 1rem;
-        width: 52px;
-        height: 52px;
-        font-size: 1.3rem;
+        width: 44px;
+        height: 44px;
+        font-size: 1.1rem;
+        position: fixed; /* Ensure sticky on mobile */
       }
     }
 


### PR DESCRIPTION
Changes:
- Aligned theme toggle and chatbot buttons vertically (same right position)
- Made buttons smaller on mobile to save space:
  * Tablet (768px): 52px buttons
  * Mobile (480px): 48px buttons
  * Small (380px): 44px buttons
- Ensured both buttons stay fixed/sticky on mobile (explicit position: fixed)
- Removed pulsing animation from theme toggle for cleaner look
- Standardized positioning across all breakpoints

Both buttons now use consistent sizing and spacing at all screen sizes.