### PR TITLE
Fix lifetime card overflow in Spanish version

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -5419,7 +5419,6 @@
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
                 Asegura tu acceso de por vida ahora.
-              LIMITADO • <span data-count="150">150</span> ESPACIOS RESTANTES
               </p>
             </div>
 


### PR DESCRIPTION
Remove duplicate "LIMITADO • 150 ESPACIOS RESTANTES" text that was causing overflow in the lifetime pricing card. The badge at the top already shows "LIMITADO • 150 CUPOS DISPONIBLES".