### PR TITLE
Complete comprehensive fixes for Japanese site

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -3588,7 +3588,7 @@
                 type="email"
                 id="trialEmail"
                 name="email"
-                placeholder="your@email.com"
+                placeholder="メールアドレス"
                 required
                 style="width:100%;padding:1rem;border-radius:8px;border:1px solid var(--border);background:var(--bg-soft);color:var(--text);font-size:1rem;font-family:inherit"
               >
@@ -5469,19 +5469,19 @@
               限定 • <span data-count="150">150</span> 残り枠
             </div>
 
-            <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">ライフタイムアクセス</div>
+            <div class="pill" id="plan-lifetime-title" style="background:rgba(249,162,60,0.15);color:var(--warn);font-weight:700">ライフタイム</div>
 
-            <div class="price" style="white-space:nowrap"><span id="lifetime-display-price">$1,799</span> <span class="pill">一度きりの支払い</span></div>
+            <div class="price" style="white-space:nowrap"><span id="lifetime-display-price">$1,799</span> <span class="pill">買い切り</span></div>
 
             <div style="text-align:center;margin:1.5rem 0;padding:1.25rem;background:rgba(249,162,60,.08);border:1px solid rgba(249,162,60,.25);border-radius:8px">
               <p style="font-size:1rem;color:var(--text);margin:0 0 .5rem 0;font-weight:600">
-                一度の支払いで、永久にあなたのもの。
+                1回の支払いで永久に
               </p>
               <p style="font-size:.9rem;color:var(--muted);margin:0 0 .25rem 0">
-                今日$1,799 = その後$0/月
+                今日$1,799 = 以降$0/月
               </p>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">
-                今すぐライフタイムアクセスを確保しましょう。
+                今すぐ確保
               </p>
             </div>
 
@@ -5524,7 +5524,7 @@
                 <a href="https://signalpilotlabs.lemonsqueezy.com/buy/81822d54-6e08-4c26-b2f0-d5d5e3cdd25e" class="btn btn-secondary" style="width:100%;display:block" target="_blank" rel="noopener">💳 カードで支払う</a>
               </div>
 
-              <div id="error-soldout-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:1rem;font-weight:500;text-align:center">⚠️ Lifetime is sold out. Waitlist is available below.</div>
+              <div id="error-soldout-lifetime" style="display:none;color:#ff6b6b;font-size:.85rem;margin-top:1rem;font-weight:500;text-align:center">⚠️ ライフタイムプランは完売しました。以下のウェイトリストをご利用ください。</div>
 
               <button class="btn btn-disabled" id="lt-soldout" type="button" style="display:none">売り切れ — 下記のウェイトリストに参加</button>
 
@@ -5700,10 +5700,10 @@
             対象： <span class="typewriter-footer" style="color:var(--brand);font-weight:600"></span>
           </p>
           <p style="color:var(--muted);font-size:.85rem;line-height:1.6;margin:0 0 1rem 0">
-            82の無料レッスン + 7 premium TradingView indicators.
+            82の無料レッスン + 7つのプレミアムTradingViewインジケーター
           </p>
           <div style="display:flex;gap:.8rem;margin-top:1rem">
-            <a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.9rem;transition:color .2s" title="Email">Email</a>
+            <a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.9rem;transition:color .2s" title="メール">メール</a>
           </div>
         </div>
 
@@ -5774,7 +5774,7 @@
 
     <div class="modal-card">
 
-      <header><h3 id="cardNotifyTitle">Card checkout notification</h3><button class="modal-close" data-close aria-label="Close">✕</button></header>
+      <header><h3 id="cardNotifyTitle">カード決済通知</h3><button class="modal-close" data-close aria-label="閉じる">✕</button></header>
 
       <form id="card-notify-form" action="https://formspree.io/f/mldpnrop" method="POST">
 
@@ -5791,10 +5791,10 @@
           </div>
         </div>
 
-        <label for="cn-tv">TradingView username</label>
+        <label for="cn-tv">TradingViewユーザー名</label>
         <input id="cn-tv" name="tradingview" placeholder="@your.tradingview" required>
 
-        <button class="btn btn-primary" type="submit">Notification signup</button><a class="btn btn-ghost" href="#waitlist" style="margin-left:.4rem">Waitlist</a>
+        <button class="btn btn-primary" type="submit">通知に登録</button><a class="btn btn-ghost" href="#waitlist" style="margin-left:.4rem">ウェイトリスト</a>
 
       </form>
 
@@ -6316,7 +6316,7 @@
 
         if (!paypalWindow) {
           console.error('❌ Popup blocked! Please allow popups for this site.');
-          alert('Popup was blocked. Please allow popups and try again.');
+          alert('ポップアップがブロックされました。ポップアップを許可してもう一度お試しください。');
           return;
         }
 
@@ -7022,7 +7022,7 @@ if ('serviceWorker' in navigator) {
     }
 
     if (elements.buyButton && currentTier.price) {
-      elements.buyButton.value = `Buy Now - $${currentTier.price.toLocaleString()}`;
+      elements.buyButton.value = `今すぐ購入 - $${currentTier.price.toLocaleString()}`;
     }
 
     if (nextTier && nextTier.price) {
@@ -7308,7 +7308,7 @@ if ('serviceWorker' in navigator) {
         }
       } catch (error) {
         console.error('Trial signup error:', error);
-        alert('Something went wrong. Please try again or email support@signalpilot.io');
+        alert('問題が発生しました。もう一度お試しいただくか、support@signalpilot.ioまでメールでお問い合わせください。');
         submitBtn.disabled = false;
         submitBtn.textContent = originalText;
       }
@@ -7364,7 +7364,7 @@ if ('serviceWorker' in navigator) {
 
       } catch (error) {
         console.error('Newsletter signup error:', error);
-        alert('Something went wrong. Please try again or email support@signalpilot.io');
+        alert('問題が発生しました。もう一度お試しいただくか、support@signalpilot.ioまでメールでお問い合わせください。');
         footerNewsletterBtn.disabled = false;
         footerNewsletterBtn.textContent = originalText;
       }
@@ -7981,7 +7981,7 @@ if ('serviceWorker' in navigator) {
 </script>
 
 <!-- Back to Top Button -->
-<button id="backToTop" aria-label="Back to top" title="Back to top">↑</button>
+<button id="backToTop" aria-label="トップに戻る" title="トップに戻る">↑</button>
 
 <script>
   // Back to top button functionality


### PR DESCRIPTION
Translation fixes:
- Fix 'Buy Now' button to Japanese (今すぐ購入)
- Fix email placeholder to Japanese (メールアドレス)
- Fix 'Notification signup' and 'Waitlist' buttons
- Fix 'Lifetime sold out' message
- Fix popup blocked alert message
- Fix all error messages
- Fix 'TradingView username' label
- Fix 'Card checkout notification' modal header
- Fix 'Email' link text in footer
- Fix 'Back to top' button aria-label
- Fix 'premium' text in footer

Layout fixes:
- Shorten lifetime pricing card text to prevent overflow
  - "ライフタイムアクセス" → "ライフタイム"
  - "一度きりの支払い" → "買い切り"
  - "一度の支払いで、永久にあなたのもの" → "1回の支払いで永久に"
  - "今すぐライフタイムアクセスを確保しましょう" → "今すぐ確保"