### PR TITLE
Remove language toggle buttons from all Italian pages headers

### DIFF
--- a/it/faq.html
+++ b/it/faq.html
@@ -187,13 +187,8 @@
       max-height: 64px;
     }
 
-    header .container > .lang-dropdown,
     header .container > #themeToggle {
       flex-shrink: 0;
-    }
-
-    header .container > .lang-dropdown + #themeToggle {
-      margin-left: -0.8rem;
     }
 
     .brand {
@@ -316,55 +311,6 @@
     }
 
     .nav-dropdown-menu a:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
-    }
-
-    .lang-dropdown {
-      position: relative;
-      flex-shrink: 0;
-    }
-
-    .lang-dropdown-menu {
-      position: fixed;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.75rem;
-      min-width: 160px;
-      max-height: 400px;
-      overflow-y: auto;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 9999;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
-
-    .lang-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
-
-    .lang-dropdown-menu button {
-      display: block;
-      width: 100%;
-      padding: 0.6rem 0.8rem;
-      border: none;
-      background: transparent;
-      border-radius: 6px;
-      color: var(--muted);
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-
-    .lang-dropdown-menu button:hover {
       background: rgba(91, 138, 255, 0.15);
       color: var(--text);
     }
@@ -859,12 +805,6 @@
           <li><a href="/it/#pricing">Prezzi</a></li>
         </ul>
       </nav>
-
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Selezione lingua" aria-expanded="false" aria-haspopup="true">
-          <span>IT</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn" type="button" aria-label="Selezione tema">
         <span id="theme-icon">◐</span>
@@ -1443,87 +1383,6 @@
           dropdownOpen = false;
         }
       });
-    })();
-
-    // Language Dropdown
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
-
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      const languages = [
-        { code: 'en', name: 'English' },
-        { code: 'de', name: 'Deutsch' },
-        { code: 'fr', name: 'Français' },
-        { code: 'es', name: 'Español' },
-        { code: 'it', name: 'Italiano' },
-        { code: 'zh', name: '中文' },
-        { code: 'ru', name: 'Русский' },
-        { code: 'ar', name: 'العربية' },
-        { code: 'pt', name: 'Português' },
-        { code: 'tr', name: 'Türkçe' },
-        { code: 'ja', name: '日本語' },
-        { code: 'ko', name: '한국어' },
-        { code: 'vi', name: 'Tiếng Việt' },
-        { code: 'th', name: 'ไทย' },
-        { code: 'hi', name: 'हिन्दी' },
-        { code: 'id', name: 'Bahasa Indonesia' },
-        { code: 'hu', name: 'Magyar' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.textContent = lang.name;
-        btn.onclick = () => selectLanguage(lang);
-        langMenu.appendChild(btn);
-      });
-
-      document.body.appendChild(langMenu);
-
-      let menuOpen = false;
-
-      langBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        menuOpen = !menuOpen;
-        langMenu.classList.toggle('show', menuOpen);
-        langBtn.setAttribute('aria-expanded', menuOpen);
-
-        if (menuOpen) {
-          const rect = langBtn.getBoundingClientRect();
-          langMenu.style.top = (rect.bottom + 8) + 'px';
-          langMenu.style.left = (rect.left - langMenu.offsetWidth + rect.width) + 'px';
-        }
-      });
-
-      document.addEventListener('click', function(e) {
-        if (menuOpen && !langBtn.contains(e.target) && !langMenu.contains(e.target)) {
-          menuOpen = false;
-          langMenu.classList.remove('show');
-          langBtn.setAttribute('aria-expanded', 'false');
-        }
-      });
-
-      function selectLanguage(lang) {
-        const supportedLangs = {
-          'en': '/faq.html',
-          'de': '/de/faq.html',
-          'fr': '/fr/faq.html',
-          'es': '/es/faq.html',
-          'it': '/it/faq.html',
-          'ja': '/ja/faq.html',
-          'pt': '/pt/faq.html',
-          'hu': '/hu/faq.html'
-        };
-
-        if (supportedLangs[lang.code]) {
-          window.location.href = supportedLangs[lang.code];
-        } else {
-          // For unsupported languages, stay on current page
-          console.log('Language not yet supported:', lang.code);
-        }
-      }
     })();
 
     // FAQ Search Functionality

--- a/it/index.html
+++ b/it/index.html
@@ -741,7 +741,6 @@
     header button,
     header a,
     .menu-toggle,
-    #langToggle,
     #themeToggle,
     .btn {
       white-space:nowrap !important;
@@ -801,7 +800,6 @@
 
       /* Ensure header buttons adapt to smaller text when necessary */
       header .btn,
-      header #langToggle,
       header #themeToggle {
         font-size: .8rem !important;
         padding: .4rem .6rem !important;
@@ -809,13 +807,6 @@
         overflow: hidden !important;
         text-overflow: ellipsis !important;
         flex-shrink: 1 !important;
-      }
-
-      /* Language button - allow slight shrinking if needed */
-      header #langToggle span {
-        max-width: 30px !important;
-        overflow: hidden !important;
-        text-overflow: clip !important;
       }
 
       /* CTA button - ensure it doesn't overflow */
@@ -2058,66 +2049,11 @@
     }
 
 
-    /* Language Dropdown - container only (menu created as body child in JavaScript) */
-    .lang-dropdown{
-      position:relative;
-      flex-shrink:0;
-      z-index:67 !important;
-    }
+    #themeToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
 
