### PR TITLE
Fix: Uniform styling for all 3 sticky buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1400,27 +1400,27 @@
       }
     }
 
-    /* Back to top button - all screens */
+    /* Back to top button - all screens - matches theme/chatbot style */
     #backToTop {
       position: fixed;
-      bottom: 170px;
+      bottom: 160px;
       right: 20px;
-      width: 50px;
-      height: 50px;
+      width: 60px;
+      height: 60px;
       border-radius: 50%;
-      background: rgba(91,138,255,.9);
-      border: 1px solid rgba(91,138,255,.3);
-      color: #fff;
+      background: rgba(255,255,255,.06);
+      border: 1px solid rgba(255,255,255,.14);
+      color: #9fdcff;
       font-size: 1.5rem;
       cursor: pointer;
       z-index: 998;
       opacity: 0;
       visibility: hidden;
-      transition: all 0.3s ease;
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       display: flex;
       align-items: center;
       justify-content: center;
-      box-shadow: 0 4px 12px rgba(91,138,255,.3);
+      box-shadow: 0 4px 12px rgba(0,0,0,.3);
     }
 
     #backToTop.show {
@@ -1429,13 +1429,26 @@
     }
 
     #backToTop:hover {
-      background: rgba(91,138,255,1);
-      transform: translateY(-3px);
-      box-shadow: 0 6px 20px rgba(91,138,255,.5);
+      background: rgba(255,255,255,.1);
+      transform: scale(1.1);
+      box-shadow: 0 6px 20px rgba(0,0,0,.4);
     }
 
     #backToTop:active {
-      transform: translateY(-1px) scale(0.95);
+      transform: scale(0.95);
+    }
+
+    /* Light mode support for back to top */
+    html[data-theme="light"] #backToTop {
+      background: #f6f8fc;
+      border-color: #d7def0;
+      color: #0f1524;
+      box-shadow: 0 4px 12px rgba(0,0,0,.1);
+    }
+
+    html[data-theme="light"] #backToTop:hover {
+      background: #eef1f9;
+      box-shadow: 0 6px 20px rgba(0,0,0,.15);
     }
 
     .measure{max-width:var(--measure)}
@@ -7714,7 +7727,7 @@ if ('serviceWorker' in navigator) {
 
     // Force sticky positioning with inline styles
     backToTopBtn.style.position = 'fixed';
-    backToTopBtn.style.bottom = '170px';
+    backToTopBtn.style.bottom = '160px';
     backToTopBtn.style.right = '20px';
     backToTopBtn.style.zIndex = '998';
 


### PR DESCRIPTION
All buttons now:
- Same size: 60px × 60px
- Same transparent background: rgba(255,255,255,.06)
- Same border: 1px solid rgba(255,255,255,.14)
- Same hover effect: scale(1.1)
- Aligned in straight vertical line

Button positions:
- Chatbot: bottom 20px
- Theme: bottom 90px
- Back to top: bottom 160px (70px spacing)

Removed blue gradient from back to top button
Added light mode support to match other buttons