### PR TITLE
Fix duplicate text and language inconsistencies

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -3194,7 +3194,6 @@
 
           <li><a href="#pricing">Precios</a></li>
 
-          <li><a href="/affiliates.html">Afiliados</a></li>
           <li><a href="/es/affiliates.html">Afiliados</a></li>
 
         </ul>
@@ -3248,7 +3247,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Detección de ciclos sin repintado • 7 indicadores premium para <span id="typed-text" style="color:var(--brand);font-weight:600">traders serios</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Detección de ciclos sin repintado • 7 indicadores premium para <span id="typed-text" style="color:var(--brand);font-weight:600">traders profesionales</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
           </p>
 
         </div>
@@ -4253,10 +4252,6 @@
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Detección de ciclos de cuatro capas (Pentarch™) más seis herramientas de análisis especializadas. Análisis de estructura de mercado <span data-quality="elite">élite</span>.
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">The Elite <span data-count="7" data-text-mode>7</span></h2>
-
-        <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. <span data-quality="elite">Elite</span> market structure analysis.
         </p>
 
 
@@ -5928,14 +5923,7 @@
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro Educativo</a>
         <a href="/faq.html">Centro de Preguntas</a>
         <a href="#pricing">Precios</a>
-        <a href="/affiliates.html">Afiliados</a>
-        <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Try Free 7 Days →</a>
-        <a href="#inside">What's inside</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a>
-        <a href="/faq.html">FAQ Center</a>
-        <a href="#pricing">Pricing</a>
-        <a href="/affiliates.html">Affiliates</a>
+        <a href="/es/affiliates.html">Afiliados</a>
       `;
 
       // Assemble menu
@@ -7600,7 +7588,7 @@ if ('serviceWorker' in navigator) {
     if (!textElement) return;
 
     const words = [
-      'traders serios',
+      'traders profesionales',
       'day traders',
       'swing traders',
       'scalpers',


### PR DESCRIPTION
- Translate animation text from 'traders serios' to 'traders profesionales'
- Remove duplicate English 'The Elite 7' section
- Remove duplicate 'Afiliados' navigation link
- Remove duplicate English links from mobile menu
- Update all affiliates links to point to Spanish version