### PR TITLE
REMOVE: Pre-pricing education CTA section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4190,20 +4190,6 @@
     </script>
 
 
-    <!-- EDUCATION CTA BEFORE PRICING -->
-    <div class="container" style="text-align:center;margin:4rem auto;max-width:800px;padding:2rem;border:2px dashed var(--border);border-radius:16px">
-      <p style="color:var(--muted);font-size:1.05rem;margin-bottom:1rem">
-        <strong>Not ready to buy?</strong> Start with our free education hub.
-      </p>
-      <p style="color:var(--muted-2);font-size:.9rem;margin-bottom:1.5rem">
-        82 lessons • Zero cost • No credit card • Available to everyone
-      </p>
-      <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="color:var(--brand);text-decoration:none;font-weight:600;font-size:1.05rem">
-        Access Free Education →
-      </a>
-    </div>
-
-
     <!-- PRICING -->
 
     <section id="pricing" class="section">


### PR DESCRIPTION
Deleted 'Not ready to buy? Start with our free education hub' section entirely.

Reason: Education is already promoted in multiple places:
- Hero section (main CTA)
- What's Inside section banner
- Footer newsletter
- FAQ item at top

No need for another education CTA right before pricing.