### PR TITLE
Fix interactive comparison slider alignment on mobile to match PT site

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -1036,7 +1036,7 @@
 
       /* Fix comparison slider on mobile */
       #comparison-slider {
-        max-width: 100% !important;
+        max-width: calc(100vw - 2rem) !important;
         margin-left: auto !important;
         margin-right: auto !important;
       }
@@ -1627,13 +1627,26 @@
       }
 
       #comparison-slider {
-        max-width: 100% !important;
+        max-width: calc(100vw - 2rem) !important;
         margin-left: auto !important;
         margin-right: auto !important;
       }
 
       .comparison-image {
         overflow: hidden !important;
+      }
+
+      /* SAFETY NET: Prevent any div with large max-width from overflowing - EXCEPT comparison slider */
+      div[style*="max-width"]:not(#comparison-slider):not(#slider-overlay) {
+        max-width: 100% !important;
+        box-sizing: border-box !important;
+      }
+
+      /* Ensure all images respect container width - EXCEPT comparison slider images */
+      img:not(#overlay-image):not([alt*="Signal Pilot"]) {
+        max-width: 100% !important;
+        height: auto !important;
+        box-sizing: border-box !important;
       }
     }
 


### PR DESCRIPTION
- Change comparison slider max-width from 100% to calc(100vw - 2rem) on mobile
- Add SAFETY NET rules to prevent overflow while exempting comparison slider elements
- Ensure images respect container width except overlay images
- Fixes applied to both mobile breakpoints (@media max-width:768px)

This matches the Portuguese site's working implementation and ensures the before/after comparison images are perfectly aligned on mobile devices.