### PR TITLE
Fix lifetime card overflow with stacked layout

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -5369,7 +5369,7 @@
 
             <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">Accès À Vie</div>
 
-            <div class="price" style="white-space:nowrap"><span id="lifetime-display-price">$1,799</span> <span class="pill" style="font-size:.7rem;padding:.3rem .6rem">paiement unique</span></div>
+            <div class="price" style="white-space:normal;display:flex;flex-direction:column;align-items:center;gap:.5rem"><span id="lifetime-display-price">$1,799</span> <span class="pill" style="font-size:.75rem;padding:.35rem .7rem">paiement unique</span></div>
 
             <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(249,162,60,.08);border:1px solid rgba(249,162,60,.25);border-radius:8px">
               <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">


### PR DESCRIPTION
Changed lifetime price display from horizontal to vertical:
- Changed from white-space:nowrap to white-space:normal
- Added display:flex with flex-direction:column
- Stacked price and "paiement unique" vertically with gap
- Increased pill font-size slightly to .75rem for better readability
- Price now displays cleanly without horizontal overflow