### PR TITLE
Simplify Elite Seven indicators section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4102,7 +4102,6 @@
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
               <span class="badge" style="font-size:.75rem;margin-left:.5rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;padding:.3rem .7rem;text-transform:uppercase;letter-spacing:.5px;white-space:nowrap">★ FLAGSHIP</span>
             </div>
-            <div class="punch" style="font-size:1.1rem;line-height:1.4">Complete trend regime detection system. Not just isolated signals—the full market cycle.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4137,7 +4136,6 @@
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div class="punch"><span data-count="10" data-text-mode>10</span> systems combined into one overlay.<br>All confirmations in a single indicator.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4173,7 +4171,6 @@
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div class="punch">Institutional accumulation & distribution patterns.<br>Real-time smart money tracking.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4209,7 +4206,6 @@
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div class="punch">Cumulative delta tracking for demand/supply pressure.<br>Follow the real buying and selling power.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4245,7 +4241,6 @@
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div class="punch">HTF levels, D/W/M pivots, VWAP, VAL/POC zones.<br>All key price levels in one clean view.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4281,7 +4276,6 @@
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div class="punch">Multi-symbol tracking dashboard & screener.<br>See your best setups ranked at a glance.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Docs</a>
@@ -4316,7 +4310,6 @@
             <div class="title mod">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div class="punch">Four oscillators vote on every bar.<br>Multi-confirmation timing system.</div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Docs</a>


### PR DESCRIPTION
Removed description text from all 7 indicators. Each indicator now shows only the name, Details button, and Docs link for a cleaner presentation.