### PR TITLE
Improve TradingView indicator text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -3071,7 +3071,7 @@
         <div style="text-align:center;margin-bottom:3rem">
 
           <h1 class="headline xl">
-            <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:var(--brand);font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professional TradingView Indicators</span>
+            <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:white;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professional TradingView Indicators</span>
             The edge isn't seeing more. It's seeing what matters.
           </h1>
 


### PR DESCRIPTION
Changed "Professional TradingView Indicators" from gradient color to white to improve contrast and make the main headline "The edge isn't seeing more..." more prominent and readable.