### PR TITLE
FIX: Explicit min-heights for each pricing card section

### DIFF
--- a/index.html
+++ b/index.html
@@ -828,22 +828,35 @@
     .pricing-grid .card.plan {
       display:grid;
       grid-template-rows:auto auto auto auto 1fr auto; /* header | price | desc | badge | list | actions */
-      min-height:1150px; /* Force minimum height to ensure uniform cards */
+      min-height:1200px; /* Force minimum height to ensure uniform cards */
     }
 
-    /* Make badges same height */
-    .pricing-grid .card.plan > div:nth-of-type(1) {
-      min-height:60px;
+    /* Pill - force consistent height */
+    .pricing-grid .card.plan > .pill {
+      min-height:50px;
       display:flex;
-      flex-direction:column;
-      justify-content:flex-end;
+      align-items:center;
+      justify-content:center;
+    }
+
+    /* Price - force consistent height */
+    .pricing-grid .card.plan > .price {
+      min-height:70px;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+
+    /* Paragraph under price - force consistent height (lifetime has 2 lines) */
+    .pricing-grid .card.plan > p {
+      min-height:70px;
     }
 
     /* Make UL lists fill remaining space equally */
-    .pricing-grid .card.plan ul {
+    .pricing-grid .card.plan > ul {
       margin:0;
       padding-left:1.5rem;
-      min-height:200px; /* Ensure consistent spacing */
+      min-height:250px; /* Ensure consistent spacing even with different item counts */
     }
 
     /* Fix text overflow in buttons - allow wrapping */


### PR DESCRIPTION
- Set min-height for pill (50px), price (70px), paragraph (70px)
- Increased UL min-height to 250px for consistent spacing
- Increased overall card min-height to 1200px
- Each section now has explicit height constraints for uniform layout