### PR TITLE
IMPROVE: Remove indicator icons and add education benefit

### DIFF
--- a/index.html
+++ b/index.html
@@ -3275,7 +3275,6 @@
             </div>
 
             <div class="title mod">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
               <span class="badge" style="font-size:.75rem;margin-left:.5rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;padding:.3rem .7rem;text-transform:uppercase;letter-spacing:.5px;white-space:nowrap">★ FLAGSHIP</span>
             </div>
@@ -3346,7 +3345,6 @@
             </div>
 
             <div class="title mod">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/><circle cx="7" cy="7" r="1" fill="currentColor"/><circle cx="17" cy="7" r="1" fill="currentColor"/><circle cx="7" cy="17" r="1" fill="currentColor"/><circle cx="17" cy="17" r="1" fill="currentColor"/></svg>
               <h3 style="white-space:nowrap">SP — Omnideck</h3>
             </div>
             <div class="punch">Ten systems combined into one overlay indicator.</div>
@@ -3386,7 +3384,6 @@
             </div>
 
             <div class="title mod">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s4-8 10-8 10 8 10 8-4 8-10 8-10-8-10-8z"/><circle cx="12" cy="12" r="2.5"/><rect x="8" y="17" width="1.2" height="4" opacity=".3"/><rect x="11.4" y="16" width="1.2" height="5" opacity=".3"/><rect x="14.8" y="17" width="1.2" height="4" opacity=".3"/></svg>
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
             <div class="punch">Tracks institutional accumulation/distribution patterns in real-time.</div>
@@ -3421,7 +3418,6 @@
             </div>
 
             <div class="title mod">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 17l6-6 4 4 8-8"/><path d="M21 7v6h-6"/><path d="M3 22h18" opacity=".3"/><rect x="5" y="18" width="2" height="4" opacity=".4"/><rect x="11" y="14" width="2" height="8" opacity=".4"/><rect x="17" y="10" width="2" height="12" opacity=".4"/></svg>
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
             <div class="punch">Cumulative delta tracking shows demand/supply pressure over time.</div>
@@ -3456,7 +3452,6 @@
             </div>
 
             <div class="title mod">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 12h18M3 18h18"/><circle cx="7" cy="6" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="17" cy="18" r="1.5" fill="currentColor"/><path d="M21 6v12" opacity=".3" stroke-width="1.5"/></svg>
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
             <div class="punch">HTF levels, D/W/M pivots, VWAP, VAL/POC—all key zones in one view.</div>
@@ -3492,7 +3487,6 @@
             </div>
 
             <div class="title mod">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="10" r="7"/><path d="M7 10h10M12 3v14M9 6l6 8M15 6l-6 8" opacity=".25" stroke-width="1.5"/><ellipse cx="12" cy="17.5" rx="5" ry="1.8"/><path d="M7 17.5c0 1 2.2 1.8 5 1.8s5-.8 5-1.8"/></svg>
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
             <div class="punch">Support/resistance matrix with probability‑weighted breakout zones.</div>
@@ -3528,7 +3522,6 @@
             </div>
 
             <div class="title mod">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 13c2-4 6-4 8 0s6 4 10-2"/><circle cx="7" cy="13" r="1.2"/><circle cx="15" cy="13" r="1.2"/></svg>
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
             <div class="punch">Four oscillators vote on every bar. Multi-confirmation timing system.</div>
@@ -3607,6 +3600,10 @@
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
                   <span><strong>7 elite systems included</strong> — complete toolkit</span>
+                </li>
+                <li class="comparison-item comparison-item-positive">
+                  <span class="comparison-bullet comparison-bullet-positive">•</span>
+                  <span><strong>Free education included</strong> — learn how to use each tool</span>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
- Remove SVG icons from all 7 indicator cards (cleaner design after badge removal)
- Add "Free education included" to comparison section benefits