### PR TITLE
Fix: Slider buttons smaller + animated text layout shift

### DIFF
--- a/index.html
+++ b/index.html
@@ -2910,7 +2910,7 @@
           </h1>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0">
-            Non-repainting cycle detection • 7 premium indicators for <span id="typed-text" style="color:var(--brand);font-weight:600">serious traders</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Non-repainting cycle detection • 7 premium indicators for <span id="typed-text" style="color:var(--brand);font-weight:600;display:inline-block;min-width:160px;text-align:left">serious traders</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
           </p>
 
           <!-- Hero CTAs -->
@@ -4473,14 +4473,14 @@
         </div>
 
         <!-- Slider Controls -->
-        <div style="display:flex;justify-content:center;gap:1rem;margin-bottom:1.5rem;flex-wrap:nowrap;align-items:stretch">
-          <button id="btn-before" class="btn btn-secondary" style="padding:0.6rem 1.2rem;font-size:0.9rem;height:44px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center">
+        <div style="display:flex;justify-content:center;gap:0.8rem;margin-bottom:1.5rem;flex-wrap:nowrap;align-items:stretch">
+          <button id="btn-before" class="btn btn-secondary" style="padding:0.5rem 1rem;font-size:0.85rem;height:38px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center">
             ← Before
           </button>
-          <button id="btn-autoplay" class="btn btn-primary" style="padding:0.6rem 1.2rem;font-size:0.9rem;height:44px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center">
+          <button id="btn-autoplay" class="btn btn-primary" style="padding:0.5rem 1rem;font-size:0.85rem;height:38px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center">
             ▶ Auto Play
           </button>
-          <button id="btn-after" class="btn btn-secondary" style="padding:0.6rem 1.2rem;font-size:0.9rem;height:44px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center">
+          <button id="btn-after" class="btn btn-secondary" style="padding:0.5rem 1rem;font-size:0.85rem;height:38px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center">
             After →
           </button>
         </div>


### PR DESCRIPTION
- Reduced Before/Autoplay/After button sizes (38px height, 0.85rem font)
- Fixed animated text wrapping by setting min-width:160px on #typed-text
- Prevents layout shift when phrases change from short to long