### PR TITLE
Fix overlay image not displaying different image in slider

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -1086,12 +1086,12 @@
       /* CRITICAL: Allow overlay image to have dynamic width set by JS */
       #overlay-image {
         max-width: none !important;
-        width: auto !important;
         height: 100% !important;
         object-fit: contain !important;
         position: absolute !important;
         top: 0 !important;
         left: 0 !important;
+        display: block !important;
       }
 
       /* CRITICAL: Ensure slider overlay maintains proper dimensions */
@@ -1138,22 +1138,18 @@
       }
 
       /* Ensure most images respect container width (except slider images) */
-      img {
+      img:not(#comparison-slider img) {
         max-width: 100% !important;
         height: auto !important;
         box-sizing: border-box !important;
       }
 
-      /* Override for slider images */
-      #comparison-slider img {
-        max-width: none !important;
-      }
-
       /* Ensure background slider image fits properly */
       #comparison-slider .comparison-image:not(#slider-overlay) img {
-        max-width: 100% !important;
         width: 100% !important;
         height: 100% !important;
+        max-width: 100% !important;
+        object-fit: contain !important;
       }
 
       /* Prevent overflow - but exclude slider components */


### PR DESCRIPTION
- Removed width: auto constraint that prevented JS from setting overlay width
- Simplified image CSS rules to avoid conflicts with slider functionality
- Excluded comparison slider images from general image constraints
- Ensured overlay image can be dynamically sized by JavaScript
- Background and overlay images now properly differentiated