### PR TITLE
CRITICAL: Add early-executing script to clear Google Translate cookies

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,53 @@
 <head>
   <meta charset="utf-8" />
 
+  <!-- CRITICAL: Clear Google Translate cookies IMMEDIATELY if English is selected -->
+  <script>
+    (function() {
+      try {
+        // Check URL parameter first
+        var urlParams = new URLSearchParams(window.location.search);
+        var urlLang = urlParams.get('lang');
+
+        // Check localStorage
+        var savedLang = localStorage.getItem('sp_lang') || 'en';
+
+        // If URL says English or localStorage says English, nuke Google Translate cookies NOW
+        if (urlLang === 'en' || savedLang === 'en') {
+          console.log('[GT-EARLY] Clearing Google Translate cookies for English');
+
+          // Get root domain
+          var hostname = location.hostname.replace(/^www\./, '');
+          var parts = hostname.split('.');
+          var rootDomain = parts.length > 2 ? parts.slice(-2).join('.') : hostname;
+
+          // Nuclear cookie clearing - all variations
+          var cookieNames = ['googtrans', 'googtrans(2)', 'googtrans(0)', 'googtrans(1)'];
+          var domains = ['', '; domain=.' + rootDomain, '; domain=' + hostname];
+          var paths = ['/', '/en'];
+
+          cookieNames.forEach(function(name) {
+            domains.forEach(function(domain) {
+              paths.forEach(function(path) {
+                document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
+                document.cookie = name + '=/en/en; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
+                document.cookie = name + '=; max-age=0; path=' + path + domain;
+              });
+            });
+          });
+
+          // Force English on HTML element
+          document.documentElement.lang = 'en';
+          document.documentElement.dir = 'ltr';
+
+          console.log('[GT-EARLY] Cookies cleared, language set to English');
+        }
+      } catch(e) {
+        console.error('[GT-EARLY] Error:', e);
+      }
+    })();
+  </script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
   <!-- Prevent aggressive caching on mobile browsers -->


### PR DESCRIPTION
The root cause was a race condition: Google Translate reads cookies when the page loads, BEFORE our JavaScript could clear them.

Solution: Added synchronous <script> at the very top of <head> that:
- Runs IMMEDIATELY before anything else loads
- Checks localStorage and URL params for English selection
- Clears ALL Google Translate cookie variations synchronously
- Forces HTML lang='en' and dir='ltr'
- Logs with [GT-EARLY] prefix for debugging

This script executes BEFORE Google Translate can read its cookies, preventing it from auto-translating when English is selected.

Key differences from previous approach:
- Runs synchronously in <head>, not in document.ready
- Executes before ANY other scripts or content
- Uses simple ES5 JavaScript for maximum compatibility
- Cannot be blocked by async loading issues