### PR TITLE
IMPROVE: Make education value more specific in comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -3620,7 +3620,7 @@
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Free education included</strong> — learn how to use each tool</span>
+                  <span><strong>82 lessons + 50+ page docs</strong> — master your journey</span>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
- Change from generic 'Free education included' to '82 lessons + 50+ page docs'
- Add 'master your journey' tagline for aspirational messaging
- Quantify the educational value with specific numbers