### PR TITLE
Remove all emojis from site for professional appearance

### DIFF
--- a/index.html
+++ b/index.html
@@ -2847,8 +2847,8 @@
 
 
       <div class="lang-dropdown">
-        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Language selection" aria-expanded="false" aria-haspopup="true" style="font-size:1.3rem;padding:.5rem .7rem">
-          <span>🌐</span>
+        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Language selection" aria-expanded="false" aria-haspopup="true" style="font-size:.85rem;padding:.5rem .7rem">
+          <span>EN</span>
         </button>
       </div>
 
@@ -3287,7 +3287,7 @@
             <!-- Education CTA -->
             <div style="background:linear-gradient(135deg,rgba(62,213,152,.08),rgba(62,213,152,.02));padding:2rem;border-radius:12px;border:1px solid rgba(62,213,152,.2);margin-top:1.5rem">
               <p style="color:var(--text);font-weight:600;margin-bottom:0.75rem;font-size:1.05rem">
-                📚 While you wait, start learning:
+                While you wait, start learning:
               </p>
               <p style="color:var(--muted);font-size:0.9rem;margin-bottom:1.25rem">
                 Access our complete 82-lesson education hub for free
@@ -4032,7 +4032,7 @@
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
                 <li>• Shows current phase (ACCUMULATION vs DISTRIBUTION) with strength percentage (0-100%)</li>
                 <li>• Duration tracking — how long institutions have been building/exiting positions</li>
-                <li>• ⚡ Early warning flashes when pattern is weakening</li>
+                <li>• Early warning flashes when pattern is weakening</li>
                 <li>• Built-in position calculator suggests risk levels based on current regime</li>
               </ul>
               <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Example: "ACCUMULATION 82%" = strong institutional buying detected. Follow the money.</p>
@@ -4211,7 +4211,7 @@
             <!-- Right Column: Signal Pilot -->
             <div class="comparison-column">
               <h3 class="comparison-heading comparison-heading-positive">
-                ✓ <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>
+                <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>
               </h3>
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
@@ -4985,7 +4985,7 @@
               SAVE <span data-count="489" data-prefix="$">489</span>
             </div>
 
-            <div class="pill" id="plan-yearly-title" style="background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff;font-size:.95rem;padding:.7rem 1.2rem">💎 BEST VALUE</div>
+            <div class="pill" id="plan-yearly-title" style="background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff;font-size:.95rem;padding:.7rem 1.2rem">BEST VALUE</div>
 
             <div class="price">
               $699 <span class="pill">/year</span>
@@ -5051,7 +5051,7 @@
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
             <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
-              ⚡ LIMITED • <span data-count="150">150</span> SLOTS LEFT
+              LIMITED • <span data-count="150">150</span> SLOTS LEFT
             </div>
 
             <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">Lifetime Access</div>
@@ -5166,13 +5166,13 @@
 
       <!-- EDUCATION HUB -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-0">
