### PR TITLE
Remove Google Translate feature and manual edits

### DIFF
--- a/de/faq.html
+++ b/de/faq.html
@@ -140,42 +140,21 @@
       z-index: 1;
     }
 
-    /* Google Translate fixes */
-    body > .skiptranslate {
+    
+
       display: none !important;
     }
 
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-gadget {
       color: inherit !important;
     }
 
     nav font,
     nav span:not(.dropdown-arrow),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    button font,
-    button span:not(#theme-icon):not(.dropdown-arrow) {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-    }
+    
 
     nav a,
     nav button,
-    #langToggle,
-    #themeToggle {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
+    
 
     .sr-only {
       position: absolute;
@@ -224,14 +203,9 @@
       max-height: 64px;
     }
 
-    header .container > .lang-dropdown,
-    header .container > #themeToggle {
-      flex-shrink: 0;
-    }
+    header .container > 
 
-    header .container > .lang-dropdown + #themeToggle {
-      margin-left: -0.8rem;
-    }
+    header .container > 
 
     .brand {
       display: flex;
@@ -357,54 +331,15 @@
       color: var(--text);
     }
 
-    .lang-dropdown {
-      position: relative;
-      flex-shrink: 0;
-    }
+    
 
-    .lang-dropdown-menu {
-      position: fixed;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.75rem;
-      min-width: 160px;
-      max-height: 400px;
-      overflow-y: auto;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 9999;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
+    
 
-    .lang-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
+    
 
-    .lang-dropdown-menu button {
-      display: block;
-      width: 100%;
-      padding: 0.6rem 0.8rem;
-      border: none;
-      background: transparent;
-      border-radius: 6px;
-      color: var(--muted);
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
+    
 
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
-    }
+    
 
     .btn {
       background: var(--bg-soft);
@@ -897,11 +832,6 @@
         </ul>
       </nav>
 
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Sprachauswahl" aria-expanded="false" aria-haspopup="true">
-          <span>DE</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn" type="button" aria-label="Design-Auswahl">
         <span id="theme-icon">◐</span>
@@ -909,28 +839,6 @@
     </div>
   </header>
 
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-  <!-- Hidden select for Google Translate compatibility -->
-  <select id="langSel" style="display:none;" aria-hidden="true">
-    <option value="en">English</option>
-    <option value="de">Deutsch</option>
-    <option value="fr">Français</option>
-    <option value="es">Español</option>
-    <option value="it">Italiano</option>
-    <option value="zh">中文</option>
-    <option value="ru">Русский</option>
-    <option value="ar">العربية</option>
-    <option value="pt">Português</option>
-    <option value="tr">Türkçe</option>
-    <option value="ja">日本語</option>
-    <option value="ko">한국어</option>
-    <option value="vi">Tiếng Việt</option>
-    <option value="th">ไทย</option>
-    <option value="hi">हिन्दी</option>
-    <option value="id">Bahasa Indonesia</option>
-  </select>
 
   <!-- Hero -->
   <section class="hero">
@@ -1505,183 +1413,7 @@
       });
     })();
 
-    // Language Dropdown (same as roadmap.html)
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
 
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      const languages = [
-        { code: 'en', name: 'English' },
-        { code: 'de', name: 'Deutsch' },
-        { code: 'fr', name: 'Français' },
-        { code: 'es', name: 'Español' },
-        { code: 'it', name: 'Italiano' },
-        { code: 'zh', name: '中文' },
-        { code: 'ru', name: 'Русский' },
-        { code: 'ar', name: 'العربية' },
-        { code: 'pt', name: 'Português' },
-        { code: 'tr', name: 'Türkçe' },
-        { code: 'ja', name: '日本語' },
-        { code: 'ko', name: '한국어' },
-        { code: 'vi', name: 'Tiếng Việt' },
-        { code: 'th', name: 'ไทย' },
-        { code: 'hi', name: 'हिन्दी' },
-        { code: 'id', name: 'Bahasa Indonesia' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.textContent = lang.name;
-        btn.onclick = () => selectLanguage(lang);
-        langMenu.appendChild(btn);
-      });
-
-      document.body.appendChild(langMenu);
-
-      let menuOpen = false;
-
-      langBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        menuOpen = !menuOpen;
-        langMenu.classList.toggle('show', menuOpen);
-        langBtn.setAttribute('aria-expanded', menuOpen);
-
-        if (menuOpen) {
-          const rect = langBtn.getBoundingClientRect();
-          langMenu.style.top = (rect.bottom + 8) + 'px';
-          langMenu.style.left = (rect.left - langMenu.offsetWidth + rect.width) + 'px';
-        }
-      });
-
-      document.addEventListener('click', function(e) {
-        if (menuOpen && !langBtn.contains(e.target) && !langMenu.contains(e.target)) {
-          menuOpen = false;
-          langMenu.classList.remove('show');
-          langBtn.setAttribute('aria-expanded', 'false');
-        }
-      });
-
-      function selectLanguage(lang) {
-        console.log('Language selected:', lang.code);
-
-        // Helper functions from page load script
-        function baseDomain(host) {
-          const p = host.split('.');
-          return p.length > 2 ? p.slice(-2).join('.') : host;
-        }
-
-        function setCookie(name, value, days, domain) {
-          let expires = '';
-          if (days) {
-            const d = new Date();
-            d.setTime(d.getTime() + days * 864e5);
-            expires = '; expires=' + d.toUTCString();
-          }
-          const dom = domain ? '; domain=' + domain : '';
-          document.cookie = name + '=' + value + expires + '; path=/' + dom;
-        }
-
-        function setGoogTrans(langCode) {
-          const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-          const val = '/en/' + target;
-          setCookie('googtrans', val, 365);
-          const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-          setCookie('googtrans', val, 365, root);
-        }
-
-        function applyDirLang(langCode) {
-          document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-          document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-        }
-
-        function loadGTE() {
-          if (window.__gte_loading || window.google) return;
-          window.__gte_loading = true;
-          const s = document.createElement('script');
-          s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-          s.async = true;
-          document.head.appendChild(s);
-        }
-
-        // Save to localStorage
-        localStorage.setItem('sp_lang', lang.code);
-
-        // Set cookies and attributes
-        setGoogTrans(lang.code);
-        applyDirLang(lang.code);
-
-        // Load translate script if not English
-        if (lang.code !== 'en') loadGTE();
-
-        // Reload page to apply translation
-        location.reload();
-      }
-    })();
-
-    // Google Translate Initialization
-    window.googleTranslateElementInit = function() {
-      if (!window.google || !google.translate) return;
-      new google.translate.TranslateElement({
-        pageLanguage: 'en',
-        includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-        autoDisplay: false
-      }, 'google_translate_container');
-    };
-
-    // Load saved language on page load
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading || window.google) return;
-        window.__gte_loading = true;
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-      const saved = localStorage.getItem(LANG_KEY) || 'en';
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      if (sel) sel.value = code;
-      setGoogTrans(code);
-      applyDirLang(code);
-      if (code !== 'en') loadGTE();
-    })();
 
     // FAQ Search Functionality
     const searchInput = document.getElementById('faqSearch');

--- a/de/index.html
+++ b/de/index.html
@@ -2,47 +2,6 @@
 <html lang="de" dir="ltr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
