### PR TITLE
FIX: Increased light mode background opacity for visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,16 +387,16 @@
     @keyframes orbFloat {
       0%, 100% {
         background:
-          radial-gradient(circle 800px at 20% 30%, rgba(59, 130, 246, 0.08), transparent 50%),
-          radial-gradient(circle 600px at 80% 70%, rgba(168, 85, 247, 0.06), transparent 50%),
-          radial-gradient(circle 700px at 50% 50%, rgba(14, 165, 233, 0.05), transparent 50%),
+          radial-gradient(circle 900px at 20% 30%, rgba(59, 130, 246, 0.15), transparent 60%),
+          radial-gradient(circle 700px at 80% 70%, rgba(168, 85, 247, 0.12), transparent 60%),
+          radial-gradient(circle 800px at 50% 50%, rgba(14, 165, 233, 0.1), transparent 60%),
           #ffffff;
       }
       50% {
         background:
-          radial-gradient(circle 800px at 30% 40%, rgba(59, 130, 246, 0.1), transparent 50%),
-          radial-gradient(circle 600px at 70% 60%, rgba(168, 85, 247, 0.08), transparent 50%),
-          radial-gradient(circle 700px at 60% 40%, rgba(14, 165, 233, 0.07), transparent 50%),
+          radial-gradient(circle 900px at 30% 40%, rgba(59, 130, 246, 0.18), transparent 60%),
+          radial-gradient(circle 700px at 70% 60%, rgba(168, 85, 247, 0.15), transparent 60%),
+          radial-gradient(circle 800px at 60% 40%, rgba(14, 165, 233, 0.13), transparent 60%),
           #ffffff;
       }
     }
@@ -415,10 +415,10 @@
       z-index: -1;
       pointer-events: none;
       background-image:
-        linear-gradient(rgba(59, 130, 246, 0.03) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(59, 130, 246, 0.03) 1px, transparent 1px);
+        linear-gradient(rgba(59, 130, 246, 0.06) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(59, 130, 246, 0.06) 1px, transparent 1px);
       background-size: 50px 50px;
-      opacity: 0.4;
+      opacity: 0.6;
     }
 
     /* Enhanced cards in light mode */
@@ -768,11 +768,11 @@
 
       background:
 
-        radial-gradient(circle 800px at 20% 30%, rgba(59, 130, 246, 0.08), transparent 50%),
+        radial-gradient(circle 900px at 20% 30%, rgba(59, 130, 246, 0.15), transparent 60%),
 
-        radial-gradient(circle 600px at 80% 70%, rgba(168, 85, 247, 0.06), transparent 50%),
+        radial-gradient(circle 700px at 80% 70%, rgba(168, 85, 247, 0.12), transparent 60%),
 
-        radial-gradient(circle 700px at 50% 50%, rgba(14, 165, 233, 0.05), transparent 50%),
+        radial-gradient(circle 800px at 50% 50%, rgba(14, 165, 233, 0.1), transparent 60%),
 
         #ffffff;
 
@@ -807,16 +807,16 @@
     }
 
     html[data-theme="light"] body::after{
-      opacity:.15;
+      opacity:.25;
       background-image:
-        radial-gradient(1px 1px at 15% 25%, #3b82f6, transparent 50%),
-        radial-gradient(1.5px 1.5px at 85% 15%, #a855f7, transparent 50%),
-        radial-gradient(1px 1px at 45% 75%, #0ea5e9, transparent 50%),
-        radial-gradient(1.5px 1.5px at 70% 85%, #8b5cf6, transparent 50%),
-        radial-gradient(1px 1px at 25% 60%, #3b82f6, transparent 50%),
-        radial-gradient(1px 1px at 90% 50%, #06b6d4, transparent 50%),
-        linear-gradient(transparent 31px, var(--grid-line) 32px, transparent 33px),
-        linear-gradient(90deg, transparent 31px, var(--grid-line) 32px, transparent 33px);
+        radial-gradient(2px 2px at 15% 25%, #3b82f6, transparent 50%),
+        radial-gradient(3px 3px at 85% 15%, #a855f7, transparent 50%),
+        radial-gradient(2px 2px at 45% 75%, #0ea5e9, transparent 50%),
+        radial-gradient(3px 3px at 70% 85%, #8b5cf6, transparent 50%),
+        radial-gradient(2px 2px at 25% 60%, #3b82f6, transparent 50%),
+        radial-gradient(2px 2px at 90% 50%, #06b6d4, transparent 50%),
+        linear-gradient(transparent 31px, rgba(59, 130, 246, 0.08) 32px, transparent 33px),
+        linear-gradient(90deg, transparent 31px, rgba(59, 130, 246, 0.08) 32px, transparent 33px);
       background-size: 100% 100%, 100% 100%, 100% 100%, 100% 100%, 100% 100%, 100% 100%, 64px 64px, 64px 64px;
       animation: particleFloat 30s linear infinite;
     }


### PR DESCRIPTION
Problem: Background effects were too subtle (opacity 0.05-0.08) - basically invisible

Solution: Significantly increased all opacity values:

Gradient Orbs (body::before):
- Increased from 0.08/0.06/0.05 → 0.15/0.12/0.1 (~2x stronger)
- Animation peak: up to 0.18/0.15/0.13
- Larger circles: 900px/700px/800px (was 800px/600px/700px)

Floating Particles (body::after):
- Opacity: 0.15 → 0.25 (67% increase)
- Particle size: 1px → 2px, 1.5px → 3px (doubled!)
- Grid lines: changed to explicit blue color rgba(59, 130, 246, 0.08)

Grid Overlay (html::before):
- Line opacity: 0.03 → 0.06 (doubled)
- Overall opacity: 0.4 → 0.6 (50% increase)

Light mode should now have clearly visible:
✨ Blue/purple gradient orbs drifting across page
✨ Floating colored particles
✨ Subtle grid texture

No more plain white background!