### PR TITLE
TEST BUILD #5: Disable PayPal button lazy rendering to fix mobile scr…

### DIFF
--- a/index.html
+++ b/index.html
@@ -5230,7 +5230,8 @@
     // ===== PAYPAL LIVE =====
     const PAYPAL_LIVE = true;
 
-    if (PAYPAL_LIVE) {
+    // TEMPORARY TEST: Disable PayPal button lazy rendering to diagnose mobile scroll crash
+    /*if (PAYPAL_LIVE) {
       // MONTHLY = $99 = P-1WW85539FH424981JND52S7A
       lazyRenderSub('P-1WW85539FH424981JND52S7A','paypal-button-container-P-1WW85539FH424981JND52S7A','tv-monthly','monthly','consent-monthly');
 
@@ -5238,9 +5239,10 @@
 
       // YEARLY = $699 = P-1S895034P48824141ND52VBA
       lazyRenderSub('P-1S895034P48824141ND52VBA','paypal-button-container-P-1S895034P48824141ND52VBA','tv-yearly','yearly','consent-yearly');
-      
+
       // Lifetime button - using simple form (no SDK conflict)
-    }
+    }*/
+    // END TEMPORARY TEST
 
 
 


### PR DESCRIPTION
…oll crash

DIAGNOSTIC TEST - LIKELY ROOT CAUSE FOUND!

User reported: "can't go past lifetime pricing card"

Previous tests eliminated:
❌ Cookie banner/analytics: STILL BROKEN
❌ Google Translate: STILL BROKEN
❌ Chatbot: STILL BROKEN
❌ Particles system: STILL BROKEN

Now testing: PayPal button lazy rendering system

ROOT CAUSE ANALYSIS:
The lazyRenderSub() function uses IntersectionObserver to detect when pricing section comes into view (300px rootMargin), then calls renderSub() which does EXTREMELY heavy operations:

1. Loads PayPal SDK and renders button iframes
2. Creates MutationObserver watching ENTIRE subtree for style changes
3. Runs querySelectorAll('*') on ALL elements repeatedly
4. Manipulates styles on every element (forceTransparentBg)
5. Does this with multiple setTimeouts (50ms, 150ms, 500ms, 1000ms)
6. MutationObserver triggers on every style/class change in subtree

This creates a perfect storm on mobile:
- Heavy PayPal iframe injection
- Aggressive DOM manipulation during scroll
- MutationObserver firing constantly
- querySelectorAll('*') killing performance
- All happening right when user scrolls to pricing section

This commit temporarily disables:
- lazyRenderSub() calls for monthly plan
- lazyRenderSub() calls for yearly plan
- (Lifetime uses simple form, not affected)

Testing hypothesis:
- If scrolling WORKS now → PayPal lazy rendering is the culprit (VERY LIKELY)
- If STILL BROKEN → Need to investigate CSS or other inline scripts

All changes clearly marked with "TEMPORARY TEST" for easy reversal.