-        <strong id="faq-question-0">📚 Where can I learn to use these indicators?</strong>
+        <strong id="faq-question-0">Where can I learn to use these indicators?</strong>
         <p id="faq-answer-0" class="note">We provide a <strong>free 82-lesson education hub</strong> covering everything from beginner basics to institutional strategies. Available to everyone—no purchase required. <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="color:var(--brand);font-weight:600">Start learning free →</a></p>
       </div>
 
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
-        <strong id="faq-question-1">🔄 Do the signals repaint?</strong>
+        <strong id="faq-question-1">Do the signals repaint?</strong>
         <p id="faq-answer-1" class="note"><strong style="background:linear-gradient(135deg,#3ed598,#2ec98a);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Zero repainting. Guaranteed.</strong> All signals finalize on candle close. We audit every indicator for lookahead bias. If you can prove any repaint, we pay you <strong style="background:linear-gradient(135deg,#f9a23c,#ff8c42);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">$100 USD</strong>. What you see in history is exactly what you would have seen live.</p>
       </div>
 
@@ -5189,17 +5189,17 @@
 
       <!-- PRICING & ACCESS -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-4">
-        <strong id="faq-question-4">⏱️ How fast is activation?</strong>
+        <strong id="faq-question-4">How fast is activation?</strong>
         <p id="faq-answer-4" class="note"><strong>Typically 12-24 hours.</strong> TradingView invite-only access arrives via email. TradingView notifications will show the invite. For urgent requests, email <a href="mailto:support@signalpilot.io" style="color:var(--brand);text-decoration:none">support@signalpilot.io</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-5">
-        <strong id="faq-question-5">💎 What's included in my plan?</strong>
+        <strong id="faq-question-5">What's included in my plan?</strong>
         <p id="faq-answer-5" class="note">Every plan includes: <strong>The Elite Seven</strong>, all future updates, ongoing support, documentation, presets, and access to new indicators as they launch. Lifetime includes everything, forever.</p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-6">
-        <strong id="faq-question-6">🔐 How many devices can I use?</strong>
+        <strong id="faq-question-6">How many devices can I use?</strong>
         <p id="faq-answer-6" class="note">One TradingView username per license. You can sign in on unlimited devices with that username. <strong>Account sharing is prohibited</strong>—each subscription is tied to one TradingView account.</p>
       </div>
 
@@ -5211,18 +5211,18 @@
 
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
-        <strong id="faq-question-8">📊 What timeframes work best?</strong>
+        <strong id="faq-question-8">What timeframes work best?</strong>
         <p id="faq-answer-8" class="note">All timeframes supported—1-minute to yearly charts. <strong>Most popular:</strong> 15m-1H for day trading, 4H-Daily for swing trading. Pentarch's 5-phase cycle adapts to your timeframe automatically. Education Hub covers timeframe optimization strategies.</p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
-        <strong id="faq-question-9">🎯 Can I use multiple indicators together?</strong>
+        <strong id="faq-question-9">Can I use multiple indicators together?</strong>
         <p id="faq-answer-9" class="note"><strong>Absolutely!</strong> The Elite Seven are designed to work together. Popular combos: <strong>Pentarch + Volume Oracle</strong> for cycle timing with smart money confirmation, or <strong>Omnideck + Janus Atlas</strong> for complete market structure analysis with key levels.</p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-10">
-        <strong id="faq-question-10">🛠️ Do I need coding skills?</strong>
+        <strong id="faq-question-10">Do I need coding skills?</strong>
         <p id="faq-answer-10" class="note"><strong>Zero coding required.</strong> All indicators are plug-and-play. We include <strong>200+ preset configurations</strong> (Lifetime plan) pre-tuned for different strategies. Just load the preset, apply to chart, done. Advanced users can customize settings, but it's optional.</p>
       </div>
 
@@ -5288,8 +5288,8 @@
             82 free lessons + 7 premium TradingView indicators.
           </p>
           <div style="display:flex;gap:.8rem;margin-top:1rem">
-            <a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:1.3rem;transition:color .2s" title="GitHub">⚡</a>
-            <a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:1.3rem;transition:color .2s" title="Email">📧</a>
+            <a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.9rem;transition:color .2s" title="GitHub">GitHub</a>
+            <a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.9rem;transition:color .2s" title="Email">Email</a>
           </div>
         </div>
 
@@ -5319,8 +5319,8 @@
           <ul style="list-style:none;padding:0;margin:0">
             <li style="margin-bottom:.4rem"><a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">GitHub</a></li>
             <li style="margin-bottom:.4rem"><a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">support@signalpilot.io</a></li>
-            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--brand);text-decoration:none;font-size:.85rem;font-weight:600;transition:color .2s">Roadmap 🚀</a></li>
-            <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--good);text-decoration:none;font-size:.85rem;font-weight:600;transition:color .2s">Affiliate Program 💰</a></li>
+            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--brand);text-decoration:none;font-size:.85rem;font-weight:600;transition:color .2s">Roadmap</a></li>
+            <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--good);text-decoration:none;font-size:.85rem;font-weight:600;transition:color .2s">Affiliate Program</a></li>
           </ul>
         </div>
 
@@ -5527,9 +5527,9 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Start Free 7-Day Trial →</a>
         <a href="#inside">What's inside</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">📚 Documentation</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">🎓 Education Hub</a>
-        <a href="/faq.html">❓ FAQ Center</a>
+        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
+        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a>
+        <a href="/faq.html">FAQ Center</a>
         <a href="#pricing">Pricing</a>
         <a href="/affiliates.html" style="color:#3ed598;font-weight:600">Affiliates</a>
       `;


### PR DESCRIPTION
Changes:
- Language selector: 🌐 → EN
- Trial CTA: Removed 📚
- Features: Removed ⚡
- Comparison: Removed ✓
- Pricing badges: Removed 💎 and ⚡
- FAQ questions: Removed all emojis (📚🔄⏱️💎🔐📊🎯🛠️)
- Footer: Removed ⚡📧🚀💰 from links
- Mobile menu: Removed 📚🎓❓ from navigation
- Resources dropdown: Already removed in previous commit

The site now has a clean, professional look across all sections.