### PR TITLE
Italian translation - Final double-check fixes

### DIFF
--- a/it/index.html
+++ b/it/index.html
@@ -3319,7 +3319,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Hub Educativo</a></li>
-              <li><a href="/faq.html">Centro FAQ</a></li>
+              <li><a href="/it/faq.html">Centro FAQ</a></li>
             </ul>
           </li>
 
@@ -3680,7 +3680,7 @@
               <input type="checkbox" id="trialConsent" required>
               <span>
                 Comprendo che <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> è solo educativo. Nessuna consulenza finanziaria.
-                <a href="/terms.html" style="color:var(--brand)">Termini</a>
+                <a href="/it/terms.html" style="color:var(--brand)">Termini</a>
               </span>
             </label>
 
@@ -5718,7 +5718,7 @@
 
     <!-- View All FAQs Link -->
     <div style="text-align:center;margin-top:2.5rem">
-      <a href="/faq.html" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+      <a href="/it/faq.html" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
         Vedi FAQ Complete (oltre 30 Domande) →
       </a>
       <p style="color:var(--muted-2);font-size:.85rem;margin-top:.8rem">Guide di configurazione, strategie e dettagli tecnici</p>
@@ -5789,10 +5789,10 @@
         <div>
           <h4 style="margin:0 0 .8rem 0;font-size:.95rem;font-weight:600;color:var(--text)">Legale</h4>
           <ul style="list-style:none;padding:0;margin:0">
-            <li style="margin-bottom:.4rem"><a href="privacy.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Politica sulla Privacy</a></li>
-            <li style="margin-bottom:.4rem"><a href="terms.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Termini di Servizio</a></li>
-            <li style="margin-bottom:.4rem"><a href="refund.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Politica di Rimborso</a></li>
-            <li style="margin-bottom:.4rem"><a href="manage-subscription.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Gestisci Abbonamento</a></li>
+            <li style="margin-bottom:.4rem"><a href="/it/privacy.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Politica sulla Privacy</a></li>
+            <li style="margin-bottom:.4rem"><a href="/it/terms.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Termini di Servizio</a></li>
+            <li style="margin-bottom:.4rem"><a href="/it/refund.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Politica di Rimborso</a></li>
+            <li style="margin-bottom:.4rem"><a href="/it/manage-subscription.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Gestisci Abbonamento</a></li>
           </ul>
         </div>
 
@@ -5801,8 +5801,8 @@
           <ul style="list-style:none;padding:0;margin:0">
             <li style="margin-bottom:.4rem"><a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">GitHub</a></li>
             <li style="margin-bottom:.4rem"><a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">support@signalpilot.io</a></li>
-            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Roadmap</a></li>
-            <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Programma Affiliati</a></li>
+            <li style="margin-bottom:.4rem"><a href="/it/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Roadmap</a></li>
+            <li style="margin-bottom:.4rem"><a href="/it/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Programma Affiliati</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
Fixed remaining localization issues:
- Updated all footer links to point to Italian versions (/it/privacy.html, /it/terms.html, etc.)
- Updated FAQ and terms links throughout the page to use /it/ paths
- Verified Signal Pilot brand name uses Gugi font consistently everywhere (via .brand CSS class and inline styles)

All footer links now correctly route to Italian pages:
- Privacy Policy: /it/privacy.html
- Terms of Service: /it/terms.html
- Refund Policy: /it/refund.html
- Manage Subscription: /it/manage-subscription.html
- Roadmap: /it/roadmap.html
- Affiliates: /it/affiliates.html
- FAQ: /it/faq.html