### PR TITLE
REMOVE: Unnecessary sections for leaner conversion flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -2210,19 +2210,6 @@
             <a href="#pricing" class="btn btn-ghost" style="padding:1rem 1.75rem;font-size:1.05rem;display:inline-flex!important;visibility:visible!important;opacity:1!important;color:#9fdcff!important;border:2px solid rgba(255,255,255,.5)!important;background:rgba(255,255,255,.15)!important">Or Buy Now</a>
           </div>
 
-          <!-- Affiliate Secondary Message -->
-          <div style="margin:2rem 0 3rem">
-            <a href="/affiliates.html" style="display:inline-flex;align-items:center;gap:.6rem;padding:.65rem 1.2rem;background:rgba(62,213,152,.12);border:1px solid rgba(62,213,152,.25);border-radius:8px;color:#3ed598;font-weight:600;text-decoration:none;font-size:.9rem;transition:all .2s ease">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="width:18px;height:18px">
-                <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
-              </svg>
-              <span>Content Creator? Earn 30% commission</span>
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px">
-                <path d="M5 12h14M12 5l7 7-7 7"/>
-              </svg>
-            </a>
-          </div>
-
         </div>
 
         <!-- HERO VIDEO - Full Width -->
@@ -2501,110 +2488,6 @@
           <div style="display:flex;align-items:center;gap:0.5rem;background:rgba(91,138,255,.08);border:1px solid rgba(91,138,255,.25);padding:0.75rem 1.25rem;border-radius:8px">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
             <span style="font-size:0.9rem;font-weight:600;color:#5b8aff">No Credit Card • Access Within 24h</span>