-    /* Language dropdown menu - created as direct child of body, needs to work on ALL screen sizes */
-    .lang-dropdown-menu {
-      position: fixed !important;
-      top: 70px;
-      right: 20px;
-      background: rgba(10, 12, 20, 0.98);
-      border: 2px solid rgba(255, 255, 255, 0.4);
-      border-radius: 12px;
-      padding: 0.5rem;
-      min-width: 180px;
-      max-height: 500px;
-      overflow-y: auto;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-      z-index: 76 !important;
-      opacity: 0 !important;
-      visibility: hidden !important;
-      transform: translateY(-10px);
-      transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
-      display: flex !important;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-    .lang-dropdown-menu.active {
-      opacity: 1 !important;
-      visibility: visible !important;
-      transform: translateY(0) !important;
-    }
-    .lang-dropdown-menu button {
-      padding: 0.6rem 0.9rem;
-      background: transparent;
-      border: none;
-      border-radius: 8px;
-      color: #b7c2d9;
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: #fff;
-    }
-
-
-    #themeToggle,
-    #langToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
-
-    /* Make theme and language buttons smaller on mobile */
+    /* Make theme button smaller on mobile */
     @media (max-width:768px){
-      #themeToggle,
-      #langToggle{
+      #themeToggle{
         padding:.3rem !important;
         font-size:0.8rem !important;
         min-width:40px;
@@ -2127,18 +2063,10 @@
         justify-content:center !important;
       }
 
-      #themeToggle span,
-      #langToggle span{
+      #themeToggle span{
         display:flex !important;
         align-items:center !important;
         justify-content:center !important;
-      }
-
-      /* Fix language dropdown menu on mobile */
-      .lang-dropdown-menu {
-        right: 10px;
-        min-width: 160px;
-        max-width: calc(100vw - 20px);
       }
 
       /* Ensure header doesn't exceed viewport width and allows natural height */
@@ -2229,8 +2157,7 @@
     }
 
 
-    /* CRITICAL FIX: Ensure language/theme buttons stay visible */
-    .lang-dropdown,
+    /* CRITICAL FIX: Ensure theme button stays visible */
     #themeToggle,
     .menu-toggle{
       position:relative;
@@ -2274,13 +2201,8 @@
       }
 
       /* Better mobile header button sizing */
-      .lang-dropdown,
       #themeToggle {
         flex-shrink: 0;
-      }
-
-      #themeToggle,
-      #langToggle {
         min-width: 44px; /* iOS minimum tap target */
         min-height: 44px;
       }
@@ -2630,7 +2552,6 @@
 
       /* Extra small screens - further reduce header button sizes for translated text */
       header .btn,
-      header #langToggle,
       header #themeToggle {
         font-size: .75rem !important;
         padding: .35rem .5rem !important;
@@ -3120,14 +3041,6 @@
         </ul>
 
       </nav>
-
-
-
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Selezione lingua" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text)">
-          <span>🇺🇸</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Selezione tema" style="padding:.5rem .7rem;color:var(--text)">
         <span id="theme-icon">
@@ -6751,17 +6664,7 @@ if ('serviceWorker' in navigator) {
       });
     });
 
-    // 6. TRACK LANGUAGE SELECTOR
-    const langToggle = document.getElementById('langToggle');
-    if (langToggle) {
-      langToggle.addEventListener('click', function() {
-        trackEvent('language_selector_open', {});
-      });
-    }
-
-    // Language dropdown analytics now integrated into the language dropdown JavaScript above
-
-    // 7. TRACK THEME TOGGLE
+    // 6. TRACK THEME TOGGLE
     const themeToggle = document.getElementById('themeToggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', function() {

--- a/it/roadmap.html
+++ b/it/roadmap.html
@@ -196,13 +196,8 @@
       max-height: 64px !important;
     }
 
-    header .container > .lang-dropdown,
     header .container > #themeToggle {
       flex-shrink: 0;
-    }
-
-    header .container > .lang-dropdown + #themeToggle {
-      margin-left: -0.8rem;
     }
 
     .brand {
@@ -384,56 +379,6 @@
     html[data-theme="light"] .nav-dropdown-menu a:hover {
       background: rgba(59,130,246,.12);
       color: #0f172a;
-    }
-
-    /* Language Dropdown */
-    .lang-dropdown {
-      position: relative;
-      flex-shrink: 0;
-    }
-
-    .lang-dropdown-menu {
-      position: fixed;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.75rem;
-      min-width: 160px;
-      max-height: 400px;
-      overflow-y: auto;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 9999;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
-
-    .lang-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
-
-    .lang-dropdown-menu button {
-      display: block;
-      width: 100%;
-      padding: 0.6rem 0.8rem;
-      border: none;
-      background: transparent;
-      border-radius: 6px;
-      color: var(--muted);
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
     }
 
     .btn {
@@ -1001,12 +946,6 @@
           <li><a href="/it/#pricing">Prezzi</a></li>
         </ul>
       </nav>
-
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Language selection" aria-expanded="false" aria-haspopup="true">
-          <span>🌐</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn" type="button" aria-label="Theme selection">
         <span id="theme-icon">🌙</span>


### PR DESCRIPTION
Removed language selector button and all related code from:
- /it/index.html - Removed button, CSS, and tracking code
- /it/faq.html - Removed button, CSS, and JavaScript
- /it/roadmap.html - Removed button and CSS

This ensures a clean header with only the theme toggle button. No more language switching functionality on Italian pages.