-
-  <!-- CRITICAL: Set Google Translate to English IMMEDIATELY if English is selected -->
-  <script>
-    (function() {
-      try {
-        // Check URL parameter first
-        var urlParams = new URLSearchParams(window.location.search);
-        var urlLang = urlParams.get('lang');
-
-        // Check localStorage
-        var savedLang = localStorage.getItem('sp_lang') || 'en';
-
-        // If URL says English or localStorage says English, set googtrans to /en/en
-        if (urlLang === 'en' || savedLang === 'en') {
-          console.log('[GT-EARLY] Setting Google Translate to English (/en/en)');
-
-          // Get root domain
-          var hostname = location.hostname.replace(/^www\./, '');
-          var parts = hostname.split('.');
-          var rootDomain = parts.length > 2 ? parts.slice(-2).join('.') : hostname;
-
-          // Set long expiration for the /en/en cookie
-          var expires = new Date(Date.now() + 365 * 864e5).toUTCString();
-
-          // Set googtrans to /en/en on all domains
-          // This tells Google Translate: "English to English" = no translation
-          document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/';
-          document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/; domain=.' + rootDomain;
-
-          // Force English on HTML element
-          document.documentElement.lang = 'en';
-          document.documentElement.dir = 'ltr';
-
-          console.log('[GT-EARLY] Cookie set to /en/en, language set to English');
-        }
-      } catch(e) {
-        console.error('[GT-EARLY] Error:', e);
-      }
-    })();
-  </script>
-
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
   <!-- Prevent aggressive caching on mobile browsers -->
@@ -773,168 +732,6 @@
 
     *{box-sizing:border-box}
 
-    /* Google Translate fixes - prevent layout breaking */
-    body > .skiptranslate {
-      display: none !important;
-    }
-
-    body {
-      top: 0 !important;
-      position: relative !important;
-    }
-
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-menu-value span {
-      color: inherit !important;
-    }
-
-    .goog-te-gadget {
-      color: inherit !important;
-    }
-
-    /* Make Google Translate font wrappers inherit original text size */
-    font {
-      font-size: inherit !important;
-      line-height: inherit !important;
-    }
-
-    /* Specific adjustments for different text sizes */
-    h1 font, h2 font, h3 font, .headline font {
-      font-size: inherit !important;
-    }
-
-    p font, li font, div font {
-      font-size: inherit !important;
-    }
-
-    .btn font, button font, a font {
-      font-size: inherit !important;
-    }
-
-    /* CRITICAL: Force Google Translate font/span wrappers to not block clicks */
-    nav[aria-label="Hauptnavigation"] font,
-    nav[aria-label="Hauptnavigation"] span:not(.mobile-nav-title),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    .lang-dropdown-menu font,
-    .lang-dropdown-menu span,
-    .menu-toggle font,
-    .menu-toggle span,
-    #langToggle font,
-    #langToggle span,
-    .nav-dropdown font,
-    .nav-dropdown span,
-    button font,
-    button span,
-    .btn font,
-    .btn span {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-      opacity: 1 !important;
-      visibility: visible !important;
-    }
-
-    /* Force mobile menu text to be white and ALWAYS visible */
-    @media (max-width:1400px){
-      /* Dark mode mobile menu (default) */
-      nav[aria-label="Hauptnavigation"],
-      nav[aria-label="Hauptnavigation"] *,
-      nav[aria-label="Hauptnavigation"] font,
-      nav[aria-label="Hauptnavigation"] span,
-      .mobile-nav-header,
-      .mobile-nav-header *,
-      .mobile-nav-title,
-      .mobile-nav-close,
-      #mainnav,
-      #mainnav *,
-      #mainnav font,
-      #mainnav span,
-      #mainnav a,
-      #mainnav button,
-      #mainnav li,
-      #mainnav ul {
-        color: #ffffff !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        text-shadow: 0 1px 2px rgba(0,0,0,0.5) !important;
-      }
-
-      /* Light mode mobile menu - dark text on light background */
-      html[data-theme="light"] nav[aria-label="Hauptnavigation"],
-      html[data-theme="light"] nav[aria-label="Hauptnavigation"] *,
-      html[data-theme="light"] nav[aria-label="Hauptnavigation"] font,
-      html[data-theme="light"] nav[aria-label="Hauptnavigation"] span,
-      html[data-theme="light"] .mobile-nav-header,
-      html[data-theme="light"] .mobile-nav-header *,
-      html[data-theme="light"] .mobile-nav-title,
-      html[data-theme="light"] .mobile-nav-close,
-      html[data-theme="light"] #mainnav,
-      html[data-theme="light"] #mainnav *,
-      html[data-theme="light"] #mainnav font,
-      html[data-theme="light"] #mainnav span,
-      html[data-theme="light"] #mainnav a,
-      html[data-theme="light"] #mainnav button,
-      html[data-theme="light"] #mainnav li,
-      html[data-theme="light"] #mainnav ul {
-        color: #0f172a !important;
-        text-shadow: none !important;
-      }
-
-      /* Make sure links have proper styling */
-      #mainnav a,
-      nav[aria-label="Hauptnavigation"] a {
-        display: block !important;
-        padding: 0.7rem 1rem !important;
-        color: #ffffff !important;
-        text-decoration: none !important;
-        border-radius: 8px !important;
-        background: transparent !important;
-      }
-
-      html[data-theme="light"] #mainnav a,
-      html[data-theme="light"] nav[aria-label="Hauptnavigation"] a {
-        color: #0f172a !important;
-      }
-
-      #mainnav a:hover,
-      nav[aria-label="Hauptnavigation"] a:hover {
-        background: rgba(91,138,255,.2) !important;
-      }
-
-      html[data-theme="light"] #mainnav a:hover,
-      html[data-theme="light"] nav[aria-label="Hauptnavigation"] a:hover {
-        background: rgba(91,138,255,.15) !important;
-      }
-    }
-
-    /* Ensure clickable elements always work */
-    nav[aria-label="Hauptnavigation"] a,
-    nav[aria-label="Hauptnavigation"] button,
-    .lang-dropdown button,
-    .lang-dropdown-menu button,
-    .menu-toggle,
-    #langToggle,
-    #menuToggle,
-    .mobile-nav-close {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
-
-    /* Fix header squeezing when Google Translate is active */
-    header .container,
-    header .nav {
-      min-width: 0 !important;
-      flex-shrink: 0 !important;
-    }
 
     header .brand {
       flex-shrink: 0 !important;
@@ -951,7 +748,6 @@
     header button,
     header a,
     .menu-toggle,
-    #langToggle,
     #themeToggle,
     .btn {
       white-space:nowrap !important;
@@ -1011,7 +807,6 @@
 
       /* Ensure header buttons adapt to smaller text when necessary */
       header .btn,
-      header #langToggle,
       header #themeToggle {
         font-size: .8rem !important;
         padding: .4rem .6rem !important;
@@ -1019,13 +814,6 @@
         overflow: hidden !important;
         text-overflow: ellipsis !important;
         flex-shrink: 1 !important;
-      }
-
-      /* Language button - allow slight shrinking if needed */
-      header #langToggle span {
-        max-width: 30px !important;
-        overflow: hidden !important;
-        text-overflow: clip !important;
       }
 
       /* CTA button - ensure it doesn't overflow */
@@ -2268,66 +2056,11 @@
     }
 
 
-    /* Language Dropdown - container only (menu created as body child in JavaScript) */
-    .lang-dropdown{
-      position:relative;
-      flex-shrink:0;
-      z-index:67 !important;
-    }
+    #themeToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
 
