### PR TITLE
TEST BUILD #4: Disable particles system to diagnose mobile scroll crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -5448,11 +5448,13 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
+  // TEMPORARY TEST: Skip particles.js to diagnose mobile scroll crash
   loadScript('assets/device-capability.js', function() {
     loadScript('assets/themes.js', function() {
-      loadScript('assets/particles.js', function() {
+      // Skip particles.js for testing
+      // loadScript('assets/particles.js', function() {
         loadScript('assets/theme-switcher.js');
-      });
+      // });
     });
   });
 })();


### PR DESCRIPTION
DIAGNOSTIC TEST - NOT FOR PRODUCTION

Previous tests eliminated:
❌ Cookie banner/analytics: STILL BROKEN
❌ Google Translate: STILL BROKEN
❌ Chatbot: STILL BROKEN

Now testing: Particles system (assets/particles.js) as potential cause

This commit temporarily disables:
- assets/particles.js loading

The particles system is a heavy script that:
- Creates and manipulates canvas elements
- Uses requestAnimationFrame for continuous rendering
- Performs complex drawing operations (stars, snowflakes, bubbles, etc.)
- Can consume significant GPU/CPU resources on mobile
- Runs constantly in the background

Canvas rendering + requestAnimationFrame loops are known to:
- Crash older mobile browsers
- Conflict with scroll performance
- Cause memory issues on low-end devices

Testing hypothesis:
- If mobile scrolling WORKS without particles → particles system is the culprit
- If mobile scrolling STILL BREAKS → need to investigate CSS or core HTML

All changes clearly marked with "TEMPORARY TEST" for easy reversal.