### PR TITLE
Force mobile carousel and FAQ fixes with !important flags

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -951,25 +951,38 @@
         overflow-x:hidden !important;
       }
 
-      /* FIX: FAQ grid overflow on mobile */
-      #faq .card,
-      #faq div[style*="grid-template-columns"] {
+      /* FIX: FAQ grid overflow on mobile - force single column */
+      #faq div[style*="grid-template-columns"],
+      #faq div[style*="minmax"] {
+        display: grid !important;
         grid-template-columns: 1fr !important;
-        min-width: 0 !important;
+        gap: 1rem !important;
         max-width: 100% !important;
-        overflow-wrap: break-word !important;
-        word-break: break-word !important;
+        width: 100% !important;
       }
 
-      #faq div[style*="minmax"] {
-        grid-template-columns: 1fr !important;
+      #faq .card {
+        min-width: 0 !important;
+        max-width: 100% !important;
+        width: 100% !important;
+        overflow-wrap: break-word !important;
+        word-break: break-word !important;
+        box-sizing: border-box !important;
       }
 
       #faq strong,
-      #faq .note {
+      #faq .note,
+      #faq p {
         overflow-wrap: break-word !important;
         word-break: break-word !important;
         max-width: 100% !important;
+        hyphens: auto !important;
+      }
+
+      /* Ensure all FAQ text wraps properly */
+      #faq * {
+        max-width: 100% !important;
+        box-sizing: border-box !important;
       }
 
       main{
@@ -3805,33 +3818,34 @@
                 display: none;
               }
 
-              /* CRITICAL: Fix carousel container overflow */
+              /* CRITICAL: Make carousel wrapper full-width on mobile */
               #pentarch-carousel {
-                gap: 0.5rem;
-                margin-left: calc(-1 * clamp(14px, 4vw, 22px));
-                margin-right: calc(-1 * clamp(14px, 4vw, 22px));
-                padding-left: clamp(14px, 4vw, 22px);
-                padding-right: clamp(14px, 4vw, 22px);
-                width: 100vw;
-                max-width: 100vw;
+                gap: 0.5rem !important;
+                margin-left: calc(-1 * clamp(14px, 4vw, 22px)) !important;
+                margin-right: calc(-1 * clamp(14px, 4vw, 22px)) !important;
+                padding-left: clamp(14px, 4vw, 22px) !important;
+                padding-right: clamp(14px, 4vw, 22px) !important;
+                width: 100vw !important;
+                max-width: 100vw !important;
               }
 
-              /* Ensure carousel items are properly sized */
+              /* Make carousel parent wrapper full-width too */
+              #pentarch-carousel::-webkit-scrollbar {
+                display: none;
+              }
+
+              /* Ensure carousel items are properly sized - one per view */
               .carousel-item {
-                flex: 0 0 calc(100vw - (2 * clamp(14px, 4vw, 22px)));
-                min-height: 200px;
-                max-width: calc(100vw - (2 * clamp(14px, 4vw, 22px)));
+                flex: 0 0 calc(100vw - (2 * clamp(14px, 4vw, 22px))) !important;
+                min-height: 200px !important;
+                max-width: calc(100vw - (2 * clamp(14px, 4vw, 22px))) !important;
+                width: calc(100vw - (2 * clamp(14px, 4vw, 22px))) !important;
               }
 
               .carousel-item img {
-                object-fit: cover;
-                width: 100%;
-                height: 100%;
-              }
-
-              /* Fix carousel container parent */
-              #pentarch-carousel::-webkit-scrollbar {
-                display: none;
+                object-fit: cover !important;
+                width: 100% !important;
+                height: 100% !important;
               }
             }
 


### PR DESCRIPTION
Carousel Fixes:
- Add !important flags to ALL carousel mobile styles to override inline styles
- Inline styles on #pentarch-carousel have gap:1.5rem which was not being overridden
- Force gap: 0.5rem, width: 100vw, and proper negative margins
- Force carousel-item width to calc(100vw - 2 * padding) for perfect alignment
- Each image now takes exactly one full viewport width

FAQ Fixes:
- More aggressive selectors to target the grid container
- Force grid-template-columns: 1fr to override minmax(280px, 1fr)
- Add box-sizing: border-box to all FAQ elements
- Add hyphens: auto for better text breaking
- Apply max-width: 100% to ALL FAQ children elements

These !important flags ensure mobile styles always win over inline styles.