### PR TITLE
Add missing critical CSS for hamburger menu button

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2320,7 +2320,13 @@
 
 
     /* CRITICAL FIX: Ensure language/theme buttons stay visible */
-    
+    .lang-dropdown,
+    #themeToggle,
+    .menu-toggle{
+      position:relative;
+      z-index:100 !important;
+      flex-shrink:0 !important;
+    }
 
     /* Ensure nav links (including FAQ) don't get covered by buttons */
     nav[aria-label="Main"] ul li {
@@ -2378,6 +2384,7 @@
         display:inline-flex;
         align-items:center;
         justify-content:center;
+        gap:0.4rem;
         position:relative;
         z-index:68 !important;
       }


### PR DESCRIPTION
Fixed the French site by adding critical CSS that was present on all other language sites:

1. Added z-index and flex-shrink rules for .menu-toggle to ensure it stays visible and properly positioned
2. Added gap:0.4rem for proper spacing between "Menu" and "☰"
3. Ensures button doesn't get covered by other header elements

This matches the exact implementation on EN, ES, PT, and DE sites.