### PR TITLE
Add SAFETY NET rules for perfect comparison slider alignment

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -1565,6 +1565,19 @@
       .comparison-image {
         overflow: hidden !important;
       }
+
+      /* SAFETY NET: Prevent any div with large max-width from overflowing - EXCEPT comparison slider */
+      div[style*="max-width"]:not(#comparison-slider):not(#slider-overlay) {
+        max-width: 100% !important;
+        box-sizing: border-box !important;
+      }
+
+      /* Ensure all images respect container width - EXCEPT comparison slider images */
+      img:not(#overlay-image):not([alt*="Signal Pilot"]) {
+        max-width: 100% !important;
+        height: auto !important;
+        box-sizing: border-box !important;
+      }
     }
 
     /* Landscape mobile optimization */


### PR DESCRIPTION
Added critical safety net CSS rules from Portuguese/Japanese sites that prevent other elements from interfering with comparison slider alignment:

**Safety Net Rule 1** (lines 1569-1573):
Prevent ANY div with inline max-width styles from overflowing, EXCEPT the comparison slider (#comparison-slider) and slider overlay (#slider-overlay). This ensures other page elements don't break mobile layout while allowing the comparison slider to maintain its special calc(100vw - 2rem) sizing.

**Safety Net Rule 2** (lines 1575-1580):
Force ALL images to respect container width (max-width: 100%, height: auto), EXCEPT the comparison slider images (#overlay-image and images with "Signal Pilot" in alt text). This prevents random images from breaking mobile layout while preserving comparison slider's special image handling.

These safety net rules work together with the previously added:
- Section viewport constraints (max-width: 100vw)
- Container padding (1rem left/right)
- Comparison slider calc(100vw - 2rem)

to ensure perfect alignment on all mobile devices by preventing CSS conflicts from other page elements.