### PR TITLE
Fix interactive comparison slider perfect alignment on mobile

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2600,11 +2600,27 @@
 
     /* Mobile optimizations */
     @media (max-width:768px){
+      /* CRITICAL: Force all sections to respect viewport width */
+      .section {
+        max-width: 100vw !important;
+        overflow-x: hidden !important;
+        box-sizing: border-box !important;
+        padding:clamp(2rem,6vw,3rem) 0;
+      }
+
+      /* CRITICAL: Force containers to respect viewport */
+      .container, .stack {
+        max-width: 100vw !important;
+        overflow-x: hidden !important;
+        box-sizing: border-box !important;
+        padding-left: 1rem !important;
+        padding-right: 1rem !important;
+      }
+
       .hero-ctas{flex-direction:column;width:100%;gap:.7rem}
       .hero-ctas .btn{width:100%;justify-content:center;padding:.65rem 1rem !important;font-size:.85rem !important}
       .headline.xl{font-size:clamp(2.5rem,10vw,3.5rem);line-height:1.15;font-weight:900 !important;letter-spacing:-0.02em}
       .proof-bar{justify-content:center}
-      .section{padding:clamp(2rem,6vw,3rem) 0}
 
       /* Make hero description smaller on mobile */
       .hero > div > div > p[style*="font-size:1.15rem"],


### PR DESCRIPTION
Added critical viewport constraints missing from French site that Portuguese site has for perfect mobile alignment:

**Root Cause**: The comparison slider and its container sections were not properly constrained to viewport width on mobile, causing misalignment.

**Fixes Applied** (matching Portuguese site exactly):

1. **Section Viewport Constraints** (lines 2603-2609)
   - Force max-width: 100vw to respect viewport
   - Add overflow-x: hidden to prevent horizontal scroll
   - Ensure box-sizing: border-box for proper sizing
   - Maintain responsive padding with clamp()

2. **Container/Stack Viewport Constraints** (lines 2611-2618)
   - Force max-width: 100vw on all containers and stack elements
   - Add overflow-x: hidden to prevent overflow
   - Set consistent padding-left/right: 1rem
   - Ensure box-sizing: border-box

3. **Comparison Slider Specific** (already applied in previous commit)
   - max-width: calc(100vw - 2rem) accounts for container padding

These three fixes work together to ensure perfect alignment:
- The section respects viewport width
- The container adds consistent 1rem padding
- The slider calculates its width accounting for that padding

Result: Interactive comparison slider images now stack perfectly aligned on all mobile devices, exactly matching Portuguese site implementation.