-    /* Language dropdown menu - created as direct child of body, needs to work on ALL screen sizes */
-    .lang-dropdown-menu {
-      position: fixed !important;
-      top: 70px;
-      right: 20px;
-      background: rgba(10, 12, 20, 0.98);
-      border: 2px solid rgba(255, 255, 255, 0.4);
-      border-radius: 12px;
-      padding: 0.5rem;
-      min-width: 180px;
-      max-height: 500px;
-      overflow-y: auto;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-      z-index: 76 !important;
-      opacity: 0 !important;
-      visibility: hidden !important;
-      transform: translateY(-10px);
-      transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
-      display: flex !important;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-    .lang-dropdown-menu.active {
-      opacity: 1 !important;
-      visibility: visible !important;
-      transform: translateY(0) !important;
-    }
-    .lang-dropdown-menu button {
-      padding: 0.6rem 0.9rem;
-      background: transparent;
-      border: none;
-      border-radius: 8px;
-      color: #b7c2d9;
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: #fff;
-    }
-
-
-    #themeToggle,
-    #langToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
-
-    /* Make theme and language buttons smaller on mobile */
+    /* Make theme button smaller on mobile */
     @media (max-width:768px){
-      #themeToggle,
-      #langToggle{
+      #themeToggle{
         padding:.3rem !important;
         font-size:0.8rem !important;
         min-width:40px;
@@ -2337,18 +2070,10 @@
         justify-content:center !important;
       }
 
-      #themeToggle span,
-      #langToggle span{
+      #themeToggle span{
         display:flex !important;
         align-items:center !important;
         justify-content:center !important;
-      }
-
-      /* Fix language dropdown menu on mobile */
-      .lang-dropdown-menu {
-        right: 10px;
-        min-width: 160px;
-        max-width: calc(100vw - 20px);
       }
 
       /* Ensure header doesn't exceed viewport width and allows natural height */
@@ -2439,8 +2164,7 @@
     }
 
 
-    /* CRITICAL FIX: Ensure language/theme buttons stay visible */
-    .lang-dropdown,
+    /* CRITICAL FIX: Ensure theme button stays visible */
     #themeToggle,
     .menu-toggle{
       position:relative;
@@ -2484,13 +2208,8 @@
       }
 
       /* Better mobile header button sizing */
-      .lang-dropdown,
       #themeToggle {
         flex-shrink: 0;
-      }
-
-      #themeToggle,
-      #langToggle {
         min-width: 44px; /* iOS minimum tap target */
         min-height: 44px;
       }
@@ -2838,9 +2557,8 @@
       .price{font-size:1.8rem}
       .cta-inner .bar .note{display:none}
 
-      /* Extra small screens - further reduce header button sizes for translated text */
+      /* Extra small screens - further reduce header button sizes */
       header .btn,
-      header #langToggle,
       header #themeToggle {
         font-size: .75rem !important;
         padding: .35rem .5rem !important;
@@ -3330,14 +3048,6 @@
         </ul>
 
       </nav>
-
-
-
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Sprachauswahl" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text)">
-          <span>🇺🇸</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Themenauswahl" style="padding:.5rem .7rem;color:var(--text)">
         <span id="theme-icon">
@@ -5872,10 +5582,6 @@
 
 
 
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-
 
   <!-- =======================================================================
        SCRIPT: CONFIG + UTILITIES
@@ -6068,7 +5774,6 @@
 
     /* ======================== Resources Dropdown ======================== */
 
-    // Use event delegation for Google Translate compatibility
     (function() {
       let dropdownOpen = false;
 
@@ -6122,156 +5827,6 @@
     })();
 
 
-    /* ======================== Language Dropdown - Direct child of body ======================== */
-
-    // Language dropdown - create as direct child of body to escape stacking context
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
-
-      // Create language dropdown menu
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      // Create language buttons
-      const languages = [
-        { code: 'en', name: 'English', flag: '🇺🇸' },
-        { code: 'de', name: 'Deutsch', flag: '🇩🇪' },
-        { code: 'fr', name: 'Français', flag: '🇫🇷' },
-        { code: 'es', name: 'Español', flag: '🇪🇸' },
-        { code: 'it', name: 'Italiano', flag: '🇮🇹' },
-        { code: 'zh', name: '中文', flag: '🇨🇳' },
-        { code: 'ru', name: 'Русский', flag: '🇷🇺' },
-        { code: 'ar', name: 'العربية', flag: '🇸🇦' },
-        { code: 'pt', name: 'Português', flag: '🇵🇹' },
-        { code: 'tr', name: 'Türkçe', flag: '🇹🇷' },
-        { code: 'ja', name: '日本語', flag: '🇯🇵' },
-        { code: 'ko', name: '한국어', flag: '🇰🇷' },
-        { code: 'vi', name: 'Tiếng Việt', flag: '🇻🇳' },
-        { code: 'th', name: 'ไทย', flag: '🇹🇭' },
-        { code: 'hi', name: 'हिन्दी', flag: '🇮🇳' },
-        { code: 'id', name: 'Bahasa Indonesia', flag: '🇮🇩' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.setAttribute('data-lang', lang.code);
-        btn.textContent = lang.flag + ' ' + lang.name;
-        btn.addEventListener('click', function() {
-          // Helper functions
-          function baseDomain(host) {
-            const p = host.split('.');
-            return p.length > 2 ? p.slice(-2).join('.') : host;
-          }
-
-          function setCookie(name, value, days, domain) {
-            let expires = '';
-            if (days) {
-              const d = new Date();
-              d.setTime(d.getTime() + days * 864e5);
-              expires = '; expires=' + d.toUTCString();
-            }
-            const dom = domain ? '; domain=' + domain : '';
-            document.cookie = name + '=' + value + expires + '; path=/' + dom;
-          }
-
-          function setGoogTrans(langCode) {
-            const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-            const val = '/en/' + target;
-            setCookie('googtrans', val, 365);
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            setCookie('googtrans', val, 365, root);
-          }
-
-          function applyDirLang(langCode) {
-            document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-            document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-          }
-
-          // Save to localStorage
-          localStorage.setItem('sp_lang', lang.code);
-
-          // Set cookies and attributes
-          if (lang.code === 'en') {
-            // For English: Set googtrans to /en/en (English to English = no translation)
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            const expires = new Date(Date.now() + 365 * 864e5).toUTCString();
-
-            // Set to /en/en which tells Google Translate "English to English" (no translation)
-            document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/';
-            document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/; domain=' + root;
-
-            applyDirLang('en');
-
-            // Track event if analytics available
-            if (typeof trackEvent === 'function') {
-              trackEvent('language_change', {
-                language: 'en',
-                language_name: lang.name
-              });
-            }
-
-            console.log('[GT] Switching to English - setting googtrans=/en/en');
-
-            // Use location.replace for a true hard reload without history
-            setTimeout(() => {
-              location.replace(location.pathname + '?lang=en&t=' + Date.now());
-            }, 50);
-          } else {
-            setGoogTrans(lang.code);
-            applyDirLang(lang.code);
-
-            // Track event if analytics available
-            if (typeof trackEvent === 'function') {
-              trackEvent('language_change', {
-                language: lang.code,
-                language_name: lang.name
-              });
-            }
-
-            console.log('[GT] Language changed to:', lang.code);
-            location.reload();
-          }
-        });
-        langMenu.appendChild(btn);
-      });
-
-      // CRITICAL: Append directly to body (escapes header's stacking context)
-      document.body.appendChild(langMenu);
-
-      // Open/close functions
-      function open() {
-        langMenu.classList.add('active');
-        langBtn.setAttribute('aria-expanded', 'true');
-      }
-
-      function close() {
-        langMenu.classList.remove('active');
-        langBtn.setAttribute('aria-expanded', 'false');
-      }
-
-      function toggle() {
-        if (langMenu.classList.contains('active')) {
-          close();
-        } else {
-          open();
-        }
-      }
-
-      // Event listeners
-      langBtn.addEventListener('click', function(e) {
-        toggle();
-      });
-
-      // Close when clicking outside
-      document.addEventListener('click', function(e) {
-        if (langMenu.classList.contains('active')) {
-          if (!langMenu.contains(e.target) && !langBtn.contains(e.target)) {
-            close();
-          }
-        }
-      });
-    })();
 
 
 
