### PR TITLE
FIX: Update affiliate contact email to support@signalpilot.io

### DIFF
--- a/affiliates.html
+++ b/affiliates.html
@@ -720,8 +720,8 @@
       <div style="background:var(--bg-soft);padding:2.5rem;border-radius:var(--radius);border:1px solid var(--border);margin-bottom:2rem">
         <p style="color:var(--muted);margin-bottom:1.5rem;line-height:1.7">
           <strong style="color:var(--text)">To apply:</strong> Email us at
-          <a href="mailto:affiliates@signalpilot.io" style="color:var(--brand);text-decoration:none;font-weight:500">
-            affiliates@signalpilot.io
+          <a href="mailto:support@signalpilot.io" style="color:var(--brand);text-decoration:none;font-weight:500">
+            support@signalpilot.io
           </a>
         </p>
         <p style="color:var(--muted);font-size:0.95rem;line-height:1.7">
@@ -733,12 +733,12 @@
         </p>
       </div>
 
-      <a href="mailto:affiliates@signalpilot.io" class="btn btn-primary" style="padding:1.25rem 2.5rem;font-size:1.15rem">
+      <a href="mailto:support@signalpilot.io" class="btn btn-primary" style="padding:1.25rem 2.5rem;font-size:1.15rem">
         Apply Now →
       </a>
 
       <p style="color:var(--muted-2);font-size:0.9rem;margin-top:1.5rem">
-        Questions? Email us at <a href="mailto:affiliates@signalpilot.io" style="color:var(--brand);text-decoration:none">affiliates@signalpilot.io</a>
+        Questions? Email us at <a href="mailto:support@signalpilot.io" style="color:var(--brand);text-decoration:none">support@signalpilot.io</a>
       </p>
     </div>
   </section>


### PR DESCRIPTION
- Replace all instances of affiliates@signalpilot.io with support@signalpilot.io
- Centralizes affiliate inquiries through main support channel