### PR TITLE
UX: Boost light mode background opacity by 50% for visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,16 +387,16 @@
     @keyframes orbFloat {
       0%, 100% {
         background:
-          radial-gradient(circle 900px at 20% 30%, rgba(59, 130, 246, 0.15), transparent 60%),
-          radial-gradient(circle 700px at 80% 70%, rgba(168, 85, 247, 0.12), transparent 60%),
-          radial-gradient(circle 800px at 50% 50%, rgba(14, 165, 233, 0.1), transparent 60%),
+          radial-gradient(circle 900px at 20% 30%, rgba(59, 130, 246, 0.22), transparent 60%),
+          radial-gradient(circle 700px at 80% 70%, rgba(168, 85, 247, 0.18), transparent 60%),
+          radial-gradient(circle 800px at 50% 50%, rgba(14, 165, 233, 0.15), transparent 60%),
           #ffffff;
       }
       50% {
         background:
-          radial-gradient(circle 900px at 30% 40%, rgba(59, 130, 246, 0.18), transparent 60%),
-          radial-gradient(circle 700px at 70% 60%, rgba(168, 85, 247, 0.15), transparent 60%),
-          radial-gradient(circle 800px at 60% 40%, rgba(14, 165, 233, 0.13), transparent 60%),
+          radial-gradient(circle 900px at 30% 40%, rgba(59, 130, 246, 0.27), transparent 60%),
+          radial-gradient(circle 700px at 70% 60%, rgba(168, 85, 247, 0.23), transparent 60%),
+          radial-gradient(circle 800px at 60% 40%, rgba(14, 165, 233, 0.20), transparent 60%),
           #ffffff;
       }
     }
@@ -415,10 +415,10 @@
       z-index: -1;
       pointer-events: none;
       background-image:
-        linear-gradient(rgba(59, 130, 246, 0.06) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(59, 130, 246, 0.06) 1px, transparent 1px);
+        linear-gradient(rgba(59, 130, 246, 0.09) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(59, 130, 246, 0.09) 1px, transparent 1px);
       background-size: 50px 50px;
-      opacity: 0.6;
+      opacity: 0.9;
     }
 
     /* Enhanced cards in light mode */
@@ -768,11 +768,11 @@
 
       background:
 
-        radial-gradient(circle 900px at 20% 30%, rgba(59, 130, 246, 0.15), transparent 60%),
+        radial-gradient(circle 900px at 20% 30%, rgba(59, 130, 246, 0.22), transparent 60%),
 
-        radial-gradient(circle 700px at 80% 70%, rgba(168, 85, 247, 0.12), transparent 60%),
+        radial-gradient(circle 700px at 80% 70%, rgba(168, 85, 247, 0.18), transparent 60%),
 
-        radial-gradient(circle 800px at 50% 50%, rgba(14, 165, 233, 0.1), transparent 60%),
+        radial-gradient(circle 800px at 50% 50%, rgba(14, 165, 233, 0.15), transparent 60%),
 
         #ffffff;
 
@@ -807,7 +807,7 @@
     }
 
     html[data-theme="light"] body::after{
-      opacity:.25;
+      opacity:.38;
       background-image:
         radial-gradient(2px 2px at 15% 25%, #3b82f6, transparent 50%),
         radial-gradient(3px 3px at 85% 15%, #a855f7, transparent 50%),
@@ -815,8 +815,8 @@
         radial-gradient(3px 3px at 70% 85%, #8b5cf6, transparent 50%),
         radial-gradient(2px 2px at 25% 60%, #3b82f6, transparent 50%),
         radial-gradient(2px 2px at 90% 50%, #06b6d4, transparent 50%),
-        linear-gradient(transparent 31px, rgba(59, 130, 246, 0.08) 32px, transparent 33px),
-        linear-gradient(90deg, transparent 31px, rgba(59, 130, 246, 0.08) 32px, transparent 33px);
+        linear-gradient(transparent 31px, rgba(59, 130, 246, 0.12) 32px, transparent 33px),
+        linear-gradient(90deg, transparent 31px, rgba(59, 130, 246, 0.12) 32px, transparent 33px);
       background-size: 100% 100%, 100% 100%, 100% 100%, 100% 100%, 100% 100%, 100% 100%, 64px 64px, 64px 64px;
       animation: particleFloat 30s linear infinite;
     }


### PR DESCRIPTION
Per user request, increased ALL background effect opacities by 50%:

Gradient Orbs (body::before):
- Base: 0.15 → 0.22, 0.12 → 0.18, 0.10 → 0.15
- Animation peak: 0.18 → 0.27, 0.15 → 0.23, 0.13 → 0.20 Result: Much more vibrant blue/purple orbs

Floating Particles & Grid (body::after):
- Overall opacity: 0.25 → 0.38 (52% increase)
- Grid line color: 0.08 → 0.12 (50% increase) Result: Particles and grid much more visible

Grid Overlay (html::before):
- Line color: 0.06 → 0.09 (50% increase)
- Overall opacity: 0.6 → 0.9 (50% increase) Result: Prominent grid texture

Light mode now has significantly stronger visual effects while remaining tasteful.