### PR TITLE
Remove Google Translate from Portuguese site

### DIFF
--- a/pt/faq.html
+++ b/pt/faq.html
@@ -140,43 +140,6 @@
       z-index: 1;
     }
 
-    /* Google Translate fixes */
-    body > .skiptranslate {
-      display: none !important;
-    }
-
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-gadget {
-      color: inherit !important;
-    }
-
-    nav font,
-    nav span:not(.dropdown-arrow),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    button font,
-    button span:not(#theme-icon):not(.dropdown-arrow) {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-    }
-
-    nav a,
-    nav button,
-    #langToggle,
-    #themeToggle {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
-
     .sr-only {
       position: absolute;
       width: 1px;
@@ -908,29 +871,6 @@
       </button>
     </div>
   </header>
-
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-  <!-- Hidden select for Google Translate compatibility -->
-  <select id="langSel" style="display:none;" aria-hidden="true">
-    <option value="en">English</option>
-    <option value="de">Deutsch</option>
-    <option value="fr">Français</option>
-    <option value="es">Español</option>
-    <option value="it">Italiano</option>
-    <option value="zh">中文</option>
-    <option value="ru">Русский</option>
-    <option value="ar">العربية</option>
-    <option value="pt">Português</option>
-    <option value="tr">Türkçe</option>
-    <option value="ja">日本語</option>
-    <option value="ko">한국어</option>
-    <option value="vi">Tiếng Việt</option>
-    <option value="th">ไทย</option>
-    <option value="hi">हिन्दी</option>
-    <option value="id">Bahasa Indonesia</option>
-  </select>
 
   <!-- Hero -->
   <section class="hero">

--- a/pt/index.html
+++ b/pt/index.html
@@ -730,191 +730,6 @@
 
     *{box-sizing:border-box}
 
-    /* Google Translate fixes - prevent layout breaking */
-    body > .skiptranslate {
-      display: none !important;
-    }
-
-    body {
-      top: 0 !important;
-      position: relative !important;
-    }
-
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-menu-value span {
-      color: inherit !important;
-    }
-
-    .goog-te-gadget {
-      color: inherit !important;
-    }
-
-    /* Make Google Translate text smaller and more proportional */
-    font {
-      font-size: 0.85em !important;
-      line-height: inherit !important;
-    }
-
-    /* Specific adjustments for different text sizes */
-    h1 font, h2 font, h3 font, .headline font {
-      font-size: 0.88em !important;
-    }
-
-    p font, li font, div font {
-      font-size: 0.85em !important;
-    }
-
-    .btn font, button font, a font {
-      font-size: 0.86em !important;
-    }
-
-    /* CRITICAL: Force Google Translate font/span wrappers to not block clicks */
-    nav[aria-label="Principal"] font,
-    nav[aria-label="Principal"] span:not(.mobile-nav-title),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    .lang-dropdown-menu font,
-    .lang-dropdown-menu span,
-    .menu-toggle font,
-    .menu-toggle span,
-    #langToggle font,
-    #langToggle span,
-    .nav-dropdown font,
-    .nav-dropdown span,
-    button font,
-    button span,
-    .btn font,
-    .btn span {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-      opacity: 1 !important;
-      visibility: visible !important;
-    }
-
-    /* Force mobile menu text to be white and ALWAYS visible */
-    @media (max-width:1400px){
-      /* Dark mode mobile menu (default) */
-      nav[aria-label="Principal"],
-      nav[aria-label="Principal"] *,
-      nav[aria-label="Principal"] font,
-      nav[aria-label="Principal"] span,
-      .mobile-nav-header,
-      .mobile-nav-header *,
-      .mobile-nav-title,
-      .mobile-nav-close,
-      #mainnav,
-      #mainnav *,
-      #mainnav font,
-      #mainnav span,
-      #mainnav a,
-      #mainnav button,
-      #mainnav li,
-      #mainnav ul {
-        color: #ffffff !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        text-shadow: 0 1px 2px rgba(0,0,0,0.5) !important;
-      }
-
-      /* Light mode mobile menu - dark text on light background */
-      html[data-theme="light"] nav[aria-label="Principal"],
-      html[data-theme="light"] nav[aria-label="Principal"] *,
-      html[data-theme="light"] nav[aria-label="Principal"] font,
-      html[data-theme="light"] nav[aria-label="Principal"] span,
-      html[data-theme="light"] .mobile-nav-header,
-      html[data-theme="light"] .mobile-nav-header *,
-      html[data-theme="light"] .mobile-nav-title,
-      html[data-theme="light"] .mobile-nav-close,
-      html[data-theme="light"] #mainnav,
-      html[data-theme="light"] #mainnav *,
-      html[data-theme="light"] #mainnav font,
-      html[data-theme="light"] #mainnav span,
-      html[data-theme="light"] #mainnav a,
-      html[data-theme="light"] #mainnav button,
-      html[data-theme="light"] #mainnav li,
-      html[data-theme="light"] #mainnav ul {
-        color: #0f172a !important;
-        text-shadow: none !important;
-      }
-
-      /* Make sure links have proper styling */
-      #mainnav a,
-      nav[aria-label="Principal"] a {
-        display: block !important;
-        padding: 0.7rem 1rem !important;
-        color: #ffffff !important;
-        text-decoration: none !important;
-        border-radius: 8px !important;
-        background: transparent !important;
-      }
-
-      html[data-theme="light"] #mainnav a,
-      html[data-theme="light"] nav[aria-label="Principal"] a {
-        color: #0f172a !important;
-      }
-
-      #mainnav a:hover,
-      nav[aria-label="Principal"] a:hover {
-        background: rgba(91,138,255,.2) !important;
-      }
-
-      html[data-theme="light"] #mainnav a:hover,
-      html[data-theme="light"] nav[aria-label="Principal"] a:hover {
-        background: rgba(91,138,255,.15) !important;
-      }
-    }
-
-    /* Ensure clickable elements always work */
-    nav[aria-label="Principal"] a,
-    nav[aria-label="Principal"] button,
-    .lang-dropdown button,
-    .lang-dropdown-menu button,
-    .menu-toggle,
-    #langToggle,
-    #menuToggle,
-    .mobile-nav-close {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
-
-    /* Fix header squeezing when Google Translate is active */
-    header .container,
-    header .nav {
-      min-width: 0 !important;
-      flex-shrink: 0 !important;
-    }
-
-    header .brand {
-      flex-shrink: 0 !important;
-      min-width: auto !important;
-      white-space:nowrap !important;
-    }
-
-    header nav[aria-label="Principal"] {
-      flex-shrink: 1 !important;
-      min-width: 0 !important;
-    }
-
-    /* Prevent all header buttons and text from wrapping */
-    header button,
-    header a,
-    .menu-toggle,
-    #langToggle,
-    #themeToggle,
-    .btn {
-      white-space:nowrap !important;
-      flex-shrink:0 !important;
-    }
-
     /* Prevent horizontal scroll */
     body{
       overflow-x:hidden;
@@ -6068,13 +5883,6 @@
 
   </div>
 
-
-
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-
-
   <!-- =======================================================================
        SCRIPT: CONFIG + UTILITIES
        ======================================================================= -->
@@ -6266,7 +6074,6 @@
 
     /* ======================== Recursos Dropdown ======================== */
 
-    // Use event delegation for Google Translate compatibility
     (function() {
       let dropdownOpen = false;
 
@@ -6356,48 +6163,16 @@
         btn.setAttribute('data-lang', lang.code);
         btn.textContent = lang.flag + ' ' + lang.name;
         btn.addEventListener('click', function() {
-          // Helper functions
-          function baseDomain(host) {
-            const p = host.split('.');
-            return p.length > 2 ? p.slice(-2).join('.') : host;
-          }
-
-          function setCookie(name, value, dias, domain) {
-            let expires = '';
-            if (days) {
-              const d = new Date();
-              d.setTime(d.getTime() + dias * 864e5);
-              expires = '; expires=' + d.toUTCString();
-            }
-            const dom = domain ? '; domain=' + domain : '';
-            document.cookie = name + '=' + value + expires + '; path=/' + dom;
-          }
-
-          function setGoogTrans(langCode) {
-            const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-            const val = '/en/' + target;
-            setCookie('googtrans', val, 365);
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            setCookie('googtrans', val, 365, root);
-          }
-
           function applyDirLang(langCode) {
             document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
             document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
           }
 
-          // Economize to localStorage
+          // Save to localStorage
           localStorage.setItem('sp_lang', lang.code);
 
-          // Set cookies and attributes
-          if (lang.code === 'en') {
-            // Clear translation for English
-            clearGoogTrans();
-            applyDirLang('en');
-          } else {
-            setGoogTrans(lang.code);
-            applyDirLang(lang.code);
-          }
+          // Set document language attributes
+          applyDirLang(lang.code);
 
           // Track event if analytics available
           if (typeof trackEvent === 'function') {
@@ -6407,9 +6182,9 @@
             });
           }
 
-          console.log('[GT] Language changed to:', lang.code);
+          console.log('Language changed to:', lang.code);
 
-          // Reload page to apply translation (page load script will handle GT init)
+          // Reload page
           location.reload();
         });
         langMenu.appendChild(btn);
@@ -6522,176 +6297,6 @@
     (function(){function show(){const s=document.getElementById('thanks'); if(location.hash==='#thanks') s.style.display='block';}
 
       window.addEventListener('hashchange',show); show();})();
-
-
-
-    /* ======================== Google Translate (on demand) ======================== */
-
-    // Google Translate Initialization with robust error handling
-    window.googleTranslateElementInit = function() {
-      console.log('[GT] Init called');
-      if (!window.google || !google.translate || !google.translate.TranslateElement) {
-        console.warn('[GT] Google Translate API not ready');
-        return;
-      }
-
-      const container = document.getElementById('google_translate_container');
-      if (!container) {
-        console.error('[GT] Container not found');
-        return;
-      }
-
-      try {
-        new google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-          autoDisplay: false
-        }, 'google_translate_container');
-        console.log('[GT] Widget created successfully');
-        window.__gte_initialized = true;
-      } catch (error) {
-        console.error('[GT] Failed to create widget:', error);
-      }
-    };
-
-    // Load saved language on page load with robust polling
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, dias, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + dias * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function clearGoogTrans() {
-        // Clear the googtrans cookie por setting it to expire immediately
-        document.cookie = 'googtrans=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        document.cookie = 'googtrans=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=' + root;
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading) {
-          console.log('[GT] Already loading');
-          return;
-        }
-        if (window.google && window.google.translate) {
-          console.log('[GT] Already loaded');
-          googleTranslateElementInit();
-          return;
-        }
-
-        console.log('[GT] Loading script...');
-        window.__gte_loading = true;
-
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        s.onerror = function() {
-          console.error('[GT] Script failed to load');
-          window.__gte_loading = false;
-          // Retry after 2 seconds
-          setTimeout(function() {
-            if (!window.google) {
-              console.log('[GT] Retrying...');
-              loadGTE();
-            }
-          }, 2000);
-        };
-        s.onload = function() {
-          console.log('[GT] Script loaded');
-          // Poll for initialization
-          let attempts = 0;
-          const checkInit = setInterval(function() {
-            attempts++;
-            if (window.__gte_initialized || attempts > 50) {
-              clearInterval(checkInit);
-              if (!window.__gte_initialized) {
-                console.warn('[GT] Init timeout after ' + attempts + ' attempts');
-              }
-            }
-          }, 100);
-        };
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-      const saved = localStorage.getItem(LANG_KEY) || 'en';
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      console.log('[GT] Saved language:', code);
-
-      if (sel) sel.value = code;
-
-      // Only set translation cookies for non-English languages
-      if (code !== 'en') {
-        setGoogTrans(code);
-        applyDirLang(code);
-      } else {
-        // Clear translation cookies for English
-        clearGoogTrans();
-        applyDirLang('en');
-      }
-
-      // Update language button text to show current language
-      const langBtn = document.getElementById('langToggle');
-      if (langBtn) {
-        const langText = langBtn.querySelector('span');
-        if (langText) {
-          const flagMap = {
-            'en': '🇺🇸', 'de': '🇩🇪', 'fr': '🇫🇷', 'es': '🇪🇸',
-            'it': '🇮🇹', 'zh': '🇨🇳', 'ru': '🇷🇺', 'ar': '🇸🇦',
-            'pt': '🇵🇹', 'tr': '🇹🇷', 'ja': '🇯🇵', 'ko': '🇰🇷',
-            'vi': '🇻🇳', 'th': '🇹🇭', 'hi': '🇮🇳', 'id': '🇮🇩'
-          };
-          langText.textContent = (flagMap[code] || '🌐') + ' ' + code.toUpperCase();
-        }
-      }
-
-      // Load on DOMContentLoaded to ensure page is ready
-      if (code !== 'en') {
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(loadGTE, 500); // Small delay to let page settle
-          });
-        } else {
-          setTimeout(loadGTE, 500);
-        }
-      }
-
-      sel.addEventListener('change', e => {
-        const v = e.target.value;
-        localStorage.setItem(LANG_KEY, v);
-        setGoogTrans(v);
-        applyDirLang(v);
-        if (v !== 'en') loadGTE();
-        location.reload();
-      });
-    })();
 
 
 

