### PR TITLE
Fix comparison slider mobile alignment + hamburger menu styling

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2249,12 +2249,26 @@
       transition:all 0.2s ease;
       position:relative;
       z-index:45;
+      cursor:pointer;
     }
-    
+
     .menu-toggle:hover{
       background:linear-gradient(135deg, rgba(91,138,255,.3), rgba(91,138,255,.15));
       transform:translateY(-1px);
       box-shadow:0 6px 16px rgba(0,0,0,.4);
+    }
+
+    /* Light mode menu toggle button styling */
+    html[data-theme="light"] .menu-toggle {
+      border-color:rgba(30,41,59,.2);
+      background:linear-gradient(135deg, rgba(91,138,255,.15), rgba(91,138,255,.08));
+      color:#0f172a;
+      box-shadow:0 2px 8px rgba(0,0,0,.1);
+    }
+
+    html[data-theme="light"] .menu-toggle:hover {
+      background:linear-gradient(135deg, rgba(91,138,255,.25), rgba(91,138,255,.12));
+      box-shadow:0 4px 12px rgba(0,0,0,.15);
     }
 
 
@@ -2776,6 +2790,20 @@
       .toggle-details {
         flex: 1;
         min-width: 120px;
+      }
+
+      /* FIX: Slider control buttons - wrap and shrink on very small screens */
+      div[style*="margin-bottom:1.5rem"] button[id*="btn-"] {
+        padding: 0.4rem 0.65rem !important;
+        font-size: 0.75rem !important;
+        min-height: 36px !important;
+        height: 36px !important;
+      }
+
+      /* FIX: Slider controls container - allow wrapping on very small screens */
+      section .container > div[style*="gap:0.8rem"][style*="margin-bottom:1.5rem"] {
+        flex-wrap: wrap !important;
+        gap: 0.5rem !important;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */


### PR DESCRIPTION
TWO CRITICAL FIXES:

**1. Comparison Slider Mobile Alignment** (lines 2781-2793)

Added mobile-specific responsive rules for slider control buttons at 480px breakpoint to prevent horizontal overflow on small screens:

- Shrink button padding: 0.4rem 0.65rem (from 0.5rem 1rem)
- Reduce font size: 0.75rem (from 0.85rem)
- Smaller min-height: 36px (from 38px)
- Enable flex-wrap on button container (was nowrap causing overflow)
- Reduce gap: 0.5rem (from 0.8rem)

This prevents the three buttons (← Avant, ▶ Lecture Auto, Après →) from causing horizontal scroll on very small mobile devices (<480px).

**2. Hamburger Menu Button Styling** (lines 2252, 2261-2272)

Fixed ugly/broken menu toggle button appearance:

- Added cursor:pointer for proper clickable appearance
- Added light mode styling (was missing, causing grey/ugly look):
  - Light theme: Softer blue gradient background
  - Dark text (#0f172a) on light background
  - Proper borders and shadows for both themes
  - Hover states for both dark and light modes

Menu button now looks polished and professional in both themes instead of showing as ugly grey text.

These fixes ensure the comparison slider aligns perfectly on ALL mobile devices and the hamburger menu button looks proper in all scenarios.