### PR TITLE
Add missing hreflang tags to Turkish translation pages

### DIFF
--- a/tr/faq.html
+++ b/tr/faq.html
@@ -6,6 +6,17 @@
   <title>Eksiksiz SSS — Signal Pilot</title>
   <meta name="description" content="Signal Pilot göstergeleri, eğitim, fiyatlandırma ve destek hakkında tüm konuları kapsayan kapsamlı SSS.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/faq.html">
+
+  <!-- Hreflang tags -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
+
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/tr/manage-subscription.html
+++ b/tr/manage-subscription.html
@@ -6,6 +6,17 @@
   <title>Aboneliği Yönet — Signal Pilot</title>
   <meta name="description" content="Signal Pilot aboneliğinizi yönetin — ödeme yöntemlerini güncelleyin, duraklatın/devam ettirin, iptal edin veya fatura geçmişini görüntüleyin—hepsi self-service.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/manage-subscription.html">
+
+  <!-- Hreflang tags -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
+
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -6,6 +6,17 @@
   <title>Gizlilik Politikası — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Gizlilik Politikası — Verilerinizi nasıl topladığımız, kullandığımız ve koruduğumuz.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/privacy.html">
+
+  <!-- Hreflang tags -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
+
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/tr/refund.html
+++ b/tr/refund.html
@@ -6,6 +6,17 @@
   <title>İade Politikası — Signal Pilot</title>
   <meta name="description" content="Signal Pilot İade Politikası — Gösterge aboneliklerimiz için açık, adil iade şartları.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/refund.html">
+
+  <!-- Hreflang tags -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
+
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 


### PR DESCRIPTION
Add proper hreflang tags to 4 Turkish pages that were missing them:
- tr/faq.html
- tr/manage-subscription.html
- tr/privacy.html
- tr/refund.html

All Turkish pages now have complete hreflang tags pointing to:
- en (English - default)
- tr (Turkish)
- es (Spanish)
- de (German)
- fr (French)
- ja (Japanese)
- pt-BR (Portuguese Brazil)
- x-default (fallback)

This improves SEO by helping search engines understand the language variants of each page.