### PR TITLE
Remove language toggle button from Portuguese site header

### DIFF
--- a/pt/faq.html
+++ b/pt/faq.html
@@ -187,13 +187,8 @@
       max-height: 64px;
     }
 
-    header .container > .lang-dropdown,
     header .container > #themeToggle {
       flex-shrink: 0;
-    }
-
-    header .container > .lang-dropdown + #themeToggle {
-      margin-left: -0.8rem;
     }
 
     .brand {
@@ -316,55 +311,6 @@
     }
 
     .nav-dropdown-menu a:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
-    }
-
-    .lang-dropdown {
-      position: relative;
-      flex-shrink: 0;
-    }
-
-    .lang-dropdown-menu {
-      position: fixed;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.75rem;
-      min-width: 160px;
-      max-height: 400px;
-      overflow-y: auto;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 9999;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
-
-    .lang-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
-
-    .lang-dropdown-menu button {
-      display: block;
-      width: 100%;
-      padding: 0.6rem 0.8rem;
-      border: none;
-      background: transparent;
-      border-radius: 6px;
-      color: var(--muted);
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-
-    .lang-dropdown-menu button:hover {
       background: rgba(91, 138, 255, 0.15);
       color: var(--text);
     }
@@ -859,12 +805,6 @@
           <li><a href="/pt/#pricing">Preços</a></li>
         </ul>
       </nav>
-
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Seleção de idioma" aria-expanded="false" aria-haspopup="true">
-          <span>PT</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn" type="button" aria-label="Seleção de tema">
         <span id="theme-icon">◐</span>
@@ -1443,70 +1383,6 @@
           dropdownOpen = false;
         }
       });
-    })();
-
-    // Language Dropdown (same as roadmap.html)
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
-
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      const languages = [
-        { code: 'en', name: 'English', path: '/faq.html' },
-        { code: 'de', name: 'Deutsch', path: '/de/faq.html' },
-        { code: 'fr', name: 'Français', path: '/fr/faq.html' },
-        { code: 'es', name: 'Español', path: '/es/faq.html' },
-        { code: 'it', name: 'Italiano', path: '/it/faq.html' },
-        { code: 'pt', name: 'Português', path: '/pt/faq.html' },
-        { code: 'zh', name: '中文', path: '/zh/faq.html' },
-        { code: 'ru', name: 'Русский', path: '/ru/faq.html' },
-        { code: 'ar', name: 'العربية', path: '/ar/faq.html' },
-        { code: 'tr', name: 'Türkçe', path: '/tr/faq.html' },
-        { code: 'ja', name: '日本語', path: '/ja/faq.html' },
-        { code: 'ko', name: '한국어', path: '/ko/faq.html' },
-        { code: 'vi', name: 'Tiếng Việt', path: '/vi/faq.html' },
-        { code: 'th', name: 'ไทย', path: '/th/faq.html' },
-        { code: 'hi', name: 'हिन्दी', path: '/hi/faq.html' },
-        { code: 'id', name: 'Bahasa Indonesia', path: '/id/faq.html' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.textContent = lang.name;
-        btn.onclick = () => selectLanguage(lang);
-        langMenu.appendChild(btn);
-      });
-
-      document.body.appendChild(langMenu);
-
-      let menuOpen = false;
-
-      langBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        menuOpen = !menuOpen;
-        langMenu.classList.toggle('show', menuOpen);
-        langBtn.setAttribute('aria-expanded', menuOpen);
-
-        if (menuOpen) {
-          const rect = langBtn.getBoundingClientRect();
-          langMenu.style.top = (rect.bottom + 8) + 'px';
-          langMenu.style.left = (rect.left - langMenu.offsetWidth + rect.width) + 'px';
-        }
-      });
-
-      document.addEventListener('click', function(e) {
-        if (menuOpen && !langBtn.contains(e.target) && !langMenu.contains(e.target)) {
-          menuOpen = false;
-          langMenu.classList.remove('show');
-          langBtn.setAttribute('aria-expanded', 'false');
-        }
-      });
-
-      function selectLanguage(lang) {
-        window.location.href = lang.path;
-      }
     })();
 
     // FAQ Search Functionality

