### PR TITLE
Fix hamburger menu button styling on French site

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -866,12 +866,6 @@
       min-width: 0 !important;
     }
 
-    /* Prevent all header buttons and text from wrapping */
-    header button,
-    header a,
-    .menu-toggle,
-    
-
     /* Prevent horizontal scroll */
     body{
       overflow-x:hidden;


### PR DESCRIPTION
Removed incomplete CSS selector (lines 870-873) that was causing syntax error and preventing .menu-toggle button styles from applying. The button now properly displays with gradient background, borders, shadows, and hover effects.