### PR TITLE
CRITICAL MOBILE FIXES: Chatbot UX and page rendering

### DIFF
--- a/assets/chatbot.css
+++ b/assets/chatbot.css
@@ -604,14 +604,14 @@ html[data-theme="light"] .sp-chatbot-toggle svg {
 @media (max-width: 480px) {
   .sp-chatbot-window {
     position: fixed;
-    inset: 0;
     bottom: 0;
     right: 0;
+    left: 0;
     width: 100%;
-    height: 100%;
+    height: 85vh; /* Don't take full screen - leave room for top */
     max-width: none;
-    max-height: none;
-    border-radius: 0;
+    max-height: 85vh;
+    border-radius: 16px 16px 0 0; /* Rounded top corners only */
   }
 
   .sp-chatbot-header {

--- a/assets/chatbot.js
+++ b/assets/chatbot.js
@@ -609,7 +609,10 @@ Email: support@signalpilot.io`;
         if (messages.children.length === 0) {
           addMessage(knowledgeBase.greetings[0]);
         }
-        document.getElementById('sp-chatbot-input').focus();
+        // Only auto-focus on desktop to avoid triggering mobile keyboard
+        if (window.innerWidth > 768) {
+          document.getElementById('sp-chatbot-input').focus();
+        }
       }
     });
 

--- a/index.html
+++ b/index.html
@@ -1909,9 +1909,10 @@
         z-index: 0 !important;
       }
 
-      header, main, section, footer {
-        position: relative !important;
-        z-index: 1 !important;
+      /* Don't force positioning on all sections - causes layout issues */
+      header {
+        position: relative;
+        z-index: 100;
       }
     }
   </style>


### PR DESCRIPTION
Fixed three critical mobile issues reported by users:

1. CHATBOT FULLSCREEN ISSUE (chatbot.css)
   - Changed from 100vh to 85vh height on mobile
   - Added bottom-sheet style (rounded top corners)
   - Prevents chatbot from covering entire screen
   - Before: inset: 0, height: 100%
   - After: height: 85vh, border-radius: 16px 16px 0 0

2. KEYBOARD AUTO-POPUP (chatbot.js:612)
   - Input auto-focused on desktop only (> 768px)
   - Prevents mobile keyboard from appearing on chatbot open
   - More professional UX - user controls when to type

3. PAGE RENDERING ISSUE (index.html:1912-1916)
   - Removed forced z-index/position on all sections
   - Was causing content below pricing to be hidden
   - Only apply positioning to header, not all sections
   - Fixes: Content below pricing card now visible

All fixes tested for mobile breakpoints: 480px, 768px