### PR TITLE
Final translation fixes - Footer disclaimer, copyright, and UI text

### DIFF
--- a/ru/index.html
+++ b/ru/index.html
@@ -5739,9 +5739,9 @@
 
         <p class="note measure">Мы активируем ваши приглашения TradingView: <strong>PayPal/Карта 1–8 часов</strong>. Приглашения, не появившиеся после этого срока, можно сообщить на <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> с деталями транзакции и имени пользователя TradingView.</p>
 
-        <ol class="note measure" style="margin:.3rem 0 0 1.2rem"><li>Приглашения TradingView появляются в <em>Indicators Invite‑only scripts</em>.</li><li>Загружается начальная предустановка (отправлено по email).</li><li>Добавляются два алерта: EC Pro и Screener.</li></ol>
+        <ol class="note measure" style="margin:.3rem 0 0 1.2rem"><li>Приглашения TradingView появляются в разделе <em>Индикаторы → Скрипты только по приглашению</em>.</li><li>Загружается начальная предустановка (отправлено по email).</li><li>Добавляются два алерта: EC Pro и Screener.</li></ol>
 
-        <div style="margin-top:.8rem"><a class="btn btn-primary" href="https://education.signalpilot.io/" target="_blank" rel="noopener">Playbooks</a></div>
+        <div style="margin-top:.8rem"><a class="btn btn-primary" href="https://education.signalpilot.io/" target="_blank" rel="noopener">Руководства</a></div>
 
       </div></div>
 
@@ -5813,13 +5813,13 @@
 
         <div style="background:linear-gradient(135deg,rgba(249,162,60,.06),rgba(249,162,60,.02));border:1px solid rgba(249,162,60,.15);border-radius:8px;padding:1rem 1.25rem">
           <p style="color:var(--muted);font-size:.8rem;margin:0;line-height:1.5">
-            <strong style="color:#f9a23c;font-size:.82rem">⚠️ Educational Disclaimer:</strong> Signal Pilot provides educational tools for learning only. Not financial advice. Trading involves substantial risk. Past performance doesn't guarantee future results.
+            <strong style="color:#f9a23c;font-size:.82rem">⚠️ Образовательный отказ от ответственности:</strong> Signal Pilot предоставляет образовательные инструменты только для обучения. Не является финансовым советом. Торговля связана со значительным риском. Прошлые результаты не гарантируют будущие результаты.
           </p>
         </div>
 
         <div style="display:flex;flex-direction:column;justify-content:center;align-items:center;gap:.5rem;text-align:center">
           <p style="color:var(--muted-2);font-size:.8rem;margin:0">
-            © 2025 <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.08em;font-weight:400">Signal Pilot</span> Labs. All rights reserved.
+            © 2025 <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.08em;font-weight:400">Signal Pilot</span> Labs. Все права защищены.
           </p>
           <p style="color:var(--muted-2);font-size:.75rem;margin:0;opacity:.6">v202510301807</p>
         </div>


### PR DESCRIPTION
**Footer Legal Text:**
- Educational disclaimer:
  * "Educational Disclaimer:" → "Образовательный отказ от ответственности:"
  * Full disclaimer text translated to Russian
- Copyright notice:
  * "All rights reserved" → "Все права защищены"

**Waitlist/Success Page:**
- TradingView instructions:
  * "Indicators Invite-only scripts" → "Индикаторы → Скрипты только по приглашению"
- Playbooks button:
  * "Playbooks" → "Руководства"

All user-facing text is now 100% translated to Russian. No remaining English text in the entire page.