### PR TITLE
Fix mobile header navigation UX issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -1237,7 +1237,22 @@
 
     @media (max-width:1400px){
       /* Ensure header buttons have adequate space */
-      .nav{padding:.7rem 0}
+      .nav{
+        padding:.7rem 0;
+        gap:.5rem; /* Better spacing between header buttons */
+      }
+
+      /* Better mobile header button sizing */
+      .lang-dropdown,
+      #themeToggle {
+        flex-shrink: 0;
+      }
+
+      #themeToggle,
+      #langToggle {
+        min-width: 44px; /* iOS minimum tap target */
+        min-height: 44px;
+      }
 
       .menu-toggle{
         display:inline-flex;
@@ -1278,6 +1293,8 @@
         transition: transform 0.3s ease;
         overflow-y: auto;
         box-shadow: -8px 0 32px rgba(0, 0, 0, 0.8);
+        /* Add safe area for notched phones */
+        padding-top: env(safe-area-inset-top);
       }
       .mobile-nav.active {
         transform: translateX(0);
@@ -1286,19 +1303,34 @@
       /* Menu content styling */
       .mobile-nav-header {
         padding: 1.5rem 1.25rem;
+        padding-top: max(1.5rem, calc(1rem + env(safe-area-inset-top)));
         border-bottom: 1px solid rgba(255, 255, 255, 0.1);
         display: flex;
         align-items: center;
         justify-content: space-between;
+        min-height: 60px; /* Ensure enough space for close button */
       }
 
       .mobile-nav-close {
-        background: none;
+        background: rgba(255, 255, 255, 0.1);
         border: none;
         color: #fff;
-        font-size: 1.5rem;
+        font-size: 2rem;
         cursor: pointer;
-        padding: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        line-height: 1;
+        border-radius: 8px;
+        min-width: 44px; /* iOS minimum tap target */
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background 0.2s ease;
+      }
+
+      .mobile-nav-close:hover,
+      .mobile-nav-close:active {
+        background: rgba(255, 255, 255, 0.2);
       }
 
       .mobile-nav-links {
@@ -4721,8 +4753,17 @@
         document.body.style.overflow = '';
       }
 
+      function toggle() {
+        const isOpen = mobileNav.classList.contains('active');
+        if (isOpen) {
+          close();
+        } else {
+          open();
+        }
+      }
+
       // Event listeners
-      menuBtn.addEventListener('click', open);
+      menuBtn.addEventListener('click', toggle); // Changed from open to toggle
       closeBtn.addEventListener('click', close);
       backdrop.addEventListener('click', close);
 


### PR DESCRIPTION
Fixed three critical mobile header/menu issues:

1. MOBILE MENU POSITIONING (lines 1289-1319)
   - Added safe-area-inset-top for notched phones
   - Increased header min-height to 60px
   - Made close button much larger (2rem font, 44x44px tap target)
   - Added visible background to close button for better visibility
   - Now "MENU" text is clearly visible and X is easy to tap

2. MENU TOGGLE FUNCTIONALITY (lines 4741-4751)
   - Changed menu button from open-only to toggle behavior
   - Now clicking menu button opens AND closes the menu
   - No longer need to reach for X button to close
   - Better UX: tap menu button again to close

3. HEADER BUTTON LAYOUT (lines 1240-1255)
   - Increased gap between header buttons (.5rem)
   - Added minimum tap targets (44x44px) for language/theme buttons
   - Prevented buttons from shrinking (flex-shrink: 0)
   - Better spacing prevents overlapping on small screens

All changes follow iOS Human Interface Guidelines for tap targets and safe areas. Tested for mobile viewports <= 1400px.