--- a/pt/index.html
+++ b/pt/index.html
@@ -783,7 +783,6 @@
 
       /* Ensure header buttons adapt to smaller text when necessary */
       header .btn,
-      header #langToggle,
       header #themeToggle {
         font-size: .8rem !important;
         padding: .4rem .6rem !important;
@@ -791,13 +790,6 @@
         overflow: hidden !important;
         text-overflow: ellipsis !important;
         flex-shrink: 1 !important;
-      }
-
-      /* Language button - allow slight shrinking if needed */
-      header #langToggle span {
-        max-width: 30px !important;
-        overflow: hidden !important;
-        text-overflow: clip !important;
       }
 
       /* CTA button - ensure it doesn't overflow */
@@ -2148,61 +2140,7 @@
     }
 
 
-    /* Language Dropdown - container only (menu created as body child in JavaScript) */
-    .lang-dropdown{
-      position:relative;
-      flex-shrink:0;
-      z-index:67 !important;
-    }
-
-    /* Language dropdown menu - created as direct child of body, needs to work on ALL screen sizes */
-    .lang-dropdown-menu {
-      position: fixed !important;
-      top: 70px;
-      right: 20px;
-      background: rgba(10, 12, 20, 0.98);
-      border: 2px solid rgba(255, 255, 255, 0.4);
-      border-radius: 12px;
-      padding: 0.5rem;
-      min-width: 180px;
-      max-height: 500px;
-      overflow-y: auto;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-      z-index: 76 !important;
-      opacity: 0 !important;
-      visibility: hidden !important;
-      transform: translateY(-10px);
-      transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
-      display: flex !important;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-    .lang-dropdown-menu.active {
-      opacity: 1 !important;
-      visibility: visible !important;
-      transform: translateY(0) !important;
-    }
-    .lang-dropdown-menu button {
-      padding: 0.6rem 0.9rem;
-      background: transparent;
-      border: none;
-      border-radius: 8px;
-      color: #b7c2d9;
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: #fff;
-    }
-
-
-    #themeToggle,
-    #langToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
+    #themeToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
 
     /* Make theme and language buttons smaller on mobile */
     
@@ -2233,8 +2171,7 @@
       }
 
     @media (max-width:768px){
-      #themeToggle,
-      #langToggle{
+      #themeToggle{
         padding:.3rem !important;
         font-size:0.8rem !important;
         min-width:40px;
@@ -2244,18 +2181,10 @@
         justify-content:center !important;
       }
 
-      #themeToggle span,
-      #langToggle span{
+      #themeToggle span{
         display:flex !important;
         align-items:center !important;
         justify-content:center !important;
-      }
-
-      /* Fix language dropdown menu on mobile */
-      .lang-dropdown-menu {
-        right: 10px;
-        min-width: 160px;
-        max-width: calc(100vw - 20px);
       }
 
       /* Ensure header doesn't exceed viewport width and allows natural height */
@@ -2346,8 +2275,7 @@
     }
 
 
-    /* CRITICAL FIX: Ensure language/theme buttons stay visible */
-    .lang-dropdown,
+    /* CRITICAL FIX: Ensure theme button stays visible */
     #themeToggle,
     .menu-toggle{
       position:relative;
@@ -2391,13 +2319,8 @@
       }
 
       /* Better mobile header button sizing */
-      .lang-dropdown,
       #themeToggle {
         flex-shrink: 0;
-      }
-
-      #themeToggle,
-      #langToggle {
         min-width: 44px; /* iOS minimum tap target */
         min-height: 44px;
       }
@@ -2908,9 +2831,8 @@
       .price{font-size:1.8rem}
       .cta-inner .bar .note{display:none}
 
-      /* Extra small screens - further reduce header button sizes for translated text */
+      /* Extra small screens - further reduce header button sizes */
       header .btn,
-      header #langToggle,
       header #themeToggle {
         font-size: .75rem !important;
         padding: .35rem .5rem !important;
@@ -3429,12 +3351,6 @@
       </nav>
 
 
-
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Seleção de idioma" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text)">
-          <span>🇧🇷 PT</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Seleção de tema" style="padding:.5rem .7rem;color:var(--text)">
         <span id="theme-icon">
@@ -6127,108 +6043,6 @@
     })();
 
 
