### PR TITLE
FIX: Uniform pricing card layouts + button alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -822,7 +822,35 @@
 
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
-    .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem}
+    .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
+
+    /* Ensure pricing cards have uniform height */
+    .pricing-grid .card.plan {
+      display:flex;
+      flex-direction:column;
+      height:100%;
+    }
+
+    /* Make actions/buttons stick to bottom */
+    .pricing-grid .card.plan .actions {
+      margin-top:auto;
+    }
+
+    /* Ensure Pay with Card buttons are properly centered */
+    .pricing-grid .btn-secondary {
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+    }
+
+    /* Mobile: Stack pricing cards vertically */
+    @media (max-width:900px){
+      .pricing-grid{
+        grid-template-columns:1fr;
+        max-width:600px;
+        margin:0 auto;
+      }
+    }
 
     .measure{max-width:var(--measure)}
 


### PR DESCRIPTION
PRICING CARD LAYOUT FIXES:

1. EQUAL HEIGHT CARDS (Safari + all browsers):
   - Added display:flex + flex-direction:column to .card.plan
   - Added height:100% to stretch all cards equally
   - Added align-items:stretch to pricing-grid
   - Now all three pricing cards are perfectly aligned with uniform height

2. BUTTONS ALIGNED AT BOTTOM:
   - Added margin-top:auto to .actions div
   - Pushes buttons to bottom of each card
   - Ensures PayPal + Card buttons are always in same row across all cards

3. "PAY WITH CARD" CENTERED:
   - Added display:inline-flex to .btn-secondary
   - Added justify-content:center + align-items:center
   - Buttons now properly centered in their containers

4. MOBILE RESPONSIVE:
   - pricing-grid switches to single column at 900px
   - max-width:600px centers cards on mobile
   - Cards stack vertically on smaller screens

RESULT:
- Safari desktop: Uniform card heights ✅
- All browsers: Buttons aligned in same row ✅
- Pay with Card: Properly centered ✅
- Mobile: Clean single-column layout ✅