### PR TITLE
Fix checkbox layout on mobile view

### DIFF
--- a/assets/deferred.css
+++ b/assets/deferred.css
@@ -731,6 +731,15 @@
     }
     
     @media (max-width:480px){
+      .consent{
+        font-size:.75rem;
+        gap:.5rem;
+      }
+
+      .consent span{
+        line-height:1.4;
+      }
+
       .modal-card{
         padding:.9rem;
       }

--- a/index.html
+++ b/index.html
@@ -2537,9 +2537,9 @@
               </p>
             </div>
 
-            <label style="display:flex;align-items:start;gap:0.75rem;margin-bottom:1.5rem;cursor:pointer">
-              <input type="checkbox" id="trialConsent" required style="margin-top:0.25rem;cursor:pointer">
-              <span style="font-size:0.9rem;color:var(--muted)">
+            <label class="consent" style="margin-bottom:1.5rem">
+              <input type="checkbox" id="trialConsent" required>
+              <span>
                 I understand <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is educational only. No financial advice.
                 <a href="/terms.html" style="color:var(--brand)">Terms</a>
               </span>


### PR DESCRIPTION
- Reduce font size to .75rem on screens ≤480px
- Tighten gap between checkbox and text to .5rem
- Optimize line-height to 1.4 for more compact layout
- Unify checkbox styling using .consent class
- Reduces text wrapping from 4 rows to 2-3 rows on mobile