@@ -6346,246 +5901,6 @@
 
 
 
-    /* ======================== Google Translate (on demand) ======================== */
-
-    // Google Translate Initialization with robust error handling
-    window.googleTranslateElementInit = function() {
-      console.log('[GT] Init called');
-      if (!window.google || !google.translate || !google.translate.TranslateElement) {
-        console.warn('[GT] Google Translate API not ready');
-        return;
-      }
-
-      const container = document.getElementById('google_translate_container');
-      if (!container) {
-        console.error('[GT] Container not found');
-        return;
-      }
-
-      try {
-        new google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-          autoDisplay: false
-        }, 'google_translate_container');
-        console.log('[GT] Widget created successfully');
-        window.__gte_initialized = true;
-      } catch (error) {
-        console.error('[GT] Failed to create widget:', error);
-      }
-    };
-
-    // Load saved language on page load with robust polling
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function clearGoogTrans() {
-        // Clear all Google Translate cookies thoroughly and aggressively
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        const cookieNames = ['googtrans', 'googtrans(2)', 'googtrans(0)', 'googtrans(1)'];
-        const domains = ['', '; domain=' + root, '; domain=' + location.hostname, '; domain=.signalpilot.io'];
-        const paths = ['/', '/en', '/en/'];
-
-        // Nuclear option: clear every possible cookie variation
-        cookieNames.forEach(name => {
-          domains.forEach(domain => {
-            paths.forEach(path => {
-              // Try deleting with empty value
-              document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
-              // Try setting to /en/en and deleting
-              document.cookie = name + '=/en/en; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
-              // Try with max-age
-              document.cookie = name + '=; max-age=0; path=' + path + domain;
-            });
-          });
-        });
-
-        // Also clear localStorage and sessionStorage
-        if (window.localStorage) {
-          localStorage.removeItem('googtrans');
-          localStorage.removeItem('googtrans(2)');
-        }
-        if (window.sessionStorage) {
-          sessionStorage.removeItem('googtrans');
-          sessionStorage.removeItem('googtrans(2)');
-        }
-
-        // Remove any Google Translate elements from DOM
-        const gtElements = [
-          '.skiptranslate',
-          '.goog-te-banner-frame',
-          '#goog-gt-tt',
-          '.goog-te-balloon-frame',
-          'iframe[src*="translate.google.com"]',
-          'iframe.goog-te-menu-frame',
-          '.goog-te-menu2'
-        ];
-        gtElements.forEach(selector => {
-          document.querySelectorAll(selector).forEach(el => el.remove());
-        });
-
-        console.log('[GT] Cleared all Google Translate cookies and elements');
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading) {
-          console.log('[GT] Already loading');
-          return;
-        }
-        if (window.google && window.google.translate) {
-          console.log('[GT] Already loaded');
-          googleTranslateElementInit();
-          return;
-        }
-
-        console.log('[GT] Loading script...');
-        window.__gte_loading = true;
-
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        s.onerror = function() {
-          console.error('[GT] Script failed to load');
-          window.__gte_loading = false;
-          // Retry after 2 seconds
-          setTimeout(function() {
-            if (!window.google) {
-              console.log('[GT] Retrying...');
-              loadGTE();
-            }
-          }, 2000);
-        };
-        s.onload = function() {
-          console.log('[GT] Script loaded');
-          // Poll for initialization
-          let attempts = 0;
-          const checkInit = setInterval(function() {
-            attempts++;
-            if (window.__gte_initialized || attempts > 50) {
-              clearInterval(checkInit);
-              if (!window.__gte_initialized) {
-                console.warn('[GT] Init timeout after ' + attempts + ' attempts');
-              }
-            }
-          }, 100);
-        };
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-
-      // Check URL parameter for forced language
-      const urlParams = new URLSearchParams(window.location.search);
-      const urlLang = urlParams.get('lang');
-
-      let saved = localStorage.getItem(LANG_KEY) || 'en';
-
-      // If URL says lang=en, force English and clear localStorage
-      if (urlLang === 'en') {
-        saved = 'en';
-        localStorage.setItem(LANG_KEY, 'en');
-        console.log('[GT] URL forced English language');
-      }
-
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      console.log('[GT] Saved language:', code);
-
-      if (sel) sel.value = code;
-
-      // Only set translation cookies for non-English languages
-      if (code !== 'en') {
-        setGoogTrans(code);
-        applyDirLang(code);
-      } else {
-        // For English: cookie already set to /en/en by early script
-        // Just ensure HTML attributes are correct
-        applyDirLang('en');
-
-        // Remove Google Translate font wrappers that might be lingering in the DOM
-        setTimeout(() => {
-          document.querySelectorAll('font').forEach(font => {
-            const parent = font.parentNode;
-            while (font.firstChild) {
-              parent.insertBefore(font.firstChild, font);
-            }
-            parent.removeChild(font);
-          });
-        }, 100);
-
-        // Clean URL after processing
-        if (urlLang === 'en') {
-          setTimeout(() => {
-            const cleanUrl = window.location.pathname;
-            window.history.replaceState({}, '', cleanUrl);
-          }, 200);
-        }
-      }
-
-      // Update language button text to show current language
-      const langBtn = document.getElementById('langToggle');
-      if (langBtn) {
-        const langText = langBtn.querySelector('span');
-        if (langText) {
-          const flagMap = {
-            'en': '🇺🇸', 'de': '🇩🇪', 'fr': '🇫🇷', 'es': '🇪🇸',
-            'it': '🇮🇹', 'zh': '🇨🇳', 'ru': '🇷🇺', 'ar': '🇸🇦',
-            'pt': '🇵🇹', 'tr': '🇹🇷', 'ja': '🇯🇵', 'ko': '🇰🇷',
-            'vi': '🇻🇳', 'th': '🇹🇭', 'hi': '🇮🇳', 'id': '🇮🇩'
-          };
-          langText.textContent = flagMap[code] || '🌐';
-        }
-      }
-
-      // Load on DOMContentLoaded to ensure page is ready
-      if (code !== 'en') {
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(loadGTE, 500); // Small delay to let page settle
-          });
-        } else {
-          setTimeout(loadGTE, 500);
-        }
-      }
-
-      sel.addEventListener('change', e => {
-        const v = e.target.value;
-        localStorage.setItem(LANG_KEY, v);
-        setGoogTrans(v);
-        applyDirLang(v);
-        if (v !== 'en') loadGTE();
-        location.reload();
-      });
-    })();
 
 
 
@@ -7368,17 +6683,7 @@ if ('serviceWorker' in navigator) {
       });
     });
 
-    // 6. TRACK LANGUAGE SELECTOR
-    const langToggle = document.getElementById('langToggle');
-    if (langToggle) {
-      langToggle.addEventListener('click', function() {
-        trackEvent('language_selector_open', {});
-      });
-    }
-
-    // Language dropdown analytics now integrated into the language dropdown JavaScript above
-
-    // 7. TRACK THEME TOGGLE
+    // 6. TRACK THEME TOGGLE
     const themeToggle = document.getElementById('themeToggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', function() {

--- a/de/roadmap.html
+++ b/de/roadmap.html
@@ -140,44 +140,23 @@
       z-index: 1;
     }
 
-    /* Google Translate fixes */
-    body > .skiptranslate {
+    
+
       display: none !important;
     }
 
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-gadget {
       color: inherit !important;
     }
 
     /* Prevent Google Translate from blocking clicks */
     nav font,
     nav span:not(.dropdown-arrow),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    button font,
-    button span:not(#theme-icon):not(.dropdown-arrow) {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-    }
+    
 
     /* Ensure buttons always work */
     nav a,
     nav button,
-    #langToggle,
-    #themeToggle {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
+    
 
     /* Screen reader only utility */
     .sr-only {
@@ -235,14 +214,9 @@
       max-height: 64px !important;
     }
 
-    header .container > .lang-dropdown,
-    header .container > #themeToggle {
-      flex-shrink: 0;
-    }
+    header .container > 
 
-    header .container > .lang-dropdown + #themeToggle {
-      margin-left: -0.8rem;
-    }
+    header .container > 
 
     .brand {
       display: flex;
@@ -426,54 +400,15 @@
     }
 
     /* Language Dropdown */
