### PR TITLE
ADD: 7-day free trial signup section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2126,9 +2126,9 @@
           </p>
 
           <!-- Hero CTAs -->
-          <div class="hero-ctas" style="margin-top:2rem;margin-bottom:3rem;justify-content:center">
-            <a href="#pricing" class="btn btn-primary" style="padding:1rem 2rem;font-size:1.05rem">Get Started</a>
-            <a href="#" onclick="document.getElementById('comparison-slider').scrollIntoView({behavior:'smooth',block:'center'});return false;" class="btn btn-ghost" style="padding:1rem 2rem;font-size:1.05rem">Try Interactive Demo</a>
+          <div class="hero-ctas" style="margin-top:2rem;margin-bottom:3rem;justify-content:center;gap:1rem">
+            <a href="#trial" class="btn btn-primary" style="padding:1rem 2rem;font-size:1.05rem">Start 7-Day Free Trial →</a>
+            <a href="#pricing" class="btn btn-ghost" style="padding:1rem 2rem;font-size:1.05rem">Or Buy Now</a>
           </div>
 
         </div>
@@ -2437,6 +2437,136 @@
 
       </div>
 
+    </section>
+
+    <!-- FREE TRIAL SECTION -->
+    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+      <div class="container" style="max-width:800px">
+
+        <div style="text-align:center;margin-bottom:3rem">
+          <div class="badgebar" style="justify-content:center;margin-bottom:1rem">
+            <span class="badge">NO CREDIT CARD REQUIRED</span>
+          </div>
+
+          <h2 class="headline lg" style="margin-bottom:1rem">
+            Try All 7 Indicators Free for 7 Days
+          </h2>
+
+          <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
+            See Pentarch cycle detection in action. Set up your alerts.
+            Test your strategies. <strong style="color:var(--brand)">Zero risk, zero commitment.</strong>
+          </p>
+        </div>
+
+        <!-- Trial Benefits -->
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1.5rem;margin-bottom:3rem">
+
+          <div style="text-align:center">
+            <div style="font-size:2rem;margin-bottom:0.5rem">✅</div>
+            <div style="font-weight:700;color:var(--text);margin-bottom:0.3rem">Full Access</div>
+            <div style="font-size:0.9rem;color:var(--muted)">All 7 indicators unlocked</div>
+          </div>
+
+          <div style="text-align:center">
+            <div style="font-size:2rem;margin-bottom:0.5rem">📚</div>
+            <div style="font-weight:700;color:var(--text);margin-bottom:0.3rem">Free Education</div>
+            <div style="font-size:0.9rem;color:var(--muted)">82 lessons + docs included</div>
+          </div>
+
+          <div style="text-align:center">
+            <div style="font-size:2rem;margin-bottom:0.5rem">💳</div>
+            <div style="font-weight:700;color:var(--text);margin-bottom:0.3rem">No Payment Info</div>
+            <div style="font-size:0.9rem;color:var(--muted)">Just your email address</div>
+          </div>
+
+          <div style="text-align:center">
+            <div style="font-size:2rem;margin-bottom:0.5rem">⏱️</div>
+            <div style="font-weight:700;color:var(--text);margin-bottom:0.3rem">Instant Setup</div>
+            <div style="font-size:0.9rem;color:var(--muted)">TradingView invite in 2 hours</div>
+          </div>
+
+        </div>
+
+        <!-- Trial Signup Form -->
+        <div style="background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(91,138,255,.02));padding:3rem;border-radius:16px;border:1px solid rgba(91,138,255,.2)">
+
+          <form id="trialForm" style="max-width:500px;margin:0 auto">
+
+            <div style="margin-bottom:1.5rem">
+              <label for="trialEmail" style="display:block;font-weight:600;margin-bottom:0.5rem;color:var(--text)">
+                Email Address
+              </label>
+              <input
+                type="email"
+                id="trialEmail"
+                name="email"
+                placeholder="your@email.com"
+                required
+                style="width:100%;padding:1rem;border-radius:8px;border:1px solid var(--border);background:var(--bg-soft);color:var(--text);font-size:1rem;font-family:inherit"
+              >
+            </div>
+
+            <div style="margin-bottom:1.5rem">
+              <label for="trialTvUsername" style="display:block;font-weight:600;margin-bottom:0.5rem;color:var(--text)">
+                TradingView Username
+              </label>
+              <input
+                type="text"
+                id="trialTvUsername"
+                name="tradingview_username"
+                placeholder="Your TradingView username"
+                required
+                style="width:100%;padding:1rem;border-radius:8px;border:1px solid var(--border);background:var(--bg-soft);color:var(--text);font-size:1rem;font-family:inherit"
+              >
+              <p style="font-size:0.85rem;color:var(--muted-2);margin-top:0.5rem">
+                We'll send your indicator invite to this TradingView account
+              </p>
+            </div>
+
+            <label style="display:flex;align-items:start;gap:0.75rem;margin-bottom:1.5rem;cursor:pointer">
+              <input type="checkbox" id="trialConsent" required style="margin-top:0.25rem;cursor:pointer">
+              <span style="font-size:0.9rem;color:var(--muted)">
+                I understand <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is educational only. No financial advice.
+                <a href="/terms.html" style="color:var(--brand)">Terms</a>
+              </span>
+            </label>
+
+            <button
+              type="submit"
+              class="btn btn-primary"
+              style="width:100%;padding:1.25rem;font-size:1.1rem;font-weight:700"
+            >
+              Start My Free Trial →
+            </button>
+
+            <p style="text-align:center;font-size:0.85rem;color:var(--muted-2);margin-top:1rem">
+              No credit card required. Cancel anytime during trial with zero charges.
+            </p>
+
+          </form>
+
+          <!-- Success Message (hidden by default) -->
+          <div id="trialSuccess" style="display:none;text-align:center;padding:2rem">
+            <div style="font-size:3rem;margin-bottom:1rem">🎉</div>
+            <h3 style="font-size:1.5rem;font-weight:700;color:var(--brand);margin-bottom:1rem">Trial Activated!</h3>
+            <p style="color:var(--text);margin-bottom:0.5rem">
+              Check your email for confirmation and next steps.
+            </p>
+            <p style="color:var(--muted);font-size:0.9rem">
+              Your TradingView invite will arrive within 2 hours.
+            </p>
+          </div>
+
+        </div>
+
+        <!-- Social Proof -->
+        <div style="text-align:center;margin-top:2rem">
+          <p style="font-size:0.9rem;color:var(--muted-2)">
+            After 7 days: $99/month or cancel for free
+          </p>
+        </div>
+
+      </div>
     </section>
 
     <!-- PENTARCH IN ACTION - PROOF GALLERY -->
