### PR TITLE
FIX: Remove extra PayPal branding from lifetime card

### DIFF
--- a/index.html
+++ b/index.html
@@ -4284,8 +4284,6 @@
               <button type="button" id="btn-lifetime-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
                 💳 Buy Now - PayPal<br><span style="font-size:.85rem">$1,799 one-time</span>
               </button>
-              <img src="https://www.paypalobjects.com/images/Debit_Credit.svg" alt="PayPal accepted cards" style="margin:0 auto;height:24px;" loading="lazy" width="120" height="24" />
-              <div style="font-size:0.75rem;text-align:center;opacity:0.7;">Powered by PayPal</div>
 
               <div style="text-align:center;margin-top:1rem">
                 <a href="https://signalpilotlabs.lemonsqueezy.com/buy/81822d54-6e08-4c26-b2f0-d5d5e3cdd25e" class="btn btn-secondary" style="width:100%;display:block" target="_blank" rel="noopener">💳 Pay with Card</a>


### PR DESCRIPTION
- Removed PayPal accepted cards image
- Removed 'Powered by PayPal' text
- All three cards now have identical action section structure
- Ensures uniform height and perfect alignment