### PR TITLE
Fix Portuguese site layout and translate remaining English content

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2863,6 +2863,23 @@
       /* Fix FAQ grid overflow on mobile - single column */
       #faq > div > div[style*="grid-template-columns"]{
         grid-template-columns:1fr !important;
+        max-width:100% !important;
+        padding:0 !important;
+      }
+
+      /* Ensure FAQ section respects viewport */
+      #faq .section,
+      #faq .container{
+        max-width:100vw !important;
+        overflow-x:hidden !important;
+        box-sizing:border-box !important;
+      }
+
+      /* FAQ cards - prevent overflow */
+      #faq .card{
+        word-wrap:break-word !important;
+        overflow-wrap:break-word !important;
+        box-sizing:border-box !important;
       }
 
       /* Footer: single column on mobile */
@@ -4571,11 +4588,11 @@
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Como um semáforo para o mercado</strong> — mostra exatamente onde você está no ciclo com 5 sinais-chave:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0;margin-bottom:1rem">
-                <li>• <strong style="color:#00FF7F">🟢 TD + IGN:</strong> Downtrend exhausting, upward momentum building (early cycle)</li>
-                <li>• <strong style="color:#FFD700">🟡 WRN:</strong> Price rising but showing weakness (caution zone)</li>
-                <li>• <strong style="color:#FF4560">🔴 CAP + BDN:</strong> Uptrend exhausting, downward momentum building (late cycle)</li>
+                <li>• <strong style="color:#00FF7F">🟢 TD + IGN:</strong> Tendência de baixa exaurindo, momentum ascendente crescendo (ciclo inicial)</li>
+                <li>• <strong style="color:#FFD700">🟡 WRN:</strong> Preço subindo mas mostrando fraqueza (zona de cautela)</li>
+                <li>• <strong style="color:#FF4560">🔴 CAP + BDN:</strong> Tendência de alta exaurindo, momentum descendente crescendo (ciclo final)</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin:0"><strong>Plus:</strong> Color-coded Pilot Line (trend direction), color-coded candles (market structure), and NanoFlow crosses (momentum strength). Works on any market, any timeframe.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin:0"><strong>Além disso:</strong> Pilot Line codificada por cores (direção da tendência), velas codificadas por cores (estrutura de mercado) e cruzamentos NanoFlow (força do momentum). Funciona em qualquer mercado, qualquer período.</p>
             </div>
           </article>
 
@@ -4603,14 +4620,14 @@
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Docs</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> powerful tools in one clean overlay.</strong> Instead of cluttering your chart, get everything you need in a single indicator:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> ferramentas poderosas em uma sobreposição limpa.</strong> Em vez de poluir seu gráfico, obtenha tudo o que você precisa em um único indicador:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• <strong>TD Sequential</strong> (exhaustion signals) • <strong>Squeeze Cloud</strong> (breakout detection)</li>
-                <li>• <strong>SuperTrend Ensemble</strong> (trend confirmation) • <strong>Bull Market Suporte Band</strong></li>
-                <li>• <strong>Supply/Demand Zones</strong> • <strong>Candlestick Patterns</strong> • <strong>Liquidity Sweeps</strong></li>
-                <li>• <strong>Regime System</strong> (bull/bear/chop) • <strong>EMA Events</strong> • <strong>Caution Warnings</strong></li>
+                <li>• <strong>TD Sequential</strong> (sinais de exaustão) • <strong>Squeeze Cloud</strong> (detecção de rompimento)</li>
+                <li>• <strong>SuperTrend Ensemble</strong> (confirmação de tendência) • <strong>Bull Market Support Band</strong></li>
+                <li>• <strong>Zonas de Oferta/Demanda</strong> • <strong>Padrões de Candlestick</strong> • <strong>Varreduras de Liquidez</strong></li>
+                <li>• <strong>Sistema de Regime</strong> (alta/baixa/lateral) • <strong>Eventos EMA</strong> • <strong>Avisos de Cautela</strong></li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Toggle each system on/off as needed. One indicator, multiple confirmations, zero clutter.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Ative/desative cada sistema conforme necessário. Um indicador, múltiplas confirmações, zero poluição.</p>
             </div>
           </article>
 
