### PR TITLE
Fix Japanese site: Remove all French text and fix broken links

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -33,6 +33,8 @@
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/">
   <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/">
   <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/">
   <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/">
 
@@ -3035,18 +3037,18 @@
       },
       {
         "@type": "Question",
-        "name": "Can I use multiple indicators together?",
+        "name": "複数のインジケーターを一緒に使用できますか？",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "もちろんです！ エリート7種類 sont conçus pour fonctionner ensemble. 人気の組み合わせ： Pentarch + Volume Oracle pour le timing de cycle avec confirmation du smart money, ou OmniDeck + Janus Atlas pour une analyse complète de la structure du marché avec niveaux clés."
+          "text": "もちろんです！エリート7種類は連携して機能するように設計されています。人気の組み合わせ：Pentarch + Volume Oracleでサイクルタイミングとスマートマネー確認、またはOmniDeck + Janus Atlasで主要レベルと市場構造の完全な分析。"
         }
       },
       {
         "@type": "Question",
-        "name": "What markets are supported?",
+        "name": "どの市場に対応していますか？",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Any market on TradingView: Stocks, indices, forex, crypto, commodities, bonds. If it has OHLC + volume data, our indicators work. Tested on 100+ symbols across all asset classes."
+          "text": "TradingView上の任意の市場：株式、インデックス、外国為替、暗号通貨、商品、債券。OHLC + 出来高データがあれば、当社のインジケーターが機能します。すべての資産クラスにわたる100以上のシンボルでテスト済みです。"
         }
       }
     ]
@@ -3258,13 +3260,13 @@
             <ul class="nav-dropdown-menu">
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
               <li><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">トレーニングセンター</a></li>
-              <li><a href="/faq.html">FAQセンター</a></li>
+              <li><a href="/ja/faq.html">FAQセンター</a></li>
             </ul>
           </li>
 
           <li><a href="#pricing">料金プラン</a></li>
 
-          <li><a href="/affiliates.html">アフィリエイト</a></li>
+          <li><a href="/ja/affiliates.html">アフィリエイト</a></li>
 
         </ul>
 
@@ -3613,7 +3615,7 @@
               <input type="checkbox" id="trialConsent" required>
               <span>
                 私は <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> が教育目的のみであり、金融アドバイスではないことを理解しています。
-                <a href="/terms.html" style="color:var(--brand)">利用規約</a>
+                <a href="/ja/terms.html" style="color:var(--brand)">利用規約</a>
               </span>
             </label>
 
@@ -5630,25 +5632,25 @@
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">複数のインジケーターを一緒に使えますか？</strong>
-        <p id="faq-answer-9" class="note"><strong>もちろんです！</strong><br>エリート7種類 sont conçus pour fonctionner ensemble.<br>人気の組み合わせ： <strong>Pentarch + Volume Oracle</strong> pour le timing de cycle avec confirmation du smart money, ou <strong>OmniDeck + Janus Atlas</strong> pour une analyse complète de la structure du marché avec niveaux clés.</p>
+        <p id="faq-answer-9" class="note"><strong>もちろんです！</strong><br>エリート7種類は連携して機能するように設計されています。<br>人気の組み合わせ： <strong>Pentarch + Volume Oracle</strong> でサイクルタイミングとスマートマネー確認、または <strong>OmniDeck + Janus Atlas</strong> で主要レベルと市場構造の完全な分析。</p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-10">
         <strong id="faq-question-10">コーディングスキルは必要ですか？</strong>
-        <p id="faq-answer-10" class="note"><strong>コーディング不要。</strong><br>すべてのインジケーターはプラグアンドプレイ。<br>Nous incluons <strong>plus de 200 configurations prédéfinies</strong> (plan À Vie) pré-ajustées pour différentes stratégies.<br>Chargez simplement le préréglage, appliquez au graphique, terminé.<br>Les utilisateurs avancés peuvent personnaliser les paramètres, mais c'est facultatif.</p>
+        <p id="faq-answer-10" class="note"><strong>コーディング不要。</strong><br>すべてのインジケーターはプラグアンドプレイ。<br><strong>200以上の事前設定</strong>（ライフタイムプラン）が含まれており、さまざまな戦略に事前調整されています。<br>プリセットを読み込み、チャートに適用するだけです。<br>上級ユーザーは設定をカスタマイズできますが、これはオプションです。</p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-11">
         <strong id="faq-question-11">どのようなサポートチャネルがありますか？</strong>
