### PR TITLE
CRITICAL FIX: Change hamburger breakpoint to 1024px for desktop nav

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -771,7 +771,7 @@
     
 
     /* Force mobile menu text to be white and ALWAYS visible */
-    @media (max-width:1400px){
+    @media (max-width:1024px){
       /* Dark mode mobile menu (default) */
       nav[aria-label="Main"],
       nav[aria-label="Main"] *,
@@ -2050,7 +2050,7 @@
       }
     }
 
-    @media (max-width:1400px){
+    @media (max-width:1024px){
       .brand{
         font-size:1.25rem;
       }
@@ -2283,7 +2283,7 @@
     }
 
     /* Even more compact before hamburger menu appears */
-    @media (max-width:1400px){
+    @media (max-width:1024px){
       nav a{padding:.5rem .6rem;font-size:.86rem}
       .nav-dropdown-toggle{padding:.5rem .6rem;font-size:.86rem}
       nav ul{gap:.35rem}
@@ -2311,18 +2311,17 @@
     }
 
     /* Hide mobile nav on desktop - it should only appear on mobile */
-    @media (min-width: 1401px) {
+    @media (min-width: 1025px) {
       .mobile-nav,
       .mobile-nav-backdrop {
         display: none !important;
       }
     }
 
-    /* Mobile hamburger menu appears at ≤1400px (increased from 1300px) */
-    /* Nav items go into hamburger menu to prevent overlap with language/theme buttons */
-    /* Activates earlier to accommodate longer text in translated languages */
+    /* Mobile hamburger menu appears at ≤1024px */
+    /* Nav items go into hamburger menu only on tablets and mobile */
 
-    @media (max-width:1400px){
+    @media (max-width:1024px){
       /* Ensure header buttons have adequate space */
       .nav{
         padding:.7rem 0;


### PR DESCRIPTION
Changed ALL breakpoints from 1400px to 1024px:
- Line 774: Mobile menu text visibility
- Line 2053: Brand font-size
- Line 2286: Compact navigation
- Line 2314: Hide mobile nav on desktop (min-width: 1025px)
- Line 2324: Hamburger menu appearance

Desktop users (1366px+ screens) now see FULL NAVIGATION Hamburger menu only appears on tablets (≤1024px) and mobile Matches standard responsive design practices