### PR TITLE
Match chatbot button style to theme selector button

### DIFF
--- a/assets/chatbot.css
+++ b/assets/chatbot.css
@@ -15,10 +15,10 @@
   width: 60px;
   height: 60px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  border: none;
+  background: rgba(255,255,255,.06);
+  border: 1px solid rgba(255,255,255,.14);
   cursor: pointer;
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+  box-shadow: 0 4px 12px rgba(0,0,0,.3);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -28,7 +28,8 @@
 
 .sp-chatbot-toggle:hover {
   transform: scale(1.1);
-  box-shadow: 0 6px 20px rgba(102, 126, 234, 0.6);
+  background: rgba(255,255,255,.1);
+  box-shadow: 0 6px 20px rgba(0,0,0,.4);
 }
 
 .sp-chatbot-toggle:active {
@@ -38,7 +39,23 @@
 .sp-chatbot-toggle svg {
   width: 28px;
   height: 28px;
-  fill: white;
+  fill: #9fdcff;
+}
+
+/* Light mode support */
+html[data-theme="light"] .sp-chatbot-toggle {
+  background: #f6f8fc;
+  border-color: #d7def0;
+  box-shadow: 0 4px 12px rgba(0,0,0,.1);
+}
+
+html[data-theme="light"] .sp-chatbot-toggle:hover {
+  background: #eef1f9;
+  box-shadow: 0 6px 20px rgba(0,0,0,.15);
+}
+
+html[data-theme="light"] .sp-chatbot-toggle svg {
+  fill: #0f1524;
 }
 
 /* ========================================


### PR DESCRIPTION
Changes:
- Updated chatbot toggle button to use same ghost button style
- Dark mode: Semi-transparent background with subtle border
- Light mode: Light gray-blue background matching theme toggle
- Icon color matches theme toggle in both modes (#9fdcff dark, #0f1524 light)
- Removed purple gradient for consistency with header buttons