### PR TITLE
Fix Google Search Console structured data errors - use English type n…

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -104,7 +104,7 @@
     "@context": "https://schema.org",
     "@graph": [
       {
-        "@type": "Produto",
+        "@type": "Product",
         "@id": "https://www.signalpilot.io/#monthly-plan",
         "name": "Signal Pilot Elite Seven - Assinatura Mensal",
         "description": "Indicadores profissionais para TradingView com detecção de ciclos Pentarch™. Todos os 7 indicadores elite mais atualizações futuras. 100% sem repintura, auditado. Funciona em ações, cripto, forex, índices e commodities.",
@@ -172,7 +172,7 @@
         ]
       },
       {
-        "@type": "Produto",
+        "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Assinatura Anual (Melhor Valor)",
         "description": "Indicadores profissionais para TradingView com detecção de ciclos Pentarch™. Economize $489/ano. Todos os 7 indicadores elite mais atualizações futuras. 100% sem repintura, auditado. Suporte prioritário e treinamento avançado incluídos.",
@@ -245,7 +245,7 @@
         ]
       },
       {
-        "@type": "Produto",
+        "@type": "Product",
         "@id": "https://www.signalpilot.io/#lifetime-plan",
         "name": "Signal Pilot Elite Seven - Acesso Vitalício (Limitado aos 100 Fundadores)",
         "description": "Indicadores profissionais para TradingView com acesso vitalício. Detecção de ciclos Pentarch™. Todos os 7 indicadores elite mais todos os lançamentos futuros para sempre. 100% sem repintura, auditado. Comunidade privada no Discord, 200+ configurações predefinidas, acesso beta, suporte prioritário.",
@@ -3266,7 +3266,7 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "Produto",
+    "@type": "Product",
     "name": "Signal Pilot — Suíte de Trading",
     "description": "Indicadores TradingView sem repintura para qualquer mercado e período. Sete indicadores elite incluindo Pentarch, OmniDeck, Volume Oracle e mais.",
     "brand": {


### PR DESCRIPTION
…ames

**Problem:**
Google Search Console reported 3 critical errors for Portuguese site: "Invalid object type for field 'itemReviewed'" for all product ratings.

**Root Cause:**
Schema.org type names were translated to Portuguese:
- "@type": "Produto" (WRONG - Portuguese)

Schema.org requires type names in English regardless of content language.

**Fix:**
Changed all 4 instances from "Produto" to "Product":

1. Line 107: Monthly plan Product
2. Line 175: Yearly plan Product
3. Line 248: Lifetime plan Product
4. Line 3269: Main trading suite Product

**Validation:**
The AggregateRating objects are correctly nested inside Product objects:
```json
{
  "@type": "Product",
  "name": "Signal Pilot Elite Seven - Assinatura Mensal",
  "aggregateRating": {
    "@type": "AggregateRating",
    "ratingValue": "4.8",
    ...
  }
}
```

When AggregateRating is nested in Product, the Product automatically becomes the itemReviewed. This is the correct Schema.org structure.

**Note:**
All other schema properties (name, description, etc.) remain in Portuguese as intended - only the @type field must be in English.

Google Search Console should now validate all 4 products successfully.