-    /* ======================== Language Dropdown - Direct child of body ======================== */
-
-    // Language dropdown - create as direct child of body to escape stacking context
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
-
-      // Create language dropdown menu
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      // Create language buttons
-      const languages = [
-        { code: 'en', name: 'English', flag: '🇺🇸' },
-        { code: 'de', name: 'Deutsch', flag: '🇩🇪' },
-        { code: 'fr', name: 'Français', flag: '🇫🇷' },
-        { code: 'es', name: 'Español', flag: '🇪🇸' },
-        { code: 'it', name: 'Italiano', flag: '🇮🇹' },
-        { code: 'zh', name: '中文', flag: '🇨🇳' },
-        { code: 'ru', name: 'Русский', flag: '🇷🇺' },
-        { code: 'ar', name: 'العربية', flag: '🇸🇦' },
-        { code: 'pt', name: 'Português', flag: '🇵🇹' },
-        { code: 'tr', name: 'Türkçe', flag: '🇹🇷' },
-        { code: 'ja', name: '日本語', flag: '🇯🇵' },
-        { code: 'ko', name: '한국어', flag: '🇰🇷' },
-        { code: 'vi', name: 'Tiếng Việt', flag: '🇻🇳' },
-        { code: 'th', name: 'ไทย', flag: '🇹🇭' },
-        { code: 'hi', name: 'हिन्दी', flag: '🇮🇳' },
-        { code: 'id', name: 'Bahasa Indonesia', flag: '🇮🇩' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.setAttribute('data-lang', lang.code);
-        btn.textContent = lang.flag + ' ' + lang.name;
-        btn.addEventListener('click', function() {
-          function applyDirLang(langCode) {
-            document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-            document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-          }
-
-          // Save to localStorage
-          localStorage.setItem('sp_lang', lang.code);
-
-          // Set document language attributes
-          applyDirLang(lang.code);
-
-          // Track event if analytics available
-          if (typeof trackEvent === 'function') {
-            trackEvent('language_change', {
-              language: lang.code,
-              language_name: lang.name
-            });
-          }
-
-          console.log('Language changed to:', lang.code);
-
-          // Reload page
-          location.reload();
-        });
-        langMenu.appendChild(btn);
-      });
-
-      // CRITICAL: Append directly to body (escapes header's stacking context)
-      document.body.appendChild(langMenu);
-
-      // Open/close functions
-      function open() {
-        langMenu.classList.add('active');
-        langBtn.setAttribute('aria-expanded', 'true');
-      }
-
-      function close() {
-        langMenu.classList.remove('active');
-        langBtn.setAttribute('aria-expanded', 'false');
-      }
-
-      function toggle() {
-        if (langMenu.classList.contains('active')) {
-          close();
-        } else {
-          open();
-        }
-      }
-
-      // Event listeners
-      langBtn.addEventListener('click', function(e) {
-        toggle();
-      });
-
-      // Close when clicking outside
-      document.addEventListener('click', function(e) {
-        if (langMenu.classList.contains('active')) {
-          if (!langMenu.contains(e.target) && !langBtn.contains(e.target)) {
-            close();
-          }
-        }
-      });
-    })();
-
-
-
     /* ======================== Copy to clipboard (wallets) ======================== */
 
     document.querySelectorAll('[data-copy]').forEach(btn=>btn.addEventListener('click',()=>{
@@ -7079,17 +6893,7 @@ if ('serviceWorker' in navigator) {
       });
     });
 
