### PR TITLE
Debug mobile scroll crash with diagnostic tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -4809,7 +4809,8 @@
         { code: 'id', name: 'Bahasa Indonesia' }
       ];
 
-      languages.forEach(lang => {
+      /* TEMPORARY TEST: Disable Google Translate language dropdown to diagnose mobile scroll crash */
+      /*languages.forEach(lang => {
         const btn = document.createElement('button');
         btn.setAttribute('data-lang', lang.code);
         btn.textContent = lang.name;
@@ -4867,7 +4868,8 @@
           close();
         });
         langMenu.appendChild(btn);
-      });
+      });*/
+      /* END TEMPORARY TEST */
 
       // CRITICAL: Append directly to body (escapes header's stacking context)
       document.body.appendChild(langMenu);
@@ -4993,7 +4995,8 @@
 
       function applyDirLang(lang){ document.documentElement.lang=(lang==='zh')?'zh-CN':lang; document.documentElement.dir=(lang==='ar')?'rtl':'ltr'; }
 
-      window.googleTranslateElementInit=function(){ if(!window.google||!google.translate)return; new google.translate.TranslateElement({pageLanguage:'en',includedLanguages:'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',autoDisplay:false},'google_translate_container'); };
+      /* TEMPORARY TEST: Disable Google Translate initialization to diagnose mobile scroll crash */
+      /*window.googleTranslateElementInit=function(){ if(!window.google||!google.translate)return; new google.translate.TranslateElement({pageLanguage:'en',includedLanguages:'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',autoDisplay:false},'google_translate_container'); };
 
       function loadGTE(){ if(window.__gte_loading || window.google) return; window.__gte_loading=true; const s=document.createElement('script'); s.src='https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit'; s.async=true; document.head.appendChild(s); }
 
@@ -5001,7 +5004,8 @@
 
       sel.value=code; setGoogTrans(code); applyDirLang(code); if(code!=='en') loadGTE();
 
-      sel.addEventListener('change',e=>{ const v=e.target.value; localStorage.setItem(LANG_KEY,v); setGoogTrans(v); applyDirLang(v); if(v!=='en') loadGTE(); location.reload(); });
+      sel.addEventListener('change',e=>{ const v=e.target.value; localStorage.setItem(LANG_KEY,v); setGoogTrans(v); applyDirLang(v); if(v!=='en') loadGTE(); location.reload(); });*/
+      /* END TEMPORARY TEST */
 
     })();
 


### PR DESCRIPTION
DIAGNOSTIC TEST - NOT FOR PRODUCTION

After cookie banner test failed, now testing Google Translate as potential cause. This commit temporarily disables:
1. Google Translate auto-loading on page load
2. Google Translate language dropdown functionality
3. googleTranslateElementInit function
4. loadGTE() function that loads translate script

Google Translate is known to:
- Add non-passive scroll listeners
- Heavily manipulate DOM on scroll
- Inject iframes and wrappers that can break layout
- Cause performance issues on mobile browsers

Testing hypothesis:
- If mobile scrolling WORKS without Google Translate → Google Translate is the culprit
- If mobile scrolling STILL BREAKS → Need to investigate other causes

Previous test results:
- Cookie banner/analytics disabled: STILL BROKEN ❌
- Now testing: Google Translate disabled

All changes clearly marked with "TEMPORARY TEST" for easy reversal.