### PR TITLE
Fix canonical URL for Turkish homepage

### DIFF
--- a/tr/index.html
+++ b/tr/index.html
@@ -67,7 +67,7 @@
   <meta name="rating" content="general">
   <meta name="revisit-after" content="7 days">
 
-  <link rel="canonical" href="https://www.signalpilot.io/">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/">


### PR DESCRIPTION
The canonical URL for tr/index.html was incorrectly pointing to the English homepage (https://www.signalpilot.io/) instead of the Turkish homepage (https://www.signalpilot.io/tr/).

This SEO fix ensures:
- Search engines properly index the Turkish version
- No duplicate content issues
- Correct language attribution for Turkish users