-    // 6. TRACK LANGUAGE SELECTOR
-    const langToggle = document.getElementById('langToggle');
-    if (langToggle) {
-      langToggle.addEventListener('click', function() {
-        trackEvent('language_selector_open', {});
-      });
-    }
-
-    // Language dropdown analytics now integrated into the language dropdown JavaScript above
-
-    // 7. TRACK THEME TOGGLE
+    // 6. TRACK THEME TOGGLE
     const themeToggle = document.getElementById('themeToggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', function() {

--- a/pt/roadmap.html
+++ b/pt/roadmap.html
@@ -196,13 +196,8 @@
       max-height: 64px !important;
     }
 
-    header .container > .lang-dropdown,
     header .container > #themeToggle {
       flex-shrink: 0;
-    }
-
-    header .container > .lang-dropdown + #themeToggle {
-      margin-left: -0.8rem;
     }
 
     .brand {
@@ -384,56 +379,6 @@
     html[data-theme="light"] .nav-dropdown-menu a:hover {
       background: rgba(59,130,246,.12);
       color: #0f172a;
-    }
-
-    /* Language Dropdown */
-    .lang-dropdown {
-      position: relative;
-      flex-shrink: 0;
-    }
-
-    .lang-dropdown-menu {
-      position: fixed;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.75rem;
-      min-width: 160px;
-      max-height: 400px;
-      overflow-y: auto;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 9999;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
-
-    .lang-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
-
-    .lang-dropdown-menu button {
-      display: block;
-      width: 100%;
-      padding: 0.6rem 0.8rem;
-      border: none;
-      background: transparent;
-      border-radius: 6px;
-      color: var(--muted);
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
     }
 
     .btn {
@@ -1002,12 +947,6 @@
         </ul>
       </nav>
 
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Seleção de idioma" aria-expanded="false" aria-haspopup="true">
-          <span>🌐</span>
-        </button>
-      </div>
-
       <button id="themeToggle" class="btn" type="button" aria-label="Seleção de tema">
         <span id="theme-icon">🌙</span>
       </button>
@@ -1226,86 +1165,6 @@
           dropdownOpen = false;
         }
       });
-    })();
-
-    // Language Dropdown
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
-
-      // Create language dropdown menu
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      // Create language buttons
-      const languages = [
-        { code: 'en', name: 'English' },
-        { code: 'de', name: 'Deutsch' },
-        { code: 'fr', name: 'Français' },
-        { code: 'es', name: 'Español' },
-        { code: 'it', name: 'Italiano' },
-        { code: 'zh', name: '中文' },
-        { code: 'ru', name: 'Русский' },
-        { code: 'ar', name: 'العربية' },
-        { code: 'pt', name: 'Português' },
-        { code: 'tr', name: 'Türkçe' },
-        { code: 'ja', name: '日本語' },
-        { code: 'ko', name: '한국어' },
-        { code: 'vi', name: 'Tiếng Việt' },
-        { code: 'th', name: 'ไทย' },
-        { code: 'hi', name: 'हिन्दी' },
-        { code: 'id', name: 'Bahasa Indonesia' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.textContent = lang.name;
-        btn.onclick = () => selectLanguage(lang);
-        langMenu.appendChild(btn);
-      });
-
-      document.body.appendChild(langMenu);
-
-      let menuOpen = false;
-
-      langBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        menuOpen = !menuOpen;
-        langMenu.classList.toggle('show', menuOpen);
-        langBtn.setAttribute('aria-expanded', menuOpen);
-
-        if (menuOpen) {
-          const rect = langBtn.getBoundingClientRect();
-          langMenu.style.top = (rect.bottom + 8) + 'px';
-          langMenu.style.left = (rect.left - langMenu.offsetWidth + rect.width) + 'px';
-        }
-      });
-
-      document.addEventListener('click', function(e) {
-        if (menuOpen && !langBtn.contains(e.target) && !langMenu.contains(e.target)) {
-          menuOpen = false;
-          langMenu.classList.remove('show');
-          langBtn.setAttribute('aria-expanded', 'false');
-        }
-      });
-
-      function selectLanguage(lang) {
-        console.log('Language selected:', lang.code);
-
-        function applyDirLang(langCode) {
-          document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-          document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-        }
-
-        // Save to localStorage
-        localStorage.setItem('sp_lang', lang.code);
-
-        // Set document language attributes
-        applyDirLang(lang.code);
-
-        // Reload page to apply translation
-        location.reload();
-      }
     })();
 
     // Smooth scroll for nav links with offset


### PR DESCRIPTION
Manually removed all language dropdown/selector UI elements from Portuguese pages:
- Removed language toggle button from header HTML (pt/index.html, pt/faq.html, pt/roadmap.html)
- Removed all CSS for language dropdown menu (.lang-dropdown, .lang-dropdown-menu)
- Removed JavaScript code that creates and manages language dropdown functionality
- Removed analytics tracking for language selector

The Portuguese site no longer shows a language switcher button in the header.

Files modified:
- pt/index.html
- pt/faq.html
- pt/roadmap.html