### PR TITLE
FIX: Uniform pricing card heights + consistent spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -822,13 +822,13 @@
 
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
-    .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:start}
+    .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;
       grid-template-rows:auto auto auto auto 1fr auto; /* header | price | desc | badge | list | actions */
-      height:100%;
+      min-height:1150px; /* Force minimum height to ensure uniform cards */
     }
 
     /* Make badges same height */
@@ -839,10 +839,11 @@
       justify-content:flex-end;
     }
 
-    /* Make UL lists fill remaining space */
+    /* Make UL lists fill remaining space equally */
     .pricing-grid .card.plan ul {
       margin:0;
       padding-left:1.5rem;
+      min-height:200px; /* Ensure consistent spacing */
     }
 
     /* Fix text overflow in buttons - allow wrapping */


### PR DESCRIPTION
- Changed align-items:stretch to force equal card heights
- Added min-height:1150px to ensure uniform card sizing
- Added min-height:200px to UL to maintain consistent gaps
- Fixes spacing inconsistency between UL end and TradingView field