### PR TITLE
Fix Arabic translation: Translate remaining English text

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5876,22 +5876,22 @@ html[lang="ar"] [style*="text-align:center"] {
         </div>
 
         <div>
-          <h4 style="margin:0 0 .8rem 0;font-size:.95rem;font-weight:600;color:var(--text)">Legal</h4>
+          <h4 style="margin:0 0 .8rem 0;font-size:.95rem;font-weight:600;color:var(--text)">قانوني</h4>
           <ul style="list-style:none;padding:0;margin:0">
-            <li style="margin-bottom:.4rem"><a href="privacy.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Privacy Policy</a></li>
-            <li style="margin-bottom:.4rem"><a href="terms.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Terms of Service</a></li>
-            <li style="margin-bottom:.4rem"><a href="refund.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Refund Policy</a></li>
-            <li style="margin-bottom:.4rem"><a href="manage-subscription.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Manage Subscription</a></li>
+            <li style="margin-bottom:.4rem"><a href="/ar/privacy.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">سياسة الخصوصية</a></li>
+            <li style="margin-bottom:.4rem"><a href="/ar/terms.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">شروط الخدمة</a></li>
+            <li style="margin-bottom:.4rem"><a href="/ar/refund.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">سياسة الاسترداد</a></li>
+            <li style="margin-bottom:.4rem"><a href="/ar/manage-subscription.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">إدارة الاشتراك</a></li>
           </ul>
         </div>
 
         <div>
-          <h4 style="margin:0 0 .8rem 0;font-size:.95rem;font-weight:600;color:var(--text)">Connect</h4>
+          <h4 style="margin:0 0 .8rem 0;font-size:.95rem;font-weight:600;color:var(--text)">تواصل</h4>
           <ul style="list-style:none;padding:0;margin:0">
             <li style="margin-bottom:.4rem"><a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">GitHub</a></li>
             <li style="margin-bottom:.4rem"><a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">support@signalpilot.io</a></li>
-            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Roadmap</a></li>
-            <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Affiliate Program</a></li>
+            <li style="margin-bottom:.4rem"><a href="/ar/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">خارطة الطريق</a></li>
+            <li style="margin-bottom:.4rem"><a href="/ar/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">برنامج الشراكة</a></li>
           </ul>
         </div>
 
@@ -5902,13 +5902,13 @@ html[lang="ar"] [style*="text-align:center"] {
 
         <div style="background:linear-gradient(135deg,rgba(249,162,60,.06),rgba(249,162,60,.02));border:1px solid rgba(249,162,60,.15);border-radius:8px;padding:1rem 1.25rem">
           <p style="color:var(--muted);font-size:.8rem;margin:0;line-height:1.5">
-            <strong style="color:#f9a23c;font-size:.82rem">⚠️ Educational Disclaimer:</strong> Signal Pilot provides educational tools for learning only. Not financial advice. Trading involves substantial risk. Past performance doesn't guarantee future results.
+            <strong style="color:#f9a23c;font-size:.82rem">⚠️ إخلاء مسؤولية تعليمي:</strong> يوفر Signal Pilot أدوات تعليمية للتعلم فقط. ليست نصيحة مالية. ينطوي التداول على مخاطر كبيرة. الأداء السابق لا يضمن النتائج المستقبلية.
           </p>
         </div>
 
         <div style="display:flex;flex-direction:column;justify-content:center;align-items:center;gap:.5rem;text-align:center">
           <p style="color:var(--muted-2);font-size:.8rem;margin:0">
-            © 2025 <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.08em;font-weight:400">Signal Pilot</span> Labs. All rights reserved.
+            © 2025 <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.08em;font-weight:400">Signal Pilot</span> Labs. جميع الحقوق محفوظة.
           </p>
           <p style="color:var(--muted-2);font-size:.75rem;margin:0;opacity:.6">v202510301807</p>
         </div>
@@ -7728,15 +7728,15 @@ if ('serviceWorker' in navigator) {
 <div id="cookie-consent-banner">
   <div class="cookie-consent-container">
     <div class="cookie-consent-text">
-      <h3>🍪 Cookies</h3>
+      <h3>🍪 ملفات تعريف الارتباط</h3>
       <p>
-        We use analytics cookies (Clarity & GA4) to improve your experience. <a href="/privacy.html">Privacy Policy</a>
+        نستخدم ملفات تعريف الارتباط للتحليلات (Clarity وGA4) لتحسين تجربتك. <a href="/ar/privacy.html">سياسة الخصوصية</a>
       </p>
     </div>
     <div class="cookie-consent-actions">
-      <button id="cookie-accept-all" class="cookie-consent-btn cookie-consent-btn-accept">Accept</button>
-      <button id="cookie-decline-all" class="cookie-consent-btn cookie-consent-btn-decline">Decline</button>
-      <button id="cookie-settings" class="cookie-consent-btn cookie-consent-btn-settings">Settings</button>
+      <button id="cookie-accept-all" class="cookie-consent-btn cookie-consent-btn-accept">قبول</button>
+      <button id="cookie-decline-all" class="cookie-consent-btn cookie-consent-btn-decline">رفض</button>
+      <button id="cookie-settings" class="cookie-consent-btn cookie-consent-btn-settings">الإعدادات</button>
     </div>
   </div>
 </div>
@@ -7745,16 +7745,16 @@ if ('serviceWorker' in navigator) {
 <div id="cookie-preferences-modal">
   <div class="cookie-preferences-content">
     <div class="cookie-preferences-header">
-      <h2>Cookie Preferences</h2>
-      <button id="cookie-preferences-close" class="cookie-preferences-close" aria-label="Close">&times;</button>
+      <h2>تفضيلات ملفات تعريف الارتباط</h2>
+      <button id="cookie-preferences-close" class="cookie-preferences-close" aria-label="إغلاق">&times;</button>
     </div>
 
     <div class="cookie-preferences-body">
       <div class="cookie-category">
         <div class="cookie-category-header">
           <h3 class="cookie-category-title">
-            Essential Cookies
-            <span class="cookie-category-badge badge-required">Required</span>
+            ملفات تعريف الارتباط الأساسية
+            <span class="cookie-category-badge badge-required">مطلوب</span>
           </h3>
           <label class="cookie-toggle">
             <input type="checkbox" checked disabled>
@@ -7762,27 +7762,27 @@ if ('serviceWorker' in navigator) {
           </label>
         </div>
         <p class="cookie-category-description">
-          These cookies are necessary for the website to function and cannot be disabled. They include session management, payment processing, and security features.
+          هذه ملفات تعريف الارتباط ضرورية لعمل الموقع ولا يمكن تعطيلها. وهي تشمل إدارة الجلسات ومعالجة الدفع وميزات الأمان.
         </p>
       </div>
 
       <div class="cookie-category">
         <div class="cookie-category-header">
-          <h3 class="cookie-category-title">Analytics Cookies</h3>
+          <h3 class="cookie-category-title">ملفات تعريف الارتباط للتحليلات</h3>
           <label class="cookie-toggle">
             <input type="checkbox" id="analytics-toggle">
             <span class="cookie-toggle-slider"></span>
           </label>
         </div>
         <p class="cookie-category-description">
-          We use Microsoft Clarity and Google Analytics to understand how visitors interact with our site. This helps us improve your experience. These cookies collect anonymized data including page views, time spent, and navigation patterns.
+          نستخدم Microsoft Clarity وGoogle Analytics لفهم كيفية تفاعل الزوار مع موقعنا. هذا يساعدنا على تحسين تجربتك. تجمع ملفات تعريف الارتباط هذه بيانات مجهولة الهوية بما في ذلك مشاهدات الصفحة والوقت المستغرق وأنماط التنقل.
         </p>
       </div>
     </div>
 
     <div class="cookie-preferences-footer">
-      <button id="cookie-cancel-preferences" class="cookie-consent-btn cookie-consent-btn-decline">Cancel</button>
-      <button id="cookie-save-preferences" class="cookie-consent-btn cookie-consent-btn-accept">Save Preferences</button>
+      <button id="cookie-cancel-preferences" class="cookie-consent-btn cookie-consent-btn-decline">إلغاء</button>
+      <button id="cookie-save-preferences" class="cookie-consent-btn cookie-consent-btn-accept">حفظ التفضيلات</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixed English text leakage in ar/index.html:
- Footer Legal section: Translated 'Legal', 'Privacy Policy', 'Terms of Service', 'Refund Policy', 'Manage Subscription'
- Footer Connect section: Translated 'Connect', 'Roadmap', 'Affiliate Program'
- Cookie banner: Translated all text including heading, description, and buttons
- Cookie preferences modal: Translated all sections and buttons
- Disclaimer: Translated educational disclaimer and copyright notice
- Updated all internal links to point to /ar/ versions

All user-facing text is now in Arabic with proper RTL support.