### PR TITLE
Optimize French site for all devices by adding device-optimizations.css

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -1555,8 +1555,9 @@
         max-width: 100% !important;
       }
 
+      /* FIX: Comparison slider - constrain width on mobile only */
       #comparison-slider {
-        max-width: 100% !important;
+        max-width: calc(100vw - 2rem) !important;
         margin-left: auto !important;
         margin-right: auto !important;
       }
@@ -2449,6 +2450,37 @@
 
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
+
+      /* Light mode mobile menu styling */
+      html[data-theme="light"] .mobile-nav {
+        background: #f8fafc;
+        box-shadow: -8px 0 32px rgba(0, 0, 0, 0.15);
+      }
+
+      html[data-theme="light"] .mobile-nav-header {
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+      }
+
+      html[data-theme="light"] .mobile-nav-close {
+        background: rgba(0, 0, 0, 0.05);
+        color: #0f172a;
+      }
+
+      html[data-theme="light"] .mobile-nav-close:hover,
+      html[data-theme="light"] .mobile-nav-close:active {
+        background: rgba(0, 0, 0, 0.1);
+      }
+
+      html[data-theme="light"] .mobile-nav-links a {
+        color: #475569;
+        border-left-color: transparent;
+      }
+
+      html[data-theme="light"] .mobile-nav-links a:active {
+        background: rgba(91, 138, 255, 0.1);
+        border-left-color: #5b8aff;
+        color: #0f172a;
+      }
 
     }
 


### PR DESCRIPTION
Two critical mobile fixes to match Portuguese site perfection:

1. **Comparison Slider Mobile Alignment**
   - Changed from `max-width: 100%` to `max-width: calc(100vw - 2rem)`
   - This ensures perfect alignment with proper padding on all mobile devices
   - Images now stack perfectly on top of each other without overflow
   - Matches Portuguese site implementation exactly

2. **Mobile Hamburger Menu Light Mode Styling**
   - Added comprehensive light mode styling for mobile navigation panel
   - Light background (#f8fafc) instead of dark (#0a0c14)
   - Proper contrast for text and close button in light mode
   - Softer shadows and borders for light theme
   - Menu is now fully visible and properly styled in both dark and light modes

Both fixes ensure the French site mobile experience matches the Portuguese site's perfect implementation.