### PR TITLE
FIX: Normalize lifetime description font-size to .85rem

### DIFF
--- a/index.html
+++ b/index.html
@@ -4249,7 +4249,7 @@
 
             <div class="price"><span id="lifetime-display-price">$1,799</span> <span class="pill">one‑time</span></div>
 
-            <p style="font-size:.9rem;color:var(--muted);margin:.5rem 0 1rem 0;text-align:center">
+            <p style="font-size:.85rem;color:var(--muted);margin:.5rem 0 1rem 0;text-align:center">
               <strong style="color:#fff">One payment, lifetime access</strong><br>
               <span style="font-size:.85rem">≈ $110/month for year 1, then $0/month forever</span>
             </p>


### PR DESCRIPTION
- Changed lifetime card paragraph from .9rem to .85rem
- Matches Monthly and Yearly card font-sizes
- Ensures perfectly consistent paragraph heights across all cards