### PR TITLE
Fix hamburger menu styling on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2496,6 +2496,9 @@
 
       .menu-toggle{
         display:inline-flex;
+        align-items:center;
+        justify-content:center;
+        gap:0.4rem;
         position:relative;
         z-index:68 !important;
       }


### PR DESCRIPTION
Add proper flexbox alignment properties to the .menu-toggle button to fix text and icon misalignment on mobile devices. The button now properly centers content with align-items, justify-content, and gap.