### PR TITLE
Remove Google Translate from Turkish site

### DIFF
--- a/tr/faq.html
+++ b/tr/faq.html
@@ -151,43 +151,6 @@
       z-index: 1;
     }
 
-    /* Google Translate fixes */
-    body > .skiptranslate {
-      display: none !important;
-    }
-
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-gadget {
-      color: inherit !important;
-    }
-
-    nav font,
-    nav span:not(.dropdown-arrow),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    button font,
-    button span:not(#theme-icon):not(.dropdown-arrow) {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-    }
-
-    nav a,
-    nav button,
-    #langToggle,
-    #themeToggle {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
-
     .sr-only {
       position: absolute;
       width: 1px;
@@ -813,29 +776,6 @@
       </button>
     </div>
   </header>
-
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-  <!-- Hidden select for Google Translate compatibility -->
-  <select id="langSel" style="display:none;" aria-hidden="true">
-    <option value="en">English</option>
-    <option value="de">Deutsch</option>
-    <option value="fr">Français</option>
-    <option value="es">Español</option>
-    <option value="it">Italiano</option>
-    <option value="zh">中文</option>
-    <option value="ru">Русский</option>
-    <option value="ar">العربية</option>
-    <option value="pt">Português</option>
-    <option value="tr">Türkçe</option>
-    <option value="ja">日本語</option>
-    <option value="ko">한국어</option>
-    <option value="vi">Tiếng Việt</option>
-    <option value="th">ไทย</option>
-    <option value="hi">हिन्दी</option>
-    <option value="id">Bahasa Indonesia</option>
-  </select>
 
   <!-- Hero -->
   <section class="hero">

--- a/tr/index.html
+++ b/tr/index.html
@@ -3,46 +3,6 @@
 <head>
   <meta charset="utf-8" />
 
-  <!-- CRITICAL: Set Google Translate to English IMMEDIATELY if English is selected -->
-  <script>
-    (function() {
-      try {
-        // Check URL parameter first
-        var urlParams = new URLSearchParams(window.location.search);
-        var urlLang = urlParams.get('lang');
-
-        // Check localStorage
-        var savedLang = localStorage.getItem('sp_lang') || 'en';
-
-        // If URL says English or localStorage says English, set googtrans to /en/en
-        if (urlLang === 'en' || savedLang === 'en') {
-          console.log('[GT-EARLY] Setting Google Translate to English (/en/en)');
-
-          // Get root domain
-          var hostname = location.hostname.replace(/^www\./, '');
-          var parts = hostname.split('.');
-          var rootDomain = parts.length > 2 ? parts.slice(-2).join('.') : hostname;
-
-          // Set long expiration for the /en/en cookie
-          var expires = new Date(Date.now() + 365 * 864e5).toUTCString();
-
-          // Set googtrans to /en/en on all domains
-          // This tells Google Translate: "English to English" = no translation
-          document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/';
-          document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/; domain=.' + rootDomain;
-
-          // Force English on HTML element
-          document.documentElement.lang = 'en';
-          document.documentElement.dir = 'ltr';
-
-          console.log('[GT-EARLY] Cookie set to /en/en, language set to English');
-        }
-      } catch(e) {
-        console.error('[GT-EARLY] Error:', e);
-      }
-    })();
-  </script>
-
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
   <!-- Prevent aggressive caching on mobile browsers -->
@@ -773,82 +733,11 @@
 
     *{box-sizing:border-box}
 
-    /* Google Translate fixes - prevent layout breaking */
-    body > .skiptranslate {
-      display: none !important;
-    }
-
-    body {
-      top: 0 !important;
-      position: relative !important;
-    }
-
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-menu-value span {
-      color: inherit !important;
-    }
-
-    .goog-te-gadget {
-      color: inherit !important;
-    }
-
-    /* Make Google Translate font wrappers inherit original text size */
-    font {
-      font-size: inherit !important;
-      line-height: inherit !important;
-    }
-
-    /* Specific adjustments for different text sizes */
-    h1 font, h2 font, h3 font, .headline font {
-      font-size: inherit !important;
-    }
-
-    p font, li font, div font {
-      font-size: inherit !important;
-    }
-
-    .btn font, button font, a font {
-      font-size: inherit !important;
-    }
-
-    /* CRITICAL: Force Google Translate font/span wrappers to not block clicks */
-    nav[aria-label="Main"] font,
-    nav[aria-label="Main"] span:not(.mobile-nav-title),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    .lang-dropdown-menu font,
-    .lang-dropdown-menu span,
-    .menu-toggle font,
-    .menu-toggle span,
-    #langToggle font,
-    #langToggle span,
-    .nav-dropdown font,
-    .nav-dropdown span,
-    button font,
-    button span,
-    .btn font,
-    .btn span {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-      opacity: 1 !important;
-      visibility: visible !important;
-    }
-
     /* Force mobile menu text to be white and ALWAYS visible */
     @media (max-width:1400px){
       /* Dark mode mobile menu (default) */
       nav[aria-label="Main"],
       nav[aria-label="Main"] *,
-      nav[aria-label="Main"] font,
       nav[aria-label="Main"] span,
       .mobile-nav-header,
       .mobile-nav-header *,
@@ -856,7 +745,6 @@
       .mobile-nav-close,
       #mainnav,
       #mainnav *,
-      #mainnav font,
       #mainnav span,
       #mainnav a,
       #mainnav button,
@@ -871,7 +759,6 @@
       /* Light mode mobile menu - dark text on light background */
       html[data-theme="light"] nav[aria-label="Main"],
       html[data-theme="light"] nav[aria-label="Main"] *,
-      html[data-theme="light"] nav[aria-label="Main"] font,
       html[data-theme="light"] nav[aria-label="Main"] span,
       html[data-theme="light"] .mobile-nav-header,
       html[data-theme="light"] .mobile-nav-header *,
@@ -879,7 +766,6 @@
       html[data-theme="light"] .mobile-nav-close,
       html[data-theme="light"] #mainnav,
       html[data-theme="light"] #mainnav *,
-      html[data-theme="light"] #mainnav font,
       html[data-theme="light"] #mainnav span,
       html[data-theme="light"] #mainnav a,
       html[data-theme="light"] #mainnav button,
@@ -929,7 +815,7 @@
       cursor: pointer !important;
     }
 
-    /* Fix header squeezing when Google Translate is active */
+    /* Fix header layout */
     header .container,
     header .nav {
       min-width: 0 !important;
@@ -5872,11 +5758,6 @@
 
 
 
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-
-
   <!-- =======================================================================
        SCRIPT: CONFIG + UTILITIES
        ======================================================================= -->
@@ -6068,7 +5949,7 @@
 
     /* ======================== Resources Dropdown ======================== */
 
-    // Use event delegation for Google Translate compatibility
+    // Resources dropdown functionality
     (function() {
       let dropdownOpen = false;
 
@@ -6158,79 +6039,14 @@
         btn.setAttribute('data-lang', lang.code);
         btn.textContent = lang.flag + ' ' + lang.name;
         btn.addEventListener('click', function() {
-          // Helper functions
-          function baseDomain(host) {
-            const p = host.split('.');
-            return p.length > 2 ? p.slice(-2).join('.') : host;
-          }
-
-          function setCookie(name, value, days, domain) {
-            let expires = '';
-            if (days) {
-              const d = new Date();
-              d.setTime(d.getTime() + days * 864e5);
-              expires = '; expires=' + d.toUTCString();
-            }
-            const dom = domain ? '; domain=' + domain : '';
-            document.cookie = name + '=' + value + expires + '; path=/' + dom;
-          }
-
-          function setGoogTrans(langCode) {
-            const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-            const val = '/en/' + target;
-            setCookie('googtrans', val, 365);
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            setCookie('googtrans', val, 365, root);
-          }
-
-          function applyDirLang(langCode) {
-            document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-            document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-          }
-
-          // Save to localStorage
-          localStorage.setItem('sp_lang', lang.code);
-
-          // Set cookies and attributes
+          // Navigate to the appropriate language version
           if (lang.code === 'en') {
-            // For English: Set googtrans to /en/en (English to English = no translation)
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            const expires = new Date(Date.now() + 365 * 864e5).toUTCString();
-
-            // Set to /en/en which tells Google Translate "English to English" (no translation)
-            document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/';
-            document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/; domain=' + root;
-
-            applyDirLang('en');
-
-            // Track event if analytics available
-            if (typeof trackEvent === 'function') {
-              trackEvent('language_change', {
-                language: 'en',
-                language_name: lang.name
-              });
-            }
-
-            console.log('[GT] Switching to English - setting googtrans=/en/en');
-
-            // Use location.replace for a true hard reload without history
-            setTimeout(() => {
-              location.replace(location.pathname + '?lang=en&t=' + Date.now());
-            }, 50);
+            window.location.href = '/';
+          } else if (lang.code === 'tr') {
+            window.location.href = '/tr/';
           } else {
-            setGoogTrans(lang.code);
-            applyDirLang(lang.code);
-
-            // Track event if analytics available
-            if (typeof trackEvent === 'function') {
-              trackEvent('language_change', {
-                language: lang.code,
-                language_name: lang.name
-              });
-            }
-
-            console.log('[GT] Language changed to:', lang.code);
-            location.reload();
+            // Default to English for other languages
+            window.location.href = '/';
           }
         });
         langMenu.appendChild(btn);
@@ -6343,249 +6159,6 @@
     (function(){function show(){const s=document.getElementById('thanks'); if(location.hash==='#thanks') s.style.display='block';}
 
       window.addEventListener('hashchange',show); show();})();
-
-
-
-    /* ======================== Google Translate (on demand) ======================== */
-
-    // Google Translate Initialization with robust error handling
-    window.googleTranslateElementInit = function() {
-      console.log('[GT] Init called');
-      if (!window.google || !google.translate || !google.translate.TranslateElement) {
-        console.warn('[GT] Google Translate API not ready');
-        return;
-      }
-
-      const container = document.getElementById('google_translate_container');
-      if (!container) {
-        console.error('[GT] Container not found');
-        return;
-      }
-
-      try {
-        new google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-          autoDisplay: false
-        }, 'google_translate_container');
-        console.log('[GT] Widget created successfully');
-        window.__gte_initialized = true;
-      } catch (error) {
-        console.error('[GT] Failed to create widget:', error);
-      }
-    };
-
-    // Load saved language on page load with robust polling
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function clearGoogTrans() {
-        // Clear all Google Translate cookies thoroughly and aggressively
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        const cookieNames = ['googtrans', 'googtrans(2)', 'googtrans(0)', 'googtrans(1)'];
-        const domains = ['', '; domain=' + root, '; domain=' + location.hostname, '; domain=.signalpilot.io'];
-        const paths = ['/', '/en', '/en/'];
-
-        // Nuclear option: clear every possible cookie variation
-        cookieNames.forEach(name => {
-          domains.forEach(domain => {
-            paths.forEach(path => {
-              // Try deleting with empty value
-              document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
-              // Try setting to /en/en and deleting
-              document.cookie = name + '=/en/en; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
-              // Try with max-age
-              document.cookie = name + '=; max-age=0; path=' + path + domain;
-            });
-          });
-        });
-
-        // Also clear localStorage and sessionStorage
-        if (window.localStorage) {
-          localStorage.removeItem('googtrans');
-          localStorage.removeItem('googtrans(2)');
-        }
-        if (window.sessionStorage) {
-          sessionStorage.removeItem('googtrans');
-          sessionStorage.removeItem('googtrans(2)');
-        }
-
-        // Remove any Google Translate elements from DOM
-        const gtElements = [
-          '.skiptranslate',
-          '.goog-te-banner-frame',
-          '#goog-gt-tt',
-          '.goog-te-balloon-frame',
-          'iframe[src*="translate.google.com"]',
-          'iframe.goog-te-menu-frame',
-          '.goog-te-menu2'
-        ];
-        gtElements.forEach(selector => {
-          document.querySelectorAll(selector).forEach(el => el.remove());
-        });
-
-        console.log('[GT] Cleared all Google Translate cookies and elements');
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading) {
-          console.log('[GT] Already loading');
-          return;
-        }
-        if (window.google && window.google.translate) {
-          console.log('[GT] Already loaded');
-          googleTranslateElementInit();
-          return;
-        }
-
-        console.log('[GT] Loading script...');
-        window.__gte_loading = true;
-
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        s.onerror = function() {
-          console.error('[GT] Script failed to load');
-          window.__gte_loading = false;
-          // Retry after 2 seconds
-          setTimeout(function() {
-            if (!window.google) {
-              console.log('[GT] Retrying...');
-              loadGTE();
-            }
-          }, 2000);
-        };
-        s.onload = function() {
-          console.log('[GT] Script loaded');
-          // Poll for initialization
-          let attempts = 0;
-          const checkInit = setInterval(function() {
-            attempts++;
-            if (window.__gte_initialized || attempts > 50) {
-              clearInterval(checkInit);
-              if (!window.__gte_initialized) {
-                console.warn('[GT] Init timeout after ' + attempts + ' attempts');
-              }
-            }
-          }, 100);
-        };
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-
-      // Check URL parameter for forced language
-      const urlParams = new URLSearchParams(window.location.search);
-      const urlLang = urlParams.get('lang');
-
-      let saved = localStorage.getItem(LANG_KEY) || 'en';
-
-      // If URL says lang=en, force English and clear localStorage
-      if (urlLang === 'en') {
-        saved = 'en';
-        localStorage.setItem(LANG_KEY, 'en');
-        console.log('[GT] URL forced English language');
-      }
-
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      console.log('[GT] Saved language:', code);
-
-      if (sel) sel.value = code;
-
-      // Only set translation cookies for non-English languages
-      if (code !== 'en') {
-        setGoogTrans(code);
-        applyDirLang(code);
-      } else {
-        // For English: cookie already set to /en/en by early script
-        // Just ensure HTML attributes are correct
-        applyDirLang('en');
-
-        // Remove Google Translate font wrappers that might be lingering in the DOM
-        setTimeout(() => {
-          document.querySelectorAll('font').forEach(font => {
-            const parent = font.parentNode;
-            while (font.firstChild) {
-              parent.insertBefore(font.firstChild, font);
-            }
-            parent.removeChild(font);
-          });
-        }, 100);
-
-        // Clean URL after processing
-        if (urlLang === 'en') {
-          setTimeout(() => {
-            const cleanUrl = window.location.pathname;
-            window.history.replaceState({}, '', cleanUrl);
-          }, 200);
-        }
-      }
-
-      // Update language button text to show current language
-      const langBtn = document.getElementById('langToggle');
-      if (langBtn) {
-        const langText = langBtn.querySelector('span');
-        if (langText) {
-          const flagMap = {
-            'en': '🇺🇸', 'de': '🇩🇪', 'fr': '🇫🇷', 'es': '🇪🇸',
-            'it': '🇮🇹', 'zh': '🇨🇳', 'ru': '🇷🇺', 'ar': '🇸🇦',
-            'pt': '🇵🇹', 'tr': '🇹🇷', 'ja': '🇯🇵', 'ko': '🇰🇷',
-            'vi': '🇻🇳', 'th': '🇹🇭', 'hi': '🇮🇳', 'id': '🇮🇩'
-          };
-          langText.textContent = flagMap[code] || '🌐';
-        }
-      }
-
-      // Load on DOMContentLoaded to ensure page is ready
-      if (code !== 'en') {
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(loadGTE, 500); // Small delay to let page settle
-          });
-        } else {
-          setTimeout(loadGTE, 500);
-        }
-      }
-
-      sel.addEventListener('change', e => {
-        const v = e.target.value;
-        localStorage.setItem(LANG_KEY, v);
-        setGoogTrans(v);
-        applyDirLang(v);
-        if (v !== 'en') loadGTE();
-        location.reload();
-      });
-    })();
 
 
 

