### PR TITLE
Fix: Only 1 arrow per FAQ question (was showing 3-4)

### DIFF
--- a/assets/deferred.css
+++ b/assets/deferred.css
@@ -245,7 +245,8 @@
       border-color: var(--brand);
     }
 
-    #faq .card strong {
+    /* Only target the question strong (direct child), not answer strong tags */
+    #faq .card > strong {
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -253,7 +254,7 @@
       padding-right: 2rem;
     }
 
-    #faq .card strong::after {
+    #faq .card > strong::after {
       content: '▼';
       position: absolute;
       right: 1.2rem;
@@ -263,14 +264,14 @@
     }
 
     /* Remove arrows from first 4 FAQs (always expanded) */
-    #faq .card:nth-child(1) strong::after,
-    #faq .card:nth-child(2) strong::after,
-    #faq .card:nth-child(3) strong::after,
-    #faq .card:nth-child(4) strong::after {
+    #faq .card:nth-child(1) > strong::after,
+    #faq .card:nth-child(2) > strong::after,
+    #faq .card:nth-child(3) > strong::after,
+    #faq .card:nth-child(4) > strong::after {
       content: none;
     }
 
-    #faq .card.expanded strong::after {
+    #faq .card.expanded > strong::after {
       transform: rotate(180deg);
       color: var(--brand);
     }


### PR DESCRIPTION
Problem: CSS was adding arrows to ALL <strong> tags in FAQ cards
- Question had 1 arrow
- Each bold text in answer also got an arrow
- FAQ 7 had 4 arrows total (question + 3 in answer)

Solution: Changed selector from 'strong' to '> strong'
- Only targets direct child strong (the question)
- Ignores strong tags inside answer paragraphs
- Now exactly 1 arrow per collapsible FAQ