### PR TITLE
Optimize pricing cards for Portuguese longer text

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -3059,6 +3059,26 @@
         padding:1rem 0.5rem !important;
         font-size:0.85rem !important;
       }
+
+      /* PORTUGUESE-SPECIFIC: Additional pricing card optimizations for longer text */
+      .pricing-grid .card.plan .pill {
+        font-size: 0.75rem !important;
+        padding: 0.4rem 0.8rem !important;
+      }
+
+      .pricing-grid .card.plan .price {
+        font-size: clamp(2rem, 8vw, 2.5rem) !important;
+      }
+
+      .pricing-grid .card.plan button {
+        font-size: 0.85rem !important;
+        padding: 0.9rem !important;
+      }
+
+      .pricing-grid .card.plan label.consent {
+        font-size: 0.8rem !important;
+        line-height: 1.4 !important;
+      }
     }
 
     /* Video caption responsive sizing */
@@ -5692,12 +5712,12 @@
 
             <div class="price">$99 <span class="pill">/mês</span></div>
 
-            <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(91,138,255,.06);border:1px solid rgba(91,138,255,.2);border-radius:8px">
-              <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">
-                Pague mensalmente, cancele a qualquer momento
+            <div style="text-align:center;margin:1.5rem 0;padding:1rem;background:rgba(91,138,255,.06);border:1px solid rgba(91,138,255,.2);border-radius:8px">
+              <p style="font-size:.95rem;color:var(--text);margin:0 0 .4rem 0;font-weight:600;line-height:1.3">
+                Pague mensalmente, cancele quando quiser
               </p>
-              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
-                Opção mais flexível. Sem compromisso necessário.
+              <p style="font-size:.8rem;color:var(--muted);margin:0;line-height:1.4">
+                Flexível. Sem compromisso.
               </p>
             </div>
 
@@ -5749,8 +5769,8 @@
 
           <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledpor="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
-            <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
-              SAVE <span data-count="489" data-prefix="$">489</span>
+            <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.75rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
+              ECONOMIZE <span data-count="489" data-prefix="$">489</span>
             </div>
 
             <div class="pill" id="plan-yearly-title" style="background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff;font-size:.95rem;padding:.7rem 1.2rem">MELHOR VALOR</div>
@@ -5759,15 +5779,15 @@
               $699 <span class="pill">/ano</span>
             </div>
 
-            <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(62,213,152,.08);border:1px solid rgba(62,213,152,.25);border-radius:8px">
-              <p style="font-size:1.1rem;margin:0 0 .5rem 0;font-weight:700">
+            <div style="text-align:center;margin:1.5rem 0;padding:1rem;background:rgba(62,213,152,.08);border:1px solid rgba(62,213,152,.25);border-radius:8px">
+              <p style="font-size:1rem;margin:0 0 .4rem 0;font-weight:700">
                 <span style="background:linear-gradient(135deg,#3ed598,#2ec98a);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Economize <span data-count="489" data-prefix="$">489</span>/ano</span>
               </p>
-              <p style="font-size:.9rem;color:var(--text);margin:0 0 .25rem 0">
+              <p style="font-size:.85rem;color:var(--text);margin:0 0 .2rem 0">
                 Apenas $58/mês equivalente
               </p>
-              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
-                Cobrado $699 anualmente. Melhor valor para traders comprometidos.
+              <p style="font-size:.8rem;color:var(--muted);margin:0;line-height:1.4">
+                Cobrado $699 anualmente. Melhor valor.
               </p>
             </div>
 
@@ -5818,22 +5838,22 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledpor="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
-              LIMITADO • <span data-count="150">150</span> SLOTS LEFT
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.75rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+              LIMITADO • <span data-count="150">150</span> VAGAS
             </div>
 
             <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">Acesso Vitalício</div>
 
-            <div class="price" style="white-space:nowrap"><span id="lifetime-display-price">$1,799</span> <span class="pill">pagamento único</span></div>
+            <div class="price" style="display:flex;flex-wrap:wrap;gap:0.5rem;align-items:center;justify-content:center"><span id="lifetime-display-price">$1,799</span> <span class="pill" style="font-size:0.75rem">único</span></div>
 
-            <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(249,162,60,.08);border:1px solid rgba(249,162,60,.25);border-radius:8px">
-              <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">
+            <div style="text-align:center;margin:1.5rem 0;padding:1rem;background:rgba(249,162,60,.08);border:1px solid rgba(249,162,60,.25);border-radius:8px">
+              <p style="font-size:.95rem;color:var(--text);margin:0 0 .4rem 0;font-weight:600">
                 Pague uma vez. Seu para sempre.
               </p>
-              <p style="font-size:.9rem;color:var(--muted);margin:0 0 .25rem 0">
-                $1,799 today = $0/mês after
+              <p style="font-size:.85rem;color:var(--muted);margin:0 0 .2rem 0">
+                $1,799 hoje = $0/mês depois
               </p>
-              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
+              <p style="font-size:.8rem;color:var(--muted);margin:0;line-height:1.4">
                 Garanta acesso vitalício agora.
               </p>
             </div>
@@ -5869,8 +5889,8 @@
               </div>
 
               <!-- Step 3: Buy Now -->
-              <button type="button" id="btn-lifetime-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
-                💳 Comprar Agora - PayPal<br><span style="font-size:.85rem">$1,799 pagamento único</span>
+              <button type="button" id="btn-lifetime-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.9rem;font-weight:700;line-height:1.4">
+                💳 Comprar Agora - PayPal<br><span style="font-size:.8rem">$1,799 único</span>
               </button>
 
               <div style="text-align:center;margin-top:1rem">


### PR DESCRIPTION
**Text Content Fixes:**
- Translate "SLOTS LEFT" → "VAGAS" (pt/index.html:5822)
- Translate "SAVE" → "ECONOMIZE" (pt/index.html:5753)
- Translate "$1,799 today = $0/mês after" → "$1,799 hoje = $0/mês depois" (pt/index.html:5834)
- Shorten "pagamento único" → "único" in multiple locations for compactness

**Font Size Reductions:**
- Badge font: 0.82rem → 0.75rem for better fit
- Price pill: added smaller 0.75rem sizing
- Button text: 0.95rem → 0.9rem with tighter line-height
- Info box text: reduced from 1rem/0.9rem/0.85rem → 0.95rem/0.85rem/0.8rem
- Consent label: reduced to 0.8rem with 1.4 line-height

**Spacing Optimizations:**
- Info box padding: 1.25rem → 1rem
- Info box margins: 0.5rem/0.25rem → 0.4rem/0.2rem
- Tighter line-heights throughout (1.5 → 1.3/1.4)

**Layout Improvements:**
- Lifetime price display: nowrap → flexbox with wrap for "$1,799 único"
- Monthly description shortened: "a qualquer momento" → "quando quiser"
- Yearly description shortened: "para traders comprometidos" removed

**Portuguese-Specific Mobile CSS (pt/index.html:3063-3081):**
- Pill font-size: 0.75rem
- Price: clamp(2rem, 8vw, 2.5rem) for responsive sizing
- Button font: 0.85rem
- Consent label: 0.8rem with 1.4 line-height

All cards now properly fit Portuguese text without overflow on mobile.