### PR TITLE
Remove accessibility skip link from header

### DIFF
--- a/assets/deferred.css
+++ b/assets/deferred.css
@@ -435,24 +435,6 @@
 
     .sr-only{position:absolute!important;width:1px;height:1px;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;padding:0}
 
-    /* Skip to Content Link */
-    .skip-to-content{
-      position:absolute;
-      top:-40px;
-      left:0;
-      background:var(--brand);
-      color:#fff;
-      padding:0.75rem 1.5rem;
-      text-decoration:none;
-      font-weight:700;
-      border-radius:0 0 8px 0;
-      z-index:10000;
-      transition:top 0.3s;
-    }
-    .skip-to-content:focus{
-      top:0;
-    }
-
     /* Lazy Section Loading - Desktop only, disabled on mobile for flawless performance */
     @media (min-width:769px){
       .lazy-section{

--- a/index.html
+++ b/index.html
@@ -1848,9 +1848,6 @@
 
 <body>
 
-<!-- Skip to Content Link (Accessibility) -->
-<a href="#main-content" class="skip-to-content">Skip to main content</a>
-
 <!-- CRITICAL: Force elements visible on mobile IMMEDIATELY -->
 <script>
 (function(){


### PR DESCRIPTION
Removed the blue "Skip to main content" accessibility link and its CSS styling as it appeared unprofessional at the top of the page.