-          </div>
-        </div>
-
-        <!-- Trial Benefits Checklist -->
-        <div style="max-width:600px;margin:0 auto 2.5rem;padding:2rem 2.5rem;background:rgba(91,138,255,.05);border:1px solid rgba(91,138,255,.2);border-radius:12px">
-          <h3 style="font-size:1.2rem;font-weight:700;color:var(--text);margin:0 0 1.5rem 0;text-align:center">What's Included In Your Trial</h3>
-          <div style="display:grid;gap:0.9rem">
-            <div style="display:flex;align-items:start;gap:0.75rem">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5" style="flex-shrink:0;margin-top:2px"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="color:var(--text);line-height:1.6">Instant access to all 7 indicators</span>
-            </div>
-            <div style="display:flex;align-items:start;gap:0.75rem">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5" style="flex-shrink:0;margin-top:2px"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="color:var(--text);line-height:1.6">82 free education lessons included</span>
-            </div>
-            <div style="display:flex;align-items:start;gap:0.75rem">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5" style="flex-shrink:0;margin-top:2px"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="color:var(--text);line-height:1.6">Full documentation & video tutorials</span>
-            </div>
-            <div style="display:flex;align-items:start;gap:0.75rem">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5" style="flex-shrink:0;margin-top:2px"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="color:var(--text);line-height:1.6">Email support during trial</span>
-            </div>
-            <div style="display:flex;align-items:start;gap:0.75rem">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5" style="flex-shrink:0;margin-top:2px"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="color:var(--text);line-height:1.6">No credit card required</span>
-            </div>
-            <div style="display:flex;align-items:start;gap:0.75rem">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5" style="flex-shrink:0;margin-top:2px"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="color:var(--text);line-height:1.6">Trial expires automatically after 7 days — no action needed</span>
-            </div>
-          </div>
-        </div>
-
-        <!-- 7-Day Trial Timeline -->
-        <div style="max-width:800px;margin:0 auto 3rem;padding:2.5rem;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(91,138,255,.03));border:1px solid rgba(91,138,255,.25);border-radius:12px">
-          <h3 style="font-size:1.3rem;font-weight:700;color:var(--text);margin:0 0 0.5rem 0;text-align:center">📅 Your 7-Day Trial Journey</h3>
-          <p style="text-align:center;color:var(--muted);margin:0 0 2rem 0;font-size:0.95rem">Here's how to get the most from your trial</p>
-
-          <div style="display:grid;gap:1.5rem">
-            <!-- Day 1 -->
-            <div style="display:flex;gap:1rem;align-items:start">
-              <div style="flex-shrink:0;width:50px;height:50px;background:linear-gradient(135deg,#5b8aff,#76ddff);border-radius:10px;display:flex;align-items:center;justify-content:center;font-weight:700;color:white;font-size:0.85rem">DAY 1</div>
-              <div style="flex:1">
-                <div style="font-weight:700;color:var(--text);margin-bottom:0.4rem">Setup & First Chart <span style="color:var(--muted);font-weight:400;font-size:0.9rem">(15 minutes)</span></div>
-                <div style="color:var(--muted);font-size:0.95rem;line-height:1.6">
-                  → Add Pentarch to your chart<br>
-                  → Understand the 5 cycle phases (TD, IGN, WRN, CAP, BDN)<br>
-                  → Watch it identify current market position
-                </div>
-              </div>
-            </div>
-
-            <!-- Day 2 -->
-            <div style="display:flex;gap:1rem;align-items:start">
-              <div style="flex-shrink:0;width:50px;height:50px;background:linear-gradient(135deg,#5b8aff,#76ddff);border-radius:10px;display:flex;align-items:center;justify-content:center;font-weight:700;color:white;font-size:0.85rem">DAY 2</div>
-              <div style="flex:1">
-                <div style="font-weight:700;color:var(--text);margin-bottom:0.4rem">Learn TD Sequential <span style="color:var(--muted);font-weight:400;font-size:0.9rem">(30 minutes)</span></div>
-                <div style="color:var(--muted);font-size:0.95rem;line-height:1.6">
-                  → Spot exhaustion signals with TD 9/13 counts<br>
-                  → Set your first price alerts<br>
-                  → Study real examples in Education Hub
-                </div>
-              </div>
-            </div>
-
-            <!-- Day 3-4 -->
-            <div style="display:flex;gap:1rem;align-items:start">
-              <div style="flex-shrink:0;width:50px;height:50px;background:linear-gradient(135deg,#5b8aff,#76ddff);border-radius:10px;display:flex;align-items:center;justify-content:center;font-weight:700;color:white;font-size:0.75rem;text-align:center;line-height:1.2">DAY<br>3-4</div>
-              <div style="flex:1">
-                <div style="font-weight:700;color:var(--text);margin-bottom:0.4rem">Explore The Elite Seven <span style="color:var(--muted);font-weight:400;font-size:0.9rem">(1 hour)</span></div>
-                <div style="color:var(--muted);font-size:0.95rem;line-height:1.6">
-                  → Test all 7 indicators on your favorite assets<br>
-                  → Learn how they work together for confluence<br>
-                  → Try different timeframes (15m, 1H, 4H, Daily)
-                </div>
-              </div>
-            </div>
-
-            <!-- Day 5-6 -->
-            <div style="display:flex;gap:1rem;align-items:start">
-              <div style="flex-shrink:0;width:50px;height:50px;background:linear-gradient(135deg,#5b8aff,#76ddff);border-radius:10px;display:flex;align-items:center;justify-content:center;font-weight:700;color:white;font-size:0.75rem;text-align:center;line-height:1.2">DAY<br>5-6</div>
-              <div style="flex:1">
-                <div style="font-weight:700;color:var(--text);margin-bottom:0.4rem">Real Trading Scenarios <span style="color:var(--muted);font-weight:400;font-size:0.9rem">(2 hours)</span></div>
-                <div style="color:var(--muted);font-size:0.95rem;line-height:1.6">
-                  → Paper trade with the signals<br>
-                  → Review past market cycles to see accuracy<br>
-                  → Email support with any questions
-                </div>
-              </div>
-            </div>
-
-            <!-- Day 7 -->
-            <div style="display:flex;gap:1rem;align-items:start">
-              <div style="flex-shrink:0;width:50px;height:50px;background:linear-gradient(135deg,#3ed598,#5beaa3);border-radius:10px;display:flex;align-items:center;justify-content:center;font-weight:700;color:white;font-size:0.85rem">DAY 7</div>
-              <div style="flex:1">
-                <div style="font-weight:700;color:#3ed598;margin-bottom:0.4rem">Decision Time</div>
-                <div style="color:var(--muted);font-size:0.95rem;line-height:1.6">
-                  → Does it give you an edge?<br>
-                  → Ready to upgrade? Choose your plan<br>
-                  → Not convinced? Trial expires automatically — nothing owed
-                </div>
-              </div>
-            </div>
           </div>
         </div>
 
@@ -3321,50 +3204,6 @@
             document.getElementById('swipe-hint').style.display = 'inline';
           }
         </script>
-
-      </div>
-
-    </section>
-
-    <!-- WHY WE BUILT THIS -->
-    <section id="why" class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.04),rgba(118,221,255,.02));border-top:1px solid rgba(91,138,255,.15);border-bottom:1px solid rgba(91,138,255,.15)">
-
-      <div class="container" style="max-width:900px">
-
-        <div style="text-align:center;margin-bottom:2.5rem">
-          <h2 class="headline lg" style="margin-bottom:1rem">Why We Built This</h2>
-          <p class="note" style="max-width:65ch;margin:0 auto;font-size:1.1rem;color:var(--muted-soft)">
-            Because we've been where you are.
-          </p>
-        </div>
-
-        <div class="stack" style="gap:1.5rem">
-
-          <!-- The Problem -->
-          <div style="background:var(--bg-soft);padding:1.75rem;border-radius:12px;border-left:4px solid var(--warn)">
-            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.05rem">
-              <strong style="color:var(--warn)">We know the feeling.</strong> You're surrounded by dozens of indicators. Some repaint. Others lag. Most just add noise. The more you add, the less clear it becomes.
-            </p>
-          </div>
-
-          <!-- The Solution -->
-          <div style="background:var(--bg-soft);padding:1.75rem;border-radius:12px;border-left:4px solid var(--brand)">
-            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.05rem">
-              <strong style="color:var(--brand)">So we built better ones.</strong> Every signal tested against thousands of market conditions. Nothing repaints. Nothing lags beyond what's mathematically necessary. Tools that respect your time, your capital, and your intelligence.
-            </p>
-          </div>
-
-          <!-- The Promise -->
-          <div style="text-align:center;padding:1.75rem;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04));border-radius:12px;border:1px solid rgba(91,138,255,.2)">
-            <p style="color:var(--text);line-height:1.8;margin:0;font-size:1.1rem;max-width:60ch;margin:0 auto">
-              <strong style="color:var(--brand)">We're not selling you a dream.</strong> These are tools we actually use. 1 year of development. 10,000+ hours of backtesting. And if it doesn't click? Seven days, full refund, no questions asked.
-            </p>
-            <p style="color:var(--muted);margin-top:1.25rem;font-size:0.95rem;font-style:italic">
-              Because the only thing worse than missing a trade is trading on false signals.
-            </p>
-          </div>
-
-        </div>
 
       </div>
 
