### PR TITLE
Complete Dutch translation: Translate remaining English text

### DIFF
--- a/nl/index.html
+++ b/nl/index.html
@@ -3633,7 +3633,7 @@
         <div style="display:flex;justify-content:center;margin-bottom:3rem">
           <div style="display:flex;align-items:center;gap:0.5rem;background:rgba(91,138,255,.08);border:1px solid rgba(91,138,255,.25);padding:0.75rem 1.25rem;border-radius:8px">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
-            <span style="font-size:0.9rem;font-weight:600;color:#5b8aff">No Credit Card • Access Within 24h</span>
+            <span style="font-size:0.9rem;font-weight:600;color:#5b8aff">Geen Creditcard • Toegang Binnen 24u</span>
           </div>
         </div>
 
@@ -4953,13 +4953,13 @@
         <!-- Slider Controls -->
         <div style="display:flex;justify-content:center;gap:0.8rem;margin-bottom:1.5rem;flex-wrap:nowrap;align-items:center">
           <button id="btn-before" class="btn btn-secondary" style="padding:0.5rem 1rem;font-size:0.85rem;min-height:38px;height:38px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center;line-height:1">
-            ← Before
+            ← Vooraf
           </button>
           <button id="btn-autoplay" class="btn btn-primary" style="padding:0.5rem 1rem;font-size:0.85rem;min-height:38px;height:38px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center;line-height:1">
-            ▶ Auto Play
+            ▶ Automatisch Afspelen
           </button>
           <button id="btn-after" class="btn btn-secondary" style="padding:0.5rem 1rem;font-size:0.85rem;min-height:38px;height:38px;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center;line-height:1">
-            After →
+            Daarna →
           </button>
         </div>
 
@@ -4973,7 +4973,7 @@
               alt="Grafiek zonder Signal Pilot"
               loading="eager"
               style="width:100%;height:100%;object-fit:contain;display:block"
-              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
+              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>ZONDER Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Voeg uw grafiekafbeelding toe aan:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
 
@@ -4985,7 +4985,7 @@
               alt="Grafiek met Signal Pilot"
               loading="eager"
               style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
-              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
+              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>MET Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Voeg uw grafiekafbeelding toe aan:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>
 
@@ -5123,7 +5123,7 @@
       }
 
       // Update overlay width when images load
-      const backgroundImage = slider.querySelector('img[alt="Chart without Signal Pilot"]');
+      const backgroundImage = slider.querySelector('img[alt="Grafiek zonder Signal Pilot"]');
       const foregroundImage = overlayImage;
 
       if (backgroundImage) {
@@ -5801,7 +5801,7 @@
           <ul style="list-style:none;padding:0;margin:0">
             <li style="margin-bottom:.4rem"><a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">GitHub</a></li>
             <li style="margin-bottom:.4rem"><a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">support@signalpilot.io</a></li>
-            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Roadmap</a></li>
+            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Routekaart</a></li>
             <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Partnerprogramma</a></li>
           </ul>
         </div>


### PR DESCRIPTION
Translated the following remaining English elements to Dutch:
- Trial badge: "No Credit Card • Access Within 24h" → "Geen Creditcard • Toegang Binnen 24u"
- Before/After buttons: "Before", "Auto Play", "After" → "Vooraf", "Automatisch Afspelen", "Daarna"
- Comparison slider fallback: "WITHOUT/WITH Signal Pilot" → "ZONDER/MET Signal Pilot"
- Image alt selector in JavaScript updated to match Dutch alt text
- Navigation link: "Roadmap" → "Routekaart"

All visible English text in the Dutch translation is now fully translated.