### PR TITLE
Rebuild hamburger menu button to match other language sites

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2238,83 +2238,36 @@
 
     .menu-toggle{
       display:none;
-      width:50px;
-      height:50px;
-      border-radius:50%;
-      border:1px solid rgba(255,255,255,.15);
-      background:rgba(20,25,35,.8);
-      backdrop-filter:blur(10px);
-      padding:0;
-      box-shadow:0 4px 16px rgba(0,0,0,.4);
-      transition:all 0.3s cubic-bezier(0.4,0,0.2,1);
+      border-radius:12px;
+      border:1px solid rgba(255,255,255,.25);
+      background:linear-gradient(135deg, rgba(91,138,255,.2), rgba(91,138,255,.1));
+      color:#fff;
+      padding:.6rem .85rem;
+      font-weight:700;
+      font-size:.9rem;
+      box-shadow:0 4px 12px rgba(0,0,0,.3);
+      transition:all 0.2s ease;
       position:relative;
       z-index:45;
-      cursor:pointer;
-      flex-direction:column;
-      align-items:center;
-      justify-content:center;
-      gap:0;
     }
 
     .menu-toggle:hover{
-      background:rgba(91,138,255,.25);
-      border-color:rgba(91,138,255,.4);
-      transform:translateY(-2px) scale(1.05);
-      box-shadow:0 8px 24px rgba(91,138,255,.3);
-    }
-
-    .menu-toggle:active{
-      transform:translateY(0) scale(0.98);
-    }
-
-    /* Hamburger icon bars */
-    .menu-toggle span{
-      display:block;
-      width:20px;
-      height:2px;
-      background:#fff;
-      border-radius:2px;
-      transition:all 0.3s cubic-bezier(0.4,0,0.2,1);
-      position:relative;
-    }
-
-    .menu-toggle span:nth-child(1){
-      transform:translateY(-5px);
-    }
-
-    .menu-toggle span:nth-child(3){
-      transform:translateY(5px);
-    }
-
-    /* Animate to X when menu is open */
-    .menu-toggle[aria-expanded="true"] span:nth-child(1){
-      transform:rotate(45deg);
-    }
-
-    .menu-toggle[aria-expanded="true"] span:nth-child(2){
-      opacity:0;
-      transform:scale(0);
-    }
-
-    .menu-toggle[aria-expanded="true"] span:nth-child(3){
-      transform:rotate(-45deg);
+      background:linear-gradient(135deg, rgba(91,138,255,.3), rgba(91,138,255,.15));
+      transform:translateY(-1px);
+      box-shadow:0 6px 16px rgba(0,0,0,.4);
     }
 
     /* Light mode menu toggle button styling */
     html[data-theme="light"] .menu-toggle {
-      background:rgba(255,255,255,.95);
-      border-color:rgba(30,41,59,.15);
-      box-shadow:0 4px 12px rgba(0,0,0,.08);
+      border-color:rgba(30,41,59,.2);
+      background:linear-gradient(135deg, rgba(91,138,255,.15), rgba(91,138,255,.08));
+      color:#0f172a;
+      box-shadow:0 2px 8px rgba(0,0,0,.1);
     }
 
     html[data-theme="light"] .menu-toggle:hover {
-      background:rgba(91,138,255,.12);
-      border-color:rgba(91,138,255,.3);
-      box-shadow:0 8px 24px rgba(91,138,255,.2);
-    }
-
-    html[data-theme="light"] .menu-toggle span{
-      background:#0f172a;
+      background:linear-gradient(135deg, rgba(91,138,255,.25), rgba(91,138,255,.12));
+      box-shadow:0 4px 12px rgba(0,0,0,.15);
     }
 
 
@@ -3333,11 +3286,7 @@
 
 
 
-      <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="mainnav" aria-label="Menu">
-        <span></span>
-        <span></span>
-        <span></span>
-      </button>
+      <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="mainnav">Menu ☰</button>
 
     </div>
 


### PR DESCRIPTION
Restore the French site menu button to match the exact implementation used across all other language sites (EN, ES, PT, DE):
- Rectangular button with rounded corners (12px radius)
- Blue gradient background
- "Menu ☰" text label
- Proper hover effects with lift animation
- Light and dark mode support

Removed circular button and animated bars implementation that didn't match the site's design standards.