### PR TITLE
Fix Google Translate and clean up Spanish HTML

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -12,10 +12,6 @@
 
   <title>Signal Pilot — Indicadores TradingView Sin Repintado</title>
 
-  <meta name="description" content="Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado (TD→IGN→WRN→CAP→BDN). Sin repintado, auditado. Garantía de 7 días.">
-
-  <!-- Enhanced SEO -->
-  <meta name="keywords" content="indicadores TradingView, indicadores sin repintado, Pentarch, indicadores de ciclos de mercado, TD Sequential, señales de trading, indicadores de acciones">
   <meta name="description" content="Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado (TD→IGN→WRN→CAP→BDN). Cero repintado, auditado. Garantía de reembolso de 7 días.">
 
   <!-- Enhanced SEO -->
@@ -37,10 +33,6 @@
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/">
   <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/">
-  <!-- Alternate language versions for international SEO -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/" />
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/" />
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/" />
 
   <meta name="robots" content="index,follow">
 
@@ -80,7 +72,6 @@
 
   <meta property="og:title" content="Signal Pilot — Indicadores TradingView Sin Repintado">
 
-  <meta property="og:description" content="Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado. Sin repintado, auditado. Garantía de 7 días.">
   <meta property="og:description" content="Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado. Cero repintado, auditado. Garantía de reembolso de 7 días.">
 
   <meta property="og:url" content="https://www.signalpilot.io/es/">
@@ -88,7 +79,7 @@
   <meta property="og:image" content="https://www.signalpilot.io/preview.png?v=1731035400">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="Signal Pilot - Institutional-Grade Indicators | Verified Non-Repainting • All Markets • 7-Day Money-Back">
+  <meta property="og:image:alt" content="Signal Pilot - Indicadores de Grado Institucional | Sin Repintado Verificado • Todos los Mercados • Garantía de 7 Días">
 
   <meta property="og:locale" content="es_ES">
   <meta property="og:locale:alternate" content="en_US" />
@@ -97,10 +88,9 @@
   <meta name="twitter:site" content="@signalpilot">
   <meta name="twitter:creator" content="@signalpilot">
   <meta name="twitter:title" content="Signal Pilot — Indicadores TradingView Sin Repintado">
-  <meta name="twitter:description" content="Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado. Sin repintado, auditado.">
   <meta name="twitter:description" content="Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado. Cero repintado, auditado.">
   <meta name="twitter:image" content="https://www.signalpilot.io/preview.png?v=1731035400">
-  <meta name="twitter:image:alt" content="Signal Pilot - Institutional-Grade Indicators | Verified Non-Repainting • All Markets • 7-Day Money-Back">
+  <meta name="twitter:image:alt" content="Signal Pilot - Indicadores de Grado Institucional | Sin Repintado Verificado • Todos los Mercados • Garantía de 7 Días">
 
 
 
@@ -117,8 +107,6 @@
         "@id": "https://www.signalpilot.io/#monthly-plan",
         "name": "Signal Pilot Elite Seven - Suscripción Mensual",
         "description": "Indicadores profesionales para TradingView con detección de ciclos Pentarch™. Los 7 indicadores élite más actualizaciones futuras. 100% sin repintado, auditado. Funciona en acciones, cripto, forex, índices y materias primas.",
-        "name": "Signal Pilot Elite Seven - Monthly Subscription",
-        "description": "Professional TradingView indicators with Pentarch™ cycle detection. All 7 elite indicators plus future updates. 100% non-repainting, audited. Works on stocks, crypto, forex, indices, and commodities.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -168,12 +156,6 @@
           {
             "@type": "PropertyValue",
             "name": "Indicadores Incluidos",
-            "name": "Non-Repainting",
-            "value": "100% Audited"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Indicators Included",
             "value": "7"
           },
           {
@@ -185,13 +167,6 @@
             "@type": "PropertyValue",
             "name": "Tiempo de Respuesta de Soporte",
             "value": "48 horas"
-            "name": "Markets Supported",
-            "value": "Stocks, Crypto, Forex, Indices, Commodities"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Support Response Time",
-            "value": "48 hours"
           }
         ]
       },
