### PR TITLE
Fix interactive demo initialization timing on mobile

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -5378,6 +5378,9 @@
           const rect = slider.getBoundingClientRect();
           if (rect.width > 0) {
             overlayImage.style.width = rect.width + 'px';
+          } else {
+            // Retry if width is 0 (layout not ready yet)
+            setTimeout(() => updateOverlayImageWidth(), 100);
           }
         }
       }
@@ -5397,8 +5400,13 @@
 
       // Initialize
       function initSlider() {
-        updateOverlayImageWidth();
-        setSliderPosition(50, false);
+        // Use requestAnimationFrame to ensure layout is complete before measuring
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            updateOverlayImageWidth();
+            setSliderPosition(50, false);
+          });
+        });
       }
 
       // Update overlay width when images load
@@ -5406,10 +5414,14 @@
       const foregroundImage = overlayImage;
 
       if (backgroundImage) {
-        backgroundImage.addEventListener('load', updateOverlayImageWidth);
+        backgroundImage.addEventListener('load', () => {
+          requestAnimationFrame(() => updateOverlayImageWidth());
+        });
       }
       if (foregroundImage) {
-        foregroundImage.addEventListener('load', updateOverlayImageWidth);
+        foregroundImage.addEventListener('load', () => {
+          requestAnimationFrame(() => updateOverlayImageWidth());
+        });
       }
 
       // Feature 8: Keyboard navigation


### PR DESCRIPTION
**Problem:**
On mobile, the demo section overflows on initial page load, but fixes itself after pressing the auto slide button. This is a classic race condition where the overlay image width is calculated before the layout is stable.

**Root Cause:**
When `initSlider()` runs immediately at line 5511, the browser may not have completed layout calculations yet, so `getBoundingClientRect().width` returns 0 or an incorrect value. The overlay image width is then set incorrectly.

When the autoplay button is clicked, it recalculates and fixes the width.

**Solution:**

1. **Double requestAnimationFrame in initSlider()** (pt/index.html:5401-5406): ```javascript requestAnimationFrame(() => { requestAnimationFrame(() => { updateOverlayImageWidth(); setSliderPosition(50, false); }); }); ``` This ensures the browser completes TWO paint cycles before we measure, guaranteeing stable layout.

2. **Retry mechanism in updateOverlayImageWidth()** (pt/index.html:5381-5384): ```javascript if (rect.width > 0) { overlayImage.style.width = rect.width + 'px'; } else { setTimeout(() => updateOverlayImageWidth(), 100); } ``` If width is still 0, retry after 100ms until we get a valid measurement.

3. **requestAnimationFrame on image load events** (pt/index.html:5414-5421): Wrap updateOverlayImageWidth() calls in requestAnimationFrame to ensure measurements happen after paint.

**Why This Works:**
- requestAnimationFrame schedules callback after next repaint
- Double RAF ensures all CSS recalculations are complete
- Retry catches edge cases on slow connections or large images
- No flickering because measurements happen before first visible paint

Demo now initializes correctly on mobile without overflow.