### PR TITLE
Optimize Performance Further

### DIFF
--- a/index.html
+++ b/index.html
@@ -1892,9 +1892,9 @@
       .sp-chatbot-window,
       [id*="modal"],
       [class*="modal"] {
-        opacity: unset !important;
-        visibility: unset !important;
-        display: unset !important;
+        /* Allow JS to control display, only reset opacity/visibility if needed */
+        animation: none !important;
+        transition: none !important;
       }
 
       /* Override any lazy loading or reveal classes */
@@ -1942,9 +1942,9 @@
       .sp-chatbot-window,
       [id*="modal"],
       [class*="modal"] {
-        opacity: unset !important;
-        visibility: unset !important;
-        display: unset !important;
+        /* Allow JS to control display, only reset opacity/visibility if needed */
+        animation: none !important;
+        transition: none !important;
       }
       .reveal, .lazy-section, [class*="fade"], [class*="slide"] {
         opacity: 1 !important;


### PR DESCRIPTION
The mobile emergency override was using 'display: unset !important' which prevented JavaScript from showing the cookie preferences modal when users clicked the Settings button. This left users stuck unable to save preferences.

Changed to only disable animations/transitions for modals, allowing JS to properly control display property.

Fixes: Cookie modal not appearing when Settings button is clicked