### PR TITLE
Fix French site headers and remove mobile menu

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -771,7 +771,7 @@
     
 
     /* Force mobile menu text to be white and ALWAYS visible */
-    @media (max-width:1024px){
+    @media (max-width:1400px){
       /* Dark mode mobile menu (default) */
       nav[aria-label="Main"],
       nav[aria-label="Main"] *,
@@ -2312,17 +2312,18 @@
     }
 
     /* Hide mobile nav on desktop - it should only appear on mobile */
-    @media (min-width: 1025px) {
+    @media (min-width: 1401px) {
       .mobile-nav,
       .mobile-nav-backdrop {
         display: none !important;
       }
     }
 
-    /* Mobile hamburger menu appears at ≤1024px */
-    /* Nav items go into hamburger menu only on tablets and mobile */
+    /* Mobile hamburger menu appears at ≤1400px (increased from 1024px) */
+    /* Nav items go into hamburger menu to prevent overlap with theme buttons */
+    /* Activates earlier to accommodate longer text in translated languages */
 
-    @media (max-width:1024px){
+    @media (max-width:1400px){
       /* Ensure header buttons have adequate space */
       .nav{
         padding:.7rem 0;
@@ -2330,9 +2331,11 @@
       }
 
       /* Better mobile header button sizing */
-      
+      #themeToggle {
+        flex-shrink: 0;
+      }
 
-      #themeToggle,
+      #themeToggle {
         min-width: 44px; /* iOS minimum tap target */
         min-height: 44px;
       }
@@ -3204,9 +3207,9 @@
 
     <section id="main-content" class="hero" style="position:relative;overflow:hidden">
 
-      <!-- Animated gradient orbs with parallax -->
-      <div id="parallax-orb-1" style="position:absolute;top:10%;left:10%;width:500px;height:500px;background:radial-gradient(circle,rgba(91,138,255,0.15) 0%,transparent 70%);pointer-events:none;filter:blur(60px);animation:floatOrb1 20s ease-in-out infinite;will-change:transform"></div>
-      <div id="parallax-orb-2" style="position:absolute;bottom:20%;right:15%;width:400px;height:400px;background:radial-gradient(circle,rgba(118,221,255,0.12) 0%,transparent 70%);pointer-events:none;filter:blur(50px);animation:floatOrb2 15s ease-in-out infinite;will-change:transform"></div>
+      <!-- Animated gradient orbs with parallax (animations disabled) -->
+      <div id="parallax-orb-1" style="position:absolute;top:10%;left:10%;width:500px;height:500px;background:radial-gradient(circle,rgba(91,138,255,0.15) 0%,transparent 70%);pointer-events:none;filter:blur(60px)"></div>
+      <div id="parallax-orb-2" style="position:absolute;bottom:20%;right:15%;width:400px;height:400px;background:radial-gradient(circle,rgba(118,221,255,0.12) 0%,transparent 70%);pointer-events:none;filter:blur(50px)"></div>
 
       <div class="container" style="position:relative;z-index:1">
 


### PR DESCRIPTION
…roperly

- Disable floatOrb1 and floatOrb2 animations in hero section to eliminate flickering
- Change hamburger menu breakpoint from 1024px to 1400px to match English site
- Desktop navigation now properly shows on screens > 1400px
- Hamburger menu only appears on tablets and mobile (≤ 1400px)
- Fix incomplete CSS selector for themeToggle flex-shrink