### PR TITLE
Improve: Speed up quality progression animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7298,14 +7298,22 @@ if ('serviceWorker' in navigator) {
             const sequence = qualityProgressions[qualityType];
             let currentIndex = 0;
 
-            const timer = setInterval(() => {
-              if (currentIndex >= sequence.length) {
-                clearInterval(timer);
-              } else {
+            const animateSequence = () => {
+              if (currentIndex < sequence.length) {
                 entry.target.textContent = sequence[currentIndex];
+
+                // Faster progression through early stages, stop at final word
+                const isLastItem = currentIndex === sequence.length - 1;
+                const delay = isLastItem ? 0 : 180; // 180ms for each step, stop at last
+
                 currentIndex++;
+                if (!isLastItem) {
+                  setTimeout(animateSequence, delay);
+                }
               }
-            }, 300); // Change every 300ms
+            };
+
+            animateSequence();
             return;
           }
 


### PR DESCRIPTION
- Changed from 300ms interval to 180ms for faster progression
- Refactored setInterval to setTimeout for better control
- Animation now cycles through basic → good → great → premium quickly (180ms each)
- "Elite" appears and stays permanently at the end
- Total animation time: ~720ms vs previous 1500ms (52% faster)

The animation now has more impact by moving quickly through the progression stages and landing on "elite" with emphasis.