### PR TITLE
Fix mobile hamburger menu not appearing on Turkish site

### DIFF
--- a/tr/index.html
+++ b/tr/index.html
@@ -3306,7 +3306,7 @@
 
 
 
-      <nav id="mainnav" aria-label="Ana">
+      <nav id="mainnav" aria-label="Main">
 
         <ul>
 


### PR DESCRIPTION
The navigation had aria-label="Ana" (Turkish) but all CSS media queries target aria-label="Main" (English). This caused the desktop nav to not hide on mobile, showing an overflowing header instead of the hamburger menu.

Fixed by standardizing aria-label to "Main" across all language versions to ensure CSS breakpoints work correctly.