### PR TITLE
Fix auto-translation issue - prevent unwanted language switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -6148,8 +6148,14 @@
           localStorage.setItem('sp_lang', lang.code);
 
           // Set cookies and attributes
-          setGoogTrans(lang.code);
-          applyDirLang(lang.code);
+          if (lang.code === 'en') {
+            // Clear translation for English
+            clearGoogTrans();
+            applyDirLang('en');
+          } else {
+            setGoogTrans(lang.code);
+            applyDirLang(lang.code);
+          }
 
           // Track event if analytics available
           if (typeof trackEvent === 'function') {
@@ -6334,6 +6340,13 @@
         setCookie('googtrans', val, 365, root);
       }
 
+      function clearGoogTrans() {
+        // Clear the googtrans cookie by setting it to expire immediately
+        document.cookie = 'googtrans=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
+        document.cookie = 'googtrans=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=' + root;
+      }
+
       function applyDirLang(lang) {
         document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
         document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
@@ -6391,8 +6404,16 @@
       console.log('[GT] Saved language:', code);
 
       if (sel) sel.value = code;
-      setGoogTrans(code);
-      applyDirLang(code);
+
+      // Only set translation cookies for non-English languages
+      if (code !== 'en') {
+        setGoogTrans(code);
+        applyDirLang(code);
+      } else {
+        // Clear translation cookies for English
+        clearGoogTrans();
+        applyDirLang('en');
+      }
 
       // Update language button text to show current language
       const langBtn = document.getElementById('langToggle');


### PR DESCRIPTION
Critical fixes:
- Added clearGoogTrans() function to properly delete translation cookies
- Only apply non-English translations when explicitly selected
- Clear googtrans cookie when English is selected
- Prevent automatic translation on page load unless user chose a language
- Fix for users experiencing unwanted Arabic/other language translations

This resolves the issue where the site would auto-translate to previously selected languages (like Arabic) even when users wanted English.