-    .lang-dropdown {
-      position: relative;
-      flex-shrink: 0;
-    }
+    
 
-    .lang-dropdown-menu {
-      position: fixed;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.75rem;
-      min-width: 160px;
-      max-height: 400px;
-      overflow-y: auto;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 9999;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
+    
 
-    .lang-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
+    
 
-    .lang-dropdown-menu button {
-      display: block;
-      width: 100%;
-      padding: 0.6rem 0.8rem;
-      border: none;
-      background: transparent;
-      border-radius: 6px;
-      color: var(--muted);
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
+    
 
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
-    }
+    
 
     .btn {
       background: var(--bg-soft);
@@ -1041,11 +976,6 @@
         </ul>
       </nav>
 
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Sprachauswahl" aria-expanded="false" aria-haspopup="true">
-          <span>🌐</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn" type="button" aria-label="Design-Auswahl">
         <span id="theme-icon">🌙</span>
@@ -1053,28 +983,9 @@
     </div>
   </header>
 
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
+  
 
-  <!-- Hidden select for Google Translate compatibility -->
-  <select id="langSel" style="display:none;" aria-hidden="true">
-    <option value="en">English</option>
-    <option value="de">Deutsch</option>
-    <option value="fr">Français</option>
-    <option value="es">Español</option>
-    <option value="it">Italiano</option>
-    <option value="zh">中文</option>
-    <option value="ru">Русский</option>
-    <option value="ar">العربية</option>
-    <option value="pt">Português</option>
-    <option value="tr">Türkçe</option>
-    <option value="ja">日本語</option>
-    <option value="ko">한국어</option>
-    <option value="vi">Tiếng Việt</option>
-    <option value="th">ไทย</option>
-    <option value="hi">हिन्दी</option>
-    <option value="id">Bahasa Indonesia</option>
-  </select>
+  
 
   <!-- Hero -->
   <section class="hero">
@@ -1290,185 +1201,7 @@
       });
     })();
 
-    // Language Dropdown
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
 
-      // Create language dropdown menu
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      // Create language buttons
-      const languages = [
-        { code: 'en', name: 'English' },
-        { code: 'de', name: 'Deutsch' },
-        { code: 'fr', name: 'Français' },
-        { code: 'es', name: 'Español' },
-        { code: 'it', name: 'Italiano' },
-        { code: 'zh', name: '中文' },
-        { code: 'ru', name: 'Русский' },
-        { code: 'ar', name: 'العربية' },
-        { code: 'pt', name: 'Português' },
-        { code: 'tr', name: 'Türkçe' },
-        { code: 'ja', name: '日本語' },
-        { code: 'ko', name: '한국어' },
-        { code: 'vi', name: 'Tiếng Việt' },
-        { code: 'th', name: 'ไทย' },
-        { code: 'hi', name: 'हिन्दी' },
-        { code: 'id', name: 'Bahasa Indonesia' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.textContent = lang.name;
-        btn.onclick = () => selectLanguage(lang);
-        langMenu.appendChild(btn);
-      });
-
-      document.body.appendChild(langMenu);
-
-      let menuOpen = false;
-
-      langBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        menuOpen = !menuOpen;
-        langMenu.classList.toggle('show', menuOpen);
-        langBtn.setAttribute('aria-expanded', menuOpen);
-
-        if (menuOpen) {
-          const rect = langBtn.getBoundingClientRect();
-          langMenu.style.top = (rect.bottom + 8) + 'px';
-          langMenu.style.left = (rect.left - langMenu.offsetWidth + rect.width) + 'px';
-        }
-      });
-
-      document.addEventListener('click', function(e) {
-        if (menuOpen && !langBtn.contains(e.target) && !langMenu.contains(e.target)) {
-          menuOpen = false;
-          langMenu.classList.remove('show');
-          langBtn.setAttribute('aria-expanded', 'false');
-        }
-      });
-
-      function selectLanguage(lang) {
-        console.log('Language selected:', lang.code);
-
-        // Helper functions from page load script
-        function baseDomain(host) {
-          const p = host.split('.');
-          return p.length > 2 ? p.slice(-2).join('.') : host;
-        }
-
-        function setCookie(name, value, days, domain) {
-          let expires = '';
-          if (days) {
-            const d = new Date();
-            d.setTime(d.getTime() + days * 864e5);
-            expires = '; expires=' + d.toUTCString();
-          }
-          const dom = domain ? '; domain=' + domain : '';
-          document.cookie = name + '=' + value + expires + '; path=/' + dom;
-        }
-
-        function setGoogTrans(langCode) {
-          const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-          const val = '/en/' + target;
-          setCookie('googtrans', val, 365);
-          const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-          setCookie('googtrans', val, 365, root);
-        }
-
-        function applyDirLang(langCode) {
-          document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-          document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-        }
-
-        function loadGTE() {
-          if (window.__gte_loading || window.google) return;
-          window.__gte_loading = true;
-          const s = document.createElement('script');
-          s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-          s.async = true;
-          document.head.appendChild(s);
-        }
-
-        // Save to localStorage
-        localStorage.setItem('sp_lang', lang.code);
-
-        // Set cookies and attributes
-        setGoogTrans(lang.code);
-        applyDirLang(lang.code);
-
-        // Load translate script if not English
-        if (lang.code !== 'en') loadGTE();
-
-        // Reload page to apply translation
-        location.reload();
-      }
-    })();
-
-    // Google Translate Initialization
-    window.googleTranslateElementInit = function() {
-      if (!window.google || !google.translate) return;
-      new google.translate.TranslateElement({
-        pageLanguage: 'en',
-        includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-        autoDisplay: false
-      }, 'google_translate_container');
-    };
-
-    // Load saved language on page load
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading || window.google) return;
-        window.__gte_loading = true;
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-      const saved = localStorage.getItem(LANG_KEY) || 'en';
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      if (sel) sel.value = code;
-      setGoogTrans(code);
-      applyDirLang(code);
-      if (code !== 'en') loadGTE();
-    })();
 
     // Smooth scroll for nav links with offset
     document.querySelectorAll('.sticky-nav a').forEach(link => {

--- a/fr/faq.html
+++ b/fr/faq.html
@@ -154,23 +154,18 @@
       z-index: 1;
     }
 
-    /* Google Translate fixes */
     body > .skiptranslate {
       display: none !important;
     }
 
-    .goog-te-banner-frame {
       display: none !important;
     }
 
-    .goog-te-gadget {
       color: inherit !important;
     }
 
     nav font,
     nav span:not(.dropdown-arrow),
-    .lang-dropdown font,
-    .lang-dropdown span,
     button font,
     button span:not(#theme-icon):not(.dropdown-arrow) {
       pointer-events: none !important;
@@ -185,7 +180,6 @@
 
     nav a,
     nav button,
-    #langToggle,
     #themeToggle {
       pointer-events: auto !important;
       cursor: pointer !important;
@@ -238,12 +232,10 @@
       max-height: 64px;
     }
 
-    header .container > .lang-dropdown,
     header .container > #themeToggle {
       flex-shrink: 0;
     }
 
