### PR TITLE
Fix FAQ section overflow on Spanish homepage

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -1959,6 +1959,24 @@
       to{transform:scale(1);opacity:1}
     }
 
+    /* FAQ-specific overflow fixes for Spanish text */
+    #faq .card {
+      overflow: hidden;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      hyphens: auto;
+    }
+
+    #faq .card strong,
+    #faq .card p,
+    #faq .card .note,
+    #faq .card a {
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      hyphens: auto;
+      max-width: 100%;
+    }
 
 
     /* Header */
@@ -5573,7 +5591,7 @@
     <h2 id="faq-heading" class="headline lg" style="text-align:center">Preguntas Frecuentes</h2>
     <p style="text-align:center;color:var(--muted);margin:-0.5rem 0 1.5rem 0;font-size:.9rem">Preguntas previas a la compra respondidas. Para guías de configuración: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a> o <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro Educativo</a>.</p>
 
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;max-width:1100px;margin:0 auto">
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(min(280px,100%),1fr));gap:1rem;max-width:1100px;margin:0 auto;overflow:hidden">
 
       <!-- EDUCATION HUB -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-0">

--- a/es/index.html
+++ b/es/index.html
@@ -4668,10 +4668,13 @@
               padding: 2rem;
               max-width: 800px;
               margin: 0 auto;
+              overflow: hidden;
             }
 
             .comparison-column {
               min-width: 0; /* Prevent grid blowout */
+              overflow-wrap: break-word;
+              word-wrap: break-word;
             }
 
             .comparison-heading {
@@ -4681,6 +4684,9 @@
               text-align: center;
               font-weight: 600;
               line-height: 1.2;
+              word-wrap: break-word;
+              overflow-wrap: break-word;
+              hyphens: auto;
             }
 
             .comparison-heading-negative {
@@ -4706,6 +4712,15 @@
               gap: 0.75rem;
               font-size: clamp(0.875rem, 2vw, 0.95rem);
               line-height: 1.6;
+              word-wrap: break-word;
+              overflow-wrap: break-word;
+            }
+
+            .comparison-item span {
+              word-wrap: break-word;
+              overflow-wrap: break-word;
+              hyphens: auto;
+              max-width: 100%;
             }
 
             .comparison-item-negative {


### PR DESCRIPTION
Added comprehensive overflow handling for Spanish FAQ section:
- Changed grid from minmax(280px,1fr) to minmax(min(280px,100%),1fr) to allow cards to shrink on small screens
- Added overflow:hidden to FAQ grid container
- Added word-wrap, overflow-wrap, and hyphens CSS for all FAQ card text
- Ensures long Spanish words/phrases wrap properly on all screen sizes

Fixes horizontal overflow issues caused by longer Spanish translations.