### PR TITLE
Fix: Button alignment + FAQ uniform colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -4473,14 +4473,14 @@
         </div>
 
         <!-- Slider Controls -->
-        <div style="display:flex;justify-content:center;gap:1rem;margin-bottom:1.5rem;flex-wrap:wrap;align-items:center">
-          <button id="btn-before" class="btn btn-secondary" style="padding:0.6rem 1.2rem;font-size:0.9rem;min-height:auto;height:44px">
+        <div style="display:flex;justify-content:center;gap:1rem;margin-bottom:1.5rem;flex-wrap:wrap;align-items:stretch">
+          <button id="btn-before" class="btn btn-secondary" style="padding:0.6rem 1.4rem;font-size:0.9rem;height:44px;min-width:120px;box-sizing:border-box;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center">
             ← Before
           </button>
-          <button id="btn-autoplay" class="btn btn-primary" style="padding:0.6rem 1.2rem;font-size:0.9rem;min-height:auto;height:44px">
+          <button id="btn-autoplay" class="btn btn-primary" style="padding:0.6rem 1.4rem;font-size:0.9rem;height:44px;min-width:130px;box-sizing:border-box;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center">
             ▶ Auto Play
           </button>
-          <button id="btn-after" class="btn btn-secondary" style="padding:0.6rem 1.2rem;font-size:0.9rem;min-height:auto;height:44px">
+          <button id="btn-after" class="btn btn-secondary" style="padding:0.6rem 1.4rem;font-size:0.9rem;height:44px;min-width:120px;box-sizing:border-box;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center">
             After →
           </button>
         </div>
@@ -5157,40 +5157,40 @@
 
       <!-- EDUCATION HUB -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-0">
-        <strong id="faq-question-0" style="color:var(--brand)">📚 Where can I learn to use these indicators?</strong>
+        <strong id="faq-question-0">📚 Where can I learn to use these indicators?</strong>
         <p id="faq-answer-0" class="note">We provide a <strong>free 82-lesson education hub</strong> covering everything from beginner basics to institutional strategies. Available to everyone—no purchase required. <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="color:var(--brand);font-weight:600">Start learning free →</a></p>
       </div>
 
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
-        <strong id="faq-question-1" style="color:var(--accent)">🔄 Do the signals repaint?</strong>
+        <strong id="faq-question-1">🔄 Do the signals repaint?</strong>
         <p id="faq-answer-1" class="note"><strong style="background:linear-gradient(135deg,#3ed598,#2ec98a);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Zero repainting. Guaranteed.</strong> All signals finalize on candle close. We audit every indicator for lookahead bias. If you can prove any repaint, we pay you <strong style="background:linear-gradient(135deg,#f9a23c,#ff8c42);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">$100 USD</strong>. What you see in history is exactly what you would have seen live.</p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
-        <strong id="faq-question-2" style="color:var(--accent)">💼 Is this financial advice?</strong>
+        <strong id="faq-question-2">💼 Is this financial advice?</strong>
         <p id="faq-answer-2" class="note"><strong>No.</strong> <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is an <strong>educational toolset only</strong>. We provide technical analysis tools—not investment advice, trade recommendations, or guaranteed returns. You are solely responsible for your trading decisions.</p>
       </div>
 
       <!-- TECHNICAL -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-3">
-        <strong id="faq-question-3" style="color:var(--brand-2)">💻 Does it work on free TradingView?</strong>
+        <strong id="faq-question-3">💻 Does it work on free TradingView?</strong>
         <p id="faq-answer-3" class="note"><strong>Yes!</strong> You just need enough indicator slots for your setup. <strong>Free accounts get 3 slots</strong>, which is enough for Pentarch + 1-2 filters. Pro/Premium accounts get more slots and unlimited alerts.</p>
       </div>
 
       <!-- PRICING & ACCESS -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-4">
-        <strong id="faq-question-4" style="color:var(--warn)">⏱️ How fast is activation?</strong>
+        <strong id="faq-question-4">⏱️ How fast is activation?</strong>
         <p id="faq-answer-4" class="note"><strong>Typically 12-24 hours.</strong> TradingView invite-only access arrives via email. TradingView notifications will show the invite. For urgent requests, email <a href="mailto:support@signalpilot.io" style="color:var(--brand);text-decoration:none">support@signalpilot.io</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-5">
-        <strong id="faq-question-5" style="color:var(--warn)">💎 What's included in my plan?</strong>
+        <strong id="faq-question-5">💎 What's included in my plan?</strong>
         <p id="faq-answer-5" class="note">Every plan includes: <strong>The Elite Seven</strong>, all future updates, ongoing support, documentation, presets, and access to new indicators as they launch. Lifetime includes everything, forever.</p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-6">
-        <strong id="faq-question-6" style="color:var(--warn)">🔐 How many devices can I use?</strong>
+        <strong id="faq-question-6">🔐 How many devices can I use?</strong>
         <p id="faq-answer-6" class="note">One TradingView username per license. You can sign in on unlimited devices with that username. <strong>Account sharing is prohibited</strong>—each subscription is tied to one TradingView account.</p>
       </div>
 
@@ -5202,23 +5202,23 @@
 
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
-        <strong id="faq-question-8" style="color:var(--brand-2)">📊 What timeframes work best?</strong>
+        <strong id="faq-question-8">📊 What timeframes work best?</strong>
         <p id="faq-answer-8" class="note">All timeframes supported—1-minute to yearly charts. <strong>Most popular:</strong> 15m-1H for day trading, 4H-Daily for swing trading. Pentarch's 5-phase cycle adapts to your timeframe automatically. Education Hub covers timeframe optimization strategies.</p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
-        <strong id="faq-question-9" style="color:var(--brand-2)">🎯 Can I use multiple indicators together?</strong>
+        <strong id="faq-question-9">🎯 Can I use multiple indicators together?</strong>
         <p id="faq-answer-9" class="note"><strong>Absolutely!</strong> The Elite Seven are designed to work together. Popular combos: <strong>Pentarch + Volume Oracle</strong> for cycle timing with smart money confirmation, or <strong>Omnideck + Janus Atlas</strong> for complete market structure analysis with key levels.</p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-10">
-        <strong id="faq-question-10" style="color:var(--brand)">🛠️ Do I need coding skills?</strong>
+        <strong id="faq-question-10">🛠️ Do I need coding skills?</strong>
         <p id="faq-answer-10" class="note"><strong>Zero coding required.</strong> All indicators are plug-and-play. We include <strong>200+ preset configurations</strong> (Lifetime plan) pre-tuned for different strategies. Just load the preset, apply to chart, done. Advanced users can customize settings, but it's optional.</p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-11">
-        <strong id="faq-question-11" style="color:var(--good)">💬 What support channels exist?</strong>
+        <strong id="faq-question-11">💬 What support channels exist?</strong>
         <p id="faq-answer-11" class="note"><strong>Monthly:</strong> Email support (48h response). <strong>Yearly+:</strong> Priority email (24h response). <strong>Lifetime:</strong> Private Discord community + priority support. All plans include access to 50+ pages of documentation and video tutorials.</p>
       </div>
 


### PR DESCRIPTION
Before/Autoplay/After buttons:
- Changed align-items: center → stretch
- Added min-width (120px/130px/120px)
- Added display:inline-flex, align-items:center to buttons
- Added box-sizing:border-box and flex-shrink:0
- All 3 buttons now perfectly aligned at same height

FAQ questions:
- Removed all color variations (was: brand, accent, brand-2, warn, good)
- All FAQ question headings now use default text color
- Clean uniform appearance - no more rainbow mix