### PR TITLE
Fix remaining French site issues - breakpoints and translations

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2050,7 +2050,7 @@
       }
     }
 
-    @media (max-width:1024px){
+    @media (max-width:1400px){
       .brand{
         font-size:1.25rem;
       }
@@ -5172,7 +5172,7 @@
 
         <h2 class="headline lg" style="text-align:center">Plans & Tarifs</h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
-          Trusted by <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
+          Utilisé par <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>
 
         <!-- What's Included - ALL Plans Identical -->
@@ -5595,7 +5595,7 @@
         <div>
           <h4 style="margin:0 0 .8rem 0;font-size:1.1rem;font-weight:700"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span></h4>
           <p style="color:var(--muted);font-size:.85rem;line-height:1.6;margin:0 0 1rem 0">
-            Built for <span class="typewriter-footer" style="color:var(--brand);font-weight:600"></span>
+            Conçu pour <span class="typewriter-footer" style="color:var(--brand);font-weight:600"></span>
           </p>
           <p style="color:var(--muted);font-size:.85rem;line-height:1.6;margin:0 0 1rem 0">
             82 leçons gratuites + 7 indicateurs TradingView premium.
@@ -7663,12 +7663,12 @@ if ('serviceWorker' in navigator) {
     if (!textElement) return;
 
     const words = [
-      'serious traders',
+      'traders sérieux',
       'day traders',
       'swing traders',
       'scalpers',
-      'position traders',
-      'all traders'
+      'traders de position',
+      'tous les traders'
     ];
 
     let wordIndex = 0;
@@ -7803,7 +7803,7 @@ if ('serviceWorker' in navigator) {
 <script>
   // Typewriter animation for pricing subheading
   (function() {
-    const words = ['traders worldwide', 'serious investors', 'professionals', 'traders like you'];
+    const words = ['traders dans le monde', 'investisseurs sérieux', 'professionnels', 'traders comme vous'];
     let wordIndex = 0;
     let charIndex = 0;
     let isDeleting = false;
@@ -7841,7 +7841,7 @@ if ('serviceWorker' in navigator) {
 
   // Typewriter animation for footer
   (function() {
-    const words = ['traders', 'investors', 'professionals', 'you'];
+    const words = ['traders', 'investisseurs', 'professionnels', 'vous'];
     let wordIndex = 0;
     let charIndex = 0;
     let isDeleting = false;


### PR DESCRIPTION
Final fixes for French site:
- Fixed .brand font-size breakpoint from 1024px to 1400px
- Translated all typewriter animations to French:
  - Hero: 'serious traders' → 'traders sérieux', etc.
  - Pricing: 'traders worldwide' → 'traders dans le monde', etc.
  - Footer: 'investors' → 'investisseurs', etc.
- Translated static text:
  - "Trusted by" → "Utilisé par"
  - "Built for" → "Conçu pour"

All hamburger menu breakpoints now correctly set to 1400px Aurora background transition properly configured
All navigation links include /fr/ prefix
All footer text fully translated to French