@@ -200,8 +175,6 @@
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Suscripción Anual (Mejor Valor)",
         "description": "Indicadores profesionales para TradingView con detección de ciclos Pentarch™. Ahorra $489/año. Los 7 indicadores élite más actualizaciones futuras. 100% sin repintado, auditado. Soporte prioritario y formación avanzada incluidos.",
-        "name": "Signal Pilot Elite Seven - Yearly Subscription (Best Value)",
-        "description": "Professional TradingView indicators with Pentarch™ cycle detection. Save $489/year. All 7 elite indicators plus future updates. 100% non-repainting, audited. Priority support and advanced training included.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -251,12 +224,6 @@
           {
             "@type": "PropertyValue",
             "name": "Indicadores Incluidos",
-            "name": "Non-Repainting",
-            "value": "100% Audited"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Indicators Included",
             "value": "7"
           },
           {
@@ -272,17 +239,6 @@
           {
             "@type": "PropertyValue",
             "name": "Ahorro Anual",
-            "name": "Markets Supported",
-            "value": "Stocks, Crypto, Forex, Indices, Commodities"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Support Response Time",
-            "value": "24 hours"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Annual Savings",
             "value": "$489"
           }
         ]
@@ -292,8 +248,6 @@
         "@id": "https://www.signalpilot.io/#lifetime-plan",
         "name": "Signal Pilot Elite Seven - Acceso de Por Vida (Limitado a 100 Fundadores)",
         "description": "Indicadores profesionales para TradingView con acceso de por vida. Detección de ciclos Pentarch™. Los 7 indicadores élite más todos los lanzamientos futuros para siempre. 100% sin repintado, auditado. Comunidad Discord privada, 200+ configuraciones predefinidas, acceso beta, soporte prioritario.",
-        "name": "Signal Pilot Elite Seven - Lifetime Access (Limited Founding 100)",
-        "description": "Professional TradingView indicators with lifetime access. Pentarch™ cycle detection. All 7 elite indicators plus all future releases forever. 100% non-repainting, audited. Private Discord community, 200+ preset configurations, beta access, priority support.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -312,7 +266,6 @@
             "@type": "QuantitativeValue",
             "value": "350",
             "unitText": "Cupos totales disponibles"
-            "unitText": "Total slots available"
           },
           "seller": {
             "@type": "Organization",
@@ -342,12 +295,6 @@
           {
             "@type": "PropertyValue",
             "name": "Indicadores Incluidos",
-            "name": "Non-Repainting",
-            "value": "100% Audited"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Indicators Included",
             "value": "7"
           },
           {
@@ -368,22 +315,6 @@
           {
             "@type": "PropertyValue",
             "name": "Configuraciones Predefinidas",
-            "name": "Markets Supported",
-            "value": "Stocks, Crypto, Forex, Indices, Commodities"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Access Type",
-            "value": "Lifetime"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Private Discord",
-            "value": "Yes"
-          },
-          {
-            "@type": "PropertyValue",
-            "name": "Preset Configurations",
             "value": "200+"
           }
         ]
@@ -395,7 +326,6 @@
         "url": "https://www.signalpilot.io",
         "logo": "https://www.signalpilot.io/preview.png",
         "description": "Proveedor de indicadores profesionales sin repintado para TradingView para traders serios.",
-        "description": "Provider of professional, non-repainting TradingView indicators for serious traders.",
         "sameAs": [
           "https://twitter.com/signalpilot"
         ]
@@ -405,9 +335,7 @@
         "@id": "https://www.signalpilot.io/#website",
         "url": "https://www.signalpilot.io",
         "name": "Signal Pilot — Indicadores TradingView Sin Repintado",
-        "description": "Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado. Sin repintado, auditado. Garantía de 7 días.",
-        "name": "Signal Pilot — Non-Repainting TradingView Indicators",
-        "description": "Professional cycle detection for TradingView. Pentarch™ maps complete market cycles. Zero repaint, audited. 7-day money-back guarantee.",
+        "description": "Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado. Cero repintado, auditado. Garantía de reembolso de 7 días.",
         "publisher": {
           "@id": "https://www.signalpilot.io/#organization"
         }
@@ -442,17 +370,6 @@
           "Alertas en tiempo real",
           "Plantillas de backtesting",
           "Todos los mercados: acciones, cripto, forex, índices, materias primas"
-          "Pentarch™ 5-phase cycle detection (TD→IGN→WRN→CAP→BDN)",
-          "OmniDeck all-in-one overlay (10+ systems unified)",
-          "Volume Oracle institutional flow detector",
-          "Plutus Flow cumulative delta ribbon",
-          "Janus Atlas multi-timeframe levels",
-          "Augury Grid 8-ticker watchlist",
-          "Harmonic Oscillator 4-system timing",
-          "100% non-repainting (audited)",
-          "Real-time alerts",
-          "Backtest templates",
-          "All markets: stocks, crypto, forex, indices, commodities"
         ]
       }
     ]