-    header .container > .lang-dropdown + #themeToggle {
       margin-left: -0.8rem;
     }
 
@@ -371,12 +363,10 @@
       color: var(--text);
     }
 
-    .lang-dropdown {
       position: relative;
       flex-shrink: 0;
     }
 
-    .lang-dropdown-menu {
       position: fixed;
       background: var(--bg-elev);
       border: 1px solid var(--border);
@@ -393,13 +383,11 @@
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
     }
 
-    .lang-dropdown-menu.show {
       opacity: 1;
       visibility: visible;
       transform: translateY(0);
     }
 
-    .lang-dropdown-menu button {
       display: block;
       width: 100%;
       padding: 0.6rem 0.8rem;
@@ -415,7 +403,6 @@
       font-weight: 500;
     }
 
-    .lang-dropdown-menu button:hover {
       background: rgba(91, 138, 255, 0.15);
       color: var(--text);
     }
@@ -911,11 +898,6 @@
         </ul>
       </nav>
 
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Sélection de langue" aria-expanded="false" aria-haspopup="true">
-          <span>FR</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn" type="button" aria-label="Sélection du thème">
         <span id="theme-icon">◐</span>
@@ -1498,11 +1480,9 @@
 
     // Language Dropdown
     (function() {
-      const langBtn = document.getElementById('langToggle');
       if (!langBtn) return;
 
       const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
 
       const languages = [
         { code: 'en', name: 'English', path: '/faq.html' },

--- a/fr/index.html
+++ b/fr/index.html
@@ -730,25 +730,19 @@
 
     *{box-sizing:border-box}
 
-    /* Google Translate fixes - prevent layout breaking */
-    body > .skiptranslate {
-      display: none !important;
-    }
+    
 
     body {
       top: 0 !important;
       position: relative !important;
     }
 
-    .goog-te-banner-frame {
       display: none !important;
     }
 
-    .goog-te-menu-value span {
       color: inherit !important;
     }
 
-    .goog-te-gadget {
       color: inherit !important;
     }
 
@@ -774,31 +768,7 @@
     /* CRITICAL: Force Google Translate font/span wrappers to not block clicks */
     nav[aria-label="Main"] font,
     nav[aria-label="Main"] span:not(.mobile-nav-title),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    .lang-dropdown-menu font,
-    .lang-dropdown-menu span,
-    .menu-toggle font,
-    .menu-toggle span,
-    #langToggle font,
-    #langToggle span,
-    .nav-dropdown font,
-    .nav-dropdown span,
-    button font,
-    button span,
-    .btn font,
-    .btn span {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-      opacity: 1 !important;
-      visibility: visible !important;
-    }
+    
 
     /* Force mobile menu text to be white and ALWAYS visible */
     @media (max-width:1400px){
@@ -876,15 +846,7 @@
     /* Ensure clickable elements always work */
     nav[aria-label="Main"] a,
     nav[aria-label="Main"] button,
-    .lang-dropdown button,
-    .lang-dropdown-menu button,
-    .menu-toggle,
-    #langToggle,
-    #menuToggle,
-    .mobile-nav-close {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
+    
 
     /* Fix header squeezing when Google Translate is active */
     header .container,
@@ -908,12 +870,7 @@
     header button,
     header a,
     .menu-toggle,
-    #langToggle,
-    #themeToggle,
-    .btn {
-      white-space:nowrap !important;
-      flex-shrink:0 !important;
-    }
+    
 
     /* Prevent horizontal scroll */
     body{
@@ -968,18 +925,9 @@
 
       /* Ensure header buttons adapt to smaller text when necessary */
       header .btn,
-      header #langToggle,
-      header #themeToggle {
-        font-size: .8rem !important;
-        padding: .4rem .6rem !important;
-        white-space: nowrap !important;
-        overflow: hidden !important;
-        text-overflow: ellipsis !important;
-        flex-shrink: 1 !important;
-      }
+      header 
 
       /* Language button - allow slight shrinking if needed */
-      header #langToggle span {
         max-width: 30px !important;
         overflow: hidden !important;
         text-overflow: clip !important;
@@ -2226,87 +2174,34 @@
 
 
     /* Language Dropdown - container only (menu created as body child in JavaScript) */
-    .lang-dropdown{
       position:relative;
       flex-shrink:0;
       z-index:67 !important;
     }
 
     /* Language dropdown menu - created as direct child of body, needs to work on ALL screen sizes */
-    .lang-dropdown-menu {
-      position: fixed !important;
-      top: 70px;
-      right: 20px;
-      background: rgba(10, 12, 20, 0.98);
-      border: 2px solid rgba(255, 255, 255, 0.4);
-      border-radius: 12px;
-      padding: 0.5rem;
-      min-width: 180px;
-      max-height: 500px;
-      overflow-y: auto;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-      z-index: 76 !important;
-      opacity: 0 !important;
-      visibility: hidden !important;
-      transform: translateY(-10px);
-      transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
-      display: flex !important;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-    .lang-dropdown-menu.active {
-      opacity: 1 !important;
-      visibility: visible !important;
-      transform: translateY(0) !important;
-    }
-    .lang-dropdown-menu button {
-      padding: 0.6rem 0.9rem;
-      background: transparent;
-      border: none;
-      border-radius: 8px;
-      color: #b7c2d9;
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: #fff;
-    }
+    
+    
+    
+    
 
 
     #themeToggle,
-    #langToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
+    
 
     /* Make theme and language buttons smaller on mobile */
     @media (max-width:768px){
       #themeToggle,
-      #langToggle{
-        padding:.3rem !important;
-        font-size:0.8rem !important;
-        min-width:40px;
-        min-height:40px;
-        display:inline-flex !important;
-        align-items:center !important;
-        justify-content:center !important;
-      }
+      
 
       #themeToggle span,
-      #langToggle span{
         display:flex !important;
         align-items:center !important;
         justify-content:center !important;
       }
 
       /* Fix language dropdown menu on mobile */
-      .lang-dropdown-menu {
-        right: 10px;
-        min-width: 160px;
-        max-width: calc(100vw - 20px);
-      }
+      
 
       /* Ensure header doesn't exceed viewport width and allows natural height */
       header {
@@ -2397,13 +2292,7 @@
 
 
     /* CRITICAL FIX: Ensure language/theme buttons stay visible */
-    .lang-dropdown,
-    #themeToggle,
-    .menu-toggle{
-      position:relative;
-      z-index:100 !important;
-      flex-shrink:0 !important;
-    }
+    
 
     /* Ensure nav links (including FAQ) don't get covered by buttons */
     nav[aria-label="Main"] ul li {
@@ -2441,13 +2330,9 @@
       }
 
       /* Better mobile header button sizing */
-      .lang-dropdown,
-      #themeToggle {
-        flex-shrink: 0;
-      }
+      
 
       #themeToggle,
-      #langToggle {
         min-width: 44px; /* iOS minimum tap target */
         min-height: 44px;
       }
@@ -2797,11 +2682,7 @@
 
       /* Extra small screens - further reduce header button sizes for translated text */
       header .btn,
-      header #langToggle,
-      header #themeToggle {
-        font-size: .75rem !important;
-        padding: .35rem .5rem !important;
-      }
+      header 
 
       header .cta-header {
         max-width: 120px !important;
@@ -3290,11 +3171,6 @@
 
 
 
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Language selection" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text)">
-          <span>🇺🇸</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Theme selection" style="padding:.5rem .7rem;color:var(--text)">
         <span id="theme-icon">
@@ -5826,8 +5702,7 @@
 
 
 
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
+  
 
 
 
@@ -6022,7 +5897,6 @@
 
     /* ======================== Resources Dropdown ======================== */
 
-    // Use event delegation for Google Translate compatibility
     (function() {
       let dropdownOpen = false;
 
@@ -6080,12 +5954,10 @@
 
     // Language dropdown - create as direct child of body to escape stacking context
     (function() {
-      const langBtn = document.getElementById('langToggle');
       if (!langBtn) return;
 
       // Create language dropdown menu
       const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
 
       // Create language buttons
       const languages = [
@@ -6302,244 +6174,6 @@
 
     /* ======================== Google Translate (on demand) ======================== */
 
-    // Google Translate Initialization with robust error handling
-    window.googleTranslateElementInit = function() {
-      console.log('[GT] Init called');
-      if (!window.google || !google.translate || !google.translate.TranslateElement) {
-        console.warn('[GT] Google Translate API not ready');
-        return;
-      }
-
-      const container = document.getElementById('google_translate_container');
-      if (!container) {
-        console.error('[GT] Container not found');
-        return;
-      }
-
-      try {
-        new google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-          autoDisplay: false
-        }, 'google_translate_container');
-        console.log('[GT] Widget created successfully');
-        window.__gte_initialized = true;
-      } catch (error) {
-        console.error('[GT] Failed to create widget:', error);
-      }
-    };
-
-    // Load saved language on page load with robust polling
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function clearGoogTrans() {
-        // Clear all Google Translate cookies thoroughly and aggressively
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        const cookieNames = ['googtrans', 'googtrans(2)', 'googtrans(0)', 'googtrans(1)'];
-        const domains = ['', '; domain=' + root, '; domain=' + location.hostname, '; domain=.signalpilot.io'];
-        const paths = ['/', '/en', '/en/'];
-
-        // Nuclear option: clear every possible cookie variation
-        cookieNames.forEach(name => {
-          domains.forEach(domain => {
-            paths.forEach(path => {
-              // Try deleting with empty value
-              document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
-              // Try setting to /en/en and deleting
-              document.cookie = name + '=/en/en; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
-              // Try with max-age
-              document.cookie = name + '=; max-age=0; path=' + path + domain;
-            });
-          });
-        });
-
-        // Also clear localStorage and sessionStorage
-        if (window.localStorage) {
-          localStorage.removeItem('googtrans');
-          localStorage.removeItem('googtrans(2)');
-        }
-        if (window.sessionStorage) {
-          sessionStorage.removeItem('googtrans');
-          sessionStorage.removeItem('googtrans(2)');
-        }
-
-        // Remove any Google Translate elements from DOM
-        const gtElements = [
-          '.skiptranslate',
-          '.goog-te-banner-frame',
-          '#goog-gt-tt',
-          '.goog-te-balloon-frame',
-          'iframe[src*="translate.google.com"]',
-          'iframe.goog-te-menu-frame',
-          '.goog-te-menu2'
-        ];
-        gtElements.forEach(selector => {
-          document.querySelectorAll(selector).forEach(el => el.remove());
-        });
-
-        console.log('[GT] Cleared all Google Translate cookies and elements');
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading) {
-          console.log('[GT] Already loading');
-          return;
-        }
-        if (window.google && window.google.translate) {
-          console.log('[GT] Already loaded');
-          googleTranslateElementInit();
-          return;
-        }
-
-        console.log('[GT] Loading script...');
-        window.__gte_loading = true;
-
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        s.onerror = function() {
-          console.error('[GT] Script failed to load');
-          window.__gte_loading = false;
-          // Retry after 2 seconds
-          setTimeout(function() {
-            if (!window.google) {
-              console.log('[GT] Retrying...');
-              loadGTE();
-            }
-          }, 2000);
-        };
-        s.onload = function() {
-          console.log('[GT] Script loaded');
-          // Poll for initialization
-          let attempts = 0;
-          const checkInit = setInterval(function() {
-            attempts++;
-            if (window.__gte_initialized || attempts > 50) {
-              clearInterval(checkInit);
-              if (!window.__gte_initialized) {
-                console.warn('[GT] Init timeout after ' + attempts + ' attempts');
-              }
-            }
-          }, 100);
-        };
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-
-      // Check URL parameter for forced language
-      const urlParams = new URLSearchParams(window.location.search);
-      const urlLang = urlParams.get('lang');
-
-      let saved = localStorage.getItem(LANG_KEY) || 'en';
-
-      // If URL says lang=en, force English and clear localStorage
-      if (urlLang === 'en') {
-        saved = 'en';
-        localStorage.setItem(LANG_KEY, 'en');
-        console.log('[GT] URL forced English language');
-      }
-
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      console.log('[GT] Saved language:', code);
-
-      if (sel) sel.value = code;
-
-      // Only set translation cookies for non-English languages
-      if (code !== 'en') {
-        setGoogTrans(code);
-        applyDirLang(code);
-      } else {
-        // For English: cookie already set to /en/en by early script
-        // Just ensure HTML attributes are correct
-        applyDirLang('en');
-
-        // Remove Google Translate font wrappers that might be lingering in the DOM
-        setTimeout(() => {
-          document.querySelectorAll('font').forEach(font => {
-            const parent = font.parentNode;
-            while (font.firstChild) {
-              parent.insertBefore(font.firstChild, font);
-            }
-            parent.removeChild(font);
-          });
-        }, 100);
-
-        // Clean URL after processing
-        if (urlLang === 'en') {
-          setTimeout(() => {
-            const cleanUrl = window.location.pathname;
-            window.history.replaceState({}, '', cleanUrl);
-          }, 200);
-        }
-      }
-
-      // Update language button text to show current language
-      const langBtn = document.getElementById('langToggle');
-      if (langBtn) {
-        const langText = langBtn.querySelector('span');
-        if (langText) {
-          const flagMap = {
-            'en': '🇺🇸', 'de': '🇩🇪', 'fr': '🇫🇷', 'es': '🇪🇸',
-            'it': '🇮🇹', 'zh': '🇨🇳', 'ru': '🇷🇺', 'ar': '🇸🇦',
-            'pt': '🇵🇹', 'tr': '🇹🇷', 'ja': '🇯🇵', 'ko': '🇰🇷',
-            'vi': '🇻🇳', 'th': '🇹🇭', 'hi': '🇮🇳', 'id': '🇮🇩'
-          };
-          langText.textContent = flagMap[code] || '🌐';
-        }
-      }
-
-      // Load on DOMContentLoaded to ensure page is ready
-      if (code !== 'en') {
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(loadGTE, 500); // Small delay to let page settle
-          });
-        } else {
-          setTimeout(loadGTE, 500);
-        }
-      }
-
-      sel.addEventListener('change', e => {
-        const v = e.target.value;
-        localStorage.setItem(LANG_KEY, v);
-        setGoogTrans(v);
-        applyDirLang(v);
-        if (v !== 'en') loadGTE();
-        location.reload();
-      });
-    })();
 
 
 
@@ -7323,7 +6957,6 @@ if ('serviceWorker' in navigator) {
     });
 
     // 6. TRACK LANGUAGE SELECTOR
-    const langToggle = document.getElementById('langToggle');
     if (langToggle) {
       langToggle.addEventListener('click', function() {
         trackEvent('language_selector_open', {});

--- a/fr/roadmap.html
+++ b/fr/roadmap.html
@@ -154,44 +154,23 @@
       z-index: 1;
     }
 
-    /* Google Translate fixes */
-    body > .skiptranslate {
+    
+
       display: none !important;
     }
 
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-gadget {
       color: inherit !important;
     }
 
     /* Prevent Google Translate from blocking clicks */
     nav font,
     nav span:not(.dropdown-arrow),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    button font,
-    button span:not(#theme-icon):not(.dropdown-arrow) {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-    }
+    
 
     /* Ensure buttons always work */
     nav a,
     nav button,
-    #langToggle,
-    #themeToggle {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
+    
 
     /* Screen reader only utility */
     .sr-only {
@@ -249,14 +228,9 @@
       max-height: 64px !important;
     }
 
-    header .container > .lang-dropdown,
-    header .container > #themeToggle {
-      flex-shrink: 0;
-    }
+    header .container > 
 
-    header .container > .lang-dropdown + #themeToggle {
-      margin-left: -0.8rem;
-    }
+    header .container > 
 
     .brand {
       display: flex;
@@ -440,54 +414,15 @@
     }
 
     /* Language Dropdown */
-    .lang-dropdown {
-      position: relative;
-      flex-shrink: 0;
-    }
+    
 
-    .lang-dropdown-menu {
-      position: fixed;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.75rem;
-      min-width: 160px;
-      max-height: 400px;
-      overflow-y: auto;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 9999;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
+    
 
-    .lang-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
+    
 
-    .lang-dropdown-menu button {
-      display: block;
-      width: 100%;
-      padding: 0.6rem 0.8rem;
-      border: none;
-      background: transparent;
-      border-radius: 6px;
-      color: var(--muted);
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
+    
 
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
-    }
+    
 
     .btn {
       background: var(--bg-soft);
@@ -1055,11 +990,6 @@
         </ul>
       </nav>
 
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Sélection de langue" aria-expanded="false" aria-haspopup="true">
-          <span>🌐</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn" type="button" aria-label="Sélection de thème">
         <span id="theme-icon">🌙</span>
@@ -1067,28 +997,9 @@
     </div>
   </header>
 
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
+  
 
-  <!-- Hidden select for Google Translate compatibility -->
-  <select id="langSel" style="display:none;" aria-hidden="true">
-    <option value="en">English</option>
-    <option value="de">Deutsch</option>
-    <option value="fr">Français</option>
-    <option value="es">Español</option>
-    <option value="it">Italiano</option>
-    <option value="zh">中文</option>
-    <option value="ru">Русский</option>
-    <option value="ar">العربية</option>
-    <option value="pt">Português</option>
-    <option value="tr">Türkçe</option>
-    <option value="ja">日本語</option>
-    <option value="ko">한국어</option>
-    <option value="vi">Tiếng Việt</option>
-    <option value="th">ไทย</option>
-    <option value="hi">हिन्दी</option>
-    <option value="id">Bahasa Indonesia</option>
-  </select>
+  
 
   <!-- Hero -->
   <section class="hero">
@@ -1304,185 +1215,7 @@
       });
     })();
 
