### PR TITLE
Translate all pricing cards and fix lifetime overflow

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -5235,14 +5235,14 @@
 
             <div class="pill" id="plan-monthly-title" style="background:rgba(118,221,255,0.15);color:#76ddff;font-weight:700">Mensuel</div>
 
-            <div class="price">$99 <span class="pill">/month</span></div>
+            <div class="price">$99 <span class="pill">/mois</span></div>
 
             <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(91,138,255,.06);border:1px solid rgba(91,138,255,.2);border-radius:8px">
               <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">
                 Payez mensuellement, annulez à tout moment
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
-                Most flexible option. No commitment required.
+                Option la plus flexible. Aucun engagement requis.
               </p>
             </div>
 
@@ -5265,8 +5265,8 @@
               </div>
 
               <!-- Step 2: Consent -->
-              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-monthly"><span>I understand <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is educational. No financial advice.</span></label>
-              <div id="error-consent-monthly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
+              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-monthly"><span>Je comprends que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> est éducatif. Aucun conseil financier.</span></label>
+              <div id="error-consent-monthly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consentement requis</div>
 
               <!-- PayPal Branding -->
               <div style="text-align:center;margin-bottom:1rem">
@@ -5276,7 +5276,7 @@
 
               <!-- Step 3: Subscribe -->
               <button type="button" id="btn-monthly-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
-                💳 Subscribe with PayPal<br><span style="font-size:.85rem">$99/month</span>
+                💳 S'abonner avec PayPal<br><span style="font-size:.85rem">$99/mois</span>
               </button>
 
               <div style="text-align:center;margin-top:1rem">
@@ -5301,15 +5301,15 @@
             <div class="pill" id="plan-yearly-title" style="background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff;font-size:.95rem;padding:.7rem 1.2rem">MEILLEURE VALEUR</div>
 
             <div class="price">
-              $699 <span class="pill">/year</span>
+              $699 <span class="pill">/an</span>
             </div>
 
             <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(62,213,152,.08);border:1px solid rgba(62,213,152,.25);border-radius:8px">
               <p style="font-size:1.1rem;margin:0 0 .5rem 0;font-weight:700">
-                <span style="background:linear-gradient(135deg,#3ed598,#2ec98a);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Save <span data-count="489" data-prefix="$">489</span>/year</span>
+                <span style="background:linear-gradient(135deg,#3ed598,#2ec98a);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Économisez <span data-count="489" data-prefix="$">489</span>/an</span>
               </p>
               <p style="font-size:.9rem;color:var(--text);margin:0 0 .25rem 0">
-                Just $58/month equivalent
+                Seulement $58/mois équivalent
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
                 Facturé 699$ annuellement. Meilleure valeur pour les traders engagés.
@@ -5335,8 +5335,8 @@
               </div>
 
               <!-- Step 2: Consent -->
-              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-yearly"><span>I understand <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is educational. No financial advice.</span></label>
-              <div id="error-consent-yearly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
+              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-yearly"><span>Je comprends que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> est éducatif. Aucun conseil financier.</span></label>
+              <div id="error-consent-yearly" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consentement requis</div>
 
               <!-- PayPal Branding -->
               <div style="text-align:center;margin-bottom:1rem">
@@ -5346,7 +5346,7 @@
 
               <!-- Step 3: Subscribe -->
               <button type="button" id="btn-yearly-paypal" class="btn btn-primary" style="width:100%;padding:1rem;font-size:.95rem;font-weight:700">
-                💳 Subscribe with PayPal<br><span style="font-size:.85rem">$699/year</span>
+                💳 S'abonner avec PayPal<br><span style="font-size:.85rem">$699/an</span>
               </button>
 
               <div style="text-align:center;margin-top:1rem">
@@ -5369,14 +5369,14 @@
 
             <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">Accès À Vie</div>
 
-            <div class="price" style="white-space:nowrap"><span id="lifetime-display-price">$1,799</span> <span class="pill">paiement unique</span></div>
+            <div class="price" style="white-space:nowrap"><span id="lifetime-display-price">$1,799</span> <span class="pill" style="font-size:.7rem;padding:.3rem .6rem">paiement unique</span></div>
 
             <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(249,162,60,.08);border:1px solid rgba(249,162,60,.25);border-radius:8px">
               <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">
-                Pay once. Yours forever.
+                Payez une fois. À vous pour toujours.
               </p>
               <p style="font-size:.9rem;color:var(--muted);margin:0 0 .25rem 0">
-                $1,799 today = $0/month after
+                $1,799 aujourd'hui = $0/mois après
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
                 Sécurisez l'accès à vie maintenant.
@@ -5404,8 +5404,8 @@
               </div>
 
               <!-- Step 2: Consent -->
-              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-lifetime"><span>I understand <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> is educational. No financial advice.</span></label>
-              <div id="error-consent-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consent required</div>
+              <label class="consent" style="margin-bottom:1rem"><input class="tick" type="checkbox" id="consent-lifetime"><span>Je comprends que <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> est éducatif. Aucun conseil financier.</span></label>
+              <div id="error-consent-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-bottom:1rem;font-weight:500">⚠️ Consentement requis</div>
 
               <!-- PayPal Branding -->
               <div style="text-align:center;margin-bottom:1rem">


### PR DESCRIPTION
Pricing card translations:
- Monthly: "/month" → "/mois", "Subscribe with PayPal" → "S'abonner avec PayPal"
- Yearly: "/year" → "/an", "Save" → "Économisez", "Just $58/month equivalent" → "Seulement $58/mois équivalent"
- Lifetime: "Pay once. Yours forever" → "Payez une fois. À vous pour toujours"
- All consent checkboxes: "I understand Signal Pilot is educational" → "Je comprends que Signal Pilot est éducatif"
- All error messages: "Consent required" → "Consentement requis"
- "Most flexible option. No commitment required" → "Option la plus flexible. Aucun engagement requis"

Fixed lifetime card overflow:
- Reduced "paiement unique" pill font size from default to .7rem
- Reduced padding to .3rem .6rem to prevent text overflow
- "paiement unique" is longer than English "one-time", needed size adjustment