### PR TITLE
Increase moon icon centering to -3px shift

### DIFF
--- a/index.html
+++ b/index.html
@@ -3026,7 +3026,7 @@
       </select>
 
       <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Theme selection" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon" style="display:flex;align-items:center;justify-content:center;width:14px;height:14px;transform:translateX(-1px)">
+        <span id="theme-icon" style="display:flex;align-items:center;justify-content:center;width:14px;height:14px;transform:translateX(-3px)">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:100%;height:100%;display:block;opacity:0.7">
             <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
           </svg>
@@ -5650,7 +5650,7 @@
             icon.style.transform = 'none';
             icon.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:100%;height:100%;display:block;opacity:0.7"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>';
           } else {
-            icon.style.transform = 'translateX(-1px)';
+            icon.style.transform = 'translateX(-3px)';
             icon.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:100%;height:100%;display:block;opacity:0.7"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>';
           }
         }


### PR DESCRIPTION
- Change translateX from -1px to -3px for stronger optical centering
- Moon crescent visual center is much further right, needs bigger adjustment
- Both initial HTML and JS toggle updated to use -3px