### PR TITLE
Fix footer links and remove trial button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1341,6 +1341,14 @@
       z-index: 65 !important;
     }
 
+    /* Hide mobile nav on desktop - it should only appear on mobile */
+    @media (min-width: 1401px) {
+      .mobile-nav,
+      .mobile-nav-backdrop {
+        display: none !important;
+      }
+    }
+
     /* Mobile hamburger menu appears at ≤1400px (increased from 1300px) */
     /* Nav items go into hamburger menu to prevent overlap with language/theme buttons */
     /* Activates earlier to accommodate longer text in translated languages */


### PR DESCRIPTION
Mobile nav elements (including links and CTA button) were displaying at the bottom of the page on desktop due to missing CSS rules.

Changes:
- Add @media query to hide .mobile-nav and .mobile-nav-backdrop on screens > 1400px
- Fixes clickable links appearing below copyright in footer
- Fixes "Start Free 7-Day Trial" button showing on desktop

The mobile nav is now properly hidden on desktop and only appears in the hamburger menu on mobile/tablet screens (≤1400px).