### PR TITLE
UX: Move Money-Back Guarantee after pricing cards for better conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -4057,34 +4057,6 @@
           </p>
         </div>
 
-        <!-- PROMINENT MONEY-BACK GUARANTEE -->
-        <div style="max-width:900px;margin:2rem auto;padding:2rem 2.5rem;background:linear-gradient(135deg,rgba(62,213,152,.15),rgba(62,213,152,.08));border:2px solid rgba(62,213,152,.4);border-radius:12px;text-align:center">
-          <div style="display:flex;align-items:center;justify-content:center;gap:1rem;margin-bottom:1rem">
-            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5">
-              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-              <path d="M9 12l2 2 4-4"/>
-            </svg>
-            <h3 style="font-size:1.5rem;font-weight:700;color:#3ed598;margin:0">7-Day Money-Back Guarantee</h3>
-          </div>
-          <p style="font-size:1.05rem;color:var(--text);line-height:1.6;margin:0;max-width:700px;margin:0 auto">
-            <strong>Try risk-free for 7 days.</strong> Not satisfied? Email us for a full refund—no questions asked, no hassle. You keep access during the entire trial period.
-          </p>
-          <div style="display:flex;justify-content:center;gap:2rem;margin-top:1.5rem;flex-wrap:wrap">
-            <div style="display:flex;align-items:center;gap:.5rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.95rem;color:var(--muted)">No questions asked</span>
-            </div>
-            <div style="display:flex;align-items:center;gap:.5rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.95rem;color:var(--muted)">Full refund within 7 days</span>
-            </div>
-            <div style="display:flex;align-items:center;gap:.5rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.95rem;color:var(--muted)">Keep access during trial</span>
-            </div>
-          </div>
-        </div>
-
         <!-- TRUST BADGES -->
         <div style="display:flex;justify-content:center;gap:2rem;flex-wrap:wrap;margin-bottom:2rem;opacity:.85">
           <div style="display:flex;align-items:center;gap:.5rem">
@@ -4285,7 +4257,33 @@
 
 
 
-
+        <!-- MONEY-BACK GUARANTEE (after pricing cards for maximum conversion impact) -->
+        <div style="max-width:900px;margin:3rem auto 2rem;padding:2rem 2.5rem;background:linear-gradient(135deg,rgba(62,213,152,.15),rgba(62,213,152,.08));border:2px solid rgba(62,213,152,.4);border-radius:12px;text-align:center">
+          <div style="display:flex;align-items:center;justify-content:center;gap:1rem;margin-bottom:1rem">
+            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5">
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+              <path d="M9 12l2 2 4-4"/>
+            </svg>
+            <h3 style="font-size:1.5rem;font-weight:700;color:#3ed598;margin:0">7-Day Money-Back Guarantee</h3>
+          </div>
+          <p style="font-size:1.05rem;color:var(--text);line-height:1.6;margin:0;max-width:700px;margin:0 auto">
+            <strong>Try risk-free for 7 days.</strong> Not satisfied? Email us for a full refund—no questions asked, no hassle. You keep access during the entire trial period.
+          </p>
+          <div style="display:flex;justify-content:center;gap:2rem;margin-top:1.5rem;flex-wrap:wrap">
+            <div style="display:flex;align-items:center;gap:.5rem">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
+              <span style="font-size:.95rem;color:var(--muted)">No questions asked</span>
+            </div>
+            <div style="display:flex;align-items:center;gap:.5rem">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
+              <span style="font-size:.95rem;color:var(--muted)">Full refund within 7 days</span>
+            </div>
+            <div style="display:flex;align-items:center;gap:.5rem">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="2.5"><path d="M20 6L9 17l-5-5"/></svg>
+              <span style="font-size:.95rem;color:var(--muted)">Keep access during trial</span>
+            </div>
+          </div>
+        </div>
 
       </div>
 


### PR DESCRIPTION
Changed pricing section flow from:
  Features → Guarantee → Pricing Cards
To:
  Features → Pricing Cards → Guarantee

Why this works better:
1. User sees what's included (features)
2. User sees pricing options and may hesitate
3. Guarantee removes risk objection at point of decision
4. More natural conversion flow

Psychology: Remove objections WHEN they appear, not before. Seeing the guarantee before pricing is wasted - user hasn't decided yet. Showing it after pricing catches hesitation at the critical moment.

The guarantee now serves as the final conversion nudge.