### PR TITLE
Fix overlay image width for perfect alignment

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -4966,7 +4966,7 @@
               src="/assets/showcase/chart-with.jpg"
               alt="Chart with Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>


### PR DESCRIPTION
The critical issue: the overlay image was missing width:100% in its inline styles, causing misalignment between the two stacked images.

Fixed:
- Added width:100% to #overlay-image inline style
- Now matches Portuguese site exactly: style="position:absolute;top:0;left:0;width:100%;height:100%;..."

The overlay image now spans the full width of the slider container, ensuring both images (background and overlay) are perfectly aligned and stacked on top of each other on all devices.

Verified all comparison slider elements now match Portuguese site: ✓ #comparison-slider container
✓ .comparison-image background div
✓ #slider-overlay div
✓ #overlay-image (NOW with width:100%)