### PR TITLE
Fix theme toggle flickering on French site

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -419,8 +419,8 @@
 
       color-scheme: dark;
 
-      /* Smooth theme transitions */
-      transition:background-color 0.3s ease, color 0.3s ease;
+      /* REMOVED: Smooth theme transitions - causes flickering */
+      /* transition:background-color 0.3s ease, color 0.3s ease; */
 
       /* Base surface */
 
@@ -876,17 +876,17 @@
     body{
       overflow-x:hidden;
       position:relative;
-      /* Smooth theme transitions */
-      transition:background-color 0.5s cubic-bezier(0.4, 0, 0.2, 1), color 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+      /* REMOVED: Smooth theme transitions - causes flickering */
+      /* transition:background-color 0.5s cubic-bezier(0.4, 0, 0.2, 1), color 0.5s cubic-bezier(0.4, 0, 0.2, 1); */
     }
 
-    /* Smooth transitions for all theme-dependent elements */
-    header,
+    /* REMOVED: Smooth transitions for all theme-dependent elements - causes flickering */
+    /* header,
     .card,
     .btn,
     nav a{
       transition:all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-    }
+    } */
 
     /* Scroll progress indicator */
     .scroll-progress{
@@ -1158,8 +1158,8 @@
       transform:translateZ(0);
       backface-visibility:hidden;
 
-      /* Smooth theme transitions */
-      transition:opacity 0.3s ease, filter 0.3s ease;
+      /* REMOVED: Smooth theme transitions - causes flickering */
+      /* transition:opacity 0.3s ease, filter 0.3s ease; */
 
     }
 


### PR DESCRIPTION
Remove CSS transitions that were causing visible flickering when toggling between light and dark themes. Affected elements:

1. :root element - removed background-color and color transitions
2. body element - removed background-color and color transitions
3. Theme-dependent elements (header, .card, .btn, nav a) - removed "all" transition
4. .bg-aurora background - removed opacity and filter transitions

Theme switching is now instant with no visual flickering or glitching. All hover effects and other UI transitions remain unaffected.