--- a/pt/roadmap.html
+++ b/pt/roadmap.html
@@ -140,45 +140,6 @@
       z-index: 1;
     }
 
-    /* Google Translate fixes */
-    body > .skiptranslate {
-      display: none !important;
-    }
-
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-gadget {
-      color: inherit !important;
-    }
-
-    /* Prevent Google Translate from blocking clicks */
-    nav font,
-    nav span:not(.dropdown-arrow),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    button font,
-    button span:not(#theme-icon):not(.dropdown-arrow) {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-    }
-
-    /* Ensure buttons always work */
-    nav a,
-    nav button,
-    #langToggle,
-    #themeToggle {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
-
     /* Screen reader only utility */
     .sr-only {
       position: absolute;
@@ -1053,29 +1014,6 @@
     </div>
   </header>
 
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-  <!-- Hidden select for Google Translate compatibility -->
-  <select id="langSel" style="display:none;" aria-hidden="true">
-    <option value="en">English</option>
-    <option value="de">Deutsch</option>
-    <option value="fr">Français</option>
-    <option value="es">Español</option>
-    <option value="it">Italiano</option>
-    <option value="zh">中文</option>
-    <option value="ru">Русский</option>
-    <option value="ar">العربية</option>
-    <option value="pt">Português</option>
-    <option value="tr">Türkçe</option>
-    <option value="ja">日本語</option>
-    <option value="ko">한국어</option>
-    <option value="vi">Tiếng Việt</option>
-    <option value="th">ไทย</option>
-    <option value="hi">हिन्दी</option>
-    <option value="id">Bahasa Indonesia</option>
-  </select>
-
   <!-- Hero -->
   <section class="hero">
     <div class="container">
@@ -1354,120 +1292,20 @@
       function selectLanguage(lang) {
         console.log('Language selected:', lang.code);
 
-        // Helper functions from page load script
-        function baseDomain(host) {
-          const p = host.split('.');
-          return p.length > 2 ? p.slice(-2).join('.') : host;
-        }
-
-        function setCookie(name, value, days, domain) {
-          let expires = '';
-          if (days) {
-            const d = new Date();
-            d.setTime(d.getTime() + days * 864e5);
-            expires = '; expires=' + d.toUTCString();
-          }
-          const dom = domain ? '; domain=' + domain : '';
-          document.cookie = name + '=' + value + expires + '; path=/' + dom;
-        }
-
-        function setGoogTrans(langCode) {
-          const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-          const val = '/en/' + target;
-          setCookie('googtrans', val, 365);
-          const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-          setCookie('googtrans', val, 365, root);
-        }
-
         function applyDirLang(langCode) {
           document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
           document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
         }
 
-        function loadGTE() {
-          if (window.__gte_loading || window.google) return;
-          window.__gte_loading = true;
-          const s = document.createElement('script');
-          s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-          s.async = true;
-          document.head.appendChild(s);
-        }
-
         // Save to localStorage
         localStorage.setItem('sp_lang', lang.code);
 
-        // Set cookies and attributes
-        setGoogTrans(lang.code);
+        // Set document language attributes
         applyDirLang(lang.code);
-
-        // Load translate script if not English
-        if (lang.code !== 'en') loadGTE();
 
         // Reload page to apply translation
         location.reload();
       }
-    })();
-
-    // Google Translate Initialization
-    window.googleTranslateElementInit = function() {
-      if (!window.google || !google.translate) return;
-      new google.translate.TranslateElement({
-        pageLanguage: 'en',
-        includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-        autoDisplay: false
-      }, 'google_translate_container');
-    };
-
-    // Load saved language on page load
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading || window.google) return;
-        window.__gte_loading = true;
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-      const saved = localStorage.getItem(LANG_KEY) || 'en';
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      if (sel) sel.value = code;
-      setGoogTrans(code);
-      applyDirLang(code);
-      if (code !== 'en') loadGTE();
     })();
 
     // Smooth scroll for nav links with offset


### PR DESCRIPTION
Manually removed all Google Translate code from Portuguese HTML files:
- CSS fixes and styles for Google Translate compatibility
- Hidden container divs and language selector elements
- JavaScript initialization, loading, and cookie management code
- Google Translate API script references

Files modified:
- pt/index.html (405 lines removed)
- pt/roadmap.html (164 lines removed)
- pt/faq.html (60 lines removed)

Total: 629 lines of Google Translate code removed manually using Edit tool