--- a/tr/roadmap.html
+++ b/tr/roadmap.html
@@ -150,45 +150,6 @@
       z-index: 1;
     }
 
-    /* Google Translate fixes */
-    body > .skiptranslate {
-      display: none !important;
-    }
-
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-gadget {
-      color: inherit !important;
-    }
-
-    /* Prevent Google Translate from blocking clicks */
-    nav font,
-    nav span:not(.dropdown-arrow),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    button font,
-    button span:not(#theme-icon):not(.dropdown-arrow) {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-    }
-
-    /* Ensure buttons always work */
-    nav a,
-    nav button,
-    #langToggle,
-    #themeToggle {
-      pointer-events: auto !important;
-      cursor: pointer !important;
-    }
-
     /* Screen reader only utility */
     .sr-only {
       position: absolute;
@@ -1063,29 +1024,6 @@
     </div>
   </header>
 
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-  <!-- Hidden select for Google Translate compatibility -->
-  <select id="langSel" style="display:none;" aria-hidden="true">
-    <option value="en">English</option>
-    <option value="de">Deutsch</option>
-    <option value="fr">Français</option>
-    <option value="es">Español</option>
-    <option value="it">Italiano</option>
-    <option value="zh">中文</option>
-    <option value="ru">Русский</option>
-    <option value="ar">العربية</option>
-    <option value="pt">Português</option>
-    <option value="tr">Türkçe</option>
-    <option value="ja">日本語</option>
-    <option value="ko">한국어</option>
-    <option value="vi">Tiếng Việt</option>
-    <option value="th">ไทย</option>
-    <option value="hi">हिन्दी</option>
-    <option value="id">Bahasa Indonesia</option>
-  </select>
-
   <!-- Hero -->
   <section class="hero">
     <div class="container">
@@ -1332,7 +1270,15 @@
       languages.forEach(lang => {
         const btn = document.createElement('button');
         btn.textContent = lang.name;
-        btn.onclick = () => selectLanguage(lang);
+        btn.onclick = () => {
+          if (lang.code === 'en') {
+            window.location.href = '/roadmap.html';
+          } else if (lang.code === 'tr') {
+            window.location.href = '/tr/roadmap.html';
+          } else {
+            window.location.href = '/roadmap.html';
+          }
+        };
         langMenu.appendChild(btn);
       });
 
@@ -1360,124 +1306,6 @@
           langBtn.setAttribute('aria-expanded', 'false');
         }
       });
