### PR TITLE
EMERGENCY FIX: Force all content visible on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,6 +493,20 @@
       transition:background-color 0.3s ease, color 0.3s ease;
     }
 
+    /* Emergency mobile fix: Ensure all sections are visible */
+    @media (max-width: 768px) {
+      section, main, .container, .card, article {
+        opacity: 1 !important;
+        visibility: visible !important;
+        display: block !important;
+      }
+
+      .section {
+        opacity: 1 !important;
+        visibility: visible !important;
+      }
+    }
+
     img, video, iframe{
       max-width:100%;
       height:auto;
@@ -5820,15 +5834,19 @@ if ('serviceWorker' in navigator) {
 (function() {
   'use strict';
 
-  const isMobile = window.innerWidth <= 768;
+  const isMobile = window.innerWidth <= 768 || window.innerHeight <= 768 || 'ontouchstart' in window;
   const lazyLoadSections = ['why', 'inside', 'pricing', 'faq'];
 
   // On mobile: Load all sections immediately, no lazy loading
+  // EMERGENCY FIX: Force all sections visible on mobile
   if (isMobile) {
     lazyLoadSections.forEach(id => {
       const section = document.getElementById(id);
       if (section) {
         section.classList.add('loaded');
+        section.style.opacity = '1';
+        section.style.visibility = 'visible';
+        section.style.display = 'block';
       }
     });
     return;


### PR DESCRIPTION
Critical issue: Users reporting site not loading past lifetime card and content turning black on mobile.

Fixes:
- Add !important CSS rules to force all sections visible on mobile
- Improve mobile detection (width OR height OR touch)
- Force explicit opacity, visibility, display on lazy sections
- Prevent any CSS from hiding content on mobile
- Defensive styles to ensure content always renders

This ensures mobile users can read the entire site.