### PR TITLE
Add Spanish language support to website

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -6622,8 +6622,8 @@
 
       try {
         new google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
+          pageLanguage: 'es',
+          includedLanguages: 'ar,de,en,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
           autoDisplay: false
         }, 'google_translate_container');
         console.log('[GT] Widget created successfully');


### PR DESCRIPTION
Changed pageLanguage from 'en' to 'es' to correctly identify the Spanish version. This prevents Google Translate from incorrectly translating to Arabic by default. Users can still manually translate to other languages via Google Translate widget.