-        <p id="faq-answer-11" class="note"><strong>月額 :</strong> Support par e-mail (réponse sous 48h).<br><strong>年間+：</strong> E-mail prioritaire (réponse sous 24h).<br><strong>ライフタイム：</strong> Communauté Discord privée + support prioritaire.<br>Tous les plans incluent l'accès à plus de 50 pages de documentation et de tutoriels vidéo.</p>
+        <p id="faq-answer-11" class="note"><strong>月額：</strong> メールサポート（48時間以内に返信）。<br><strong>年間+：</strong> 優先メールサポート（24時間以内に返信）。<br><strong>ライフタイム：</strong> プライベートDiscordコミュニティ + 優先サポート。<br>すべてのプランには、50ページ以上のドキュメントとビデオチュートリアルへのアクセスが含まれます。</p>
       </div>
 
     </div>
 
     <!-- View All FAQs Link -->
     <div style="text-align:center;margin-top:2.5rem">
-      <a href="/faq.html" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+      <a href="/ja/faq.html" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
         完全なFAQ（30以上の質問）を見る →
       </a>
       <p style="color:var(--muted-2);font-size:.85rem;margin-top:.8rem">セットアップガイド、戦略、技術詳細</p>
@@ -5731,8 +5733,8 @@
           <ul style="list-style:none;padding:0;margin:0">
             <li style="margin-bottom:.4rem"><a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">GitHub</a></li>
             <li style="margin-bottom:.4rem"><a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">support@signalpilot.io</a></li>
-            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">ロードマップ</a></li>
-            <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">アフィリエイトプログラム</a></li>
+            <li style="margin-bottom:.4rem"><a href="/ja/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">ロードマップ</a></li>
+            <li style="margin-bottom:.4rem"><a href="/ja/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">アフィリエイトプログラム</a></li>
           </ul>
         </div>
 
@@ -5940,9 +5942,9 @@
         <a href="#inside">アドベントカレンダー</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">トレーニングセンター</a>
-        <a href="/faq.html">FAQセンター</a>
+        <a href="/ja/faq.html">FAQセンター</a>
         <a href="#pricing">料金プラン</a>
