### PR TITLE
Fix: Center pricing cards and eliminate guarantee overflow on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1152,10 +1152,12 @@
         display: flex !important;
         flex-direction: column !important;
         gap: 2rem !important;
-        max-width: 100vw !important;
-        padding: 0 1rem !important;
+        max-width: 100% !important;
+        padding: 0 !important;
         margin: 0 auto !important;
         box-sizing: border-box !important;
+        align-items: center !important;
+        justify-content: center !important;
       }
 
       /* Individual pricing cards */
@@ -1164,9 +1166,9 @@
         flex-direction: column !important;
         height: auto !important;
         min-height: auto !important;
-        max-width: 100% !important;
-        width: 100% !important;
-        margin: 0 !important;
+        max-width: calc(100vw - 2rem) !important;
+        width: calc(100vw - 2rem) !important;
+        margin: 0 auto !important;
         padding: 1.5rem 1rem !important;
         box-sizing: border-box !important;
         overflow: visible !important;
@@ -1243,31 +1245,47 @@
       /* Fix 7-day money back guarantee - be very specific */
       #plans-grid + div,
       section .container > div[style*="max-width:900px"] {
-        max-width: calc(100vw - 2rem) !important;
-        width: calc(100vw - 2rem) !important;
-        padding: 1.5rem 1rem !important;
-        margin: 3rem auto 1rem !important;
+        max-width: calc(100% - 2rem) !important;
+        width: calc(100% - 2rem) !important;
+        padding: 1.25rem 0.75rem !important;
+        margin: 2rem auto 1rem !important;
         box-sizing: border-box !important;
+        overflow: hidden !important;
       }
 
       section .container > div[style*="max-width:900px"] h3 {
-        font-size: 1.1rem !important;
+        font-size: 1rem !important;
         line-height: 1.3 !important;
+        word-wrap: break-word !important;
       }
 
       section .container > div[style*="max-width:900px"] p {
-        font-size: 0.9rem !important;
+        font-size: 0.85rem !important;
+        word-wrap: break-word !important;
+        line-height: 1.5 !important;
       }
 
       section .container > div[style*="max-width:900px"] > div[style*="display:flex"] {
         flex-direction: column !important;
-        gap: 0.75rem !important;
+        gap: 0.5rem !important;
         align-items: flex-start !important;
       }
 
       section .container > div[style*="max-width:900px"] svg {
-        width: 30px !important;
-        height: 30px !important;
+        width: 24px !important;
+        height: 24px !important;
+        flex-shrink: 0 !important;
+      }
+
+      /* Ensure icon + text rows don't overflow */
+      section .container > div[style*="max-width:900px"] > div > div {
+        max-width: 100% !important;
+        overflow: hidden !important;
+      }
+
+      section .container > div[style*="max-width:900px"] span {
+        font-size: 0.8rem !important;
+        word-wrap: break-word !important;
       }
     }
 


### PR DESCRIPTION
Pricing Cards Centering:
- Added align-items: center and justify-content: center to pricing-grid
- Changed card width from 100% to calc(100vw - 2rem) for proper spacing
- Cards now perfectly centered with equal margins on both sides
- Removed padding from pricing-grid container to prevent offset

7-Day Money Back Guarantee Overflow Fix:
- Changed max-width from calc(100vw - 2rem) to calc(100% - 2rem)
- Reduced padding from 1.5rem 1rem to 1.25rem 0.75rem for tighter fit
- Added overflow: hidden to prevent any content bleeding
- Reduced font sizes: h3 (1rem), p (0.85rem), span (0.8rem)
- Smaller SVG icons (24px instead of 30px)
- Added word-wrap: break-word to all text elements
- Ensured icon + text rows don't overflow with max-width: 100%
- Reduced gap from 0.75rem to 0.5rem

All content now fits within viewport borders on mobile without any overflow.