### PR TITLE
Fix mobile comparison slider alignment for Japanese site

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -1319,6 +1319,13 @@
       /* Better spacing for gradient orbs on mobile */
       #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+
+      /* FIX: Comparison slider - constrain width on mobile to perfectly align images */
+      #comparison-slider {
+        max-width: calc(100vw - 2rem) !important;
+        margin-left: auto !important;
+        margin-right: auto !important;
+      }
     }
 
     @media (max-width:480px){


### PR DESCRIPTION
Add the same mobile fix used in Portuguese site to ensure the interactive comparison slider (before/after images) is perfectly aligned on mobile devices.

The fix:
- Constrains slider width to calc(100vw - 2rem) on mobile
- Centers the slider with auto margins
- Ensures both images stack perfectly on top of each other
- Matches the Portuguese site implementation exactly

This resolves the mobile alignment issue where the images weren't properly stacked on smaller screens.