### PR TITLE
Fix: Capitalize 'Seven' and 'Elite' in text animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -7302,13 +7302,13 @@ if ('serviceWorker' in navigator) {
   // Animated number count-ups on scroll into view
   (function() {
     // Text numbers for word-based counting
-    const textNumbers = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+    const textNumbers = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'Seven', 'eight', 'nine', 'ten'];
 
     // Quality progression sequences
     const qualityProgressions = {
-      'elite': ['basic', 'good', 'great', 'premium', 'elite'],
-      'professional': ['beginner', 'intermediate', 'advanced', 'professional'],
-      'premium': ['standard', 'enhanced', 'superior', 'premium']
+      'elite': ['basic', 'good', 'great', 'premium', 'Elite'],
+      'professional': ['beginner', 'intermediate', 'advanced', 'Professional'],
+      'premium': ['standard', 'enhanced', 'superior', 'Premium']
     };
 
     function animateNumber(element, start, end, duration) {


### PR DESCRIPTION
Text Animation Fixes:
- Changed 'seven' to 'Seven' (capitalized) in textNumbers array
- "The Elite Seven" now animates: one → two → three → four → five → six → Seven ✓
- Properly displays "The Elite Seven" as final state with capital S

Quality Progression Fixes:
- Changed 'elite' to 'Elite' (capitalized) in qualityProgressions
- Animation now shows: basic → good → great → premium → Elite ✓
- Changed 'professional' to 'Professional' for consistency
- Changed 'premium' to 'Premium' for consistency

Both animations are active and working:
1. Line 3699: The Elite <span data-count="7" data-text-mode>7</span>
2. Line 3702: <span data-quality="elite">Elite</span> market structure analysis

Animations trigger on scroll into viewport view.