@@ -6207,6 +6337,68 @@ if ('serviceWorker' in navigator) {
     </div>
   </div>
 </div>
+
+<!-- Trial Form Handler -->
+<script>
+(function() {
+  'use strict';
+
+  const trialForm = document.getElementById('trialForm');
+  const trialSuccess = document.getElementById('trialSuccess');
+
+  if (trialForm) {
+    trialForm.addEventListener('submit', async function(e) {
+      e.preventDefault();
+
+      const submitBtn = trialForm.querySelector('button[type="submit"]');
+      const originalText = submitBtn.textContent;
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Processing...';
+
+      const formData = {
+        email: document.getElementById('trialEmail').value,
+        tradingview_username: document.getElementById('trialTvUsername').value,
+        consent: document.getElementById('trialConsent').checked,
+        timestamp: new Date().toISOString(),
+        source: 'website_trial_form'
+      };
+
+      try {
+        // Send to your backend endpoint (you'll need to set this up)
+        // For now, we'll use a simple webhook or email service
+        const response = await fetch('https://hook.us1.make.com/YOUR_WEBHOOK_ID', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(formData)
+        });
+
+        if (response.ok) {
+          // Hide form, show success message
+          trialForm.style.display = 'none';
+          trialSuccess.style.display = 'block';
+
+          // Optional: Track conversion
+          if (typeof gtag !== 'undefined') {
+            gtag('event', 'trial_signup', {
+              event_category: 'engagement',
+              event_label: 'free_trial'
+            });
+          }
+        } else {
+          throw new Error('Submission failed');
+        }
+      } catch (error) {
+        console.error('Trial signup error:', error);
+        alert('Something went wrong. Please try again or email support@signalpilot.io');
+        submitBtn.disabled = false;
+        submitBtn.textContent = originalText;
+      }
+    });
+  }
+})();
+</script>
 
 </body>
 


### PR DESCRIPTION
- Added prominent trial section after "Why We Built This"
- Updated hero CTAs: "Start 7-Day Free Trial" (primary) + "Or Buy Now" (secondary)
- Created trial signup form with email + TradingView username
- Added 4 key benefits: Full Access, Free Education, No Payment Info, Instant Setup
- Implemented form handler with success message
- Includes consent checkbox and analytics tracking
- Form submits to webhook endpoint (needs configuration)
- No credit card required messaging throughout
- Hybrid model: keeps paid option alongside trial

This addresses conversion barrier where users hesitant about $99 can try first. Trial lowers friction, allows discovery of value before commitment.