### PR TITLE
RESTRUCTURE: Move & condense "Why We Built This" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2434,67 +2434,6 @@
 
     </section>
 
-    <!-- WHY US -->
-    <section id="why" class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.04),rgba(118,221,255,.02));border-top:1px solid rgba(91,138,255,.15);border-bottom:1px solid rgba(91,138,255,.15)">
-
-      <div class="container" style="max-width:900px">
-
-        <div style="text-align:center;margin-bottom:2.5rem">
-          <h2 class="headline lg" style="margin-bottom:1rem">Why We Built This</h2>
-          <p class="note" style="max-width:65ch;margin:0 auto;font-size:1.1rem;color:var(--muted-soft)">
-            Because we've been where you are.
-          </p>
-        </div>
-
-        <div class="stack" style="gap:2rem">
-
-          <!-- The Problem -->
-          <div style="background:var(--bg-soft);padding:2rem;border-radius:12px;border-left:4px solid var(--warn)">
-            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.05rem">
-              <strong style="color:var(--warn)">We know the feeling.</strong> You're watching your charts, surrounded by dozens of indicators. Some are repainting. Others are lagging. Most are just adding noise. You're trying to find the signal in all this chaos, but the more you add, the less clear it becomes.
-            </p>
-          </div>
-
-          <!-- The Turning Point -->
-          <div style="background:var(--bg-soft);padding:2rem;border-radius:12px;border-left:4px solid var(--brand)">
-            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.05rem">
-              <strong style="color:var(--brand)">So we made a choice.</strong> Instead of adding more indicators, we built better ones. Every line you see is there for a reason. Every signal has been tested against thousands of market conditions. Nothing repaints. Nothing lags beyond what's mathematically necessary. No false promises.
-            </p>
-          </div>
-
-          <!-- The Philosophy -->
-          <div style="background:var(--bg-soft);padding:2rem;border-radius:12px;border-left:4px solid var(--success)">
-            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.05rem">
-              <strong style="color:var(--success)">This is what we believe:</strong> The edge isn't seeing more—it's seeing what matters. It's having tools that respect your time, your capital, and your intelligence. Tools built by traders who actually use them. Who know what it's like to question every entry, to second-guess every exit, to wonder if there's a better way.
-            </p>
-          </div>
-
-          <!-- The Commitment -->
-          <div style="text-align:center;margin-top:1.5rem;padding:2rem;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04));border-radius:12px;border:1px solid rgba(91,138,255,.2)">
-            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.15rem;max-width:60ch;margin:0 auto">
-              <strong style="color:var(--brand)">We're not selling you a dream.</strong> We're giving you tools we actually use. Clear structure. Real-time signals. Audited performance. And if it doesn't click for you? Seven days, full refund, no questions asked.
-            </p>
-            <p style="color:var(--muted);margin-top:1.5rem;font-size:0.95rem;font-style:italic">
-              Because the only thing worse than missing a trade is trading on false signals.
-            </p>
-          </div>
-
-          <!-- The Origin -->
-          <div style="background:var(--bg-soft);padding:2.5rem;border-radius:12px;border-left:4px solid var(--brand);margin-top:2rem">
-            <p style="color:var(--text);line-height:1.8;font-size:1.05rem;margin:0">
-              <strong style="color:var(--brand)">Built by quantitative traders who got tired of indicators that looked great in hindsight but failed in real-time.</strong>
-            </p>
-            <p style="color:var(--muted);line-height:1.8;font-size:1.05rem;margin:1rem 0 0">
-              After 1 year of development and 10,000+ hours of backtesting, Pentarch became our unfair advantage. Now it's yours.
-            </p>
-          </div>
-
-        </div>
-
-      </div>
-
-    </section>
-
     <!-- FREE TRIAL SECTION -->
     <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
       <div class="container" style="max-width:800px">
@@ -3273,6 +3212,50 @@
             document.getElementById('swipe-hint').style.display = 'inline';
           }
         </script>
+
+      </div>
+
+    </section>
+
+    <!-- WHY WE BUILT THIS -->
+    <section id="why" class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.04),rgba(118,221,255,.02));border-top:1px solid rgba(91,138,255,.15);border-bottom:1px solid rgba(91,138,255,.15)">
+
+      <div class="container" style="max-width:900px">
+
+        <div style="text-align:center;margin-bottom:2.5rem">
+          <h2 class="headline lg" style="margin-bottom:1rem">Why We Built This</h2>
+          <p class="note" style="max-width:65ch;margin:0 auto;font-size:1.1rem;color:var(--muted-soft)">
+            Because we've been where you are.
+          </p>
+        </div>
+
+        <div class="stack" style="gap:1.5rem">
+
+          <!-- The Problem -->
+          <div style="background:var(--bg-soft);padding:1.75rem;border-radius:12px;border-left:4px solid var(--warn)">
+            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.05rem">
+              <strong style="color:var(--warn)">We know the feeling.</strong> You're surrounded by dozens of indicators. Some repaint. Others lag. Most just add noise. The more you add, the less clear it becomes.
+            </p>
+          </div>
+
+          <!-- The Solution -->
+          <div style="background:var(--bg-soft);padding:1.75rem;border-radius:12px;border-left:4px solid var(--brand)">
+            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.05rem">
+              <strong style="color:var(--brand)">So we built better ones.</strong> Every signal tested against thousands of market conditions. Nothing repaints. Nothing lags beyond what's mathematically necessary. Tools that respect your time, your capital, and your intelligence.
+            </p>
+          </div>
+
+          <!-- The Promise -->
+          <div style="text-align:center;padding:1.75rem;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04));border-radius:12px;border:1px solid rgba(91,138,255,.2)">
+            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.1rem;max-width:60ch;margin:0 auto">
+              <strong style="color:var(--brand)">We're not selling you a dream.</strong> These are tools we actually use. 1 year of development. 10,000+ hours of backtesting. And if it doesn't click? Seven days, full refund, no questions asked.
+            </p>
+            <p style="color:var(--muted);margin-top:1.25rem;font-size:0.95rem;font-style:italic">
+              Because the only thing worse than missing a trade is trading on false signals.
+            </p>
+          </div>
+
+        </div>
 
       </div>
 


### PR DESCRIPTION
Moved "Why We Built This" from before carousel to AFTER carousel for better conversion flow.

**Better Page Flow:**
Before: Hero → Why → Carousel → Features
After:  Hero → Carousel → Why → Features

Users now see WHAT the product does (charts/demo) before WHY it was built (story). This follows proven conversion psychology: Show proof first, earn trust second.

**Condensed from 5 cards to 3 cards:**

1. The Problem (kept emotional hook):
   - "We know the feeling... surrounded by dozens of indicators"
   - Shortened but kept the pain point resonance

2. The Solution (merged "Turning Point" + "Philosophy"):
   - Combined technical credibility with philosophy
   - "Nothing repaints. Tools that respect your time, capital, intelligence."

3. The Promise (merged "Commitment" + "Origin"):
   - Combined guarantee with development story
   - "1 year development. 10k hours backtesting. 7-day refund."
   - Kept powerful closing: "Because the only thing worse than missing a trade is trading on false signals."

**Result:**
- 50% less text (5 boxes → 3 boxes)
- Same emotional impact
- Better positioned after visual proof
- Still hits the heart, now with better timing

The section breathes better and lands harder after users have seen the charts.