### PR TITLE
DECLUTTER: Remove unnecessary promotional elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2186,15 +2186,9 @@
 
           <!-- Hero CTAs -->
           <div class="hero-ctas" style="margin-top:2rem;margin-bottom:1rem;display:flex;justify-content:center;gap:1rem;flex-wrap:wrap;align-items:center">
-            <a href="https://education.signalpilot.io" target="_blank" rel="noopener" class="btn btn-ghost" style="padding:1rem 1.75rem;font-size:1.05rem;display:inline-flex!important;visibility:visible!important;opacity:1!important;color:#76ddff!important;border:2px solid rgba(118,221,255,.5)!important;background:rgba(118,221,255,.12)!important">Access Free Education →</a>
             <a href="#trial" class="btn btn-primary" style="padding:1rem 1.75rem;font-size:1.05rem">Start 7-Day Trial →</a>
             <a href="#pricing" class="btn btn-ghost" style="padding:1rem 1.75rem;font-size:1.05rem;display:inline-flex!important;visibility:visible!important;opacity:1!important;color:#9fdcff!important;border:2px solid rgba(255,255,255,.5)!important;background:rgba(255,255,255,.15)!important">Or Buy Now</a>
           </div>
-
-          <!-- Small Trust Text -->
-          <p style="color:var(--muted-2);font-size:.9rem;margin:1rem auto 0">
-            7-day money-back guarantee
-          </p>
 
           <!-- Affiliate Secondary Message -->
           <div style="margin:2rem 0 3rem">
@@ -2482,24 +2476,12 @@
           </div>
         </div>
 
-        <!-- Trust Badges -->
-        <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:1.5rem;margin-bottom:3rem">
-
-          <div style="display:flex;align-items:center;gap:0.5rem;background:rgba(62,213,152,.08);border:1px solid rgba(62,213,152,.25);padding:0.75rem 1.25rem;border-radius:8px">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
-            <span style="font-size:0.9rem;font-weight:600;color:#3ed598">No Credit Card</span>
-          </div>
-
+        <!-- Trust Badge -->
+        <div style="display:flex;justify-content:center;margin-bottom:3rem">
           <div style="display:flex;align-items:center;gap:0.5rem;background:rgba(91,138,255,.08);border:1px solid rgba(91,138,255,.25);padding:0.75rem 1.25rem;border-radius:8px">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-            <span style="font-size:0.9rem;font-weight:600;color:#5b8aff">Access Within 24h</span>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+            <span style="font-size:0.9rem;font-weight:600;color:#5b8aff">No Credit Card • Access Within 24h</span>
           </div>
-
-          <div style="display:flex;align-items:center;gap:0.5rem;background:rgba(118,221,255,.08);border:1px solid rgba(118,221,255,.25);padding:0.75rem 1.25rem;border-radius:8px">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#76ddff" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-            <span style="font-size:0.9rem;font-weight:600;color:#76ddff">Full 7 Days</span>
-          </div>
-
         </div>
 
         <!-- Trial Signup Form -->
@@ -3366,7 +3348,6 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/><circle cx="7" cy="7" r="1" fill="currentColor"/><circle cx="17" cy="7" r="1" fill="currentColor"/><circle cx="7" cy="17" r="1" fill="currentColor"/><circle cx="17" cy="17" r="1" fill="currentColor"/></svg>
               <h3 style="white-space:nowrap">SP — Omnideck</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(91,138,255,.15);color:var(--brand);white-space:nowrap">ALL-IN-ONE</span>
             </div>
             <div class="punch">Ten systems combined into one overlay indicator.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details" style="margin-top:.5rem">Details ▼</button>
@@ -3407,7 +3388,6 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s4-8 10-8 10 8 10 8-4 8-10 8-10-8-10-8z"/><circle cx="12" cy="12" r="2.5"/><rect x="8" y="17" width="1.2" height="4" opacity=".3"/><rect x="11.4" y="16" width="1.2" height="5" opacity=".3"/><rect x="14.8" y="17" width="1.2" height="4" opacity=".3"/></svg>
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(62,213,152,.15);color:var(--good);white-space:nowrap">INSTITUTIONAL</span>
             </div>
             <div class="punch">Tracks institutional accumulation/distribution patterns in real-time.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details" style="margin-top:.5rem">Details ▼</button>
@@ -3443,7 +3423,6 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 17l6-6 4 4 8-8"/><path d="M21 7v6h-6"/><path d="M3 22h18" opacity=".3"/><rect x="5" y="18" width="2" height="4" opacity=".4"/><rect x="11" y="14" width="2" height="8" opacity=".4"/><rect x="17" y="10" width="2" height="12" opacity=".4"/></svg>
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">ACCUMULATION</span>
             </div>
             <div class="punch">Cumulative delta tracking shows demand/supply pressure over time.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details" style="margin-top:.5rem">Details ▼</button>