@@ -4638,14 +4655,14 @@
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Docs</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Follow the smart money.</strong> Tracks institutional accumulation/distribution patterns with confidence levels:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Siga o dinheiro inteligente.</strong> Rastreia padrões de acumulação/distribuição institucional com níveis de confiança:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Shows current phase (ACCUMULATION vs DISTRIBUTION) with strength percentage (0-100%)</li>
-                <li>• Duration tracking — how long institutions have been building/exiting positions</li>
-                <li>• Early warning flashes when pattern is weakening</li>
-                <li>• Built-in position calculator suggests risk levels based on current regime</li>
+                <li>• Mostra a fase atual (ACCUMULATION vs DISTRIBUTION) com porcentagem de força (0-100%)</li>
+                <li>• Rastreamento de duração — há quanto tempo as instituições estão construindo/saindo de posições</li>
+                <li>• Alertas precoces piscam quando o padrão está enfraquecendo</li>
+                <li>• Calculadora de posição integrada sugere níveis de risco baseados no regime atual</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Example: "ACCUMULATION 82%" = strong institutional buying detected. Follow the money.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Exemplo: "ACCUMULATION 82%" = forte compra institucional detectada. Siga o dinheiro.</p>
             </div>
           </article>
 
@@ -4673,14 +4690,14 @@
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Docs</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>The tug-of-war meter.</strong> Tracks cumulative demand vs supply pressure over time:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>O medidor de cabo de guerra.</strong> Rastreia demanda cumulativa vs pressão de oferta ao longo do tempo:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• <strong>Green ribbon:</strong> Demand winning | <strong>Red ribbon:</strong> Supply winning</li>
-                <li>• <strong>Centerline crosses:</strong> Momentum shifting direction</li>
-                <li>• <strong>White dots:</strong> Extreme pressure levels reached</li>
-                <li>• <strong>Divergence marks:</strong> Price and flow disagree (hidden weakness/strength)</li>
+                <li>• <strong>Faixa verde:</strong> Demanda vencendo | <strong>Faixa vermelha:</strong> Oferta vencendo</li>
+                <li>• <strong>Cruzamentos da linha central:</strong> Momentum mudando de direção</li>
+                <li>• <strong>Pontos brancos:</strong> Níveis extremos de pressão atingidos</li>
+                <li>• <strong>Marcas de divergência:</strong> Preço e fluxo discordam (fraqueza/força oculta)</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Reveals whether price moves have real volume support or are just noise.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Revela se os movimentos de preço têm suporte de volume real ou são apenas ruído.</p>
             </div>
           </article>
 
@@ -4708,12 +4725,12 @@
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Docs</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Auto-plots key levels.</strong> Stops you from drawing hundreds of lines manually:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Plota níveis-chave automaticamente.</strong> Evita que você desenhe centenas de linhas manualmente:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Higher timeframe levels (daily, weekly, monthly, quarterly)</li>
-                <li>• Previous session data (yesterday's high/low, last week's range, pivots)</li>
-                <li>• VWAP anchors (fair value zones) + Volume Profile (POC, VAH/VAL)</li>
-                <li>• Session markers (Asia/London/NYC opens) + Structure labels (BOS/CHoCH)</li>
+                <li>• Níveis de períodos superiores (diário, semanal, mensal, trimestral)</li>
+                <li>• Dados da sessão anterior (máxima/mínima de ontem, faixa da semana passada, pivôs)</li>
+                <li>• Âncoras VWAP (zonas de valor justo) + Perfil de Volume (POC, VAH/VAL)</li>
+                <li>• Marcadores de sessão (aberturas Ásia/Londres/NYC) + Rótulos de estrutura (BOS/CHoCH)</li>
               </ul>
               <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Seu roteiro de níveis de preço importantes onde os traders reagem. Tudo automático.</p>
             </div>
@@ -4743,13 +4760,13 @@
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Docs</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Mission control dashboard.</strong> Track 8+ markets simultaneously and see the cleanest setups first:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Painel de controle de missão.</strong> Rastreie 8+ mercados simultaneamente e veja as configurações mais limpas primeiro:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Signal direction (↑ bullish, ↓ bearish, — neutral) + time since signal</li>
-                <li>• Quality score (0-100) — higher scores = more indicators aligned</li>
-                <li>• Target prices + running P&L tracker</li>
+                <li>• Direção do sinal (↑ altista, ↓ baixista, — neutro) + tempo desde o sinal</li>
+                <li>• Pontuação de qualidade (0-100) — pontuações maiores = mais indicadores alinhados</li>
+                <li>• Preços-alvo + rastreador de P&L em execução</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Stop flipping through charts. See your ranked watchlist at a glance.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">Pare de alternar entre gráficos. Veja sua watchlist classificada rapidamente.</p>
             </div>
           </article>
 
