### PR TITLE
Add country flags to Google Translate widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -3293,10 +3293,9 @@
 
 
       <div class="lang-dropdown">
-        <a href="/es/" class="btn btn-ghost btn-sm" aria-label="Switch to Spanish" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text);text-decoration:none">
-        <a href="/es/" class="btn btn-ghost btn-sm" type="button" aria-label="Cambiar a Español" title="Switch to Spanish" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text);text-decoration:none;display:inline-flex;align-items:center;gap:0.3rem">
-          <span>🌐 ES</span>
-        </a>
+        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Language selection" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text)">
+          <span>🇺🇸 EN</span>
+        </button>
       </div>
 
       <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Theme selection" style="padding:.5rem .7rem;color:var(--text)">
@@ -6092,28 +6091,28 @@
 
       // Create language buttons
       const languages = [
-        { code: 'en', name: 'English' },
-        { code: 'de', name: 'Deutsch' },
-        { code: 'fr', name: 'Français' },
-        { code: 'es', name: 'Español' },
-        { code: 'it', name: 'Italiano' },
-        { code: 'zh', name: '中文' },
-        { code: 'ru', name: 'Русский' },
-        { code: 'ar', name: 'العربية' },
-        { code: 'pt', name: 'Português' },
-        { code: 'tr', name: 'Türkçe' },
-        { code: 'ja', name: '日本語' },
-        { code: 'ko', name: '한국어' },
-        { code: 'vi', name: 'Tiếng Việt' },
-        { code: 'th', name: 'ไทย' },
-        { code: 'hi', name: 'हिन्दी' },
-        { code: 'id', name: 'Bahasa Indonesia' }
+        { code: 'en', name: 'English', flag: '🇺🇸' },
+        { code: 'de', name: 'Deutsch', flag: '🇩🇪' },
+        { code: 'fr', name: 'Français', flag: '🇫🇷' },
+        { code: 'es', name: 'Español', flag: '🇪🇸' },
+        { code: 'it', name: 'Italiano', flag: '🇮🇹' },
+        { code: 'zh', name: '中文', flag: '🇨🇳' },
+        { code: 'ru', name: 'Русский', flag: '🇷🇺' },
+        { code: 'ar', name: 'العربية', flag: '🇸🇦' },
+        { code: 'pt', name: 'Português', flag: '🇵🇹' },
+        { code: 'tr', name: 'Türkçe', flag: '🇹🇷' },
+        { code: 'ja', name: '日本語', flag: '🇯🇵' },
+        { code: 'ko', name: '한국어', flag: '🇰🇷' },
+        { code: 'vi', name: 'Tiếng Việt', flag: '🇻🇳' },
+        { code: 'th', name: 'ไทย', flag: '🇹🇭' },
+        { code: 'hi', name: 'हिन्दी', flag: '🇮🇳' },
+        { code: 'id', name: 'Bahasa Indonesia', flag: '🇮🇩' }
       ];
 
       languages.forEach(lang => {
         const btn = document.createElement('button');
         btn.setAttribute('data-lang', lang.code);
-        btn.textContent = lang.name;
+        btn.textContent = lang.flag + ' ' + lang.name;
         btn.addEventListener('click', function() {
           // Helper functions
           function baseDomain(host) {
@@ -6400,7 +6399,13 @@
       if (langBtn) {
         const langText = langBtn.querySelector('span');
         if (langText) {
-          langText.textContent = code.toUpperCase();
+          const flagMap = {
+            'en': '🇺🇸', 'de': '🇩🇪', 'fr': '🇫🇷', 'es': '🇪🇸',
+            'it': '🇮🇹', 'zh': '🇨🇳', 'ru': '🇷🇺', 'ar': '🇸🇦',
+            'pt': '🇵🇹', 'tr': '🇹🇷', 'ja': '🇯🇵', 'ko': '🇰🇷',
+            'vi': '🇻🇳', 'th': '🇹🇭', 'hi': '🇮🇳', 'id': '🇮🇩'
+          };
+          langText.textContent = (flagMap[code] || '🌐') + ' ' + code.toUpperCase();
         }
       }
 


### PR DESCRIPTION
- Added flag emojis next to all language names in the dropdown menu
- Fixed duplicate/broken language buttons in header (lines 3296-3299)
- Replaced broken Spanish link with proper langToggle button
- Language button now shows flag + language code (e.g., "🇺🇸 EN")
- Flags update dynamically when language is changed