### PR TITLE
Fix: Remove unnecessary arrows from first 4 FAQ questions

### DIFF
--- a/assets/deferred.css
+++ b/assets/deferred.css
@@ -262,6 +262,14 @@
       transition: transform 0.3s ease;
     }
 
+    /* Remove arrows from first 4 FAQs (always expanded) */
+    #faq .card:nth-child(1) strong::after,
+    #faq .card:nth-child(2) strong::after,
+    #faq .card:nth-child(3) strong::after,
+    #faq .card:nth-child(4) strong::after {
+      content: none;
+    }
+
     #faq .card.expanded strong::after {
       transform: rotate(180deg);
       color: var(--brand);


### PR DESCRIPTION
- First 4 FAQ questions are always expanded (never collapse)
- Removed ▼/▲ arrows from these using nth-child selectors
- Only collapsible FAQs (5-12) now show arrows
- Cleaner UI without redundant indicators