### PR TITLE
Remove display:block forcing that broke layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,20 +493,6 @@
       transition:background-color 0.3s ease, color 0.3s ease;
     }
 
-    /* Emergency mobile fix: Ensure all sections are visible */
-    @media (max-width: 768px) {
-      section, main, .container, .card, article {
-        opacity: 1 !important;
-        visibility: visible !important;
-        display: block !important;
-      }
-
-      .section {
-        opacity: 1 !important;
-        visibility: visible !important;
-      }
-    }
-
     img, video, iframe{
       max-width:100%;
       height:auto;
@@ -5849,7 +5835,6 @@ if ('serviceWorker' in navigator) {
         // Force visibility with inline styles (highest priority)
         section.style.opacity = '1';
         section.style.visibility = 'visible';
-        section.style.display = 'block';
         section.style.transform = 'none';
         section.style.transition = 'none';
       }
@@ -5895,7 +5880,6 @@ window.addEventListener('load', function() {
         section.classList.remove('lazy-section');
         section.style.opacity = '1';
         section.style.visibility = 'visible';
-        section.style.display = 'block';
         section.style.transform = 'none';
       }
     });


### PR DESCRIPTION
Removed all display:block !important CSS and JS that was breaking flexbox/grid layouts. Now only forcing opacity/visibility/transform while preserving natural display properties.