### PR TITLE
Fix critical title tag bug + complete Arabic translations

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -50,7 +50,7 @@
   <meta http-equiv="Pragma" content="no-cache" />
   <meta http-equiv="Expires" content="0" />
 
-  <title>Signal Pilot — مؤشرات TradingView بدون إعادة رسم
+  <title>Signal Pilot — مؤشرات TradingView بدون إعادة رسم</title>
 
   <meta name="description" content="كشف احترافي للدورات في TradingView. تقنية Pentarch™ ترسم دورات السوق الكاملة (TD←IGN←WRN←CAP←BDN). بدون إعادة رسم، معتمد. ضمان استرداد المال لمدة 7 أيام.">
 
@@ -5059,7 +5059,7 @@ html[lang="ar"] [style*="text-align:center"] {
           <div class="comparison-image" style="position:relative;width:100%;min-height:600px;aspect-ratio:16/9;background:#0a0e18">
             <img
               src="assets/showcase/chart-without.jpg"
-              alt="Chart without Signal Pilot"
+              alt="رسم بياني بدون Signal Pilot"
               loading="eager"
               style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
@@ -5071,7 +5071,7 @@ html[lang="ar"] [style*="text-align:center"] {
             <img
               id="overlay-image"
               src="assets/showcase/chart-with.jpg"
-              alt="Chart with Signal Pilot"
+              alt="رسم بياني مع Signal Pilot"
               loading="eager"
               style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
@@ -5437,36 +5437,36 @@ html[lang="ar"] [style*="text-align:center"] {
         <!-- What's Included - ALL Plans Identical -->
         <div style="text-align:center;max-width:900px;margin:1.5rem auto;padding:1.75rem 2rem;background:linear-gradient(135deg,rgba(91,138,255,.1),rgba(91,138,255,.05));border:2px solid rgba(91,138,255,.25);border-radius:12px">
           <p style="font-size:1.05rem;color:var(--text);margin:0 0 1rem 0;font-weight:700">
-            ✨ Every plan includes the exact same features:
+            ✨ كل خطة تشمل نفس الميزات بالضبط:
           </p>
           <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:0.75rem;text-align:left;max-width:800px;margin:0 auto">
             <div style="display:flex;align-items:center;gap:.5rem">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.9rem;color:var(--muted)">All 7 elite indicators</span>
+              <span style="font-size:.9rem;color:var(--muted)">جميع المؤشرات السبعة المميزة</span>
             </div>
             <div style="display:flex;align-items:center;gap:.5rem">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.9rem;color:var(--muted)">All future indicators</span>
+              <span style="font-size:.9rem;color:var(--muted)">جميع المؤشرات المستقبلية</span>
             </div>
             <div style="display:flex;align-items:center;gap:.5rem">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.9rem;color:var(--muted)">All future updates</span>
+              <span style="font-size:.9rem;color:var(--muted)">جميع التحديثات المستقبلية</span>
             </div>
             <div style="display:flex;align-items:center;gap:.5rem">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.9rem;color:var(--muted)">Priority support</span>
+              <span style="font-size:.9rem;color:var(--muted)">دعم ذو أولوية</span>
             </div>
             <div style="display:flex;align-items:center;gap:.5rem">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.9rem;color:var(--muted)">Full documentation</span>
+              <span style="font-size:.9rem;color:var(--muted)">وثائق كاملة</span>
             </div>
             <div style="display:flex;align-items:center;gap:.5rem">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.9rem;color:var(--muted)">82 free lessons</span>
+              <span style="font-size:.9rem;color:var(--muted)">82 درساً مجانياً</span>
             </div>
           </div>
           <p style="font-size:.85rem;color:var(--muted-2);margin:1rem 0 0 0;font-style:italic">
-            Only difference between plans: how you pay (monthly, yearly, or once)
+            الفرق الوحيد بين الخطط: كيفية الدفع (شهرياً، سنوياً، أو مرة واحدة)
           </p>
         </div>
 
@@ -5474,7 +5474,7 @@ html[lang="ar"] [style*="text-align:center"] {
         <div style="display:flex;justify-content:center;gap:2rem;flex-wrap:wrap;margin-bottom:2rem;opacity:.85">
           <div style="display:flex;align-items:center;gap:.5rem">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
-            <span style="font-size:.9rem;font-weight:600">100% Non-Repainting (Audited)</span>
+            <span style="font-size:.9rem;font-weight:600">100% بدون إعادة رسم (تم التدقيق)</span>
           </div>
         </div>
 
@@ -5510,7 +5510,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <!-- الخطوة 1: اسم المستخدم -->
               <div style="background:rgba(91,138,255,.08);border:1px solid rgba(91,138,255,.2);border-radius:8px;padding:1rem;margin-bottom:.5rem">
                 <label style="font-weight:600;color:var(--brand);font-size:.9rem;margin-bottom:.5rem;display:block">
-                  TradingView Username
+                  اسم مستخدم TradingView
                 </label>
                 <div class="input-wrapper">
                   <input id="tv-monthly" placeholder="@your.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">
@@ -5580,7 +5580,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <!-- الخطوة 1: اسم المستخدم -->
               <div style="background:rgba(91,138,255,.08);border:1px solid rgba(91,138,255,.2);border-radius:8px;padding:1rem;margin-bottom:.5rem">
                 <label style="font-weight:600;color:var(--brand);font-size:.9rem;margin-bottom:.5rem;display:block">
-                  TradingView Username
+                  اسم مستخدم TradingView
                 </label>
                 <div class="input-wrapper">
                   <input id="tv-yearly" placeholder="@your.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">
@@ -5649,7 +5649,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <!-- الخطوة 1: اسم المستخدم -->
               <div style="background:rgba(91,138,255,.08);border:1px solid rgba(91,138,255,.2);border-radius:8px;padding:1rem;margin-bottom:.5rem">
                 <label style="font-weight:600;color:var(--brand);font-size:.9rem;margin-bottom:.5rem;display:block">
-                  TradingView Username
+                  اسم مستخدم TradingView
                 </label>
                 <div class="input-wrapper">
                   <input id="tv-lifetime" type="text" placeholder="@your.tradingview" required style="width:100%;padding:.75rem;padding-right:3rem;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);border-radius:6px;color:#fff;font-size:1rem">


### PR DESCRIPTION
CRITICAL FIX:
- Fixed missing </title> closing tag causing white screen

Additional Arabic translations:
- Pricing features: "All 7 elite indicators" → "جميع المؤشرات السبعة المميزة"
- "All future indicators/updates" → "جميع المؤشرات/التحديثات المستقبلية"
- "Priority support" → "دعم ذو أولوية"
- "Full documentation" → "وثائق كاملة"
- "82 free lessons" → "82 درساً مجانياً"
- "100% Non-Repainting (Audited)" → "100% بدون إعادة رسم (تم التدقيق)"
- "TradingView Username" labels (all 3 instances) → "اسم مستخدم TradingView"
- Image alt text: "Chart without/with Signal Pilot" → "رسم بياني بدون/مع Signal Pilot"
- "Every plan includes..." → "كل خطة تشمل نفس الميزات بالضبط"

Site should now render properly with all critical UI elements translated.