### PR TITLE
FIX: Light mode gradient text readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,9 @@
 
       --grid-line:rgba(30,41,59,.06);
 
+      /* Dark gradient for headings in light mode */
+      --grad:linear-gradient(90deg,#1e40af 0%,#3b82f6 35%,#0ea5e9 60%,#2563eb 85%,#1e3a8a 100%);
+
     }
 
     /* LIGHT MODE: Fix ALL white/light text to be readable on white background */
@@ -317,6 +320,40 @@
 
     html[data-theme="light"]{
       color:#0f172a;
+    }
+
+    /* FIX GRADIENT TEXT FOR LIGHT MODE - Critical for readability */
+    html[data-theme="light"] .headline {
+      background: linear-gradient(135deg, #1e40af, #7c3aed) !important;
+      -webkit-background-clip: text !important;
+      background-clip: text !important;
+      -webkit-text-fill-color: transparent !important;
+    }
+
+    /* Fix all green gradient text (success/guarantee messages) */
+    html[data-theme="light"] strong[style*="linear-gradient(135deg,#3ed598"],
+    html[data-theme="light"] span[style*="linear-gradient(135deg,#3ed598"] {
+      background: linear-gradient(135deg, #059669, #047857) !important;
+      -webkit-background-clip: text !important;
+      background-clip: text !important;
+      -webkit-text-fill-color: transparent !important;
+    }
+
+    /* Fix all orange gradient text (pricing/CTA) */
+    html[data-theme="light"] strong[style*="linear-gradient(135deg,#f9a23c"],
+    html[data-theme="light"] span[style*="linear-gradient(135deg,#f9a23c"] {
+      background: linear-gradient(135deg, #c2410c, #ea580c) !important;
+      -webkit-background-clip: text !important;
+      background-clip: text !important;
+      -webkit-text-fill-color: transparent !important;
+    }
+
+    /* Fix brand gradient text (Signal Pilot logo/branding) */
+    html[data-theme="light"] span[style*="linear-gradient(135deg,#5b8aff"] {
+      background: linear-gradient(135deg, #1e40af, #6b21a8) !important;
+      -webkit-background-clip: text !important;
+      background-clip: text !important;
+      -webkit-text-fill-color: transparent !important;
     }
 
 


### PR DESCRIPTION
Critical Fix:
- Gradient text was invisible in light mode (light gradients on white background)
- Added dark gradient variants for all gradient text elements in light mode

Changes:
1. Added --grad variable for light mode (dark blue gradient)
2. Fixed .headline class gradients (all major headings)
3. Fixed green gradient text (#3ed598) → darker green (#059669)
4. Fixed orange gradient text (#f9a23c) → darker orange (#c2410c)
5. Fixed brand gradient text (#5b8aff) → darker blue (#1e40af)

All gradient text now has proper contrast in both dark and light themes. Typing animations use CSS variables which already work correctly.