### PR TITLE
Disable flickering animations (aurora and pricing glow)

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -1148,17 +1148,18 @@
 
       mix-blend-mode:screen;
 
-      animation:aurora 36s linear infinite alternate;
+      /* DISABLED: animation causing flickering */
+      /* animation:aurora 36s linear infinite alternate; */
 
       opacity:.85;
 
       /* Performance optimization */
-      will-change:transform;
+      will-change:auto;
       transform:translateZ(0);
       backface-visibility:hidden;
 
       /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
+      transition:opacity 0.3s ease, filter 0.3s ease;
 
     }
 
@@ -5291,7 +5292,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SAVE <span data-count="489" data-prefix="$">489</span>


### PR DESCRIPTION
- Disabled aurora background animation - static gradient instead
- Disabled pricingGlow animation on yearly card - static shadow
- Changed will-change:transform to will-change:auto
- Removed background transition to prevent flickering
- All animations causing visual flickering now disabled