### PR TITLE
Shorten lifetime badge text to prevent overflow

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -5403,7 +5403,7 @@
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
             <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
-              LIMITADO • <span data-count="150">150</span> CUPOS DISPONIBLES
+              LIMITADO • <span data-count="150">150</span> RESTANTES
             </div>
 
             <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">Acceso de Por Vida</div>


### PR DESCRIPTION
Changed "LIMITADO • 150 CUPOS DISPONIBLES" to "LIMITADO • 150 RESTANTES" to match the English version length ("LIMITED • 150 SLOTS LEFT" vs "LIMITED • 150 LEFT") and prevent badge overflow on smaller screens.