### PR TITLE
Add navigation and theme selector buttons

### DIFF
--- a/assets/chatbot.js
+++ b/assets/chatbot.js
@@ -478,7 +478,7 @@ Email: support@signalpilot.io`;
           </div>
           <div>
             <div class="sp-chatbot-title">Signal Pilot Assistant</div>
-            <div class="sp-chatbot-status">Online • AI-powered</div>
+            <div class="sp-chatbot-status">AI Assistant • Automated responses</div>
           </div>
         </div>
         <button class="sp-chatbot-close" aria-label="Close chatbot">×</button>

--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -41,6 +41,12 @@
       transform: scale(0.95);
     }
 
+    .sp-theme-toggle svg {
+      width: 24px;
+      height: 24px;
+      stroke: currentColor;
+    }
+
     /* Light mode support */
     html[data-theme="light"] .sp-theme-toggle {
       background: #f6f8fc;
@@ -372,7 +378,16 @@
   function createToggleButton() {
     const button = document.createElement('button');
     button.className = 'sp-theme-toggle';
-    button.innerHTML = '🎨';
+    button.innerHTML = `
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z"/>
+        <circle cx="12" cy="12" r="1"/>
+        <circle cx="8" cy="10" r="1"/>
+        <circle cx="16" cy="10" r="1"/>
+        <circle cx="10" cy="14" r="1"/>
+        <circle cx="14" cy="14" r="1"/>
+      </svg>
+    `;
     button.setAttribute('aria-label', 'Theme selection (Ctrl+T)');
     button.setAttribute('title', 'Theme selection (Ctrl+T)');
     button.onclick = () => openThemeModal();


### PR DESCRIPTION
…hatbot status

- Replace colored 🎨 emoji with paint palette SVG icon (transparent/outline style)
- Add SVG styling to ensure proper rendering in theme button
- Update chatbot status from "Online • AI-powered" to "AI Assistant • Automated responses"
- Makes it clearer users are interacting with AI, not a human