### PR TITLE
Redesign hamburger menu button on French site

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2238,37 +2238,46 @@
 
     .menu-toggle{
       display:none;
-      border-radius:12px;
-      border:1px solid rgba(255,255,255,.25);
-      background:linear-gradient(135deg, rgba(91,138,255,.2), rgba(91,138,255,.1));
+      width:50px;
+      height:50px;
+      border-radius:50%;
+      border:1px solid rgba(255,255,255,.15);
+      background:rgba(20,25,35,.8);
+      backdrop-filter:blur(10px);
       color:#fff;
-      padding:.6rem .85rem;
-      font-weight:700;
-      font-size:.9rem;
-      box-shadow:0 4px 12px rgba(0,0,0,.3);
-      transition:all 0.2s ease;
+      padding:0;
+      font-weight:400;
+      font-size:1.4rem;
+      box-shadow:0 4px 16px rgba(0,0,0,.4);
+      transition:all 0.3s cubic-bezier(0.4,0,0.2,1);
       position:relative;
       z-index:45;
       cursor:pointer;
     }
 
     .menu-toggle:hover{
-      background:linear-gradient(135deg, rgba(91,138,255,.3), rgba(91,138,255,.15));
-      transform:translateY(-1px);
-      box-shadow:0 6px 16px rgba(0,0,0,.4);
+      background:rgba(91,138,255,.25);
+      border-color:rgba(91,138,255,.4);
+      transform:translateY(-2px) scale(1.05);
+      box-shadow:0 8px 24px rgba(91,138,255,.3);
+    }
+
+    .menu-toggle:active{
+      transform:translateY(0) scale(0.98);
     }
 
     /* Light mode menu toggle button styling */
     html[data-theme="light"] .menu-toggle {
-      border-color:rgba(30,41,59,.2);
-      background:linear-gradient(135deg, rgba(91,138,255,.15), rgba(91,138,255,.08));
+      background:rgba(255,255,255,.95);
+      border-color:rgba(30,41,59,.15);
       color:#0f172a;
-      box-shadow:0 2px 8px rgba(0,0,0,.1);
+      box-shadow:0 4px 12px rgba(0,0,0,.08);
     }
 
     html[data-theme="light"] .menu-toggle:hover {
-      background:linear-gradient(135deg, rgba(91,138,255,.25), rgba(91,138,255,.12));
-      box-shadow:0 4px 12px rgba(0,0,0,.15);
+      background:rgba(91,138,255,.12);
+      border-color:rgba(91,138,255,.3);
+      box-shadow:0 8px 24px rgba(91,138,255,.2);
     }
 
 
@@ -3287,7 +3296,7 @@
 
 
 
-      <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="mainnav">Menu ☰</button>
+      <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="mainnav" aria-label="Menu">☰</button>
 
     </div>
 


### PR DESCRIPTION
- Transform menu button to modern circular design (50x50px)
- Match theme toggle button's visual style and quality
- Add backdrop-filter blur effect for premium look
- Improve hover animations with lift and scale effects
- Show icon-only (☰) instead of "Menu ☰" text
- Add smooth cubic-bezier transitions
- Enhance both dark and light mode styling