### PR TITLE
Fix: Force sticky positioning on all 3 buttons with inline styles

### DIFF
--- a/assets/chatbot.js
+++ b/assets/chatbot.js
@@ -509,6 +509,12 @@ Email: support@signalpilot.io`;
       </div>
     `;
 
+    // Force sticky positioning with inline styles
+    toggle.style.position = 'fixed';
+    toggle.style.bottom = '20px';
+    toggle.style.right = '20px';
+    toggle.style.zIndex = '10000';
+
     document.body.appendChild(toggle);
     document.body.appendChild(window);
 

--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -376,6 +376,11 @@
     button.setAttribute('aria-label', 'Theme selection (Ctrl+T)');
     button.setAttribute('title', 'Theme selection (Ctrl+T)');
     button.onclick = () => openThemeModal();
+    // Force sticky positioning with inline styles
+    button.style.position = 'fixed';
+    button.style.bottom = '90px';
+    button.style.right = '20px';
+    button.style.zIndex = '9999';
     document.body.appendChild(button);
     return button;
   }

--- a/index.html
+++ b/index.html
@@ -7712,6 +7712,12 @@ if ('serviceWorker' in navigator) {
   (function() {
     const backToTopBtn = document.getElementById('backToTop');
 
+    // Force sticky positioning with inline styles
+    backToTopBtn.style.position = 'fixed';
+    backToTopBtn.style.bottom = '170px';
+    backToTopBtn.style.right = '20px';
+    backToTopBtn.style.zIndex = '998';
+
     // Show button when user scrolls down 400px
     window.addEventListener('scroll', function() {
       if (window.pageYOffset > 400) {


### PR DESCRIPTION
- Back to top: position fixed at bottom 170px
- Theme selector: position fixed at bottom 90px
- Chatbot: position fixed at bottom 20px
- Added inline styles via JavaScript to override any CSS conflicts
- All 3 buttons now follow user while scrolling