### PR TITLE
Center indicator name and reposition badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -4083,7 +4083,10 @@
         <div class="grid auto-300">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
-          <article class="card product" style="border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
+          <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
+
+            <!-- FLAGSHIP Badge - Top Right Corner -->
+            <span class="badge" style="position:absolute;top:1rem;right:1rem;font-size:.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;padding:.3rem .7rem;text-transform:uppercase;letter-spacing:.5px;white-space:nowrap;z-index:10">★ FLAGSHIP</span>
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
@@ -4098,9 +4101,8 @@
               </div>
             </div>
 
-            <div class="title mod">
+            <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
-              <span class="badge" style="font-size:.75rem;margin-left:.5rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;padding:.3rem .7rem;text-transform:uppercase;letter-spacing:.5px;white-space:nowrap">★ FLAGSHIP</span>
             </div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Details ▼</button>
@@ -4133,7 +4135,7 @@
               </div>
             </div>
 
-            <div class="title mod">
+            <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
@@ -4168,7 +4170,7 @@
               </div>
             </div>
 
-            <div class="title mod">
+            <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
@@ -4203,7 +4205,7 @@
               </div>
             </div>
 
-            <div class="title mod">
+            <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
@@ -4238,7 +4240,7 @@
               </div>
             </div>
 
-            <div class="title mod">
+            <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
@@ -4273,7 +4275,7 @@
               </div>
             </div>
 
-            <div class="title mod">
+            <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
@@ -4307,7 +4309,7 @@
               </div>
             </div>
 
-            <div class="title mod">
+            <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
             <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">


### PR DESCRIPTION
- Centered all indicator titles by adding justify-content:center
- Moved Pentarch FLAGSHIP badge to top-right corner with absolute positioning
- Improved visual hierarchy and card layout for flagship indicator