### PR TITLE
Implement one-time payment pricing model

### DIFF
--- a/affiliates.html
+++ b/affiliates.html
@@ -456,6 +456,9 @@
         Earn 30% Recurring Commission<br>
         <span style="background:linear-gradient(135deg,#3ed598,#2ec98a);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">For Life</span>
       </h1>
+      <p style="font-size:1.15rem;color:var(--muted);margin-bottom:1.25rem;max-width:750px;margin-left:auto;margin-right:auto">
+        Earn commissions from <span class="typewriter-affiliate" style="color:var(--brand);font-weight:600"></span>
+      </p>
       <p class="hero-subtitle" style="font-size:1.35rem;max-width:750px">
         Perfect for trading educators, course creators, and influencers.
         Promote the <strong style="color:var(--brand)">most complete trading education platform</strong>
@@ -878,5 +881,45 @@
       </p>
     </div>
   </footer>
+
+  <script>
+    // Typewriter animation for affiliate hero
+    (function() {
+      const words = ['day traders', 'swing traders', 'scalpers', 'all traders'];
+      let wordIndex = 0;
+      let charIndex = 0;
+      let isDeleting = false;
+      const typewriterElement = document.querySelector('.typewriter-affiliate');
+
+      if (!typewriterElement) return;
+
+      function type() {
+        const currentWord = words[wordIndex];
+
+        if (isDeleting) {
+          typewriterElement.textContent = currentWord.substring(0, charIndex - 1);
+          charIndex--;
+        } else {
+          typewriterElement.textContent = currentWord.substring(0, charIndex + 1);
+          charIndex++;
+        }
+
+        let typeSpeed = isDeleting ? 50 : 100;
+
+        if (!isDeleting && charIndex === currentWord.length) {
+          typeSpeed = 2000; // Pause at end
+          isDeleting = true;
+        } else if (isDeleting && charIndex === 0) {
+          isDeleting = false;
+          wordIndex = (wordIndex + 1) % words.length;
+          typeSpeed = 500; // Pause before next word
+        }
+
+        setTimeout(type, typeSpeed);
+      }
+
+      type();
+    })();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4186,6 +4186,9 @@
       <div class="container stack">
 
         <h2 class="headline lg" style="text-align:center">Plans & Pricing</h2>
+        <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
+          Trusted by <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
+        </p>
 
         <!-- What's Included - ALL Plans Identical -->
         <div style="text-align:center;max-width:900px;margin:1.5rem auto;padding:1.75rem 2rem;background:linear-gradient(135deg,rgba(91,138,255,.1),rgba(91,138,255,.05));border:2px solid rgba(91,138,255,.25);border-radius:12px">
@@ -4367,13 +4370,13 @@
 
             <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(249,162,60,.08);border:1px solid rgba(249,162,60,.25);border-radius:8px">
               <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">
-                Pay once, own forever
+                One payment. Own it forever.
               </p>
               <p style="font-size:.9rem;color:var(--muted);margin:0 0 .25rem 0">
-                ≈ $110/month year 1, then $0/month forever
+                $1,799 today = $0/month forever
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
-                Never pay again. Best for long-term traders.
+                Lock in lifetime access now.
               </p>
             </div>
 
@@ -4603,7 +4606,10 @@
         <div>
           <h4 style="margin:0 0 .8rem 0;font-size:1.1rem;font-weight:700"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span></h4>
           <p style="color:var(--muted);font-size:.85rem;line-height:1.6;margin:0 0 1rem 0">
-            Education-first trading tools. 82 free lessons + 7 premium TradingView indicators.
+            Built for <span class="typewriter-footer" style="color:var(--brand);font-weight:600"></span>
+          </p>
+          <p style="color:var(--muted);font-size:.85rem;line-height:1.6;margin:0 0 1rem 0">
+            82 free lessons + 7 premium TradingView indicators.
           </p>
           <div style="display:flex;gap:.8rem;margin-top:1rem">
             <a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:1.3rem;transition:color .2s" title="GitHub">⚡</a>
@@ -6803,6 +6809,84 @@ if ('serviceWorker' in navigator) {
     }
   }
 })();
+</script>
+
+<script>
+  // Typewriter animation for pricing subheading
+  (function() {
+    const words = ['5,000+ traders', 'serious investors', 'pros worldwide'];
+    let wordIndex = 0;
+    let charIndex = 0;
+    let isDeleting = false;
+    const typewriterElement = document.querySelector('.typewriter-pricing');
+
+    if (!typewriterElement) return;
+
+    function type() {
+      const currentWord = words[wordIndex];
+
+      if (isDeleting) {
+        typewriterElement.textContent = currentWord.substring(0, charIndex - 1);
+        charIndex--;
+      } else {
+        typewriterElement.textContent = currentWord.substring(0, charIndex + 1);
+        charIndex++;
+      }
+
+      let typeSpeed = isDeleting ? 50 : 100;
+
+      if (!isDeleting && charIndex === currentWord.length) {
+        typeSpeed = 2000; // Pause at end
+        isDeleting = true;
+      } else if (isDeleting && charIndex === 0) {
+        isDeleting = false;
+        wordIndex = (wordIndex + 1) % words.length;
+        typeSpeed = 500; // Pause before next word
+      }
+
+      setTimeout(type, typeSpeed);
+    }
+
+    type();
+  })();
+
+  // Typewriter animation for footer
+  (function() {
+    const words = ['traders', 'investors', 'professionals', 'you'];
+    let wordIndex = 0;
+    let charIndex = 0;
+    let isDeleting = false;
+    const typewriterElement = document.querySelector('.typewriter-footer');
+
+    if (!typewriterElement) return;
+
+    function type() {
+      const currentWord = words[wordIndex];
+
+      if (isDeleting) {
+        typewriterElement.textContent = currentWord.substring(0, charIndex - 1);
+        charIndex--;
+      } else {
+        typewriterElement.textContent = currentWord.substring(0, charIndex + 1);
+        charIndex++;
+      }
+
+      let typeSpeed = isDeleting ? 50 : 100;
+
+      if (!isDeleting && charIndex === currentWord.length) {
+        typeSpeed = 2000; // Pause at end
+        isDeleting = true;
+      } else if (isDeleting && charIndex === 0) {
+        isDeleting = false;
+        wordIndex = (wordIndex + 1) % words.length;
+        typeSpeed = 500; // Pause before next word
+      }
+
+      setTimeout(type, typeSpeed);
+    }
+
+    type();
+  })();
 </script>
 
 </body>


### PR DESCRIPTION
Lifetime Pricing Improvements:
- Changed "Pay once, own forever" to "One payment. Own it forever"
- Replaced confusing "≈ $110/month year 1" with clear "$1,799 today = $0/month forever"
- Updated CTA to "Lock in lifetime access now" (more inclusive, less repetitive)

Typewriter Animations Added:
- Affiliates hero: "Earn commissions from [day traders → swing traders → scalpers → all traders]"
- Pricing subheading: "Trusted by [5,000+ traders → serious investors → pros worldwide]"
- Footer tagline: "Built for [traders → investors → professionals → you]"

All animations use smooth typing/deleting effect with 2s pause at completion.