@@ -2937,7 +2854,7 @@
     "@context": "https://schema.org",
     "@type": "Product",
     "name": "Signal Pilot — Trading Suite",
-    "description": "Non‑repainting TradingView indicators for any market & timeframe. Seven elite indicators including Pentarch, OmniDeck, Volume Oracle, and more.",
+    "description": "Indicadores TradingView sin repintado para cualquier mercado y marco temporal. Siete indicadores élite incluyendo Pentarch, OmniDeck, Volume Oracle, y más.",
     "brand": {
       "@type": "Brand",
       "name": "Signal Pilot"
@@ -3096,7 +3013,7 @@
         "applicationCategory": "BusinessApplication",
         "applicationSubCategory": "Trading Indicators",
         "operatingSystem": "Web Browser",
-        "description": "Professional cycle detection for TradingView. Pentarch™ maps complete market cycles (TD→IGN→WRN→CAP→BDN). Zero repaint, audited. 7-day money-back guarantee.",
+        "description": "Detección profesional de ciclos para TradingView. Pentarch™ mapea ciclos completos del mercado (TD→IGN→WRN→CAP→BDN). Cero repintado, auditado. Garantía de reembolso de 7 días.",
         "url": "https://www.signalpilot.io/",
         "image": "https://www.signalpilot.io/preview.png",
         "screenshot": "https://www.signalpilot.io/preview.png",
@@ -3109,7 +3026,7 @@
             "priceValidUntil": "2025-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Flexible month-to-month billing with all 7 elite indicators"
+            "description": "Facturación mensual flexible con los 7 indicadores élite"
           },
           {
             "@type": "Offer",
@@ -3119,7 +3036,7 @@
             "priceValidUntil": "2025-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Annual billing - save $489 vs monthly (41% off)"
+            "description": "Facturación anual - ahorra $489 vs mensual (41% de descuento)"
           },
           {
             "@type": "Offer",
@@ -3129,7 +3046,7 @@
             "priceValidUntil": "2025-12-31",
             "availability": "https://schema.org/LimitedAvailability",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "One-time payment for lifetime access - only 350 slots available"
+            "description": "Pago único para acceso de por vida - solo 350 cupos disponibles"
           }
         ],
         "author": {
@@ -3138,16 +3055,16 @@
           "url": "https://www.signalpilot.io/"
         },
         "featureList": [
-          "SP Pentarch - 5-phase cycle detection",
-          "SP OmniDeck - 10-in-1 dashboard",
-          "SP Volume Oracle - Institutional flow tracking",
-          "SP Plutus Flow - Money flow analysis",
-          "SP Janus Atlas - Multi-timeframe key levels",
-          "SP Augury Grid - Support/resistance matrix",
-          "SP Harmonic Oscillator - Momentum signals"
+          "SP Pentarch - Detección de ciclos de 5 fases",
+          "SP OmniDeck - Panel 10 en 1",
+          "SP Volume Oracle - Rastreo de flujo institucional",
+          "SP Plutus Flow - Análisis de flujo de dinero",
+          "SP Janus Atlas - Niveles clave multi-temporales",
+          "SP Augury Grid - Matriz de soporte/resistencia",
+          "SP Harmonic Oscillator - Señales de momentum"
         ],
         "softwareVersion": "3.0",
