### PR TITLE
TEST BUILD: Temporarily disable cookie banner to diagnose mobile scro…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1800,9 +1800,9 @@
   <link rel="stylesheet" href="/assets/performance.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/performance.css"></noscript>
 
-  <!-- Cookie Consent (async) -->
-  <link rel="stylesheet" href="/assets/cookie-consent.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/cookie-consent.css"></noscript>
+  <!--TEMPORARY TEST: Cookie Consent disabled for mobile scroll debugging -->
+  <!--<link rel="stylesheet" href="/assets/cookie-consent.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/cookie-consent.css"></noscript>-->
 
   <!-- AI Chatbot (async) -->
   <link rel="stylesheet" href="/assets/chatbot.css" media="print" onload="this.media='all'">
@@ -4441,7 +4441,8 @@
 
             <li style="margin-bottom:.5rem"><a href="manage-subscription.html" style="color:var(--muted);text-decoration:none;font-size:.9rem">Manage Subscription</a></li>
 
-            <li style="margin-bottom:.5rem"><a href="#" onclick="manageCookiePreferences();return false;" style="color:var(--muted);text-decoration:none;font-size:.9rem">Manage Cookies</a></li>
+            <!-- TEMPORARY TEST: Cookie preferences link disabled -->
+            <!--<li style="margin-bottom:.5rem"><a href="#" onclick="manageCookiePreferences();return false;" style="color:var(--muted);text-decoration:none;font-size:.9rem">Manage Cookies</a></li>-->
 
           </ul>
 
@@ -5916,8 +5917,8 @@ if ('serviceWorker' in navigator) {
 })();
 </script>
 
-<!-- Cookie Consent System -->
-<script src="/assets/cookie-consent.js"></script>
+<!-- TEMPORARY TEST: Cookie Consent System disabled for mobile scroll debugging -->
+<!--<script src="/assets/cookie-consent.js"></script>-->
 
 <!-- AI Chatbot -->
 <script src="/assets/chatbot.js" defer></script>
@@ -5939,8 +5940,8 @@ if ('serviceWorker' in navigator) {
 </script>
 -->
 
-<!-- Cookie Consent Banner -->
-<div id="cookie-consent-banner">
+<!-- TEMPORARY TEST: Cookie Consent Banner disabled for mobile scroll debugging -->
+<!--<div id="cookie-consent-banner">
   <div class="cookie-consent-container">
     <div class="cookie-consent-text">
       <h3>🍪 Cookies</h3>
@@ -6000,7 +6001,8 @@ if ('serviceWorker' in navigator) {
       <button id="cookie-save-preferences" class="cookie-consent-btn cookie-consent-btn-accept">Save Preferences</button>
     </div>
   </div>
-</div>
+</div>-->
+<!-- END TEMPORARY TEST: Cookie banner and modal commented out -->
 
 </body>
 


### PR DESCRIPTION
…ll crash

DIAGNOSTIC TEST - NOT FOR PRODUCTION

This commit temporarily disables:
1. Cookie consent CSS
2. Cookie consent JavaScript
3. Cookie banner HTML
4. "Manage Cookies" footer link

Purpose: Test if Microsoft Clarity or Google Analytics scripts are causing the mobile scroll crash by adding non-passive scroll listeners.

Testing hypothesis:
- If mobile scrolling WORKS with cookie banner disabled → Analytics scripts are the culprit
- If mobile scrolling STILL BREAKS → Issue is elsewhere in the codebase

All changes are clearly marked with "TEMPORARY TEST" comments for easy reversal.

Next steps after testing:
- If analytics scripts are the problem: Wrap them in additional error handling
- If problem persists: Investigate other event listeners/DOM manipulation