@@ -4525,22 +4364,6 @@
 
     </section>
 
-    <!-- AFFILIATE CALLOUT BANNER -->
-    <section class="section" style="padding:1.5rem 0" id="affiliate-banner">
-      <div class="container">
-        <div style="background:linear-gradient(135deg,rgba(62,213,152,.1),rgba(62,213,152,.04));border:1px solid rgba(62,213,152,.2);padding:1.25rem 1.5rem;border-radius:8px;text-align:center;max-width:750px;margin:0 auto;display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:1rem">
-          <div style="flex:1;min-width:250px">
-            <p style="margin:0;font-size:.9rem;color:var(--text)">
-              <strong style="color:#3ed598">💰 Content Creators:</strong> Earn 30% recurring commission promoting Signal Pilot
-            </p>
-          </div>
-          <a href="/affiliates.html" class="btn btn-primary" style="padding:0.625rem 1.25rem;font-size:.875rem;font-weight:600;background:#3ed598;border-color:#3ed598;white-space:nowrap">
-            Join Program →
-          </a>
-        </div>
-      </div>
-    </section>
-
     <!-- FAQ -->
 
     <section id="faq" class="section" role="region" aria-labelledby="faq-heading">
@@ -4702,25 +4525,6 @@
   <footer style="border-top:1px solid var(--border);margin-top:6rem;padding:3rem 0 2rem">
 
     <div class="container">
-
-      <!-- Newsletter Signup - Full Width -->
-      <div style="background:linear-gradient(135deg,rgba(62,213,152,.06),rgba(91,138,255,.06));border:1px solid rgba(91,138,255,.2);border-radius:12px;padding:2.5rem 2rem;margin-bottom:3rem;text-align:center">
-        <h3 style="font-size:1.3rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">
-          📚 Free Education for Serious Traders
-        </h3>
-        <p style="color:var(--muted);font-size:0.95rem;line-height:1.6;max-width:600px;margin:0 auto 1.5rem">
-          82 lessons on institutional market mechanics. Free forever, no credit card. Get updates when we add new content.
-        </p>
-        <div style="display:flex;gap:0.75rem;max-width:500px;margin:0 auto;flex-wrap:wrap;justify-content:center">
-          <input type="email" placeholder="your@email.com" id="footerNewsletterEmail" style="flex:1;min-width:250px;padding:0.875rem 1rem;border-radius:8px;border:1px solid var(--border);background:var(--bg-soft);color:var(--text);font-size:0.95rem;font-family:inherit">
-          <button type="button" id="footerNewsletterBtn" class="btn btn-primary" style="padding:0.875rem 1.5rem;font-size:0.95rem;font-weight:600;white-space:nowrap">
-            Subscribe Free →
-          </button>
-        </div>
-        <p style="color:var(--muted-2);font-size:0.8rem;margin-top:0.75rem">
-          No spam. Updates on new lessons and features only.
-        </p>
-      </div>
 
       <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:3rem;margin-bottom:3rem">
 


### PR DESCRIPTION
Removed sections (Phase 1):
1. ❌ 'Why We Built This' emotional backstory (~43 lines)
2. ❌ Trial Benefits Checklist (~30 lines)
3. ❌ 7-Day Trial Timeline (~103 lines)
4. ❌ Affiliate Banner Above FAQ (~15 lines)
5. ❌ Affiliate Link in Hero (~12 lines)
6. ❌ Footer Newsletter Signup (~18 lines)

Total reduction: ~221 lines removed

Rationale:
- 'Why We Built This' = emotional fluff, doesn't drive conversions
- Trial checklist + timeline = information overload (just added, now removing)
- Affiliate promotions = wrong audience, divides attention at critical moments
- Newsletter in footer = distraction after pricing (affiliate link still in footer nav)

Result: Cleaner, faster, more focused conversion path
Next: Remove expandable product details (separate commit for safety)