### PR TITLE
FIX: Remove margin-top from lifetime pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -4245,7 +4245,7 @@
               ⚡ TIER 1: $1,799 → $2,499 in 150 sales
             </div>
 
-            <div class="pill" id="plan-lifetime-title" style="margin-top:1rem">Lifetime Access</div>
+            <div class="pill" id="plan-lifetime-title">Lifetime Access</div>
 
             <div class="price"><span id="lifetime-display-price">$1,799</span> <span class="pill">one‑time</span></div>
 


### PR DESCRIPTION
- Removed margin-top:1rem from lifetime card pill
- Badge now floats like yearly card without pushing content
- Maintains uniform card alignment across all three cards