-        "releaseNotes": "Complete market cycle mapping with zero repaint guarantee"
+        "releaseNotes": "Mapeo completo de ciclos del mercado con garantía de cero repintado"
       },
       {
         "@type": "Organization",
@@ -3161,7 +3078,7 @@
           "@type": "ContactPoint",
           "contactType": "Customer Support",
           "email": "support@signalpilot.io",
-          "availableLanguage": ["English"]
+          "availableLanguage": ["Español", "English"]
         }
       },
       {
@@ -3555,11 +3472,11 @@
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
 
-            <strong>Pentarch™</strong> maps complete market cycles with five event signals.
+            <strong>Pentarch™</strong> mapea ciclos completos del mercado con cinco señales de eventos.
 
-            Every phase from early cycle to late cycle is visible—non-repainting, close-confirmed.
+            Cada fase desde el ciclo temprano hasta el ciclo tardío es visible—sin repintado, confirmado al cierre.
 
-            Six elite companion indicators provide context, filters and timing data.
+            Seis indicadores complementarios élite proporcionan contexto, filtros y datos de sincronización.
 
           </p>
 
@@ -4746,19 +4663,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>One integrated view</strong> — unified cycle map</span>
+                  <span><strong>Una vista integrada</strong> — mapa de ciclo unificado</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% non-repainting</strong> (audited, $100 challenge)</span>
+                  <span><strong>100% sin repintado</strong> (auditado, desafío de $100)</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 elite systems included</strong> — complete toolkit</span>
+                  <span><strong>7 sistemas élite incluidos</strong> — conjunto completo de herramientas</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> lessons + 50+ page docs</strong> — master your journey</span>
+                  <span><strong><span data-count="82">82</span> lecciones + más de 50 páginas de docs</strong> — domina tu camino</span>
                 </li>
               </ul>
             </div>
@@ -5749,10 +5666,6 @@
           </div>
           <p style="font-size:1.05rem;color:var(--text);line-height:1.6;margin:0;max-width:700px;margin:0 auto">
             <strong>Garantía de reembolso de 7 días - envíanos un email para un reembolso completo.</strong> Sin preguntas, sin complicaciones. Mantienes acceso durante todo el período de prueba.
-            <h3 style="font-size:1.5rem;font-weight:700;color:#3ed598;margin:0">7-Day Money-Back Guarantee</h3>
-          </div>
-          <p style="font-size:1.05rem;color:var(--text);line-height:1.6;margin:0;max-width:700px;margin:0 auto">
-            <strong>7-Day money-back guarantee - email us for a full refund.</strong> No questions asked, no hassle. You keep access during the entire trial period.
           </p>
           <div style="display:flex;justify-content:center;gap:2rem;margin-top:1.5rem;flex-wrap:wrap">
             <div style="display:flex;align-items:center;gap:.5rem">
@@ -5913,11 +5826,7 @@
             Construido para <span class="typewriter-footer" style="color:var(--brand);font-weight:600"></span>
           </p>
           <p style="color:var(--muted);font-size:.85rem;line-height:1.6;margin:0 0 1rem 0">
-            82 lecciones gratuitas + 7 indicadores premium para TradingView.
-            Built for <span class="typewriter-footer" style="color:var(--brand);font-weight:600"></span>
-          </p>
-          <p style="color:var(--muted);font-size:.85rem;line-height:1.6;margin:0 0 1rem 0">
-            82 free lessons + 7 premium TradingView indicators.
+            82 lecciones gratuitas + 7 indicadores premium de TradingView.
           </p>
           <div style="display:flex;gap:.8rem;margin-top:1rem">
             <a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.9rem;transition:color .2s" title="Email">Email</a>
@@ -5932,13 +5841,6 @@
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Documentación</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Centro Educativo</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Preguntas Frecuentes</a></li>
-          <h4 style="margin:0 0 .8rem 0;font-size:.95rem;font-weight:600;color:var(--text)">Product</h4>
-          <ul style="list-style:none;padding:0;margin:0">
-            <li style="margin-bottom:.4rem"><a href="#inside" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Indicators</a></li>
-            <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Pricing</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Documentation</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Education Hub</a></li>
-            <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">FAQ</a></li>
           </ul>
         </div>
 
@@ -5949,10 +5851,6 @@
             <li style="margin-bottom:.4rem"><a href="terms.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Términos de Servicio</a></li>
             <li style="margin-bottom:.4rem"><a href="refund.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Política de Reembolso</a></li>
             <li style="margin-bottom:.4rem"><a href="manage-subscription.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Gestionar Suscripción</a></li>
-            <li style="margin-bottom:.4rem"><a href="privacy.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Privacy Policy</a></li>
-            <li style="margin-bottom:.4rem"><a href="terms.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Terms of Service</a></li>
-            <li style="margin-bottom:.4rem"><a href="refund.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Refund Policy</a></li>
-            <li style="margin-bottom:.4rem"><a href="manage-subscription.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Manage Subscription</a></li>
           </ul>
         </div>
 
@@ -5963,12 +5861,6 @@
             <li style="margin-bottom:.4rem"><a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">support@signalpilot.io</a></li>
             <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Hoja de Ruta</a></li>
             <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Programa de Afiliados</a></li>
-          <h4 style="margin:0 0 .8rem 0;font-size:.95rem;font-weight:600;color:var(--text)">Connect</h4>
-          <ul style="list-style:none;padding:0;margin:0">
-            <li style="margin-bottom:.4rem"><a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">GitHub</a></li>
-            <li style="margin-bottom:.4rem"><a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">support@signalpilot.io</a></li>
-            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Roadmap</a></li>
-            <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Affiliate Program</a></li>
           </ul>
         </div>
 
@@ -5980,14 +5872,12 @@
         <div style="background:linear-gradient(135deg,rgba(249,162,60,.06),rgba(249,162,60,.02));border:1px solid rgba(249,162,60,.15);border-radius:8px;padding:1rem 1.25rem">
           <p style="color:var(--muted);font-size:.8rem;margin:0;line-height:1.5">
             <strong style="color:#f9a23c;font-size:.82rem">⚠️ Aviso Educativo:</strong> Signal Pilot proporciona herramientas educativas solo para aprendizaje. No es asesoría financiera. El trading implica riesgo sustancial. El rendimiento pasado no garantiza resultados futuros.
-            <strong style="color:#f9a23c;font-size:.82rem">⚠️ Educational Disclaimer:</strong> Signal Pilot provides educational tools for learning only. Not financial advice. Trading involves substantial risk. Past performance doesn't guarantee future results.
           </p>
         </div>
 
         <div style="display:flex;flex-direction:column;justify-content:center;align-items:center;gap:.5rem;text-align:center">
           <p style="color:var(--muted-2);font-size:.8rem;margin:0">
             © 2025 <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.08em;font-weight:400">Signal Pilot</span> Labs. Todos los derechos reservados.
-            © 2025 <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.08em;font-weight:400">Signal Pilot</span> Labs. All rights reserved.
           </p>
           <p style="color:var(--muted-2);font-size:.75rem;margin:0;opacity:.6">v202510301807</p>
         </div>


### PR DESCRIPTION
- Remove duplicate meta tags (description, keywords, hreflang, og:description, twitter:description)
- Translate English meta tags to Spanish (og:image:alt, twitter:image:alt)
- Fix Schema.org structured data by removing duplicate English fields
- Translate all English content in body to Spanish
- Remove duplicate English sections in footer
- Confirm no Google Translate remnants exist

All content is now properly in Spanish with no duplicates or English text.