### PR TITLE
TEST BUILD #3: Disable chatbot to diagnose mobile scroll crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -5924,8 +5924,10 @@ if ('serviceWorker' in navigator) {
 <!-- TEMPORARY TEST: Cookie Consent System disabled for mobile scroll debugging -->
 <!--<script src="/assets/cookie-consent.js"></script>-->
 
+<!-- TEMPORARY TEST: Disable chatbot to diagnose mobile scroll crash -->
 <!-- AI Chatbot -->
-<script src="/assets/chatbot.js" defer></script>
+<!--<script src="/assets/chatbot.js" defer></script>-->
+<!-- END TEMPORARY TEST -->
 
 <!-- Device Optimization System DISABLED - FPS detection was breaking mobile rendering -->
 <!-- TODO: Re-implement without FPS detection that sets data-capability="low" -->


### PR DESCRIPTION
DIAGNOSTIC TEST - NOT FOR PRODUCTION

Previous tests eliminated:
❌ Cookie banner/analytics: STILL BROKEN
❌ Google Translate: STILL BROKEN

Now testing: Chatbot as potential cause

This commit temporarily disables:
- assets/chatbot.js loading

The chatbot is a complex script that:
- Creates dynamic DOM elements (toggle button, window, messages)
- Uses scrollIntoView({ behavior: 'smooth' }) which can conflict with scroll
- Adds multiple event listeners (click, keypress, keydown)
- Manipulates DOM during user interaction
- Has auto-resize textarea functionality

Testing hypothesis:
- If mobile scrolling WORKS without chatbot → chatbot is the culprit
- If mobile scrolling STILL BREAKS → need to investigate particles or other scripts

All changes clearly marked with "TEMPORARY TEST" for easy reversal.