### PR TITLE
Fix cookie preferences modal z-index layering

### DIFF
--- a/assets/cookie-consent.css
+++ b/assets/cookie-consent.css
@@ -167,7 +167,7 @@
   bottom: 0;
   background: rgba(0, 0, 0, 0.8);
   backdrop-filter: blur(4px);
-  z-index: 10000;
+  z-index: 10002; /* Above banner (10001) and buttons (10000-10001) */
   display: none;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Increased modal z-index from 10000 to 10002 to ensure it appears above the cookie banner (10001 on mobile) and sticky buttons (10000-10001).

This prevents the banner from showing through the modal overlay when user clicks "Settings" to customize cookie preferences.

Z-index stack is now:
- Cookie banner desktop: 9999
- Chatbot/theme toggles: 10000
- Cookie banner mobile: 10001
- Chatbot window: 10001
- Cookie preferences modal: 10002 (highest)