### PR TITLE
Revert theme toggle sticky on mobile - was breaking page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1097,24 +1097,7 @@
 
     /* Make theme and language buttons smaller on mobile */
     @media (max-width:768px){
-      /* Make theme toggle sticky/fixed on mobile */
-      #themeToggle {
-        position: fixed !important;
-        bottom: 2rem !important;
-        left: 2rem !important;
-        width: 48px !important;
-        height: 48px !important;
-        border-radius: 50% !important;
-        padding: 0 !important;
-        font-size: 1.3rem !important;
-        min-width: 48px !important;
-        display: flex !important;
-        align-items: center !important;
-        justify-content: center !important;
-        z-index: 10000 !important;
-        box-shadow: 0 4px 12px rgba(0,0,0,.3) !important;
-      }
-
+      #themeToggle,
       #langToggle{padding:.25rem .4rem !important;font-size:0.95rem !important;min-width:36px}
 
       /* Fix language dropdown menu on mobile */


### PR DESCRIPTION
The position:fixed on theme toggle was causing critical issues:
- Page not loading past lifetime purchase card
- Content turning black when scrolling
- Page unable to reload

Reverted to keep theme toggle in header on mobile (not sticky). Only chatbot button remains sticky/fixed.

This fixes the broken page rendering.