@@ -4777,13 +4794,13 @@
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Docs</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillators vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> osciladores votam.</strong> Sinais só aparecem quando múltiplos indicadores de momentum concordam:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Live vote count shows real-time breakdown (e.g., "3 Bulls, 1 Neutral")</li>
-                <li>• Star rating (★ to ★★★★) — more stars = more agreement</li>
-                <li>• Composite line combines all four oscillators for easy viewing</li>
+                <li>• Contagem de votos ao vivo mostra distribuição em tempo real (ex: "3 Bulls, 1 Neutro")</li>
+                <li>• Classificação por estrelas (★ a ★★★★) — mais estrelas = mais concordância</li>
+                <li>• Linha composta combina todos os quatro osciladores para fácil visualização</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">★★★★ = all 4 agree (high confidence). Split vote = unclear conditions.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">★★★★ = todos os 4 concordam (alta confiança). Voto dividido = condições incertas.</p>
             </div>
           </article>
 
@@ -5092,7 +5109,7 @@
           <span class="badge" style="margin-bottom:1rem">DEMO INTERATIVA</span>
           <h2 class="headline lg">A Diferença</h2>
           <p style="color:var(--muted);font-size:1.1rem;line-height:1.6;margin-top:1rem">
-            <strong style="color:var(--brand)">👆 Arraste o controle</strong> para comparar trading with and without <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>. Mesmo gráfico. Mesmo período. Clareza completamente diferente.
+            <strong style="color:var(--brand)">👆 Arraste o controle</strong> para comparar negociação com e sem <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>. Mesmo gráfico. Mesmo período. Clareza completamente diferente.
           </p>
         </div>
 
@@ -5552,10 +5569,10 @@
 
             <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(91,138,255,.06);border:1px solid rgba(91,138,255,.2);border-radius:8px">
               <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">
-                Pay monthly, cancel anytime
+                Pague mensalmente, cancele a qualquer momento
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
-                Most flexible option. No commitment required.
+                Opção mais flexível. Sem compromisso necessário.
               </p>
             </div>
 
@@ -5567,29 +5584,29 @@
                   Nome de Usuário TradingView
                 </label>
                 <div class="input-wrapper">
-                  <input id="tv-monthly" placeholder="@your.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">
+                  <input id="tv-monthly" placeholder="@seu.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">
                   <div class="checkmark">
                     <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
                       <polyline points="20 6 9 17 4 12"></polyline>
                     </svg>
                   </div>
                 </div>
-                <div id="error-tv-monthly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:.5rem;font-weight:500">⚠️ TradingView username required</div>
+                <div id="error-tv-monthly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:.5rem;font-weight:500">⚠️ Nome de usuário TradingView obrigatório</div>
               </div>
 
               <!-- Step 2: Consent -->
-              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-monthly"><span>Eu entendo que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is educational. No financial advice.</span></label>
-              <div id="error-consent-monthly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
+              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-monthly"><span>Eu entendo que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> é educacional. Não é aconselhamento financeiro.</span></label>
+              <div id="error-consent-monthly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consentimento obrigatório</div>
 
               <!-- PayPal Branding -->
               <div style="text-align:center;margin-bottom:1rem">
                 <img src="https://www.paypalobjects.com/images/Debit_Credit.svg" alt="PayPal accepted cards" style="margin:0 auto;height:24px;" loading="lazy" width="120" height="24" />
-                <div style="font-size:0.75rem;opacity:0.7;margin-top:0.25rem">Powered por PayPal</div>
+                <div style="font-size:0.75rem;opacity:0.7;margin-top:0.25rem">Powered by PayPal</div>
               </div>
 
               <!-- Step 3: Subscribe -->
               <button type="button" id="btn-monthly-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
-                💳 Subscribe with PayPal<br><span style="font-size:.85rem">$99/mês</span>
+                💳 Assinar com PayPal<br><span style="font-size:.85rem">$99/mês</span>
               </button>
 
               <div style="text-align:center;margin-top:1rem">