@@ -3479,7 +3458,6 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 12h18M3 18h18"/><circle cx="7" cy="6" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="17" cy="18" r="1.5" fill="currentColor"/><path d="M21 6v12" opacity=".3" stroke-width="1.5"/></svg>
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;background:rgba(118,221,255,.15);color:var(--accent);white-space:nowrap">KEY LEVELS</span>
             </div>
             <div class="punch">HTF levels, D/W/M pivots, VWAP, VAL/POC—all key zones in one view.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details" style="margin-top:.5rem">Details ▼</button>
@@ -3516,7 +3494,6 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="10" r="7"/><path d="M7 10h10M12 3v14M9 6l6 8M15 6l-6 8" opacity=".25" stroke-width="1.5"/><ellipse cx="12" cy="17.5" rx="5" ry="1.8"/><path d="M7 17.5c0 1 2.2 1.8 5 1.8s5-.8 5-1.8"/></svg>
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">S/R MATRIX</span>
             </div>
             <div class="punch">Support/resistance matrix with probability‑weighted breakout zones.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details" style="margin-top:.5rem">Details ▼</button>
@@ -3553,7 +3530,6 @@
             <div class="title mod">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 13c2-4 6-4 8 0s6 4 10-2"/><circle cx="7" cy="13" r="1.2"/><circle cx="15" cy="13" r="1.2"/></svg>
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
-              <span class="badge" style="font-size:.7rem;margin-left:.5rem;white-space:nowrap">TIMING</span>
             </div>
             <div class="punch">Four oscillators vote on every bar. Multi-confirmation timing system.</div>
             <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details" style="margin-top:.5rem">Details ▼</button>
@@ -3611,14 +3587,6 @@
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
                   <span>Need 3-5 separate indicators cluttering your chart</span>
                 </li>
-                <li class="comparison-item comparison-item-negative">
-                  <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Only shows entry/exit, misses the full cycle</span>
-                </li>
-                <li class="comparison-item comparison-item-negative">
-                  <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Minimal docs: "figure it out yourself"</span>
-                </li>
               </ul>
             </div>
 
@@ -3639,14 +3607,6 @@
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
                   <span><strong>7 elite systems included</strong> — complete toolkit</span>
-                </li>
-                <li class="comparison-item comparison-item-positive">
-                  <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Full 5-phase cycle</strong> (TD→IGN→WRN→CAP→BDN)</span>
-                </li>
-                <li class="comparison-item comparison-item-positive">
-                  <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>82 lessons + 50+ page docs</strong> (250k words)</span>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
Removed bloat and redundant elements for cleaner, more focused conversion path:

**1. Hero Section - Reduced CTA Competition:**
✂️ Removed "Access Free Education" button (competes with paid CTAs) ✂️ Removed "7-day money-back guarantee" text (redundant, mentioned 17x on page) Result: Hero now focuses on 2 CTAs only: "Start Trial" + "Or Buy Now"

**2. Trial Section - Condensed Trust Badges (3→1):** Before: 3 separate badges saying same thing
- "No Credit Card" (green)
- "Access Within 24h" (blue)
- "Full 7 Days" (cyan)

After: 1 combined badge
- "No Credit Card • Access Within 24h" (blue)

Result: More confident, less defensive positioning. Saves 18 lines.

**3. Indicator Badges - Removed Generic Labels:**
Removed badges from 6 of 7 indicators:
✂️ Omnideck "ALL-IN-ONE"
✂️ Volume Oracle "INSTITUTIONAL"
✂️ Plutus Flow "ACCUMULATION"
✂️ Janus Atlas "KEY LEVELS"
✂️ Augury Grid "S/R MATRIX"
✂️ Harmonic Oscillator "TIMING"

Kept ONLY: Pentarch "★ FLAGSHIP"

Result: When everything is special, nothing is. Flagship status now meaningful.

**4. Comparison Section - Streamlined (5→3 points):** Before: 5 comparison bullets per column
After: 3 strongest differentiators only

Kept core value props:
✓ One integrated view (vs conflicting signals)
✓ 100% non-repainting (vs frequent repaints)
✓ 7 elite systems (vs 3-5 separate indicators)

Removed:
- Full 5-phase cycle details (covered elsewhere)
- Documentation mentions (less impactful)

Result: Tighter comparison, faster scan, stronger focus.

**Total Impact:**
- ~40 lines removed
- Less promotional fatigue
- Cleaner conversion focus
- More confident positioning

The product is strong—letting it speak for itself without over-promoting.