### PR TITLE
Change indicator text to gray for better visual balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -3071,7 +3071,7 @@
         <div style="text-align:center;margin-bottom:3rem">
 
           <h1 class="headline xl">
-            <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:white !important;-webkit-text-fill-color:white !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professional TradingView Indicators</span>
+            <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professional TradingView Indicators</span>
             The edge isn't seeing more. It's seeing what matters.
           </h1>
 


### PR DESCRIPTION
Changed from white to gray (#9ca3af) to soften the contrast while still keeping "The edge isn't seeing more..." as the primary focus.