### PR TITLE
INTEGRATE: Connect trial signup form to Make.com webhook

### DIFF
--- a/index.html
+++ b/index.html
@@ -6384,7 +6384,7 @@ if ('serviceWorker' in navigator) {
       try {
         // Send to your backend endpoint (you'll need to set this up)
         // For now, we'll use a simple webhook or email service
-        const response = await fetch('https://hook.us1.make.com/YOUR_WEBHOOK_ID', {
+        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
Update trial form to send data to Make.com automation webhook for processing trial account signups. This enables automated email confirmations, TradingView invite management, and trial period tracking.

Webhook endpoint: https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz

Data sent includes:
- Email address
- TradingView username
- User consent
- Timestamp
- Source identifier