@@ -5622,10 +5639,10 @@
                 <span style="background:linear-gradient(135deg,#3ed598,#2ec98a);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Economize <span data-count="489" data-prefix="$">489</span>/ano</span>
               </p>
               <p style="font-size:.9rem;color:var(--text);margin:0 0 .25rem 0">
-                Just $58/mês equivalent
+                Apenas $58/mês equivalente
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
-                Billed $699 annually. Best value for committed traders.
+                Cobrado $699 anualmente. Melhor valor para traders comprometidos.
               </p>
             </div>
 
@@ -5637,29 +5654,29 @@
                   Nome de Usuário TradingView
                 </label>
                 <div class="input-wrapper">
-                  <input id="tv-yearly" placeholder="@your.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">
+                  <input id="tv-yearly" placeholder="@seu.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">
                   <div class="checkmark">
                     <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
                       <polyline points="20 6 9 17 4 12"></polyline>
                     </svg>
                   </div>
                 </div>
-                <div id="error-tv-yearly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:.5rem;font-weight:500">⚠️ TradingView username required</div>
+                <div id="error-tv-yearly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:.5rem;font-weight:500">⚠️ Nome de usuário TradingView obrigatório</div>
               </div>
 
               <!-- Step 2: Consent -->
-              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-yearly"><span>Eu entendo que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is educational. No financial advice.</span></label>
-              <div id="error-consent-yearly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
+              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-yearly"><span>Eu entendo que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> é educacional. Não é aconselhamento financeiro.</span></label>
+              <div id="error-consent-yearly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consentimento obrigatório</div>
 
               <!-- PayPal Branding -->
               <div style="text-align:center;margin-bottom:1rem">
                 <img src="https://www.paypalobjects.com/images/Debit_Credit.svg" alt="PayPal accepted cards" style="margin:0 auto;height:24px;" loading="lazy" width="120" height="24" />
-                <div style="font-size:0.75rem;opacity:0.7;margin-top:0.25rem">Powered por PayPal</div>
+                <div style="font-size:0.75rem;opacity:0.7;margin-top:0.25rem">Powered by PayPal</div>
               </div>
 
               <!-- Step 3: Subscribe -->
               <button type="button" id="btn-yearly-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
-                💳 Subscribe with PayPal<br><span style="font-size:.85rem">$699/ano</span>
+                💳 Assinar com PayPal<br><span style="font-size:.85rem">$699/ano</span>
               </button>
 
               <div style="text-align:center;margin-top:1rem">
@@ -5680,19 +5697,19 @@
               LIMITADO • <span data-count="150">150</span> SLOTS LEFT
             </div>
 
-            <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">Lifetime Access</div>
+            <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">Acesso Vitalício</div>
 
-            <div class="price" style="white-space:nowrap"><span id="lifetime-display-price">$1,799</span> <span class="pill">one‑time</span></div>
+            <div class="price" style="white-space:nowrap"><span id="lifetime-display-price">$1,799</span> <span class="pill">pagamento único</span></div>
 
             <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(249,162,60,.08);border:1px solid rgba(249,162,60,.25);border-radius:8px">
               <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">
-                Pay once. Yours forever.
+                Pague uma vez. Seu para sempre.
               </p>
               <p style="font-size:.9rem;color:var(--muted);margin:0 0 .25rem 0">
                 $1,799 today = $0/mês after
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
-                Lock in lifetime access now.
+                Garanta acesso vitalício agora.
               </p>
             </div>
 
@@ -5706,38 +5723,38 @@
                   Nome de Usuário TradingView
                 </label>
                 <div class="input-wrapper">
-                  <input id="tv-lifetime" type="text" placeholder="@your.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">
+                  <input id="tv-lifetime" type="text" placeholder="@seu.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">
                   <div class="checkmark">
                     <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
                       <polyline points="20 6 9 17 4 12"></polyline>
                     </svg>
                   </div>
                 </div>
-                <div id="error-tv-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:.5rem;font-weight:500">⚠️ TradingView username required</div>
+                <div id="error-tv-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:.5rem;font-weight:500">⚠️ Nome de usuário TradingView obrigatório</div>
               </div>
 
               <!-- Step 2: Consent -->
