### PR TITLE
Remove all Google Translate code from French site

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -746,7 +746,7 @@
       color: inherit !important;
     }
 
-    /* Make Google Translate font wrappers inherit original text size */
+    /* Make font elements inherit original text size */
     font {
       font-size: inherit !important;
       line-height: inherit !important;
@@ -765,7 +765,7 @@
       font-size: inherit !important;
     }
 
-    /* CRITICAL: Force Google Translate font/span wrappers to not block clicks */
+    /* CRITICAL: Force font/span elements to not block clicks */
     nav[aria-label="Main"] font,
     nav[aria-label="Main"] span:not(.mobile-nav-title),
     
@@ -848,7 +848,7 @@
     nav[aria-label="Main"] button,
     
 
-    /* Fix header squeezing when Google Translate is active */
+    /* Fix header layout */
     header .container,
     header .nav {
       min-width: 0 !important;
@@ -6118,14 +6118,6 @@
             document.cookie = name + '=' + value + expires + '; path=/' + dom;
           }
 
-          function setGoogTrans(langCode) {
-            const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-            const val = '/en/' + target;
-            setCookie('googtrans', val, 365);
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            setCookie('googtrans', val, 365, root);
-          }
-
           function applyDirLang(langCode) {
             document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
             document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
@@ -6134,16 +6126,8 @@
           // Save to localStorage
           localStorage.setItem('sp_lang', lang.code);
 
-          // Set cookies and attributes
+          // Set language attributes
           if (lang.code === 'en') {
-            // For English: Set googtrans to /en/en (English to English = no translation)
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            const expires = new Date(Date.now() + 365 * 864e5).toUTCString();
-
-            // Set to /en/en which tells Google Translate "English to English" (no translation)
-            document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/';
-            document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/; domain=' + root;
-
             applyDirLang('en');
 
             // Track event if analytics available
@@ -6154,14 +6138,13 @@
               });
             }
 
-            console.log('[GT] Switching to English - setting googtrans=/en/en');
+            console.log('Switching to English');
 
             // Use location.replace for a true hard reload without history
             setTimeout(() => {
               location.replace(location.pathname + '?lang=en&t=' + Date.now());
             }, 50);
           } else {
-            setGoogTrans(lang.code);
             applyDirLang(lang.code);
 
             // Track event if analytics available
@@ -6172,7 +6155,7 @@
               });
             }
 
-            console.log('[GT] Language changed to:', lang.code);
+            console.log('Language changed to:', lang.code);
             location.reload();
           }
         });
@@ -6286,11 +6269,6 @@
     (function(){function show(){const s=document.getElementById('thanks'); if(location.hash==='#thanks') s.style.display='block';}
 
       window.addEventListener('hashchange',show); show();})();
-
-
-
-    /* ======================== Google Translate (on demand) ======================== */
-
 
 
 


### PR DESCRIPTION
Removed all Google Translate related code:
- Removed Google Translate CSS comments
- Removed setGoogTrans() function
- Removed googtrans cookie setting code
- Removed Google Translate section comment
- Kept language switcher functionality without Google Translate dependency

The site now uses only native language switching without Google Translate.