### PR TITLE
Remove 'NO CREDIT CARD REQUIRED' badge from trial section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3309,10 +3309,6 @@
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
-          <div class="badgebar" style="justify-content:center;margin-bottom:1rem">
-            <span class="badge">NO CREDIT CARD REQUIRED</span>
-          </div>
-
           <h2 class="headline lg" style="margin-bottom:1rem">
             Try All 7 Indicators Free for 7 Days
           </h2>


### PR DESCRIPTION
Removed the badge element to simplify the trial section messaging.