### PR TITLE
Simplify interactive demo mobile CSS - exclude all comparison elements

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2928,33 +2928,11 @@
         max-width: 100% !important;
       }
 
-      /* FIX: Comparison slider - constrain width */
+      /* FIX: Comparison slider - constrain width on mobile only */
       #comparison-slider {
         max-width: calc(100vw - 2rem) !important;
         margin-left: auto !important;
         margin-right: auto !important;
-        box-sizing: border-box !important;
-      }
-
-      /* CRITICAL: Don't break the overlay image - it needs height:100% and max-width:none */
-      #slider-overlay {
-        max-width: 100% !important;
-        overflow: hidden !important;
-      }
-
-      /* CRITICAL: Overlay image must maintain its absolute positioning and full height */
-      #overlay-image {
-        height: 100% !important;
-        max-width: none !important;
-      }
-
-      /* FIX: Comparison container */
-      .comparison-container {
-        max-width: 100% !important;
-        width: 100% !important;
-        padding: 1rem !important;
-        overflow-x: hidden !important;
-        box-sizing: border-box !important;
       }
 
       /* FIX: Pricing grid - prevent overflow */
@@ -2985,14 +2963,14 @@
         box-sizing: border-box !important;
       }
 
-      /* SAFETY NET: Prevent any div with large max-width from overflowing */
-      div[style*="max-width"]:not(#slider-overlay) {
+      /* SAFETY NET: Prevent any div with large max-width from overflowing - EXCEPT comparison slider */
+      div[style*="max-width"]:not(#comparison-slider):not(#slider-overlay) {
         max-width: 100% !important;
         box-sizing: border-box !important;
       }
 
-      /* Ensure all images respect container width - EXCEPT overlay image */
-      img:not(#overlay-image) {
+      /* Ensure all images respect container width - EXCEPT comparison slider images */
+      img:not(#overlay-image):not([alt*="Signal Pilot"]) {
         max-width: 100% !important;
         height: auto !important;
         box-sizing: border-box !important;


### PR DESCRIPTION
**Problem:**
Interactive demo showing "3 images overlayed badly" - overly aggressive mobile CSS was interfering with the slider's delicate positioning and layering.

**Solution:**
Simplified approach - completely exclude ALL comparison slider elements from mobile overflow CSS instead of trying to selectively fix them:

1. **Exclude from div safety net** (pt/index.html:2967):
   - div[style*="max-width"]:not(#comparison-slider):not(#slider-overlay)

2. **Exclude from img safety net** (pt/index.html:2973):
   - img:not(#overlay-image):not([alt*="Signal Pilot"])
   - Excludes both overlay image AND background image by alt text

3. **Removed all overlay-specific CSS** (pt/index.html:2931-2936):
   - Removed #slider-overlay rules
   - Removed #overlay-image rules
   - Only kept simple #comparison-slider max-width constraint

**Rationale:**
The comparison slider has inline styles and JavaScript that handle all positioning. Mobile CSS should ONLY constrain the container width, not interfere with internal layout. Let the slider work as designed.

Demo should now work correctly on mobile without CSS conflicts.