### PR TITLE
Add SAFETY NET rules for comparison slider perfect alignment

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -1326,6 +1326,19 @@
         margin-left: auto !important;
         margin-right: auto !important;
       }
+
+      /* SAFETY NET: Prevent any div with large max-width from overflowing - EXCEPT comparison slider */
+      div[style*="max-width"]:not(#comparison-slider):not(#slider-overlay) {
+        max-width: 100% !important;
+        box-sizing: border-box !important;
+      }
+
+      /* Ensure all images respect container width - EXCEPT comparison slider images */
+      img:not(#overlay-image):not([alt*="Signal Pilot"]) {
+        max-width: 100% !important;
+        height: auto !important;
+        box-sizing: border-box !important;
+      }
     }
 
     @media (max-width:480px){


### PR DESCRIPTION
The comparison slider was still not perfectly aligned because other CSS rules were interfering. Added the critical SAFETY NET rules from the Portuguese site:

1. Exception for divs with max-width:
   - Prevents #comparison-slider and #slider-overlay from being constrained by general max-width rules

2. Exception for images:
   - Prevents #overlay-image from being constrained
   - Allows the slider images to maintain their original dimensions for perfect stacking

These rules work together with the calc(100vw - 2rem) constraint to ensure the interactive comparison slider images are perfectly aligned and stacked on mobile devices.

Now matches Portuguese site implementation exactly.