### PR TITLE
Fix interactive video slider alignment on mobile devices

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -2647,6 +2647,13 @@
       .carousel-item > div[style*="position:absolute"]{
         padding:1.2rem 1rem 1rem !important;
       }
+
+      /* FIX: Comparison slider - constrain width on mobile only */
+      #comparison-slider {
+        max-width: calc(100vw - 2rem) !important;
+        margin-left: auto !important;
+        margin-right: auto !important;
+      }
     }
 
     @media (max-width:480px){


### PR DESCRIPTION
- Add mobile-specific constraint: max-width: calc(100vw - 2rem) for #comparison-slider on screens ≤768px
- Ensures the Before/After comparison slider fits perfectly within viewport with proper margins
- Images now perfectly aligned on top of each other on mobile
- Matches Portuguese site's perfect mobile implementation
- Prevents horizontal overflow and improves touch interaction