### PR TITLE
Remove transparent box border from Why Traders Switch section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4445,9 +4445,6 @@
               display: grid;
               grid-template-columns: 1fr 1fr;
               gap: 2rem;
-              background: rgba(0,0,0,.2);
-              border: 1px solid rgba(91,138,255,.2);
-              border-radius: 12px;
               padding: 2rem;
               max-width: 800px;
               margin: 0 auto;


### PR DESCRIPTION
Removed visible border/background styling from the comparison container:
- Removed: background: rgba(0,0,0,.2)
- Removed: border: 1px solid rgba(91,138,255,.2)
- Removed: border-radius: 12px

The section now blends seamlessly with the rest of the page without the visible transparent box that was surrounding it.