-              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-lifetime"><span>Eu entendo que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is educational. No financial advice.</span></label>
-              <div id="error-consent-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
+              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-lifetime"><span>Eu entendo que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> é educacional. Não é aconselhamento financeiro.</span></label>
+              <div id="error-consent-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consentimento obrigatório</div>
 
               <!-- PayPal Branding -->
               <div style="text-align:center;margin-bottom:1rem">
                 <img src="https://www.paypalobjects.com/images/Debit_Credit.svg" alt="PayPal accepted cards" style="margin:0 auto;height:24px;" loading="lazy" width="120" height="24" />
-                <div style="font-size:0.75rem;opacity:0.7;margin-top:0.25rem">Powered por PayPal</div>
+                <div style="font-size:0.75rem;opacity:0.7;margin-top:0.25rem">Powered by PayPal</div>
               </div>
 
               <!-- Step 3: Buy Now -->
               <button type="button" id="btn-lifetime-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
-                💳 Buy Now - PayPal<br><span style="font-size:.85rem">$1,799 pagamento único</span>
+                💳 Comprar Agora - PayPal<br><span style="font-size:.85rem">$1,799 pagamento único</span>
               </button>
 
               <div style="text-align:center;margin-top:1rem">
                 <a href="https://signalpilotlabs.lemonsqueezy.com/buy/81822d54-6e08-4c26-b2f0-d5d5e3cdd25e" class="btn btn-secondary" style="width:100%;display:block" target="_blank" rel="noopener">💳 Pagar com Cartão</a>
               </div>
 
-              <div id="error-soldout-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:1rem;font-weight:500;text-align:center">⚠️ Lifetime is sold out. Waitlist is available below.</div>
+              <div id="error-soldout-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:1rem;font-weight:500;text-align:center">⚠️ Vitalício esgotado. Lista de espera disponível abaixo.</div>
 
-              <button class="btn btn-disabled" id="lt-soldout" type="button" style="display:none">Sold out — join waitlist below</button>
+              <button class="btn btn-disabled" id="lt-soldout" type="button" style="display:none">Esgotado — junte-se à lista de espera abaixo</button>
 
             </div>
 
@@ -5788,7 +5805,7 @@
     <h2 id="faq-heading" class="headline lg" style="text-align:center">FAQ</h2>
     <p style="text-align:center;color:var(--muted);margin:-0.5rem 0 1.5rem 0;font-size:.9rem">Perguntas pré-compra respondidas. Para guias de configuração: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a> ou <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro de Educação</a>.</p>
 
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;max-width:1100px;margin:0 auto">
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;max-width:960px;margin:0 auto">
 
       <!-- EDUCATION HUB -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-0">
@@ -5956,7 +5973,7 @@
 
         <div style="background:linear-gradient(135deg,rgba(249,162,60,.06),rgba(249,162,60,.02));border:1px solid rgba(249,162,60,.15);border-radius:8px;padding:1rem 1.25rem">
           <p style="color:var(--muted);font-size:.8rem;margin:0;line-height:1.5">
-            <strong style="color:#f9a23c;font-size:.82rem">⚠️ Educational Disclaimer:</strong> Signal Pilot provides educational tools for learning only. Not financial advice. Trading involves substantial risk. Past performance doesn't guarantee future results.
+            <strong style="color:#f9a23c;font-size:.82rem">⚠️ Aviso Educacional:</strong> Signal Pilot fornece ferramentas educacionais apenas para aprendizado. Não é aconselhamento financeiro. Negociação envolve risco substancial. Desempenho passado não garante resultados futuros.
           </p>
         </div>
 


### PR DESCRIPTION
- Reduced FAQ grid max-width from 1100px to 960px for better Portuguese text fit
- Enhanced mobile CSS with comprehensive overflow prevention for FAQ section
- Fixed PayPal branding from "Powered por PayPal" to "Powered by PayPal"
- Translated all English content in indicator descriptions:
  * Pentarch cycle phase descriptions
  * OmniDeck tool descriptions and features
  * Volume Oracle institutional tracking content
  * Plutus Flow demand/supply meter descriptions
  * Janus Atlas level plotting features
  * Augury Grid dashboard descriptions
  * Harmonic Oscillator voting system content
- Translated educational disclaimer
- Translated comparison slider text
- Fixed mixed English/Portuguese in indicator feature lists

All user-facing content now fully in Portuguese (pt-BR).