### PR TITLE
Update language button to show only flag emoji

### DIFF
--- a/index.html
+++ b/index.html
@@ -3294,7 +3294,7 @@
 
       <div class="lang-dropdown">
         <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Language selection" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text)">
-          <span>🇺🇸 EN</span>
+          <span>🇺🇸</span>
         </button>
       </div>
 
@@ -6468,7 +6468,7 @@
             'pt': '🇵🇹', 'tr': '🇹🇷', 'ja': '🇯🇵', 'ko': '🇰🇷',
             'vi': '🇻🇳', 'th': '🇹🇭', 'hi': '🇮🇳', 'id': '🇮🇩'
           };
-          langText.textContent = (flagMap[code] || '🌐') + ' ' + code.toUpperCase();
+          langText.textContent = flagMap[code] || '🌐';
         }
       }
 


### PR DESCRIPTION
Changes:
- Language toggle button now shows only the flag (e.g., 🇺🇸)
- Dropdown menu still shows flag + language name (e.g., 🇺🇸 English)
- Cleaner, more minimal design on both desktop and mobile
- Default button updated from "🇺🇸 EN" to just "🇺🇸"