### PR TITLE
Fix translated text size to match original text

### DIFF
--- a/index.html
+++ b/index.html
@@ -801,23 +801,23 @@
       color: inherit !important;
     }
 
-    /* Make Google Translate text smaller and more proportional */
+    /* Make Google Translate font wrappers inherit original text size */
     font {
-      font-size: 0.85em !important;
+      font-size: inherit !important;
       line-height: inherit !important;
     }
 
     /* Specific adjustments for different text sizes */
     h1 font, h2 font, h3 font, .headline font {
-      font-size: 0.88em !important;
+      font-size: inherit !important;
     }
 
     p font, li font, div font {
-      font-size: 0.85em !important;
+      font-size: inherit !important;
     }
 
     .btn font, button font, a font {
-      font-size: 0.86em !important;
+      font-size: inherit !important;
     }
 
     /* CRITICAL: Force Google Translate font/span wrappers to not block clicks */


### PR DESCRIPTION
Changed Google Translate font wrapper CSS from reduced sizes (0.85em-0.88em) to inherit original text sizes.

Before:
- font { font-size: 0.85em } - 15% smaller
- h1/h2/h3 font { font-size: 0.88em } - 12% smaller
- Buttons font { font-size: 0.86em } - 14% smaller

After:
- All font wrappers use font-size: inherit
- Translated text now matches original text size exactly
- Maintains all other styling (color, line-height, etc.)

This ensures translated content has the same visual weight and readability as the original English content.