### PR TITLE
Tone down affiliate banner and explore make.com integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -6418,44 +6418,8 @@ if ('serviceWorker' in navigator) {
 })();
 </script>
 
-<!-- STICKY AFFILIATE BAR -->
-<div id="affiliate-sticky-bar" style="position:fixed;bottom:0;left:0;right:0;background:linear-gradient(135deg,rgba(62,213,152,.95),rgba(46,197,133,.95));backdrop-filter:blur(10px);padding:.9rem 1.5rem;box-shadow:0 -4px 20px rgba(0,0,0,.3);z-index:9999;transform:translateY(0);transition:transform .3s ease;border-top:2px solid rgba(255,255,255,.2)">
-  <div style="max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap">
-    <div style="display:flex;align-items:center;gap:1rem;flex:1;min-width:200px">
-      <span style="font-size:1.3rem">💰</span>
-      <div>
-        <span style="color:#fff;font-weight:700;font-size:1rem;display:block;line-height:1.3">Trading Educator?</span>
-        <span style="color:rgba(255,255,255,.9);font-size:.85rem">Earn 30% recurring commission</span>
-      </div>
-    </div>
-    <div style="display:flex;align-items:center;gap:1rem">
-      <a href="/affiliates.html" style="background:#fff;color:#2ec585;padding:.7rem 1.5rem;border-radius:6px;font-weight:700;text-decoration:none;font-size:.95rem;white-space:nowrap;transition:all .2s ease;display:inline-block">
-        Join Program →
-      </a>
-      <button onclick="document.getElementById('affiliate-sticky-bar').style.transform='translateY(100%)'" style="background:transparent;border:none;color:#fff;font-size:1.5rem;cursor:pointer;padding:.25rem .5rem;opacity:.7;transition:opacity .2s ease" aria-label="Close affiliate bar">
-        ✕
-      </button>
-    </div>
-  </div>
-</div>
-
 <style>
   /* Affiliate Elements Responsive Optimization */
-
-  /* Sticky Bottom Bar */
-  @media (max-width: 640px) {
-    #affiliate-sticky-bar {
-      padding: .8rem 1rem;
-    }
-    #affiliate-sticky-bar > div {
-      flex-direction: column;
-      text-align: center;
-    }
-    #affiliate-sticky-bar a {
-      width: 100%;
-      text-align: center;
-    }
-  }
 
   /* Affiliate Banner Section - Mobile */
   @media (max-width: 768px) {


### PR DESCRIPTION
Remove the fixed-position sticky affiliate bar that was too bright and intrusive. The green gradient bar with z-index 9999 has been removed along with its associated CSS media queries.

The other affiliate promotions (banner section and hero link) remain in place as subtler alternatives.