### PR TITLE
Fix mobile overflow and image alignment for comparison slider

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -1032,6 +1032,23 @@
         white-space: normal !important;
       }
 
+      /* Fix comparison slider on mobile */
+      #comparison-slider {
+        max-width: 100% !important;
+        margin-left: auto !important;
+        margin-right: auto !important;
+      }
+
+      .comparison-image {
+        overflow: hidden !important;
+      }
+
+      /* Ensure both images are aligned perfectly */
+      .comparison-image img {
+        object-fit: contain !important;
+        display: block !important;
+      }
+
       main{
         width:100%;
         display:block;


### PR DESCRIPTION
- Set max-width: 100% on slider to prevent overflow beyond viewport
- Added overflow: hidden on comparison-image containers
- Ensured both images use object-fit: contain and display: block
- Matches working English site mobile CSS exactly
- Images now sit perfectly aligned on top of each other