-        <a href="/affiliates.html">アフィリエイト</a>
+        <a href="/ja/affiliates.html">アフィリエイト</a>
       `;
 
       // Assemble menu
@@ -7159,33 +7161,33 @@ if ('serviceWorker' in navigator) {
 <div id="cookie-consent-banner">
   <div class="cookie-consent-container">
     <div class="cookie-consent-text">
-      <h3>🍪 Cookies</h3>
+      <h3>🍪 クッキー</h3>
       <p>
-        Nous utilisons des cookies d'analyse (Clarity & GA4) pour améliorer votre expérience. <a href="/privacy.html">プライバシーポリシー</a>
+        当社は、お客様の体験を向上させるために分析クッキー（Clarity & GA4）を使用しています。<a href="/ja/privacy.html">プライバシーポリシー</a>
       </p>
     </div>
     <div class="cookie-consent-actions">
-      <button id="cookie-accept-all" class="cookie-consent-btn cookie-consent-btn-accept">Accepter</button>
-      <button id="cookie-decline-all" class="cookie-consent-btn cookie-consent-btn-decline">Refuser</button>
-      <button id="cookie-settings" class="cookie-consent-btn cookie-consent-btn-settings">Paramètres</button>
+      <button id="cookie-accept-all" class="cookie-consent-btn cookie-consent-btn-accept">同意する</button>
+      <button id="cookie-decline-all" class="cookie-consent-btn cookie-consent-btn-decline">拒否する</button>
+      <button id="cookie-settings" class="cookie-consent-btn cookie-consent-btn-settings">設定</button>
     </div>
   </div>
 </div>
 
-<!-- Préférences de Cookies Modal -->
+<!-- クッキー設定モーダル -->
 <div id="cookie-preferences-modal">
   <div class="cookie-preferences-content">
     <div class="cookie-preferences-header">
-      <h2>Préférences de Cookies</h2>
-      <button id="cookie-preferences-close" class="cookie-preferences-close" aria-label="Close">&times;</button>
+      <h2>クッキー設定</h2>
+      <button id="cookie-preferences-close" class="cookie-preferences-close" aria-label="閉じる">&times;</button>
     </div>
 
     <div class="cookie-preferences-body">
       <div class="cookie-category">
         <div class="cookie-category-header">
           <h3 class="cookie-category-title">
-            Essential Cookies
-            <span class="cookie-category-badge badge-required">Required</span>
+            必須クッキー
+            <span class="cookie-category-badge badge-required">必須</span>
           </h3>
           <label class="cookie-toggle">
             <input type="checkbox" checked disabled>
@@ -7193,27 +7195,27 @@ if ('serviceWorker' in navigator) {
           </label>
         </div>
         <p class="cookie-category-description">
-          These cookies are necessary for the website to function and cannot be disabled. They include session management, payment processing, and security features.
+          これらのクッキーは、ウェブサイトの機能に必要であり、無効にすることはできません。セッション管理、支払い処理、セキュリティ機能が含まれます。
         </p>
       </div>
 
       <div class="cookie-category">
         <div class="cookie-category-header">
-          <h3 class="cookie-category-title">Analytics Cookies</h3>
+          <h3 class="cookie-category-title">分析クッキー</h3>
           <label class="cookie-toggle">
             <input type="checkbox" id="analytics-toggle">
             <span class="cookie-toggle-slider"></span>
           </label>
         </div>
         <p class="cookie-category-description">
-          We use Microsoft Clarity and Google Analytics to understand how visitors interact with our site. This helps us improve your experience. These cookies collect anonymized data including page views, time spent, and navigation patterns.
+          当社は、訪問者がサイトとどのようにやり取りするかを理解するために、Microsoft ClarityとGoogle Analyticsを使用しています。これにより、お客様の体験を向上させることができます。これらのクッキーは、ページビュー、滞在時間、ナビゲーションパターンなどの匿名化されたデータを収集します。
         </p>
       </div>
     </div>
 
     <div class="cookie-preferences-footer">
-      <button id="cookie-cancel-preferences" class="cookie-consent-btn cookie-consent-btn-decline">Cancel</button>
-      <button id="cookie-save-preferences" class="cookie-consent-btn cookie-consent-btn-accept">Enregistrer les Préférences</button>
+      <button id="cookie-cancel-preferences" class="cookie-consent-btn cookie-consent-btn-decline">キャンセル</button>
+      <button id="cookie-save-preferences" class="cookie-consent-btn cookie-consent-btn-accept">設定を保存</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Issues fixed:
- ✅ Removed ALL French text (cookie consent, FAQ answers, structured data)
- ✅ Fixed broken internal navigation links (added /ja/ prefix to all internal links)
- ✅ Added missing hreflang tags (de, fr) to match other language pages
- ✅ Translated cookie consent banner and modal to Japanese
- ✅ Translated FAQ structured data to Japanese
- ✅ Fixed navigation menu links: /faq.html → /ja/faq.html
- ✅ Fixed footer links: /roadmap.html → /ja/roadmap.html, /affiliates.html → /ja/affiliates.html
- ✅ Fixed mobile menu links to use /ja/ paths
- ✅ Fixed privacy link in cookie consent: /privacy.html → /ja/privacy.html

All visible text now 100% Japanese.
All links now point to correct /ja/ paths.