### PR TITLE
Make theme toggle and chatbot buttons same size at all breakpoints

### DIFF
--- a/assets/chatbot.css
+++ b/assets/chatbot.css
@@ -537,16 +537,16 @@
 /* Tablet - align with theme toggle */
 @media (max-width: 768px) {
   .sp-chatbot-toggle {
-    width: 52px;
-    height: 52px;
+    width: 60px;
+    height: 60px;
     bottom: 1rem;
     right: 1rem;
     position: fixed; /* Ensure sticky on mobile */
   }
 
   .sp-chatbot-toggle svg {
-    width: 24px;
-    height: 24px;
+    width: 26px;
+    height: 26px;
   }
 }
 

--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -12,13 +12,13 @@
       position: fixed;
       bottom: 6.5rem;
       right: 2rem;
-      width: 52px;
-      height: 52px;
+      width: 60px;
+      height: 60px;
       border-radius: 50%;
       background: linear-gradient(135deg, var(--brand), var(--accent));
       border: 2px solid rgba(255, 255, 255, 0.2);
       color: white;
-      font-size: 1.4rem;
+      font-size: 1.5rem;
       cursor: pointer;
       z-index: 1001;
       display: flex;
@@ -53,9 +53,9 @@
       .sp-theme-toggle {
         bottom: max(5.5rem, calc(5.25rem + env(safe-area-inset-bottom)));
         right: 1rem;
-        width: 52px;
-        height: 52px;
-        font-size: 1.4rem;
+        width: 60px;
+        height: 60px;
+        font-size: 1.5rem;
         box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4), 0 0 16px var(--brand-glow);
         -webkit-tap-highlight-color: transparent;
         position: fixed; /* Ensure sticky on mobile */


### PR DESCRIPTION
- Desktop: Both 60px (was 52px theme, 60px chatbot)
- Tablet (768px): Both 60px (was 52px both)
- Mobile (480px): Both 48px ✓
- Small (380px): Both 44px ✓

Now perfectly matched across all screen sizes.