### PR TITLE
FIX: Pricing cards perfectly uniform + \"Subscribe\" text restored

### DIFF
--- a/index.html
+++ b/index.html
@@ -822,33 +822,40 @@
 
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
-    .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
+    .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:start}
 
-    /* Ensure pricing cards have uniform height */
+    /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
-      display:flex;
-      flex-direction:column;
+      display:grid;
+      grid-template-rows:auto auto auto auto 1fr auto; /* header | price | desc | badge | list | actions */
       height:100%;
     }
 
-    /* Ensure UL lists take equal space */
+    /* Make badges same height */
+    .pricing-grid .card.plan > div:nth-of-type(1) {
+      min-height:60px;
+      display:flex;
+      flex-direction:column;
+      justify-content:flex-end;
+    }
+
+    /* Make UL lists fill remaining space */
     .pricing-grid .card.plan ul {
-      flex-grow:1;
-      min-height:280px; /* Force consistent list heights */
+      margin:0;
+      padding-left:1.5rem;
     }
 
-    /* Make actions/buttons stick to bottom */
-    .pricing-grid .card.plan .actions {
-      margin-top:auto;
-    }
-
-    /* Fix text overflow in buttons */
+    /* Fix text overflow in buttons - allow wrapping */
     .pricing-grid .btn {
       word-wrap: break-word;
       overflow-wrap: break-word;
       white-space: normal;
       text-align: center;
-      line-height: 1.3;
+      line-height: 1.4;
+      min-height:54px;
+      display:flex;
+      align-items:center;
+      justify-content:center;
     }
 
     /* Fix label text wrapping */
@@ -860,7 +867,7 @@
 
     /* Ensure Pay with Card buttons are properly centered */
     .pricing-grid .btn-secondary {
-      display:inline-flex;
+      display:flex;
       align-items:center;
       justify-content:center;
     }
@@ -873,8 +880,10 @@
         margin:0 auto;
       }
 
-      .pricing-grid .card.plan ul {
-        min-height:auto; /* Remove fixed height on mobile */
+      .pricing-grid .card.plan {
+        display:flex;
+        flex-direction:column;
+        height:auto;
       }
     }
 
@@ -4118,8 +4127,8 @@
               <div id="error-consent-monthly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
 
               <!-- Step 3: Subscribe -->
-              <button type="button" id="btn-monthly-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:1rem;font-weight:700">
-                💳 PayPal - $99/mo
+              <button type="button" id="btn-monthly-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
+                💳 Subscribe with PayPal<br><span style="font-size:.85rem">$99/month</span>
               </button>
 
               <div style="text-align:center;margin-top:1rem">
@@ -4188,8 +4197,8 @@
               <div id="error-consent-yearly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
 
               <!-- Step 3: Subscribe -->
-              <button type="button" id="btn-yearly-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:1rem;font-weight:700">
-                💳 PayPal - $699/yr
+              <button type="button" id="btn-yearly-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
+                💳 Subscribe with PayPal<br><span style="font-size:.85rem">$699/year</span>
               </button>
 
               <div style="text-align:center;margin-top:1rem">
@@ -4258,8 +4267,8 @@
               <div id="error-consent-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
 
               <!-- Step 3: Buy Now -->
-              <button type="button" id="btn-lifetime-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:1rem;font-weight:700">
-                💳 PayPal - $1,799
+              <button type="button" id="btn-lifetime-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
+                💳 Buy Now - PayPal<br><span style="font-size:.85rem">$1,799 one-time</span>
               </button>
               <img src="https://www.paypalobjects.com/images/Debit_Credit.svg" alt="PayPal accepted cards" style="margin:0 auto;height:24px;" loading="lazy" width="120" height="24" />
               <div style="font-size:0.75rem;text-align:center;opacity:0.7;">Powered by PayPal</div>


### PR DESCRIPTION
APOLOGIES! Fixed both issues:

1. PERFECT UNIFORM ALIGNMENT (CSS Grid approach):
   - Changed from flexbox to CSS Grid layout
   - Used grid-template-rows: auto auto auto auto 1fr auto
   - Explicitly defines 6 rows: header | price | desc | badge | list | actions
   - Forces ALL cards to follow exact same structure
   - UL lists use "1fr" to fill remaining space equally
   - Result: All three cards EXACTLY the same height

2. RESTORED "SUBSCRIBE" TEXT:
   - Monthly: "💳 Subscribe with PayPal" + "$99/month"
   - Yearly: "💳 Subscribe with PayPal" + "$699/year"
   - Lifetime: "💳 Buy Now - PayPal" + "$1,799 one-time"
   - Used two-line layout with <br> and smaller price text
   - Main text: font-size .95rem
   - Price: font-size .85rem in span
   - No overflow, text wraps properly

3. BUTTON IMPROVEMENTS:
   - min-height:54px for consistent button heights
   - display:flex + align-items:center for perfect vertical centering
   - Text wraps cleanly on two lines

RESULT:
✅ All cards perfectly aligned (same height)
✅ "Subscribe" text restored as requested
✅ Clean two-line button layout
✅ No text overflow