-    // Language Dropdown
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
 
-      // Create language dropdown menu
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      // Create language buttons
-      const languages = [
-        { code: 'en', name: 'English' },
-        { code: 'de', name: 'Deutsch' },
-        { code: 'fr', name: 'Français' },
-        { code: 'es', name: 'Español' },
-        { code: 'it', name: 'Italiano' },
-        { code: 'zh', name: '中文' },
-        { code: 'ru', name: 'Русский' },
-        { code: 'ar', name: 'العربية' },
-        { code: 'pt', name: 'Português' },
-        { code: 'tr', name: 'Türkçe' },
-        { code: 'ja', name: '日本語' },
-        { code: 'ko', name: '한국어' },
-        { code: 'vi', name: 'Tiếng Việt' },
-        { code: 'th', name: 'ไทย' },
-        { code: 'hi', name: 'हिन्दी' },
-        { code: 'id', name: 'Bahasa Indonesia' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.textContent = lang.name;
-        btn.onclick = () => selectLanguage(lang);
-        langMenu.appendChild(btn);
-      });
-
-      document.body.appendChild(langMenu);
-
-      let menuOpen = false;
-
-      langBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        menuOpen = !menuOpen;
-        langMenu.classList.toggle('show', menuOpen);
-        langBtn.setAttribute('aria-expanded', menuOpen);
-
-        if (menuOpen) {
-          const rect = langBtn.getBoundingClientRect();
-          langMenu.style.top = (rect.bottom + 8) + 'px';
-          langMenu.style.left = (rect.left - langMenu.offsetWidth + rect.width) + 'px';
-        }
-      });
-
-      document.addEventListener('click', function(e) {
-        if (menuOpen && !langBtn.contains(e.target) && !langMenu.contains(e.target)) {
-          menuOpen = false;
-          langMenu.classList.remove('show');
-          langBtn.setAttribute('aria-expanded', 'false');
-        }
-      });
-
-      function selectLanguage(lang) {
-        console.log('Language selected:', lang.code);
-
-        // Helper functions from page load script
-        function baseDomain(host) {
-          const p = host.split('.');
-          return p.length > 2 ? p.slice(-2).join('.') : host;
-        }
-
-        function setCookie(name, value, days, domain) {
-          let expires = '';
-          if (days) {
-            const d = new Date();
-            d.setTime(d.getTime() + days * 864e5);
-            expires = '; expires=' + d.toUTCString();
-          }
-          const dom = domain ? '; domain=' + domain : '';
-          document.cookie = name + '=' + value + expires + '; path=/' + dom;
-        }
-
-        function setGoogTrans(langCode) {
-          const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-          const val = '/en/' + target;
-          setCookie('googtrans', val, 365);
-          const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-          setCookie('googtrans', val, 365, root);
-        }
-
-        function applyDirLang(langCode) {
-          document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-          document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-        }
-
-        function loadGTE() {
-          if (window.__gte_loading || window.google) return;
-          window.__gte_loading = true;
-          const s = document.createElement('script');
-          s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-          s.async = true;
-          document.head.appendChild(s);
-        }
-
-        // Save to localStorage
-        localStorage.setItem('sp_lang', lang.code);
-
-        // Set cookies and attributes
-        setGoogTrans(lang.code);
-        applyDirLang(lang.code);
-
-        // Load translate script if not English
-        if (lang.code !== 'en') loadGTE();
-
-        // Reload page to apply translation
-        location.reload();
-      }
-    })();
-
-    // Google Translate Initialization
-    window.googleTranslateElementInit = function() {
-      if (!window.google || !google.translate) return;
-      new google.translate.TranslateElement({
-        pageLanguage: 'en',
-        includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-        autoDisplay: false
-      }, 'google_translate_container');
-    };
-
-    // Load saved language on page load
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading || window.google) return;
-        window.__gte_loading = true;
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-      const saved = localStorage.getItem(LANG_KEY) || 'en';
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      if (sel) sel.value = code;
-      setGoogTrans(code);
-      applyDirLang(code);
-      if (code !== 'en') loadGTE();
-    })();
 
     // Smooth scroll for nav links with offset
     document.querySelectorAll('.sticky-nav a').forEach(link => {


### PR DESCRIPTION
- Removed Google Translate integration from German (de/) site
  - Removed early GT script from <head>
  - Removed GT CSS fixes and compatibility styles
  - Removed language dropdown button from header
  - Removed hidden GT container and langSel element
  - Removed GT initialization JavaScript
  - Removed language dropdown menu JavaScript
  - Removed GT analytics tracking

- Removed Google Translate integration from French (fr/) site
  - Same comprehensive removal as German site

Files modified:
- de/index.html, de/faq.html, de/roadmap.html
- fr/index.html, fr/faq.html, fr/roadmap.html

The German and French sites now display natively in their respective languages without any Google Translate functionality.