### PR TITLE
Fix: Remove 4 redundant FAQ questions (16→12)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5193,36 +5193,15 @@
         <p id="faq-answer-9" class="note"><strong>Absolutely!</strong> The Elite Seven are designed to work together. Popular combos: <strong>Pentarch + Volume Oracle</strong> for cycle timing with smart money confirmation, or <strong>Omnideck + Janus Atlas</strong> for complete market structure analysis with key levels.</p>
       </div>
 
-      <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-10">
-        <strong id="faq-question-10" style="color:var(--brand-2)">⚡ How do TradingView alerts work?</strong>
-        <p id="faq-answer-10" class="note">Set custom alerts on any indicator signal. <strong>Two pre-configured alerts included:</strong> EC Pro and Screener. <strong>Free TradingView:</strong> Limited alerts. <strong>Pro/Premium:</strong> Unlimited alerts. Alerts fire in real-time via email, SMS, or push notifications.</p>
-      </div>
-
       <!-- EDUCATION & SUPPORT -->
+      <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-10">
+        <strong id="faq-question-10" style="color:var(--brand)">🛠️ Do I need coding skills?</strong>
+        <p id="faq-answer-10" class="note"><strong>Zero coding required.</strong> All indicators are plug-and-play. We include <strong>200+ preset configurations</strong> (Lifetime plan) pre-tuned for different strategies. Just load the preset, apply to chart, done. Advanced users can customize settings, but it's optional.</p>
+      </div>
+
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-11">
-        <strong id="faq-question-11" style="color:var(--brand)">📚 What's in the Education Hub?</strong>
-        <p id="faq-answer-11" class="note"><strong>82 interactive lessons</strong> across 4 progressive tiers covering <strong>250,000+ words</strong> of curriculum. Topics: Market structure, cycle detection, order flow, liquidity dynamics, risk management. Includes quizzes, progress tracking, and real chart examples. Access: <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">education.signalpilot.io</a></p>
-      </div>
-
-      <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-12">
-        <strong id="faq-question-12" style="color:var(--brand)">🛠️ Do I need coding skills?</strong>
-        <p id="faq-answer-12" class="note"><strong>Zero coding required.</strong> All indicators are plug-and-play. We include <strong>200+ preset configurations</strong> (Lifetime plan) pre-tuned for different strategies. Just load the preset, apply to chart, done. Advanced users can customize settings, but it's optional.</p>
-      </div>
-
-      <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-13">
-        <strong id="faq-question-13" style="color:var(--good)">💬 What support channels exist?</strong>
-        <p id="faq-answer-13" class="note"><strong>Monthly:</strong> Email support (48h response). <strong>Yearly+:</strong> Priority email (24h response). <strong>Lifetime:</strong> Private Discord community + priority support. All plans include access to 50+ pages of documentation and video tutorials.</p>
-      </div>
-
-      <!-- ADVANCED FEATURES -->
-      <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-14">
-        <strong id="faq-question-14">🔬 Can I backtest the indicators?</strong>
-        <p id="faq-answer-14" class="note"><strong>Yes!</strong> All indicators work with TradingView's Strategy Tester. Backtest templates included. Test on years of historical data. <strong>Important:</strong> Past performance doesn't guarantee future results—backtesting is for education and system validation only.</p>
-      </div>
-
-      <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-15">
-        <strong id="faq-question-15">🌍 What markets are supported?</strong>
-        <p id="faq-answer-15" class="note"><strong>Any market on TradingView:</strong> Stocks, indices, forex, crypto, commodities, bonds. If it has OHLC + volume data, our indicators work. Tested on 100+ symbols across all asset classes. Multi-market compatibility built-in.</p>
+        <strong id="faq-question-11" style="color:var(--good)">💬 What support channels exist?</strong>
+        <p id="faq-answer-11" class="note"><strong>Monthly:</strong> Email support (48h response). <strong>Yearly+:</strong> Priority email (24h response). <strong>Lifetime:</strong> Private Discord community + priority support. All plans include access to 50+ pages of documentation and video tutorials.</p>
       </div>
 
     </div>


### PR DESCRIPTION
Removed:
- How do TradingView alerts work (technical detail)
- What's in Education Hub (duplicate of first question)
- Can I backtest (too technical for homepage)
- What markets supported (can go in detailed FAQ)

Kept only essential pre-purchase questions