### PR TITLE
Fix: Make theme selector and chatbot sticky + horizontal footer links…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1368,20 +1368,35 @@
         color: #3ed598 !important;
       }
 
-      /* Footer card links */
+      /* Footer card links - make horizontal/less vertical */
+      footer > .container > div[style*="grid-template-columns"] > div ul {
+        display: flex !important;
+        flex-wrap: wrap !important;
+        gap: 0.4rem 0.5rem !important;
+        line-height: 1.3 !important;
+      }
+
       footer > .container > div[style*="grid-template-columns"] > div ul li {
-        margin-bottom: 0.4rem !important;
+        margin-bottom: 0 !important;
+        display: inline !important;
+      }
+
+      footer > .container > div[style*="grid-template-columns"] > div ul li:not(:last-child)::after {
+        content: " •" !important;
+        color: rgba(255,255,255,.2) !important;
+        margin-left: 0.5rem !important;
       }
 
       footer > .container > div[style*="grid-template-columns"] > div ul li a {
-        font-size: 0.75rem !important;
+        font-size: 0.7rem !important;
         transition: all 0.2s ease !important;
-        display: inline-block !important;
+        display: inline !important;
+        line-height: 1.3 !important;
       }
 
       footer > .container > div[style*="grid-template-columns"] > div ul li a:hover {
-        transform: translateX(2px) !important;
         opacity: 1 !important;
+        color: var(--brand) !important;
       }
 
       /* Sticky buttons on mobile - bottom right corner */
@@ -2703,6 +2718,49 @@
     ]
   }
   </script>
+
+  <!-- Sticky buttons override - must load last to override theme-switcher.js -->
+  <style>
+    /* Force sticky positioning for theme selector and chatbot on ALL screen sizes */
+    button.sp-theme-toggle,
+    .sp-theme-toggle {
+      position: fixed !important;
+      bottom: 90px !important;
+      right: 20px !important;
+      z-index: 9999 !important;
+      top: auto !important;
+      left: auto !important;
+      transform: none !important;
+    }
+
+    button.sp-chatbot-toggle,
+    .sp-chatbot-toggle {
+      position: fixed !important;
+      bottom: 20px !important;
+      right: 20px !important;
+      z-index: 10000 !important;
+      top: auto !important;
+      left: auto !important;
+      transform: none !important;
+    }
+
+    /* Mobile specific adjustments */
+    @media (max-width: 768px) {
+      button.sp-theme-toggle,
+      .sp-theme-toggle {
+        bottom: 90px !important;
+        right: 20px !important;
+        position: fixed !important;
+      }
+
+      button.sp-chatbot-toggle,
+      .sp-chatbot-toggle {
+        bottom: 20px !important;
+        right: 20px !important;
+        position: fixed !important;
+      }
+    }
+  </style>
 
 </head>
 


### PR DESCRIPTION
… on mobile

Sticky buttons:
- Added override styles at end of <head> to ensure buttons are truly fixed
- Theme selector (🎨) positioned at bottom: 90px with z-index: 9999
- Chatbot button positioned at bottom: 20px with z-index: 10000
- Used higher specificity selectors to override theme-switcher.js styles

Footer improvements:
- Changed footer card links from vertical to horizontal layout
- Added bullet separators between links for better readability
- Reduced font size to 0.7rem and compact line-height
- Links now wrap and display inline instead of stacking vertically