### PR TITLE
ADD: Three strategic education CTAs (non-disruptive placement)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2600,9 +2600,22 @@
             <p style="color:var(--text);margin-bottom:0.5rem">
               Check your email for confirmation and next steps.
             </p>
-            <p style="color:var(--muted);font-size:0.9rem">
+            <p style="color:var(--muted);font-size:0.9rem;margin-bottom:2rem">
               Your TradingView invite will arrive within 2 hours.
             </p>
+
+            <!-- Education CTA -->
+            <div style="background:linear-gradient(135deg,rgba(62,213,152,.08),rgba(62,213,152,.02));padding:2rem;border-radius:12px;border:1px solid rgba(62,213,152,.2);margin-top:1.5rem">
+              <p style="color:var(--text);font-weight:600;margin-bottom:0.75rem;font-size:1.05rem">
+                📚 While you wait, start learning:
+              </p>
+              <p style="color:var(--muted);font-size:0.9rem;margin-bottom:1.25rem">
+                Access our complete 82-lesson education hub for free
+              </p>
+              <a href="https://education.signalpilot.io" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:0.5rem;background:var(--good);border-color:var(--good)">
+                Start Learning Free →
+              </a>
+            </div>
           </div>
 
         </div>
@@ -4142,6 +4155,20 @@
     </script>
 
 
+    <!-- EDUCATION CTA BEFORE PRICING -->
+    <div class="container" style="text-align:center;margin:4rem auto;max-width:800px;padding:2rem;border:2px dashed var(--border);border-radius:16px">
+      <p style="color:var(--muted);font-size:1.05rem;margin-bottom:1rem">
+        <strong>Not ready to buy?</strong> Try our free education hub first.
+      </p>
+      <p style="color:var(--muted-2);font-size:.9rem;margin-bottom:1.5rem">
+        82 lessons • Zero cost • No credit card • Start anytime
+      </p>
+      <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="color:var(--brand);text-decoration:none;font-weight:600;font-size:1.05rem">
+        Explore Free Education →
+      </a>
+    </div>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">
@@ -4510,6 +4537,12 @@
     <p style="text-align:center;color:var(--muted);margin:-1rem 0 2rem 0;font-size:.95rem">Pre-purchase questions answered. For setup guides and strategies, visit <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a> or <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a>.</p>
 
     <div class="grid auto-300">
+
+      <!-- EDUCATION HUB -->
+      <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-0">
+        <strong id="faq-question-0" style="color:var(--good)">📚 Where can I learn to use these indicators?</strong>
+        <p id="faq-answer-0" class="note">We provide a <strong>free 82-lesson education hub</strong> covering everything from beginner basics to institutional strategies. Available to everyone—no purchase required. <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="color:var(--brand);font-weight:600">Start learning free →</a></p>
+      </div>
 
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">


### PR DESCRIPTION
PLACEMENTS:
1. FAQ section - New item: 'Where can I learn to use these indicators?'
   - Emphasizes free 82-lesson hub
   - Helpful answer to common question
   - Green color (var(--good)) to highlight

2. Trial form success message - 'While you wait, start learning'
   - Appears after form submission
   - Smart timing during wait period
   - Green gradient box with CTA button

3. Before pricing section - 'Not ready to buy? Try education first'
   - Last touchpoint before pricing
   - Dashed border (non-intrusive)
   - Alternative path for hesitant users

STRATEGY:
- All 3 in different contexts (no clustering)
- Passive CTAs (no popups or interruptions)
- Reinforces 'free education' as competitive edge
- Multiple conversion paths