### PR TITLE
Remove unsupported languages from language selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -5910,17 +5910,13 @@
         { code: 'fr', name: 'Français', flag: '🇫🇷' },
         { code: 'es', name: 'Español', flag: '🇪🇸' },
         { code: 'it', name: 'Italiano', flag: '🇮🇹' },
-        { code: 'zh', name: '中文', flag: '🇨🇳' },
         { code: 'ru', name: 'Русский', flag: '🇷🇺' },
         { code: 'ar', name: 'العربية', flag: '🇸🇦' },
         { code: 'pt', name: 'Português', flag: '🇵🇹' },
         { code: 'tr', name: 'Türkçe', flag: '🇹🇷' },
         { code: 'ja', name: '日本語', flag: '🇯🇵' },
-        { code: 'ko', name: '한국어', flag: '🇰🇷' },
-        { code: 'vi', name: 'Tiếng Việt', flag: '🇻🇳' },
-        { code: 'th', name: 'ไทย', flag: '🇹🇭' },
-        { code: 'hi', name: 'हिन्दी', flag: '🇮🇳' },
-        { code: 'id', name: 'Bahasa Indonesia', flag: '🇮🇩' }
+        { code: 'hu', name: 'Magyar', flag: '🇭🇺' },
+        { code: 'nl', name: 'Nederlands', flag: '🇳🇱' }
       ];
 
       languages.forEach(lang => {

--- a/ru/index.html
+++ b/ru/index.html
@@ -5908,17 +5908,13 @@
         { code: 'fr', name: 'Français', flag: '🇫🇷' },
         { code: 'es', name: 'Español', flag: '🇪🇸' },
         { code: 'it', name: 'Italiano', flag: '🇮🇹' },
-        { code: 'zh', name: '中文', flag: '🇨🇳' },
         { code: 'ru', name: 'Русский', flag: '🇷🇺' },
         { code: 'ar', name: 'العربية', flag: '🇸🇦' },
         { code: 'pt', name: 'Português', flag: '🇵🇹' },
         { code: 'tr', name: 'Türkçe', flag: '🇹🇷' },
         { code: 'ja', name: '日本語', flag: '🇯🇵' },
-        { code: 'ko', name: '한국어', flag: '🇰🇷' },
-        { code: 'vi', name: 'Tiếng Việt', flag: '🇻🇳' },
-        { code: 'th', name: 'ไทย', flag: '🇹🇭' },
-        { code: 'hi', name: 'हिन्दी', flag: '🇮🇳' },
-        { code: 'id', name: 'Bahasa Indonesia', flag: '🇮🇩' }
+        { code: 'hu', name: 'Magyar', flag: '🇭🇺' },
+        { code: 'nl', name: 'Nederlands', flag: '🇳🇱' }
       ];
 
       languages.forEach(lang => {


### PR DESCRIPTION
- Removed languages without directories: Chinese (zh), Korean (ko), Vietnamese (vi), Thai (th), Hindi (hi), Indonesian (id)
- Added missing languages with directories: Hungarian (hu), Dutch (nl)
- Language selector now only shows languages with actual translations
- Applies to both index.html and ru/index.html