### PR TITLE
FIX: Light mode background now shows animated effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,21 +383,7 @@
 
     /* ==================== LIGHT MODE GORGEOUS EFFECTS ==================== */
 
-    /* Animated gradient orbs for light mode */
-    html[data-theme="light"] body::before {
-      content: '';
-      position: fixed;
-      inset: 0;
-      z-index: -2;
-      pointer-events: none;
-      background:
-        radial-gradient(circle 800px at 20% 30%, rgba(59, 130, 246, 0.08), transparent 50%),
-        radial-gradient(circle 600px at 80% 70%, rgba(168, 85, 247, 0.06), transparent 50%),
-        radial-gradient(circle 700px at 50% 50%, rgba(14, 165, 233, 0.05), transparent 50%),
-        #ffffff;
-      animation: orbFloat 20s ease-in-out infinite;
-    }
-
+    /* Keyframe animations for light mode backgrounds */
     @keyframes orbFloat {
       0%, 100% {
         background:
@@ -413,19 +399,6 @@
           radial-gradient(circle 700px at 60% 40%, rgba(14, 165, 233, 0.07), transparent 50%),
           #ffffff;
       }
-    }
-
-    /* Floating particles for light mode */
-    html[data-theme="light"] body::after {
-      opacity: 0.15 !important;
-      background-image:
-        radial-gradient(1px 1px at 15% 25%, #3b82f6, transparent 50%),
-        radial-gradient(1.5px 1.5px at 85% 15%, #a855f7, transparent 50%),
-        radial-gradient(1px 1px at 45% 75%, #0ea5e9, transparent 50%),
-        radial-gradient(1.5px 1.5px at 70% 85%, #8b5cf6, transparent 50%),
-        radial-gradient(1px 1px at 25% 60%, #3b82f6, transparent 50%),
-        radial-gradient(1px 1px at 90% 50%, #06b6d4, transparent 50%) !important;
-      animation: particleFloat 30s linear infinite;
     }
 
     @keyframes particleFloat {
@@ -795,13 +768,15 @@
 
       background:
 
-        radial-gradient(1000px 600px at -6% -8%, rgba(59,130,246,.08), transparent 60%),
+        radial-gradient(circle 800px at 20% 30%, rgba(59, 130, 246, 0.08), transparent 50%),
 
-        radial-gradient(900px 550px at 108% -10%, rgba(96,165,250,.06), transparent 62%),
+        radial-gradient(circle 600px at 80% 70%, rgba(168, 85, 247, 0.06), transparent 50%),
 
-        radial-gradient(1000px 600px at 52% 118%, rgba(14,165,233,.06), transparent 64%),
+        radial-gradient(circle 700px at 50% 50%, rgba(14, 165, 233, 0.05), transparent 50%),
 
         #ffffff;
+
+      animation: orbFloat 20s ease-in-out infinite;
 
     }
 
@@ -832,7 +807,18 @@
     }
 
     html[data-theme="light"] body::after{
-      opacity:.25;
+      opacity:.15;
+      background-image:
+        radial-gradient(1px 1px at 15% 25%, #3b82f6, transparent 50%),
+        radial-gradient(1.5px 1.5px at 85% 15%, #a855f7, transparent 50%),
+        radial-gradient(1px 1px at 45% 75%, #0ea5e9, transparent 50%),
+        radial-gradient(1.5px 1.5px at 70% 85%, #8b5cf6, transparent 50%),
+        radial-gradient(1px 1px at 25% 60%, #3b82f6, transparent 50%),
+        radial-gradient(1px 1px at 90% 50%, #06b6d4, transparent 50%),
+        linear-gradient(transparent 31px, var(--grid-line) 32px, transparent 33px),
+        linear-gradient(90deg, transparent 31px, var(--grid-line) 32px, transparent 33px);
+      background-size: 100% 100%, 100% 100%, 100% 100%, 100% 100%, 100% 100%, 100% 100%, 64px 64px, 64px 64px;
+      animation: particleFloat 30s linear infinite;
     }
 
 


### PR DESCRIPTION
Issue: Background was still plain white in light mode
Cause: Duplicate conflicting styles - new styles were being overridden by existing ones

Fix:
- Updated EXISTING html[data-theme="light"] body::before (line 794) to include animated gradient orbs with 20s animation
- Updated EXISTING html[data-theme="light"] body::after (line 836) to include floating particles with 30s animation + grid overlay
- Removed duplicate body::before and body::after declarations
- Kept @keyframes animations (orbFloat, particleFloat)
- Kept grid overlay and enhanced card styles

Light mode now has:
✨ Animated blue/purple gradient orbs that slowly drift ✨ Floating particle effects for depth
✨ Subtle grid overlay for tech aesthetic
✨ Glassmorphic cards with backdrop blur

Background is no longer plain white!