### PR TITLE
Fix mobile comparison slider alignment - update JavaScript calculation

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -5075,9 +5075,12 @@
       // Update overlay image width to match slider container
       function updateOverlayImageWidth() {
         if (overlayImage && slider) {
-          const rect = slider.getBoundingClientRect();
-          if (rect.width > 0) {
-            overlayImage.style.width = rect.width + 'px';
+          const width = slider.clientWidth;
+          if (width > 0) {
+            overlayImage.style.width = width + 'px';
+          } else {
+            // Retry if width is 0 (layout not ready yet)
+            setTimeout(() => updateOverlayImageWidth(), 100);
           }
         }
       }


### PR DESCRIPTION
The issue was in the JavaScript function that calculates the overlay image width. Changed to match Portuguese site exactly:

Changes:
1. Use slider.clientWidth instead of getBoundingClientRect().width
   - clientWidth is more reliable for getting actual element width
   - Works better across different browsers and mobile devices

2. Add retry logic when width is 0
   - Important for mobile where layout may not be ready immediately
   - Retries after 100ms if width calculation fails

This fixes the mobile alignment issue where the overlay image wasn't getting the correct width, causing the two images to not stack perfectly on top of each other.

The function now matches the Portuguese site implementation exactly.