### PR TITLE
UX: Apply gorgeous card hover effects from affiliates page to main site

### DIFF
--- a/index.html
+++ b/index.html
@@ -932,9 +932,17 @@
 
 
 
-    .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0}
+    .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:hidden;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
+
+    .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease}
+
+    .card:hover::before{transform:scaleX(1)}
+
+    .card:hover{border-color:rgba(91,138,255,0.4);transform:translateY(-6px);box-shadow:0 20px 60px rgba(91,138,255,0.2);background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.04))}
 
     html[data-theme="light"] .card{border-color:rgba(10,20,40,.10);background:linear-gradient(180deg,rgba(10,20,40,.03),rgba(10,20,40,.01))}
+
+    html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
 
 


### PR DESCRIPTION
Added the same stunning hover effects to all .card elements on main site:
- Gradient top line reveal (brand → accent)
- 6px lift with smooth cubic-bezier easing
- Glowing brand-colored shadow
- Background brightening on hover
- Light theme optimized variants

Enhances visual polish for FAQ cards and all card-based sections.