-
-      function selectLanguage(lang) {
-        console.log('Language selected:', lang.code);
-
-        // Helper functions from page load script
-        function baseDomain(host) {
-          const p = host.split('.');
-          return p.length > 2 ? p.slice(-2).join('.') : host;
-        }
-
-        function setCookie(name, value, days, domain) {
-          let expires = '';
-          if (days) {
-            const d = new Date();
-            d.setTime(d.getTime() + days * 864e5);
-            expires = '; expires=' + d.toUTCString();
-          }
-          const dom = domain ? '; domain=' + domain : '';
-          document.cookie = name + '=' + value + expires + '; path=/' + dom;
-        }
-
-        function setGoogTrans(langCode) {
-          const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-          const val = '/en/' + target;
-          setCookie('googtrans', val, 365);
-          const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-          setCookie('googtrans', val, 365, root);
-        }
-
-        function applyDirLang(langCode) {
-          document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-          document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-        }
-
-        function loadGTE() {
-          if (window.__gte_loading || window.google) return;
-          window.__gte_loading = true;
-          const s = document.createElement('script');
-          s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-          s.async = true;
-          document.head.appendChild(s);
-        }
-
-        // Save to localStorage
-        localStorage.setItem('sp_lang', lang.code);
-
-        // Set cookies and attributes
-        setGoogTrans(lang.code);
-        applyDirLang(lang.code);
-
-        // Load translate script if not English
-        if (lang.code !== 'en') loadGTE();
-
-        // Reload page to apply translation
-        location.reload();
-      }
-    })();
-
-    // Google Translate Initialization
-    window.googleTranslateElementInit = function() {
-      if (!window.google || !google.translate) return;
-      new google.translate.TranslateElement({
-        pageLanguage: 'en',
-        includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-        autoDisplay: false
-      }, 'google_translate_container');
-    };
-
-    // Load saved language on page load
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading || window.google) return;
-        window.__gte_loading = true;
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-      const saved = localStorage.getItem(LANG_KEY) || 'en';
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      if (sel) sel.value = code;
-      setGoogTrans(code);
-      applyDirLang(code);
-      if (code !== 'en') loadGTE();
     })();
 
     // Smooth scroll for nav links with offset


### PR DESCRIPTION
- Remove all Google Translate initialization code from tr/index.html
- Remove Google Translate CSS fixes from all Turkish pages
- Remove hidden Google Translate containers and select elements
- Replace Google Translate language switching with simple navigation
- Update language dropdowns to redirect to appropriate language versions

All Google Translate functionality has been completely removed from:
- tr/index.html
- tr/faq.html
- tr/roadmap.html