### PR TITLE
Fix hamburger menu button text alignment

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2377,6 +2377,8 @@
 
       .menu-toggle{
         display:inline-flex;
+        align-items:center;
+        justify-content:center;
         position:relative;
         z-index:68 !important;
       }


### PR DESCRIPTION
Added flexbox alignment properties to center the menu button text properly.

The button was showing "Menu ☰" text misaligned at the edge/top of the button because when display:inline-flex was set at the 1400px breakpoint, there were no alignment properties to center the content.

**Fix** (line 2380-2381):
Added to .menu-toggle at @media (max-width:1400px):
- align-items:center (vertical centering)
- justify-content:center (horizontal centering)

This ensures the "Menu ☰" text is properly centered within the button instead of appearing at the edge, matching the appearance of all other working language sites (Portuguese, Spanish, German, English, Japanese).