### PR TITLE
Fix interactive demo by excluding overlay image from mobile CSS

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2931,25 +2931,21 @@
       /* FIX: Comparison slider - constrain width */
       #comparison-slider {
         max-width: calc(100vw - 2rem) !important;
-        width: calc(100vw - 2rem) !important;
-        margin-left: 1rem !important;
-        margin-right: 1rem !important;
+        margin-left: auto !important;
+        margin-right: auto !important;
         box-sizing: border-box !important;
       }
 
-      /* FIX: Comparison images - prevent overflow */
-      .comparison-image {
+      /* CRITICAL: Don't break the overlay image - it needs height:100% and max-width:none */
+      #slider-overlay {
         max-width: 100% !important;
-        width: 100% !important;
         overflow: hidden !important;
-        box-sizing: border-box !important;
       }
 
-      .comparison-image img {
-        max-width: 100% !important;
-        width: 100% !important;
-        height: auto !important;
-        object-fit: contain !important;
+      /* CRITICAL: Overlay image must maintain its absolute positioning and full height */
+      #overlay-image {
+        height: 100% !important;
+        max-width: none !important;
       }
 
       /* FIX: Comparison container */
@@ -2990,13 +2986,13 @@
       }
 
       /* SAFETY NET: Prevent any div with large max-width from overflowing */
-      div[style*="max-width"] {
+      div[style*="max-width"]:not(#slider-overlay) {
         max-width: 100% !important;
         box-sizing: border-box !important;
       }
 
-      /* Ensure all images respect container width */
-      img {
+      /* Ensure all images respect container width - EXCEPT overlay image */
+      img:not(#overlay-image) {
         max-width: 100% !important;
         height: auto !important;
         box-sizing: border-box !important;


### PR DESCRIPTION
**Problem:**
The interactive comparison slider was broken on mobile due to aggressive CSS overrides that were breaking the overlay image's positioning.

**Root Causes:**
1. `img { height: auto !important }` at pt/index.html:2995 was forcing the overlay image to height:auto instead of required height:100%
2. `img { max-width: 100% !important }` was breaking overlay's max-width:none
3. `div[style*="max-width"]` was potentially affecting slider containers

**Solution:**
- Excluded #overlay-image from blanket img rules (pt/index.html:2995)
- Excluded #slider-overlay from div max-width safety net (pt/index.html:2989)
- Added explicit CSS to protect overlay image properties (pt/index.html:2939-2949):
  * #slider-overlay: max-width: 100%, overflow: hidden
  * #overlay-image: height: 100%, max-width: none
- Removed overly aggressive .comparison-image styles that broke functionality

**Technical Details:**
The overlay image requires specific styles to work:
- position: absolute
- height: 100% (NOT auto)
- max-width: none (NOT 100%)
- object-fit: contain

The slider JavaScript dynamically adjusts overlay width to match container, so CSS must not interfere with these critical properties.

Interactive demo now works correctly on both desktop and mobile.