### PR TITLE
Restore Gugi font styling for Signal Pilot in FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -5345,7 +5345,7 @@
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
         <strong id="faq-question-2">Is this financial advice?</strong>
-        <p id="faq-answer-2" class="note"><strong>No.</strong><br>Signal Pilot is an <strong>educational toolset only</strong>.<br>We provide technical analysis tools—not investment advice, trade recommendations, or guaranteed returns.<br>You are solely responsible for your trading decisions.</p>
+        <p id="faq-answer-2" class="note"><strong>No.</strong><br><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is an <strong>educational toolset only</strong>.<br>We provide technical analysis tools—not investment advice, trade recommendations, or guaranteed returns.<br>You are solely responsible for your trading decisions.</p>
       </div>
 
       <!-- TECHNICAL -->


### PR DESCRIPTION
Reverted accidental removal of Gugi font styling from "Signal Pilot" text in FAQ answer 2. The user only requested color removal, not font changes.

Restored: font-family:'Gugi', text-transform:uppercase, letter-spacing:.1em