### PR TITLE
Add: Arrow to 'Does it work on free TradingView?' FAQ

### DIFF
--- a/assets/deferred.css
+++ b/assets/deferred.css
@@ -263,11 +263,10 @@
       transition: transform 0.3s ease;
     }
 
-    /* Remove arrows from first 4 FAQs (always expanded) */
+    /* Remove arrows from first 3 FAQs (always expanded) */
     #faq .card:nth-child(1) > strong::after,
     #faq .card:nth-child(2) > strong::after,
-    #faq .card:nth-child(3) > strong::after,
-    #faq .card:nth-child(4) > strong::after {
+    #faq .card:nth-child(3) > strong::after {
       content: none;
     }
 

--- a/index.html
+++ b/index.html
@@ -5173,7 +5173,7 @@
       </div>
 
       <!-- TECHNICAL -->
-      <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-3">
+      <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-3">
         <strong id="faq-question-3" style="color:var(--brand-2)">💻 Does it work on free TradingView?</strong>
         <p id="faq-answer-3" class="note"><strong>Yes!</strong> You just need enough indicator slots for your setup. <strong>Free accounts get 3 slots</strong>, which is enough for Pentarch + 1-2 filters. Pro/Premium accounts get more slots and unlimited alerts.</p>
       </div>


### PR DESCRIPTION
- Made question 4 collapsible (was always expanded)
- Changed aria-expanded from true → false
- Removed from 'no arrow' CSS rule
- Now only first 3 FAQs are always expanded
- Questions 4-12 are collapsible with arrows