### PR TITLE
Fix screenshot placeholders and make all descriptions two-liners

### DIFF
--- a/index.html
+++ b/index.html
@@ -4161,13 +4161,21 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/omnideck-screenshot.jpg" alt="Omnideck all-in-one indicator" style="width:100%;height:100%;object-fit:cover" loading="eager">
+              <img src="assets/screenshots/omnideck-screenshot.jpg" alt="Omnideck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <!-- Placeholder overlay -->
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Omnideck Screenshot</p>
+                  <p style="font-size:.75rem;color:var(--muted-2);margin:0">16:9 ratio recommended</p>
+                </div>
+              </div>
             </div>
 
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Omnideck</h3>
             </div>
-            <div class="punch"><span data-count="10" data-text-mode>10</span> systems combined into one overlay indicator.</div>
+            <div class="punch"><span data-count="10" data-text-mode>10</span> systems combined into one overlay.<br>All confirmations in a single indicator.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4189,13 +4197,21 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle institutional flow tracking" style="width:100%;height:100%;object-fit:cover" loading="eager">
+              <img src="assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle institutional flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <!-- Placeholder overlay -->
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Volume Oracle Screenshot</p>
+                  <p style="font-size:.75rem;color:var(--muted-2);margin:0">16:9 ratio recommended</p>
+                </div>
+              </div>
             </div>
 
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div class="punch">Tracks institutional accumulation/distribution patterns in real-time.</div>
+            <div class="punch">Institutional accumulation & distribution patterns.<br>Real-time smart money tracking.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4217,13 +4233,21 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow cumulative delta tracking" style="width:100%;height:100%;object-fit:cover" loading="eager">
+              <img src="assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow cumulative delta tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <!-- Placeholder overlay -->
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Plutus Flow Screenshot</p>
+                  <p style="font-size:.75rem;color:var(--muted-2);margin:0">16:9 ratio recommended</p>
+                </div>
+              </div>
             </div>
 
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div class="punch">Cumulative delta tracking shows demand/supply pressure over time.</div>
+            <div class="punch">Cumulative delta tracking for demand/supply pressure.<br>Follow the real buying and selling power.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4245,13 +4269,21 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover" loading="eager">
+              <img src="assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <!-- Placeholder overlay -->
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Janus Atlas Screenshot</p>
+                  <p style="font-size:.75rem;color:var(--muted-2);margin:0">16:9 ratio recommended</p>
+                </div>
+              </div>
             </div>
 
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div class="punch">HTF levels, D/W/M pivots, VWAP, VAL/POC—all key zones in one view.</div>
+            <div class="punch">HTF levels, D/W/M pivots, VWAP, VAL/POC zones.<br>All key price levels in one clean view.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4273,13 +4305,21 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover" loading="eager">
+              <img src="assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <!-- Placeholder overlay -->
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Augury Grid Screenshot</p>
+                  <p style="font-size:.75rem;color:var(--muted-2);margin:0">16:9 ratio recommended</p>
+                </div>
+              </div>
             </div>
 
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div class="punch">Support/resistance matrix with probability‑weighted breakout zones.</div>
+            <div class="punch">Multi-symbol tracking dashboard & screener.<br>See your best setups ranked at a glance.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4300,13 +4340,21 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover" loading="eager">
+              <img src="assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <!-- Placeholder overlay -->
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+                <div style="text-align:center;padding:1rem">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+                  <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Harmonic Oscillator Screenshot</p>
+                  <p style="font-size:.75rem;color:var(--muted-2);margin:0">16:9 ratio recommended</p>
+                </div>
+              </div>
             </div>
 
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div class="punch">Four oscillators vote on every bar. Multi-confirmation timing system.</div>
+            <div class="punch">Four oscillators vote on every bar.<br>Multi-confirmation timing system.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Docs</a>


### PR DESCRIPTION
1. Added screenshot placeholders to all 6 remaining indicators:
   - Omnideck, Volume Oracle, Plutus Flow, Janus Atlas, Augury Grid, Harmonic Oscillator
   - All now match Pentarch's placeholder style with:
     * img tag with display:none and class="indicator-screenshot"
     * Overlay div with blue gradient background and icon * Text showing "Add [Indicator] Screenshot" + "16:9 ratio recommended"

2. Made all indicator descriptions consistent two-liners:
   - Pentarch: Already two lines (long description)
   - Omnideck: "10 systems combined into one overlay. / All confirmations in a single indicator."
   - Volume Oracle: "Institutional accumulation & distribution patterns. / Real-time smart money tracking."
   - Plutus Flow: "Cumulative delta tracking for demand/supply pressure. / Follow the real buying and selling power."
   - Janus Atlas: "HTF levels, D/W/M pivots, VWAP, VAL/POC zones. / All key price levels in one clean view."
   - Augury Grid: "Multi-symbol tracking dashboard & screener. / See your best setups ranked at a glance."
   - Harmonic Oscillator: "Four oscillators vote on every bar. / Multi-confirmation timing system."

All indicators now have uniform placeholder appearance and consistent two-line descriptions!