### PR TITLE
Unify Details and Docs button alignment across all indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -1548,6 +1548,13 @@
 
     .btn-sm{padding:.5rem .8rem; font-size:.92rem; line-height:1.1}
 
+    /* Ensure punch lines have consistent height for uniform button alignment */
+    .card.product .punch {
+      min-height: 60px;
+      display: flex;
+      align-items: center;
+    }
+
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
@@ -2446,6 +2453,11 @@
       .toggle-details {
         flex: 1;
         min-width: 120px;
+      }
+
+      /* Adjust punch line min-height for mobile to accommodate text wrapping */
+      .card.product .punch {
+        min-height: 70px;
       }
 
       /* Extra small screens - video maintains aspect ratio */


### PR DESCRIPTION
Fixed inconsistent button positioning caused by varying punch line lengths:

- Added min-height (60px) to .card.product .punch to ensure consistent vertical space regardless of text content length
- Used flexbox alignment to vertically center text within punch area
- Added mobile-specific adjustment (70px min-height) for better text wrapping on smaller screens

All 7 indicator cards now have Details ▼ and Docs buttons aligned at the same vertical position for a cleaner, more uniform appearance.