### PR TITLE
Fix Dutch directory language and remove translation

### DIFF
--- a/nl/affiliates.html
+++ b/nl/affiliates.html
@@ -872,7 +872,7 @@
       <div style="display:flex;justify-content:center;gap:2rem;flex-wrap:wrap;margin-bottom:1.5rem">
         <a href="/">Home</a>
         <a href="/#pricing">Prijzen</a>
-        <a href="/faq.html">FAQ</a>
+        <a href="/nl/faq.html">FAQ</a>
         <a href="https://docs.signalpilot.io" target="_blank">Documentatie</a>
         <a href="https://education.signalpilot.io" target="_blank">Onderwijs</a>
       </div>

--- a/nl/faq.html
+++ b/nl/faq.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Veelgestelde Vragen — Signal Pilot</title>
-  <meta name="description" content="Umfassende Veelgestelde Vragen zu Signal Pilot Indikatoren, Bildung, Preisgestaltung und Support.">
+  <meta name="description" content="Uitgebreide veelgestelde vragen over Signal Pilot indicatoren, onderwijs, prijzen en ondersteuning.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
@@ -711,95 +711,95 @@
         "name": "Wat is Signal Pilot?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Signal Pilot ist eine Suite von 7 Elite-TradingView-Indikatoren, die für die vollständige Erkennung von Marktzyklen entwickelt wurden. Unser Flaggschiff-Indikator, Pentarch, bildet 5-phasige Umkehrsequenzen (TD→IGN→WRN→CAP→BDN) über jeden Zeitrahmen und Markt ab. Alle Indikatoren sind 100% nicht-repainting und wurden auf Lookahead-Bias überprüft."
+          "text": "Signal Pilot is een suite van 7 elite TradingView-indicatoren die zijn ontworpen voor volledige detectie van marktcycli. Onze vlaggenschip-indicator, Pentarch, brengt 5-fase omkeringssequenties (TD→IGN→WRN→CAP→BDN) in kaart over elk tijdsbestek en elke markt. Alle indicatoren zijn 100% non-repainting en getest op lookahead-bias."
         }
       },
       {
         "@type": "Question",
-        "name": "Malen sich die Signale neu?",
+        "name": "Worden de signalen opnieuw getekend?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Null Neuzeichnung. Garantiert. Alle Signale werden beim Kerzenschluss abgeschlossen. Wir überprüfen jeden Indikator auf Lookahead-Bias. Wenn Sie einen Neuzeichnung nachweisen können, zahlen wir Ihnen 100 USD. Was Sie in der Geschichte sehen, ist genau das, was Sie live gesehen hätten."
+          "text": "Nul herschikking. Gegarandeerd. Alle signalen worden bevestigd bij kaarssluiting. We testen elke indicator op lookahead-bias. Als u herschikking kunt bewijzen, betalen we u 100 USD. Wat u in de geschiedenis ziet, is precies wat u live zou hebben gezien."
         }
       },
       {
         "@type": "Question",
-        "name": "Wie viel kostet Signal Pilot?",
+        "name": "Hoeveel kost Signal Pilot?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Wir bieten 3 Pläne an: Monatlich (99 USD/Monat), Jährlich (699 USD/Jahr - sparen Sie 41%) und Lifetime (1.799-3.499 USD mit dynamischer Preisgestaltung). Alle Pläne umfassen die gleichen 7 indicatoren mit 7-Tage-Geld-zurück-Garantie."
+          "text": "We bieden 3 plannen aan: Maandelijks (99 USD/maand), Jaarlijks (699 USD/jaar - bespaar 41%) en Lifetime (1.799-3.499 USD met dynamische prijzen). Alle plannen bevatten dezelfde 7 indicatoren met 7-dagen-geld-terug-garantie."
         }
       },
       {
         "@type": "Question",
-        "name": "Funktioniert es auf kostenlosem TradingView?",
+        "name": "Werkt het op gratis TradingView?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Ja! Sie benötigen nur genug Indikator-Slots für Ihr Setup. Kostenlose Konten erhalten 3 Slots, was für Pentarch + 1-2 Filter ausreicht. Pro/Premium-Konten haben mehr Slots und unbegrenzte Alerts. Indikatoren funktionieren identisch über alle TradingView-Plan-Ebenen."
+          "text": "Ja! U heeft alleen voldoende indicator-slots nodig voor uw setup. Gratis accounts krijgen 3 slots, wat voldoende is voor Pentarch + 1-2 filters. Pro/Premium-accounts hebben meer slots en onbeperkte alerts. Indicatoren werken identiek op alle TradingView-planniveaus."
         }
       },
       {
         "@type": "Question",
-        "name": "Welche Märkte werden unterstützt?",
+        "name": "Welke markten worden ondersteund?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Beliebiger Markt auf TradingView: Aktien, Indizes, Devisenkurse, Cryptowährungen, Grondstoffen, Anleihen, Futures, Optionen. Wenn es OHLC + Volumendaten hat, funktionieren unsere Indikatoren. Getestet auf 100+ Symbolen über alle Anlageklassen."
+          "text": "Elke markt op TradingView: Aandelen, Indices, Forex, Cryptocurrencies, Grondstoffen, Obligaties, Futures, Opties. Als het OHLC + volumegegevens heeft, werken onze indicatoren. Getest op 100+ symbolen over alle activaklassen."
         }
       },
       {
         "@type": "Question",
-        "name": "Kann ich eine Rückerstattung bekommen?",
+        "name": "Kan ik een restitutie krijgen?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Ja! 7-Tage-Geld-zurück-Garantie für alle Pläne. Wenn Sie innerhalb von 7 Tagen nach dem Kauf unzufrieden sind, senden Sie uns eine E-Mail zur vollständigen Rückerstattung. Keine Fragen gestellt, keine Strafe."
+          "text": "Ja! 7-dagen-geld-terug-garantie voor alle plannen. Als u binnen 7 dagen na aankoop niet tevreden bent, stuur ons dan een e-mail voor volledige restitutie. Geen vragen gesteld, geen boete."
         }
       },
       {
         "@type": "Question",
-        "name": "Wie fange ich nach dem Kauf an?",
+        "name": "Hoe begin ik na aankoop?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Nach dem Kauf erhalten Sie innerhalb von 1-8 Stunden eine TradingView-Einladung (normalerweise unter 2 Stunden). Überprüfen Sie Ihre E-Mail und TradingView-Benachrichtigungen. Akzeptieren Sie die Einladung, und die Indikatoren erscheinen unter \"Indikatoren → Einladungs-exklusive Scripts\"."
+          "text": "Na aankoop ontvangt u binnen 1-8 uur een TradingView-uitnodiging (meestal binnen 2 uur). Controleer uw e-mail en TradingView-meldingen. Accepteer de uitnodiging en de indicatoren verschijnen onder \"Indicatoren → Uitnodiging-exclusieve scripts\"."
         }
       },
       {
         "@type": "Question",
-        "name": "Was ist SP — Pentarch?",
+        "name": "Wat is SP — Pentarch?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Pentarch ist unser Flaggschiff-Indikator für die vollständige Trend-Regime-Erkennung. Es bildet 5-phasige Marktumkehrsequenzen ab: TD (Touchdown), IGN (Zündung), WRN (Warnung), CAP (Klimax) und BDN (Zusammenbruch). Integriert 4 Ebenen: Regime-Balken, Pilot-Linie, NanoFlow-Kreuze und Event-Signale – alle nicht repainting."
+          "text": "Pentarch is onze vlaggenschip-indicator voor volledige trendregime-detectie. Het brengt 5-fase marktomkeringssequenties in kaart: TD (Touchdown), IGN (Ontsteking), WRN (Waarschuwing), CAP (Climax) en BDN (Breakdown). Integreert 4 lagen: Regime-balken, Pilot-lijn, NanoFlow-kruisingen en Event-signalen – allemaal non-repainting."
         }
       },
       {
         "@type": "Question",
-        "name": "Benötige ich Programmierkenntnisse?",
+        "name": "Heb ik programmeerkennis nodig?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Null Kodierung erforderlich. Alle Indikatoren sind Plug-and-Play. Wir enthalten 200+ vorkonfigurierte Konfigurationen für verschiedene Strategien. Laden Sie einfach die Vorgabe, wenden Sie sie auf ein Diagramm an, fertig."
+          "text": "Geen codering vereist. Alle indicatoren zijn plug-and-play. We bevatten 200+ vooraf geconfigureerde configuraties voor verschillende strategieën. Laad gewoon de voorinstelling, pas deze toe op een grafiek, klaar."
         }
       },
       {
         "@type": "Question",
-        "name": "Kann ich mehrere Indikatoren zusammen verwenden?",
+        "name": "Kan ik meerdere indicatoren samen gebruiken?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Absolut! Die Elite Seven sind so konzipiert, dass sie zusammenarbeiten. Beliebte Kombinationen: Pentarch + Volume Oracle für Zyklus-Timing mit Smart-Money-Bestätigung, Omnideck + Janus Atlas für komplette Marktstruktur mit Schlüsselniveaus."
+          "text": "Absoluut! De Elite Seven zijn ontworpen om samen te werken. Populaire combinaties: Pentarch + Volume Oracle voor cyclus-timing met smart-money-bevestiging, Omnideck + Janus Atlas voor complete marktstructuur met belangrijke niveaus."
         }
       },
       {
         "@type": "Question",
-        "name": "Welche Zeitrahmen funktionieren am besten?",
+        "name": "Welke tijdsbestekken werken het beste?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Alle Zeitrahmen unterstützt – 1-Minuten bis jährliche Diagramme. Am beliebtesten: 15m-1H für Day Trading, 4H-Daily für Swing Trading, Weekly-Monthly für Position Trading. Pentarchs 5-phasiger Zyklus passt sich automatisch an Ihren Zeitrahmen an."
+          "text": "Alle tijdsbestekken ondersteund – 1-minuut tot jaarlijkse grafieken. Meest populair: 15m-1H voor daytrading, 4H-Daily voor swing trading, Weekly-Monthly voor positiehandel. Pentarchs 5-fase cyclus past zich automatisch aan uw tijdsbestek aan."
         }
       },
       {
         "@type": "Question",
-        "name": "Wie viele Geräte kann ich verwenden?",
+        "name": "Hoeveel apparaten kan ik gebruiken?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Ein TradingView-Benutzername pro Lizenz. Sie können sich auf unbegrenzten Geräten mit diesem Benutzernamen anmelden. Account-Sharing ist verboten – jedes Abonnement ist an ein TradingView-Konto gebunden."
+          "text": "Eén TradingView-gebruikersnaam per licentie. U kunt zich aanmelden op onbeperkt aantal apparaten met die gebruikersnaam. Account-delen is verboden – elk abonnement is gekoppeld aan één TradingView-account."
         }
       }
     ]
@@ -815,25 +815,25 @@
       <a href="/" class="brand"><span>Signal Pilot</span></a>
       <nav>
         <ul>
-          <li><a href="/#why">Warum wir?</a></li>
-          <li><a href="/#inside">Was ist innen</a></li>
-          <li><a href="/roadmap.html">Roadmap</a></li>
+          <li><a href="/#why">Waarom wij?</a></li>
+          <li><a href="/#inside">Wat zit erin</a></li>
+          <li><a href="/nl/roadmap.html">Roadmap</a></li>
           <li class="nav-dropdown">
             <button class="nav-dropdown-toggle" aria-expanded="false" aria-haspopup="true">
-              Ressourcen <span class="dropdown-arrow">▼</span>
+              Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Onderwijscentrum</a></li>
-              <li><a href="/faq.html">FAQ-Zentrum</a></li>
+              <li><a href="/nl/faq.html">FAQ-centrum</a></li>
             </ul>
           </li>
-          <li><a href="/#pricing">Preise</a></li>
+          <li><a href="/#pricing">Prijzen</a></li>
         </ul>
       </nav>
 
 
-      <button id="themeToggle" class="btn" type="button" aria-label="Design-Auswahl">
+      <button id="themeToggle" class="btn" type="button" aria-label="Thema keuze">
         <span id="theme-icon">◐</span>
       </button>
     </div>
@@ -844,24 +844,24 @@
   <section class="hero">
     <div class="container">
       <h1>Veelgestelde Vragen</h1>
-      <p class="subtitle">Alles, was Sie über Signal Pilot Indikatoren, Bildung, Preisgestaltung und Support wissen müssen.</p>
+      <p class="subtitle">Alles wat u moet weten over Signal Pilot indicatoren, onderwijs, prijzen en ondersteuning.</p>
 
       <!-- Search Box -->
       <div class="search-box">
         <span class="search-icon">🔍</span>
-        <input type="text" id="faqSearch" placeholder="FAQs durchsuchen..." aria-label="FAQs durchsuchen">
+        <input type="text" id="faqSearch" placeholder="Zoek in FAQ's..." aria-label="Zoek in FAQ's">
       </div>
 
       <!-- Category Navigation -->
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Alle</button>
         <button class="category-btn" data-category="getting-started">Aan de slag</button>
-        <button class="category-btn" data-category="indicators">Indikatoren</button>
+        <button class="category-btn" data-category="indicators">Indicatoren</button>
         <button class="category-btn" data-category="technical">Technisch</button>
-        <button class="category-btn" data-category="trading">Handel</button>
-        <button class="category-btn" data-category="education">Bildung</button>
-        <button class="category-btn" data-category="pricing">Preise</button>
-        <button class="category-btn" data-category="support">Unterstützung</button>
+        <button class="category-btn" data-category="trading">Handelen</button>
+        <button class="category-btn" data-category="education">Onderwijs</button>
+        <button class="category-btn" data-category="pricing">Prijzen</button>
+        <button class="category-btn" data-category="support">Ondersteuning</button>
       </div>
     </div>
   </section>
@@ -884,47 +884,47 @@
               <span>Wat is Signal Pilot?</span>
             </div>
             <div class="faq-answer">
-              Signal Pilot ist eine Suite von 7 Elite-TradingView-Indikatoren, die für die vollständige Erkennung von Marktzyklen entwickelt wurden. Unser Flaggschiff-Indikator <strong>Pentarch</strong> bildet 5-phasige Umkehrsequenzen (TD→IGN→WRN→CAP→BDN) über jeden Zeitrahmen und Markt ab. Alle Indikatoren sind <strong>100% nicht-repainting</strong> und wurden auf Lookahead-Bias überprüft.
+              Signal Pilot is een suite van 7 elite TradingView-indicatoren ontworpen voor volledige detectie van marktcycli. Onze vlaggenschip-indicator <strong>Pentarch</strong> brengt 5-fase omkeringssequenties (TD→IGN→WRN→CAP→BDN) in kaart over elk tijdsbestek en elke markt. Alle indicatoren zijn <strong>100% non-repainting</strong> en getest op lookahead-bias.
             </div>
           </div>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);"></span>
-              <span>Wie fange ich nach dem Kauf an?</span>
+              <span>Hoe begin ik na aankoop?</span>
             </div>
             <div class="faq-answer">
-              Nach dem Kauf erhalten Sie innerhalb von <strong>1-8 Stunden</strong> eine TradingView-Einladung (normalerweise unter 2 Stunden). Überprüfen Sie Ihre E-Mail und TradingView-Benachrichtigungen. Akzeptieren Sie die Einladung, und die Indikatoren erscheinen unter <strong>\"Indikatoren → Einladungs-exklusive Scripts\"</strong>. Eine Starter-Vorgabe und zwei vorkonfigurierte Alerts (EC Pro und Screener) werden automatisch geladen.
+              Na aankoop ontvangt u binnen <strong>1-8 uur</strong> een TradingView-uitnodiging (meestal binnen 2 uur). Controleer uw e-mail en TradingView-meldingen. Accepteer de uitnodiging en de indicatoren verschijnen onder <strong>"Indicatoren → Uitnodiging-exclusieve scripts"</strong>. Een starter-voorinstelling en twee vooraf geconfigureerde alerts (EC Pro en Screener) worden automatisch geladen.
             </div>
           </div>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);"></span>
-              <span>Benötige ich Handelserfahrung, um Signal Pilot zu verwenden?</span>
+              <span>Heb ik handelservaring nodig om Signal Pilot te gebruiken?</span>
             </div>
             <div class="faq-answer">
-              Signal Pilot ist für alle Erfahrungsstufen konzipiert. <strong>Anfänger</strong> können mit unserem <strong>82-Lektionen-Onderwijscentrum</strong> beginnen, das Grundlagen der Marktstruktur abdeckt. <strong>Mittlere Händler</strong> profitieren von klaren Zyklussignalen und Konvergenzbeteiligten. <strong>Geavanceerde Händler</strong> können die Einstellungen anpassen und Indikatoren für ausgefeilte Strategien kombinieren.
+              Signal Pilot is ontworpen voor alle ervaringsniveaus. <strong>Beginners</strong> kunnen beginnen met ons <strong>82-lessen Onderwijscentrum</strong> dat de basisprincipes van marktstructuur behandelt. <strong>Gemiddelde traders</strong> profiteren van duidelijke cyclussignalen en convergentie. <strong>Gevorderde traders</strong> kunnen instellingen aanpassen en indicatoren combineren voor geavanceerde strategieën.
             </div>
           </div>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);"></span>
-              <span>Ist dies Finanzberatung?</span>
+              <span>Is dit financieel advies?</span>
             </div>
             <div class="faq-answer">
-              <strong>Nein.</strong> Signal Pilot ist <strong>nur ein Bildungswerkzeugset</strong>. Wir stellen technische Analyse-Tools zur Verfügung – keine Anlageberatung, Handelsempfehlungen oder garantierte Renditen. Der Handel beinhaltet ein erhebliches Verlustrisiko. Sie sind allein verantwortlich für alle Handelsentscheidungen. Unabhängige Recherche und Rücksprache mit einem qualifizierten Finanzberater werden empfohlen.
+              <strong>Nee.</strong> Signal Pilot is <strong>alleen een educatieve toolset</strong>. We bieden technische analyse-tools – geen beleggingsadvies, handelsaanbevelingen of gegarandeerde rendementen. Handelen brengt aanzienlijke verliesrisico's met zich mee. U bent alleen verantwoordelijk voor alle handelsbeslissingen. Onafhankelijk onderzoek en consultatie met een gekwalificeerde financieel adviseur worden aanbevolen.
             </div>
           </div>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);"></span>
-              <span>Was unterscheidet Signal Pilot von anderen Indikatoren?</span>
+              <span>Wat onderscheidt Signal Pilot van andere indicatoren?</span>
             </div>
             <div class="faq-answer">
-              <strong>Vollständige Zyklusabbildung</strong> (nicht nur Überkauf/Überverkauf), <strong>null Neuzeichnung</strong> (100 USD Prämie, wenn Sie eine finden), <strong>7 indicatoren enthalten</strong> (nicht separat verkauft), <strong>250.000+ Wörter Bildung</strong> (keine YouTube-Tutorials), und <strong>alle zukünftigen Versionen für immer enthalten</strong> (keine Upsells). Wir sind transparent darüber, dass es nur ein Bildungswerkzeug ist – keine gefälschten Testimonials oder unverifizierte Ansprüche.
+              <strong>Volledige cyclus mapping</strong> (niet alleen overbought/oversold), <strong>nul herschikking</strong> (100 USD premie als u het kunt vinden), <strong>7 indicatoren inbegrepen</strong> (niet apart verkocht), <strong>250.000+ woorden onderwijs</strong> (geen YouTube-tutorials), en <strong>alle toekomstige versies voor altijd inbegrepen</strong> (geen upsells). We zijn transparant dat het alleen een educatieve tool is – geen nepgetuigenissen of niet-geverifieerde claims.
             </div>
           </div>
 
@@ -935,95 +935,95 @@
       <div class="faq-category" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon"></span>
-          Die Elite Seven Indikatoren
+          De Elite Seven Indicatoren
         </h2>
         <div class="faq-grid">
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand);">📌</span>
-              <span>Was ist SP — Pentarch?</span>
+              <span>Wat is SP — Pentarch?</span>
             </div>
             <div class="faq-answer">
-              <strong>Pentarch</strong> ist unser Flaggschiff-Indikator für die vollständige Trend-Regime-Erkennung. Es bildet <strong>5-phasige Marktumkehrsequenzen</strong> ab:
+              <strong>Pentarch</strong> is onze vlaggenschip-indicator voor volledige trendregime-detectie. Het brengt <strong>5-fase marktomkeringssequenties</strong> in kaart:
               <ul>
-                <li><strong>TD (Touchdown)</strong> — Früher Zyklusumkehrung beim Verkaufserschöpfung</li>
-                <li><strong>IGN (Zündung)</strong> — Ausbruchsbestätigung mit Überzeugung</li>
-                <li><strong>WRN (Warnung)</strong> — Frühe Schwäche in Aufwärtstrends</li>
-                <li><strong>CAP (Klimax)</strong> — Ende-Zyklus-Erschöpfung mit Volumspitzen</li>
-                <li><strong>BDN (Zusammenbruch)</strong> — Bearisher Strukturbruch</li>
+                <li><strong>TD (Touchdown)</strong> — Vroege cyclusomkering bij verkoopuitputting</li>
+                <li><strong>IGN (Ontsteking)</strong> — Uitbraakbevestiging met overtuiging</li>
+                <li><strong>WRN (Waarschuwing)</strong> — Vroege zwakte in uptrends</li>
+                <li><strong>CAP (Climax)</strong> — Einde-cyclus uitputting met volumepieken</li>
+                <li><strong>BDN (Breakdown)</strong> — Bearish structuurbreuk</li>
               </ul>
-              Integriert <strong>4 Ebenen</strong>: Regime-Balken, Pilot-Linie, NanoFlow-Kreuze und Event-Signale – alle nicht repainting.
+              Integreert <strong>4 lagen</strong>: Regime-balken, Pilot-lijn, NanoFlow-kruisingen en Event-signalen – allemaal non-repainting.
             </div>
           </div>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand);">📌</span>
-              <span>Was ist SP — Omnideck?</span>
+              <span>Wat is SP — Omnideck?</span>
             </div>
             <div class="faq-answer">
-              <strong>Omnideck</strong> ist ein All-in-One-Overlay, das <strong>10 Premium-Systeme</strong> vereint: TD Sequential, Squeeze Cloud, Bull Market Support Band, SuperTrend Ensemble, Regime System, Supply/Demand Zones, Candlestick Patterns, Liquidity Sweeps, EMA Events und Caution/Danger Warnings. Jede Komponente kann unabhängig ein/ausgeschaltet werden für benutzerdefinierte Analyse.
+              <strong>Omnideck</strong> is een alles-in-één overlay die <strong>10 premium systemen</strong> combineert: TD Sequential, Squeeze Cloud, Bull Market Support Band, SuperTrend Ensemble, Regime System, Supply/Demand Zones, Candlestick Patterns, Liquidity Sweeps, EMA Events en Caution/Danger Warnings. Elke component kan onafhankelijk worden in/uitgeschakeld voor aangepaste analyse.
             </div>
           </div>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand);">📌</span>
-              <span>Was ist SP — Volume Oracle?</span>
+              <span>Wat is SP — Volume Oracle?</span>
             </div>
             <div class="faq-answer">
-              <strong>Volume Oracle</strong> verfolgt institutionelle Akkumulations-/Distributionsmuster in Echtzeit. Zeigt, wenn intelligente Investoren mit <strong>Stärkeprozentsatz</strong> (Konfidenzniveau) agieren, <strong>Dauer-Tracking</strong>, <strong>Frühwarnungsblitz</strong> vor Regime-Umkehrungen und eingebauten <strong>Positionsrechner</strong> mit Risikoniveaus.
+              <strong>Volume Oracle</strong> volgt institutionele accumulatie-/distributiepatronen in realtime. Toont wanneer slimme beleggers handelen met <strong>sterkte percentage</strong> (vertrouwensniveau), <strong>duur tracking</strong>, <strong>vroege waarschuwingsflits</strong> vóór regime-omkeringen en ingebouwde <strong>positie calculator</strong> met risiconiveaus.
             </div>
           </div>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand);">📌</span>
-              <span>Was ist SP — Plutus Flow?</span>
+              <span>Wat is SP — Plutus Flow?</span>
             </div>
             <div class="faq-answer">
-              <strong>Plutus Flow</strong> ist ein kumulatives Delta-Ribbon, das versteckten Kauf-/Verkaufsdruck offenbart. Grünes Ribbon = Käufer kontrollieren, rotes Ribbon = Verkäufer kontrollieren. Mittellinienkreuze zeigen Regime-Verschiebungen. <strong>Weiße Punkte</strong> markieren extreme Akkumulations-/Distributionsniveaus. <strong>Divergenz-Marken</strong> offenbaren gebrochene Trends, bevor der Preis bestätigt – Preis kann eine Bewegung fälschen, Volumen nicht.
+              <strong>Plutus Flow</strong> is een cumulatief delta-lint dat verborgen koop-/verkoopdruk onthult. Groen lint = kopers hebben controle, rood lint = verkopers hebben controle. Middellijnkruisingen tonen regimeverschuivingen. <strong>Witte punten</strong> markeren extreme accumulatie-/distributieniveaus. <strong>Divergentie-markeringen</strong> onthullen gebroken trends voordat de prijs bevestigt – prijs kan een beweging faken, volume niet.
             </div>
           </div>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand);">📌</span>
-              <span>Was ist SP — Janus Atlas?</span>
+              <span>Wat is SP — Janus Atlas?</span>
             </div>
             <div class="faq-answer">
-              <strong>Janus Atlas</strong> plottet automatisch institutionelle Referenzpunkte: HTF-Niveaus (täglich/wöchentlich/monatlich/vierteljährlich), vorherige Sitzungsdaten, VWAP-Anker, Volume-Profile-Zonen (POC, VAH, VAL), Sitzungsmarker (Asien, London, NY) und Struktur-Etiketten (BOS, CHoCH). Alle Niveaus werden automatisch über mehrere Zeitrahmen aktualisiert.
+              <strong>Janus Atlas</strong> plot automatisch institutionele referentiepunten: HTF-niveaus (dagelijks/wekelijks/maandelijks/kwartaal), vorige sessiegegevens, VWAP-ankers, Volume Profile-zones (POC, VAH, VAL), sessiemarkers (Azië, Londen, NY) en structuurlabels (BOS, CHoCH). Alle niveaus worden automatisch bijgewerkt over meerdere tijdsbestekken.
             </div>
           </div>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand);">📌</span>
-              <span>Was ist SP — Augury Grid?</span>
+              <span>Wat is SP — Augury Grid?</span>
             </div>
             <div class="faq-answer">
-              <strong>Augury Grid</strong> ist eine Mehrfach-Symbol-Beobachtungsliste, die <strong>8 Ticker gleichzeitig</strong> verfolgt mit Live-Tabelle, die Signalrichtung (↑ Bullish / ↓ Bearish), Zeit seit Signal, Zielpreise, Qualitätsbewertung (0-100 Konvertenzbewertung) und laufenden P&L zeigt. Sehen Sie sofort, welche Märkte die saubersten Setups haben.
+              <strong>Augury Grid</strong> is een multi-symbool watchlist die <strong>8 tickers tegelijkertijd</strong> volgt met live tabel die signaalrichting (↑ Bullish / ↓ Bearish), tijd sinds signaal, doelprijzen, kwaliteitsscore (0-100 convergentiescore) en lopende P&L toont. Zie meteen welke markten de schoonste setups hebben.
             </div>
           </div>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand);">📌</span>
-              <span>Was ist SP — Harmonic Oscillator?</span>
+              <span>Wat is SP — Harmonic Oscillator?</span>
             </div>
             <div class="faq-answer">
-              <strong>Harmonic Oscillator</strong> ist ein 4-Oszillator-Abstimmungssystem mit Sternenbewertungs-Konfidenz (★ bis ★★★★). Jeder Oszillator stimmt Bull/Bear/Neutral auf jedem Balken ab. Signalisiert nur, wenn mehrere Oszillatoren übereinstimmen. <strong>4/4 Übereinstimmung = ★★★★ Sterne</strong> = alle ausgerichtet. Handelregel: Ein Oszillator falsch ist üblich. Vier, die zustimmen, ist anders.
+              <strong>Harmonic Oscillator</strong> is een 4-oscillator stemsysteem met sterrenbeoordeling-vertrouwen (★ tot ★★★★). Elke oscillator stemt Bull/Bear/Neutraal op elke staaf. Signaleert alleen wanneer meerdere oscillatoren overeenkomen. <strong>4/4 overeenstemming = ★★★★ sterren</strong> = allemaal uitgelijnd. Handelsregel: Eén oscillator verkeerd is gebruikelijk. Vier die akkoord gaan, is anders.
             </div>
           </div>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand);">📌</span>
-              <span>Kann ich mehrere Indikatoren zusammen verwenden?</span>
+              <span>Kan ik meerdere indicatoren samen gebruiken?</span>
             </div>
             <div class="faq-answer">
-              <strong>Absolut!</strong> Die Elite Seven sind so konzipiert, dass sie zusammenarbeiten. Beliebte Kombinationen: <strong>Pentarch + Volume Oracle</strong> für Zyklus-Timing mit Smart-Money-Bestätigung, <strong>Omnideck + Janus Atlas</strong> für komplette Marktstruktur mit Schlüsselniveaus oder <strong>Harmonic Oscillator + Plutus Flow</strong> für Momentum-Bestätigung mit versteckten Divergenzen.
+              <strong>Absoluut!</strong> De Elite Seven zijn ontworpen om samen te werken. Populaire combinaties: <strong>Pentarch + Volume Oracle</strong> voor cyclus-timing met smart-money-bevestiging, <strong>Omnideck + Janus Atlas</strong> voor complete marktstructuur met sleutelniveaus of <strong>Harmonic Oscillator + Plutus Flow</strong> voor momentum-bevestiging met verborgen divergenties.
             </div>
           </div>
 
@@ -1034,77 +1034,77 @@
       <div class="faq-category" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
-          Plattform & Technisch
+          Platform & Technisch
         </h2>
         <div class="faq-grid">
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);">🔄</span>
-              <span>Malen sich die Signale neu?</span>
+              <span>Herschikken de signalen zich?</span>
             </div>
             <div class="faq-answer">
-              <strong>Null Neuzeichnung. Garantiert.</strong> Alle Signale werden beim Kerzenschluss abgeschlossen. Wir überprüfen jeden Indikator auf Lookahead-Bias. Wenn Sie einen Neuzeichnung nachweisen können, zahlen wir Ihnen <strong>100 USD</strong>. Was Sie in der Geschichte sehen, ist genau das, was Sie live gesehen hätten. Nur beim Kerzenschluss bestätigte Signale.
+              <strong>Nul herschikking. Gegarandeerd.</strong> Alle signalen worden bevestigd bij kaarssluiting. We testen elke indicator op lookahead-bias. Als u herschikking kunt bewijzen, betalen we u <strong>100 USD</strong>. Wat u in de geschiedenis ziet, is precies wat u live zou hebben gezien. Alleen bij kaarssluiting bevestigde signalen.
             </div>
           </div>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);">💻</span>
-              <span>Funktioniert es auf kostenlosem TradingView?</span>
+              <span>Werkt het op gratis TradingView?</span>
             </div>
             <div class="faq-answer">
-              <strong>Ja!</strong> Sie benötigen nur genug Indikator-Slots für Ihr Setup. <strong>Kostenlose Konten erhalten 3 Slots</strong>, was für Pentarch + 1-2 Filter ausreicht. Pro/Premium-Konten haben mehr Slots und unbegrenzte Alerts. Indikatoren funktionieren identisch über alle TradingView-Plan-Ebenen.
+              <strong>Ja!</strong> U heeft alleen voldoende indicator-slots nodig voor uw setup. <strong>Gratis accounts krijgen 3 slots</strong>, wat voldoende is voor Pentarch + 1-2 filters. Pro/Premium-accounts hebben meer slots en onbeperkte alerts. Indicatoren werken identiek op alle TradingView-planniveaus.
             </div>
           </div>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);"></span>
-              <span>Wie funktionieren TradingView-Alerts?</span>
+              <span>Hoe werken TradingView-alerts?</span>
             </div>
             <div class="faq-answer">
-              Legen Sie benutzerdefinierte Alerts für beliebige Indikator-Signale fest. <strong>Zwei vorkonfigurierte Alerts enthalten:</strong> EC Pro und Screener. <strong>Kostenloses TradingView:</strong> Begrenzte Alerts. <strong>Pro/Premium:</strong> Unbegrenzte Alerts. Alerts werden in Echtzeit per E-Mail, SMS oder Push-Benachrichtigungen ausgelöst. Vollständig benutzerdefinierte Alert-Bedingungen werden unterstützt.
+              Stel aangepaste alerts in voor elk indicatorsignaal. <strong>Twee vooraf geconfigureerde alerts inbegrepen:</strong> EC Pro en Screener. <strong>Gratis TradingView:</strong> Beperkte alerts. <strong>Pro/Premium:</strong> Onbeperkte alerts. Alerts worden in realtime getriggerd via e-mail, SMS of push-meldingen. Volledig aangepaste alert-voorwaarden worden ondersteund.
             </div>
           </div>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);">🔐</span>
-              <span>Wie viele Geräte kann ich verwenden?</span>
+              <span>Hoeveel apparaten kan ik gebruiken?</span>
             </div>
             <div class="faq-answer">
-              Ein TradingView-Benutzername pro Lizenz. Sie können sich auf <strong>unbegrenzten Geräten</strong> mit diesem Benutzernamen anmelden. <strong>Account-Sharing ist verboten</strong> – jedes Abonnement ist an ein TradingView-Konto gebunden. Verwenden Sie gleichzeitig auf Desktop, Mobilgerät, Tablet mit den gleichen Anmeldeinformationen.
+              Eén TradingView-gebruikersnaam per licentie. U kunt inloggen op <strong>onbeperkt aantal apparaten</strong> met die gebruikersnaam. <strong>Account-delen is verboden</strong> – elk abonnement is gekoppeld aan één TradingView-account. Gebruik tegelijkertijd op desktop, mobiel, tablet met dezelfde inloggegevens.
             </div>
           </div>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);">🔬</span>
-              <span>Kann ich die Indikatoren backtesten?</span>
+              <span>Kan ik de indicatoren backtesten?</span>
             </div>
             <div class="faq-answer">
-              <strong>Ja!</strong> Alle Indikatoren funktionieren mit TradingViews Strategy Tester. Backtest-Vorlagen enthalten. Test über Jahre historischer Daten über mehrere Märkte. <strong>Wichtig:</strong> Bisherige Leistung garantiert keine zukünftigen Ergebnisse – Backtesting ist nur für Bildung und Systemvalidierung.
+              <strong>Ja!</strong> Alle indicatoren werken met TradingViews Strategy Tester. Backtest-sjablonen inbegrepen. Test over jaren van historische gegevens over meerdere markten. <strong>Belangrijk:</strong> Prestaties uit het verleden garanderen geen toekomstige resultaten – backtesting is alleen voor onderwijs en systeemvalidatie.
             </div>
           </div>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);">🛠️</span>
-              <span>Benötige ich Programmierkenntnisse?</span>
+              <span>Heb ik programmeerkennis nodig?</span>
             </div>
             <div class="faq-answer">
-              <strong>Null Kodierung erforderlich.</strong> Alle Indikatoren sind Plug-and-Play. Wir enthalten <strong>200+ vorkonfigurierte Konfigurationen</strong> (Lifetime-Plan), die für verschiedene Strategien vorgegeben sind. Laden Sie einfach die Vorgabe, wenden Sie sie auf ein Diagramm an, fertig. Geavanceerde Benutzer können Einstellungen über die TradingView-Schnittstelle anpassen, aber es ist optional.
+              <strong>Geen codering vereist.</strong> Alle indicatoren zijn plug-and-play. We bevatten <strong>200+ vooraf geconfigureerde instellingen</strong> (Lifetime-plan) die zijn vooringesteld voor verschillende strategieën. Laad gewoon de voorinstelling, pas toe op een grafiek, klaar. Gevorderde gebruikers kunnen instellingen aanpassen via de TradingView-interface, maar dit is optioneel.
             </div>
           </div>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);">🌍</span>
-              <span>Welche Märkte werden unterstützt?</span>
+              <span>Welke markten worden ondersteund?</span>
             </div>
             <div class="faq-answer">
-              <strong>Beliebiger Markt auf TradingView:</strong> Aktien, Indizes, Devisenkurse, Cryptowährungen, Grondstoffen, Anleihen, Futures, Optionen. Wenn es OHLC + Volumendaten hat, funktionieren unsere Indikatoren. Getestet auf 100+ Symbolen über alle Anlageklassen. Multi-Markt-Kompatibilität eingebaut.
+              <strong>Elke markt op TradingView:</strong> Aandelen, Indices, Forex, Cryptocurrencies, Grondstoffen, Obligaties, Futures, Opties. Als het OHLC + volumegegevens heeft, werken onze indicatoren. Getest op 100+ symbolen over alle activaklassen. Multi-marktcompatibiliteit ingebouwd.
             </div>
           </div>
 
@@ -1115,57 +1115,57 @@
       <div class="faq-category" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
-          Handel & Strategie
+          Handelen & Strategie
         </h2>
         <div class="faq-grid">
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--good);"></span>
-              <span>Welche Zeitrahmen funktionieren am besten?</span>
+              <span>Welke tijdsbestekken werken het beste?</span>
             </div>
             <div class="faq-answer">
-              Alle Zeitrahmen unterstützt – <strong>1-Minuten bis jährliche Diagramme</strong>. <strong>Am beliebtesten:</strong> 15m-1H für Day Trading, 4H-Daily für Swing Trading, Weekly-Monthly für Position Trading. Pentarchs 5-phasiger Zyklus passt sich automatisch an Ihren Zeitrahmen an. Das Onderwijscentrum deckt Zeitrahmen-Optimierungsstrategien für verschiedene Handelsstile ab.
+              Alle tijdsbestekken ondersteund – <strong>1-minuut tot jaarlijkse grafieken</strong>. <strong>Meest populair:</strong> 15m-1H voor daytrading, 4H-Daily voor swing trading, Weekly-Monthly voor positiehandel. Pentarchs 5-fase cyclus past zich automatisch aan uw tijdsbestek aan. Het Onderwijscentrum behandelt tijdsbestek-optimalisatiestrategieën voor verschillende handelsstijlen.
             </div>
           </div>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--good);"></span>
-              <span>Welche Handelsstile werden unterstützt?</span>
+              <span>Welke handelsstijlen worden ondersteund?</span>
             </div>
             <div class="faq-answer">
-              <strong>Alle Handelsstile:</strong> Scalping (1m-5m), Day Trading (15m-1H), Swing Trading (4H-Daily), Position Trading (Weekly-Monthly). <strong>200+ Vorlagen enthalten</strong> (Lifetime-Plan), die für jeden Stil vorgegeben sind. Indikatoren passen sich an Ihren gewählten Zeitrahmen an – gleiche Methodik, unterschiedliche Ausführungshorizonte.
+              <strong>Alle handelsstijlen:</strong> Scalping (1m-5m), Day Trading (15m-1H), Swing Trading (4H-Daily), Position Trading (Weekly-Monthly). <strong>200+ sjablonen inbegrepen</strong> (Lifetime-plan) die zijn vooringesteld voor elke stijl. Indicatoren passen zich aan uw gekozen tijdsbestek aan – zelfde methodologie, verschillende uitvoeringshorizonten.
             </div>
           </div>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--good);">⚖️</span>
-              <span>Wie verwalte ich das Risiko?</span>
+              <span>Hoe beheer ik het risico?</span>
             </div>
             <div class="faq-answer">
-              Volume Oracle enthält eingebauten <strong>Positionsrechner mit Risikoniveaus</strong>. Janus Atlas zeigt Schlüssel-Support/Widerstand für Stop-Platzierung. Das Onderwijscentrum deckt <strong>Risikomanagement-Grundlagen</strong> ab: Positionsgrößenbestimmung, Stop-Loss-Platzierung, R-Multiple-Ziele und Portfolio-Wärmemanagement. <strong>Risikomanagement ist Ihre Verantwortung</strong> – Indikatoren stellen Informationen bereit, keine Beratung.
+              Volume Oracle bevat ingebouwde <strong>positie calculator met risiconiveaus</strong>. Janus Atlas toont belangrijke support/resistance voor stop-plaatsing. Het Onderwijscentrum behandelt <strong>risicomanagement basisprincipes</strong>: Positiegrootte, stop-loss plaatsing, R-multiple doelen en portfolio heat management. <strong>Risicomanagement is uw verantwoordelijkheid</strong> – indicatoren bieden informatie, geen advies.
             </div>
           </div>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--good);">🔍</span>
-              <span>Wie finde ich die besten Setups?</span>
+              <span>Hoe vind ik de beste setups?</span>
             </div>
             <div class="faq-answer">
-              Verwenden Sie <strong>Augury Grid</strong>, um 8 Symbole gleichzeitig mit Qualitätsbewertungen (0-100) zu scannen. Hohe Bewertungen (90+) zeigen starke Konvergenz. Kombinieren Sie <strong>Pentarch-Zyklusphasen</strong> (TD oder IGN für Einstiege) mit <strong>Volume Oracle</strong> (Akkumulations-Bestätigung) und <strong>Harmonic Oscillator</strong> (★★★★ Multi-Bestätigung). Beste Setups haben alle Systeme ausgerichtet.
+              Gebruik <strong>Augury Grid</strong> om 8 symbolen tegelijkertijd te scannen met kwaliteitsscores (0-100). Hoge scores (90+) tonen sterke convergentie. Combineer <strong>Pentarch-cyclusfasen</strong> (TD of IGN voor entries) met <strong>Volume Oracle</strong> (accumulatie-bevestiging) en <strong>Harmonic Oscillator</strong> (★★★★ multi-bevestiging). Beste setups hebben alle systemen uitgelijnd.
             </div>
           </div>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--good);">📉</span>
-              <span>Was ist mit falschen Signalen?</span>
+              <span>Hoe zit het met valse signalen?</span>
             </div>
             <div class="faq-answer">
-              <strong>Kein Indikator ist 100% genau</strong> – Märkte sind probabilistisch, nicht deterministisch. Signal Pilot reduziert falsche Signale durch <strong>Multi-Layer-Konvergenz</strong>: Pentarch erfordert alle 4 Ebenen ausgerichtet, Harmonic Oscillator braucht 3-4 Stimmen, die zustimmen, Volume Oracle zeigt Stärkeprozentsatz. <strong>Risikomanagement > Signalgenauigkeit</strong>. Das Onderwijscentrum lehrt ordnungsgemäße Erwartungseinstellung.
+              <strong>Geen indicator is 100% nauwkeurig</strong> – markten zijn probabilistisch, niet deterministisch. Signal Pilot vermindert valse signalen door <strong>multi-layer convergentie</strong>: Pentarch vereist alle 4 lagen uitgelijnd, Harmonic Oscillator heeft 3-4 stemmen nodig die overeenkomen, Volume Oracle toont sterkte percentage. <strong>Risicomanagement > signaalnauwkeurigheid</strong>. Het Onderwijscentrum leert juiste verwachtingsvorming.
             </div>
           </div>
 
@@ -1176,47 +1176,47 @@
       <div class="faq-category" data-category="education">
         <h2 class="category-title">
           <span class="category-icon"></span>
-          Bildung & Lernen
+          Onderwijs & Leren
         </h2>
         <div class="faq-grid">
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand-2);"></span>
-              <span>Was ist im Onderwijscentrum?</span>
+              <span>Wat zit er in het Onderwijscentrum?</span>
             </div>
             <div class="faq-answer">
-              <strong>82 interaktive Lektionen</strong> über 4 fortschrittliche Ebenen, die <strong>250.000+ Wörter</strong> Lehrplan abdecken. Themen: Marktstruktur, Zykliserkennung, Order-Flow, Liquiditätsdynamik, Risikomanagement, institutionelles Verhalten. Enthalten Sie Quizze, Fortschritts-Tracking und reale Diagrammbeispiele. Zugriff: <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">education.signalpilot.io</a>
+              <strong>82 interactieve lessen</strong> over 4 progressieve niveaus die <strong>250.000+ woorden</strong> curriculum dekken. Onderwerpen: Marktstructuur, cyclus herkenning, orderflow, liquiditeitsdynamiek, risicomanagement, institutioneel gedrag. Bevat quizzen, voortgangs-tracking en echte grafiekvoorbeelden. Toegang: <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">education.signalpilot.io</a>
             </div>
           </div>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand-2);">📖</span>
-              <span>Was ist in der Documentatie?</span>
+              <span>Wat zit er in de Documentatie?</span>
             </div>
             <div class="faq-answer">
-              <strong>50+ Seiten</strong> über Setup handleidingen für jeden Indikator, Strategie-Anleitungen, Best Practices, TradingView-Alert-Konfiguration, Vorlagen-Workflows, Multi-Markt-Implementierung, Zeitrahmen-Kompatibilität und Integration mit anderen Indikatoren. Zugriff: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">docs.signalpilot.io</a>
+              <strong>50+ pagina's</strong> over setup handleidingen voor elke indicator, strategie-gidsen, best practices, TradingView-alert configuratie, sjabloon workflows, multi-markt implementatie, tijdsbestek compatibiliteit en integratie met andere indicatoren. Toegang: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">docs.signalpilot.io</a>
             </div>
           </div>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand-2);">🎬</span>
-              <span>Gibt es Video-Tutorials?</span>
+              <span>Zijn er video-tutorials?</span>
             </div>
             <div class="faq-answer">
-              <strong>Ja!</strong> Video-Inhalte enthalten Indikator-Walkthroughs, Live-Analyse-Beispiele und Strategie-Breakdowns. Jahres+ Pläne enthalten <strong>erweiterte Schulungsressourcen</strong> mit detaillierten Strategie-Videos. Lifetime-Mitglieder erhalten exklusiven Zugang zu allen aktuellen und zukünftigen Video-Inhalten. Zusätzliche Tutorials sind auf unserem YouTube-Kanal verfügbar.
+              <strong>Ja!</strong> Video-inhoud bevat indicator-walkthroughs, live analyse voorbeelden en strategie-uitsplitsingen. Jaarlijkse+ plannen bevatten <strong>uitgebreide trainingsmaterialen</strong> met gedetailleerde strategie-video's. Lifetime-leden krijgen exclusieve toegang tot alle huidige en toekomstige video-inhoud. Aanvullende tutorials zijn beschikbaar op ons YouTube-kanaal.
             </div>
           </div>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--brand-2);">💬</span>
-              <span>Gibt es eine Community?</span>
+              <span>Is er een community?</span>
             </div>
             <div class="faq-answer">
-              <strong>Lifetime-Mitglieder</strong> erhalten Zugang zu unserer <strong>privaten Discord-Community</strong> für das Leben. Verbinden Sie sich mit anderen Händlern, teilen Sie Diagramm-Analysen, diskutieren Sie Strategien und erhalten Sie schnellere Support-Antworten. Monats-/Jahres-Pläne haben nur E-mail ondersteuning – upgraden Sie auf Lifetime für Community-Zugang.
+              <strong>Lifetime-leden</strong> krijgen toegang tot onze <strong>privé Discord-community</strong> voor het leven. Maak contact met andere traders, deel grafiek-analyses, bespreek strategieën en ontvang snellere support-antwoorden. Maandelijkse/jaarlijkse plannen hebben alleen e-mail ondersteuning – upgrade naar Lifetime voor community-toegang.
             </div>
           </div>
 
@@ -1227,67 +1227,67 @@
       <div class="faq-category" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
-          Preise & Pläne
+          Prijzen & Plannen
         </h2>
         <div class="faq-grid">
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--warn);">💎</span>
-              <span>Was ist in meinem Plan enthalten?</span>
+              <span>Wat zit er in mijn plan?</span>
             </div>
             <div class="faq-answer">
-              Jeder Plan enthält: <strong>Die Elite Seven</strong> Indikatoren, alle zukünftigen Updates, laufenden Support, Documentatie, Vorlagen und Zugang zu neuen Indikatoren bei ihrer Einführung. Lifetime enthält alles, für immer. Keine Funktionen, die hinter höheren Ebenen gesperrt sind – nur Support-Geschwindigkeit und Community-Zugang unterscheiden sich.
+              Elk plan bevat: <strong>De Elite Seven</strong> indicatoren, alle toekomstige updates, doorlopende support, Documentatie, sjablonen en toegang tot nieuwe indicatoren bij lancering. Lifetime bevat alles, voor altijd. Geen functies vergrendeld achter hogere niveaus – alleen support-snelheid en community-toegang verschillen.
             </div>
           </div>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--warn);">⏱️</span>
-              <span>Wie schnell ist die Aktivierung?</span>
+              <span>Hoe snel is de activering?</span>
             </div>
             <div class="faq-answer">
-              <strong>PayPal/Karte:</strong> <strong>1–8 Stunden</strong> (normalerweise unter 2 Stunden). TradingView Einladungs-exklusiver Zugang kommt per E-Mail an. TradingView-Benachrichtigungen zeigen die Einladung. Überprüfen Sie den Spam-Ordner, wenn nicht innerhalb von 8 Stunden erhalten. Bei dringenden Problemen senden Sie E-Mail an support@signalpilot.io mit Transaktionsdetails.
+              <strong>PayPal/Kaart:</strong> <strong>1–8 uur</strong> (meestal binnen 2 uur). TradingView uitnodiging-exclusieve toegang komt via e-mail. TradingView-meldingen tonen de uitnodiging. Controleer de spam-map als u deze niet binnen 8 uur ontvangt. Bij urgente problemen stuur e-mail naar support@signalpilot.io met transactiedetails.
             </div>
           </div>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--warn);">💳</span>
-              <span>Welche Zahlungsmethoden werden akzeptiert?</span>
+              <span>Welke betaalmethoden worden geaccepteerd?</span>
             </div>
             <div class="faq-answer">
-              <strong>PayPal</strong> (Abonnement) und <strong>LemonSqueezy Card Checkout</strong> (Visa, Mastercard, Amex, etc.). Beide unterstützen wiederkehrende Abrechnungen für Monats-/Jahres-Pläne. Einmalzahlung für Lifetime-Plan. Alle Transaktionen mit industriestandardverschlüsselt. Cryptowährungszahlungen werden derzeit nicht unterstützt.
+              <strong>PayPal</strong> (abonnement) en <strong>LemonSqueezy Card Checkout</strong> (Visa, Mastercard, Amex, etc.). Beide ondersteunen terugkerende facturering voor maandelijkse/jaarlijkse plannen. Eenmalige betaling voor Lifetime-plan. Alle transacties met industriestandaard versleuteling. Cryptocurrency-betalingen worden momenteel niet ondersteund.
             </div>
           </div>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--warn);">💳</span>
-              <span>Stornierung & Rückerstattungen?</span>
+              <span>Annulering & Restituties?</span>
             </div>
             <div class="faq-answer">
-              <strong>7-Tage-Geld-zurück-Garantie:</strong> Volle Rückerstattung innerhalb von 7 Tagen nach Ihrer ersten Zahlung, keine Fragen gestellt. Nach 7 Tagen können Sie jederzeit stornieren – keine Strafe, keine Teilrückerstattungen. Sie behalten Zugang bis zum Ende Ihres aktuellen Abrechnungszeitraums.<br><br><strong>Kartenkunden:</strong> Verwalten Sie über <a href="manage-subscription.html">Self-Service-Portal</a> (Pause, Stornierung, Zahlungsupdate). <strong>PayPal-Kunden:</strong> Verwalten Sie via PayPal-Einstellungen. Siehe <a href="refund.html">vollständige Rückerstattungsrichtlinie</a>.
+              <strong>7-dagen-geld-terug-garantie:</strong> Volledige restitutie binnen 7 dagen na uw eerste betaling, geen vragen gesteld. Na 7 dagen kunt u op elk moment annuleren – geen boete, geen gedeeltelijke restituties. U behoudt toegang tot het einde van uw huidige factureringsperiode.<br><br><strong>Kaartklanten:</strong> Beheer via <a href="/nl/manage-subscription.html">Self-service portaal</a> (pauzeren, annuleren, betaling bijwerken). <strong>PayPal-klanten:</strong> Beheer via PayPal-instellingen. Zie <a href="/nl/refund.html">volledig restitutiebeleid</a>.
             </div>
           </div>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--warn);">🔄</span>
-              <span>Kann ich Pläne auf- oder abstufeln?</span>
+              <span>Kan ik plannen upgraden of downgraden?</span>
             </div>
             <div class="faq-answer">
-              <strong>Ja!</strong> Aktualisieren Sie jederzeit von Monatlich auf Jährlich oder Lifetime – kontaktieren Sie support@signalpilot.io für durchschnittliche Upgrade-Preisgestaltung. <strong>Abstufung von Jährlich zu Monatlich</strong> wird im nächsten Abrechnungszyklus wirksam. <strong>Lifetime ist permanent</strong> – keine Abstufungen, aber Sie sind für immer mit allen zukünftigen Versionen enthalten.
+              <strong>Ja!</strong> Upgrade op elk moment van Maandelijks naar Jaarlijks of Lifetime – neem contact op met support@signalpilot.io voor pro-rata upgrade prijzen. <strong>Downgrade van Jaarlijks naar Maandelijks</strong> wordt effectief in de volgende factureringscyclus. <strong>Lifetime is permanent</strong> – geen downgrades, maar u bent voor altijd inbegrepen met alle toekomstige versies.
             </div>
           </div>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--warn);"></span>
-              <span>Wird der Lifetime-Preis erhöht?</span>
+              <span>Wordt de Lifetime-prijs verhoogd?</span>
             </div>
             <div class="faq-answer">
-              <strong>Ja – dynamische Preisgestaltung</strong> erhöht sich bei Verkaufsmeilensteinen. <strong>Aktuelle Stufe 2:</strong> 2.499 USD (87/150 verkauft). <strong>Stufe 3:</strong> 3.499 USD (Verkauf 151-350). <strong>Nach 350 Verkäufen:</strong> Lifetime entfernt permanent, nur jährliche Preisgestaltung. Frühe Unterstützer zahlen weniger. <strong>Grandfather-Klausel:</strong> Alle Lifetime-Mitglieder erhalten jeden zukünftigen Indikator für immer enthalten.
+              <strong>Ja – dynamische prijzen</strong> stijgen bij verkoopmijlpalen. <strong>Huidige Tier 2:</strong> 2.499 USD (87/150 verkocht). <strong>Tier 3:</strong> 3.499 USD (verkoop 151-350). <strong>Na 350 verkopen:</strong> Lifetime permanent verwijderd, alleen jaarlijkse prijzen. Vroege supporters betalen minder. <strong>Grandfather-clausule:</strong> Alle Lifetime-leden krijgen elke toekomstige indicator voor altijd inbegrepen.
             </div>
           </div>
 
@@ -1298,17 +1298,17 @@
       <div class="faq-category" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
-          Support & Konto
+          Ondersteuning & Account
         </h2>
         <div class="faq-grid">
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);">💬</span>
-              <span>Welche Support-Kanäle gibt es?</span>
+              <span>Welke ondersteuningskanalen zijn er?</span>
             </div>
             <div class="faq-answer">
-              <strong>Monatlich:</strong> E-mail ondersteuning (48h Antwort) an support@signalpilot.io. <strong>Jahres+:</strong> Prioritäts-E-Mail (24h Antwort). <strong>Lifetime:</strong> Private Discord-Community + prioritärer Support. Alle Pläne enthalten Zugang zu 50+ Seiten Documentatie und Video-Tutorials bei <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">docs.signalpilot.io</a>.
+              <strong>Maandelijks:</strong> E-mail ondersteuning (48u reactie) naar support@signalpilot.io. <strong>Jaarlijks+:</strong> Prioriteits e-mail (24u reactie). <strong>Lifetime:</strong> Privé Discord-community + prioritaire ondersteuning. Alle plannen bevatten toegang tot 50+ pagina's Documentatie en video-tutorials op <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">docs.signalpilot.io</a>.
             </div>
           </div>
 
@@ -1318,27 +1318,27 @@
               <span>Hoe neem ik contact op met support?</span>
             </div>
             <div class="faq-answer">
-              Stuur een e-mail naar <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> met uw TradingView gebruikersnaam und Transaktionsdetails. <strong>Antwortzeiten:</strong> 48h (Monatlich), 24h (Jahres+). Bei Kontoproblemen fügen Sie eine Zahlungsbestätigung bei. Bei technischen Problemen fügen Sie Screenshots und Indikator-Einstellungen bei. Überprüfen Sie den Spam-Ordner auf Antworten.
+              Stuur een e-mail naar <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> met uw TradingView gebruikersnaam en transactiedetails. <strong>Reactietijden:</strong> 48u (Maandelijks), 24u (Jaarlijks+). Bij accountproblemen voeg een betalingsbevestiging toe. Bij technische problemen voeg screenshots en indicator-instellingen toe. Controleer de spam-map op antwoorden.
             </div>
           </div>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);">🔑</span>
-              <span>Was ist, wenn ich Zugang zu meinem TradingView-Konto verliere?</span>
+              <span>Wat als ik toegang verlies tot mijn TradingView-account?</span>
             </div>
             <div class="faq-answer">
-              Kontaktieren Sie support@signalpilot.io mit Ihren Transaktionsdetails und neuem TradingView-Benutzernamen. Wir werden Ihre Lizenz auf das neue Konto übertragen. <strong>Wichtig:</strong> Nur eine Benutzernamenänderung pro Jahr erlaubt, um Account-Sharing-Missbrauch zu verhindern. Halten Sie Ihre TradingView-Anmeldeinformationen sicher.
+              Neem contact op met support@signalpilot.io met uw transactiedetails en nieuwe TradingView-gebruikersnaam. We zullen uw licentie overzetten naar het nieuwe account. <strong>Belangrijk:</strong> Slechts één gebruikersnaamwijziging per jaar toegestaan om account-delen misbruik te voorkomen. Houd uw TradingView-inloggegevens veilig.
             </div>
           </div>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">
               <span class="faq-question-icon" style="color: var(--accent);"></span>
-              <span>Was ist, wenn ein Indikator nicht mehr funktioniert?</span>
+              <span>Wat als een indicator niet meer werkt?</span>
             </div>
             <div class="faq-answer">
-              Versuchen Sie zunächst, <strong>den Indikator zu entfernen und erneut hinzuzufügen</strong>. Überprüfen Sie die TradingView-Status-Seite auf Plattformprobleme. Stellen Sie sicher, dass Ihr TradingView-Plan genug Indikator-Slots hat. Wenn das Problem bestehen bleibt, senden Sie E-Mail an support@signalpilot.io mit: Indikator-Name, Diagrammsymbol, Zeitrahmen und Screenshot des Fehlers. Wir werden innerhalb von 24-48h untersuchen.
+              Probeer eerst <strong>de indicator te verwijderen en opnieuw toe te voegen</strong>. Controleer de TradingView-statuspagina op platformproblemen. Zorg ervoor dat uw TradingView-plan voldoende indicator-slots heeft. Als het probleem aanhoudt, stuur e-mail naar support@signalpilot.io met: Indicator-naam, grafieksymbool, tijdsbestek en screenshot van de fout. We zullen binnen 24-48u onderzoeken.
             </div>
           </div>
 
@@ -1347,12 +1347,12 @@
 
       <!-- CTA Section -->
       <div class="cta-section">
-        <h2>Haben Sie immer noch Fragen?</h2>
-        <p>Unser Support-Team ist hier, um zu helfen. Überprüfen Sie unsere Documentatie oder kontaktieren Sie uns direkt.</p>
+        <h2>Heeft u nog vragen?</h2>
+        <p>Ons supportteam staat klaar om te helpen. Bekijk onze Documentatie of neem direct contact met ons op.</p>
         <div style="display:flex;gap:1rem;justify-content:center;flex-wrap:wrap">
-          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" class="btn-primary">Documentatie anzeigen</a>
-          <a href="mailto:support@signalpilot.io" class="btn-primary">Support kontaktieren</a>
-          <a href="/#pricing" class="btn-primary">Preise anzeigen</a>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" class="btn-primary">Documentatie bekijken</a>
+          <a href="mailto:support@signalpilot.io" class="btn-primary">Contact opnemen met support</a>
+          <a href="/#pricing" class="btn-primary">Prijzen bekijken</a>
         </div>
       </div>
 
@@ -1362,7 +1362,7 @@
   <!-- Footer -->
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/">Zur Startseite</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/">Naar home</a></p>
     </div>
   </footer>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -2,47 +2,6 @@
 <html lang="nl" dir="ltr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
-
-  <!-- CRITICAL: Set Google Translate to English IMMEDIATELY if English is selected -->
-  <script>
-    (function() {
-      try {
-        // Check URL parameter first
-        var urlParams = new URLSearchParams(window.location.search);
-        var urlLang = urlParams.get('lang');
-
-        // Check localStorage
-        var savedLang = localStorage.getItem('sp_lang') || 'en';
-
-        // If URL says Dutch or localStorage says Dutch, set googtrans to /nl/nl
-        if (urlLang === 'nl' || savedLang === 'nl') {
-          console.log('[GT-EARLY] Setting Google Translate to Dutch (/nl/nl)');
-
-          // Get root domain
-          var hostname = location.hostname.replace(/^www\./, '');
-          var parts = hostname.split('.');
-          var rootDomain = parts.length > 2 ? parts.slice(-2).join('.') : hostname;
-
-          // Set long expiration for the /nl/nl cookie
-          var expires = new Date(Date.now() + 365 * 864e5).toUTCString();
-
-          // Set googtrans to /nl/nl on all domains
-          // This tells Google Translate: "Dutch to Dutch" = no translation
-          document.cookie = 'googtrans=/nl/nl; expires=' + expires + '; path=/';
-          document.cookie = 'googtrans=/nl/nl; expires=' + expires + '; path=/; domain=.' + rootDomain;
-
-          // Force Dutch on HTML element
-          document.documentElement.lang = 'nl';
-          document.documentElement.dir = 'ltr';
-
-          console.log('[GT-EARLY] Cookie set to /nl/nl, language set to Dutch');
-        }
-      } catch(e) {
-        console.error('[GT-EARLY] Error:', e);
-      }
-    })();
-  </script>
-
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
   <!-- Prevent aggressive caching on mobile browsers -->
@@ -69,7 +28,6 @@
 
   <link rel="canonical" href="https://www.signalpilot.io/">
 
-  <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/">
   <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/">
   <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/">
@@ -773,76 +731,6 @@
 
     *{box-sizing:border-box}
 
-    /* Google Translate fixes - prevent layout breaking */
-    body > .skiptranslate {
-      display: none !important;
-    }
-
-    body {
-      top: 0 !important;
-      position: relative !important;
-    }
-
-    .goog-te-banner-frame {
-      display: none !important;
-    }
-
-    .goog-te-menu-value span {
-      color: inherit !important;
-    }
-
-    .goog-te-gadget {
-      color: inherit !important;
-    }
-
-    /* Make Google Translate font wrappers inherit original text size */
-    font {
-      font-size: inherit !important;
-      line-height: inherit !important;
-    }
-
-    /* Specific adjustments for different text sizes */
-    h1 font, h2 font, h3 font, .headline font {
-      font-size: inherit !important;
-    }
-
-    p font, li font, div font {
-      font-size: inherit !important;
-    }
-
-    .btn font, button font, a font {
-      font-size: inherit !important;
-    }
-
-    /* CRITICAL: Force Google Translate font/span wrappers to not block clicks */
-    nav[aria-label="Main"] font,
-    nav[aria-label="Main"] span:not(.mobile-nav-title),
-    .lang-dropdown font,
-    .lang-dropdown span,
-    .lang-dropdown-menu font,
-    .lang-dropdown-menu span,
-    .menu-toggle font,
-    .menu-toggle span,
-    #langToggle font,
-    #langToggle span,
-    .nav-dropdown font,
-    .nav-dropdown span,
-    button font,
-    button span,
-    .btn font,
-    .btn span {
-      pointer-events: none !important;
-      color: inherit !important;
-      background: transparent !important;
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      display: inline !important;
-      opacity: 1 !important;
-      visibility: visible !important;
-    }
-
     /* Force mobile menu text to be white and ALWAYS visible */
     @media (max-width:1400px){
       /* Dark mode mobile menu (default) */
@@ -919,17 +807,12 @@
     /* Ensure clickable elements always work */
     nav[aria-label="Main"] a,
     nav[aria-label="Main"] button,
-    .lang-dropdown button,
-    .lang-dropdown-menu button,
     .menu-toggle,
-    #langToggle,
     #menuToggle,
     .mobile-nav-close {
       pointer-events: auto !important;
       cursor: pointer !important;
     }
-
-    /* Fix header squeezing when Google Translate is active */
     header .container,
     header .nav {
       min-width: 0 !important;
@@ -951,7 +834,6 @@
     header button,
     header a,
     .menu-toggle,
-    #langToggle,
     #themeToggle,
     .btn {
       white-space:nowrap !important;
@@ -1011,7 +893,6 @@
 
       /* Ensure header buttons adapt to smaller text when necessary */
       header .btn,
-      header #langToggle,
       header #themeToggle {
         font-size: .8rem !important;
         padding: .4rem .6rem !important;
@@ -1019,13 +900,6 @@
         overflow: hidden !important;
         text-overflow: ellipsis !important;
         flex-shrink: 1 !important;
-      }
-
-      /* Language button - allow slight shrinking if needed */
-      header #langToggle span {
-        max-width: 30px !important;
-        overflow: hidden !important;
-        text-overflow: clip !important;
       }
 
       /* CTA button - ensure it doesn't overflow */
@@ -2268,66 +2142,11 @@
     }
 
 
-    /* Language Dropdown - container only (menu created as body child in JavaScript) */
-    .lang-dropdown{
-      position:relative;
-      flex-shrink:0;
-      z-index:67 !important;
-    }
+    #themeToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
 
-    /* Language dropdown menu - created as direct child of body, needs to work on ALL screen sizes */
-    .lang-dropdown-menu {
-      position: fixed !important;
-      top: 70px;
-      right: 20px;
-      background: rgba(10, 12, 20, 0.98);
-      border: 2px solid rgba(255, 255, 255, 0.4);
-      border-radius: 12px;
-      padding: 0.5rem;
-      min-width: 180px;
-      max-height: 500px;
-      overflow-y: auto;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-      z-index: 76 !important;
-      opacity: 0 !important;
-      visibility: hidden !important;
-      transform: translateY(-10px);
-      transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
-      display: flex !important;
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-    .lang-dropdown-menu.active {
-      opacity: 1 !important;
-      visibility: visible !important;
-      transform: translateY(0) !important;
-    }
-    .lang-dropdown-menu button {
-      padding: 0.6rem 0.9rem;
-      background: transparent;
-      border: none;
-      border-radius: 8px;
-      color: #b7c2d9;
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: #fff;
-    }
-
-
-    #themeToggle,
-    #langToggle{flex-shrink:0;position:relative;z-index:68 !important;padding:.4rem .6rem !important;font-size:0.85rem !important;min-width:44px;display:inline-flex !important;align-items:center !important;justify-content:center !important}
-
-    /* Make theme and language buttons smaller on mobile */
+    /* Make theme button smaller on mobile */
     @media (max-width:768px){
-      #themeToggle,
-      #langToggle{
+      #themeToggle{
         padding:.3rem !important;
         font-size:0.8rem !important;
         min-width:40px;
@@ -2337,18 +2156,10 @@
         justify-content:center !important;
       }
 
-      #themeToggle span,
-      #langToggle span{
+      #themeToggle span{
         display:flex !important;
         align-items:center !important;
         justify-content:center !important;
-      }
-
-      /* Fix language dropdown menu on mobile */
-      .lang-dropdown-menu {
-        right: 10px;
-        min-width: 160px;
-        max-width: calc(100vw - 20px);
       }
 
       /* Ensure header doesn't exceed viewport width and allows natural height */
@@ -2439,8 +2250,7 @@
     }
 
 
-    /* CRITICAL FIX: Ensure language/theme buttons stay visible */
-    .lang-dropdown,
+    /* CRITICAL FIX: Ensure theme button stays visible */
     #themeToggle,
     .menu-toggle{
       position:relative;
@@ -2473,8 +2283,7 @@
     }
 
     /* Mobile hamburger menu appears at ≤1400px (increased from 1300px) */
-    /* Nav items go into hamburger menu to prevent overlap with language/theme buttons */
-    /* Activates earlier to accommodate longer text in translated languages */
+    /* Nav items go into hamburger menu to prevent overlap with theme button */
 
     @media (max-width:1400px){
       /* Ensure header buttons have adequate space */
@@ -2484,13 +2293,8 @@
       }
 
       /* Better mobile header button sizing */
-      .lang-dropdown,
       #themeToggle {
         flex-shrink: 0;
-      }
-
-      #themeToggle,
-      #langToggle {
         min-width: 44px; /* iOS minimum tap target */
         min-height: 44px;
       }
@@ -2838,9 +2642,8 @@
       .price{font-size:1.8rem}
       .cta-inner .bar .note{display:none}
 
-      /* Extra small screens - further reduce header button sizes for translated text */
+      /* Extra small screens - further reduce header button sizes */
       header .btn,
-      header #langToggle,
       header #themeToggle {
         font-size: .75rem !important;
         padding: .35rem .5rem !important;
@@ -3209,8 +3012,7 @@
         "contactPoint": {
           "@type": "ContactPoint",
           "contactType": "Klantenondersteuning",
-          "email": "support@signalpilot.io",
-          "availableLanguage": ["English", "Nederlands"]
+          "email": "support@signalpilot.io"
         }
       },
       {
@@ -3319,25 +3121,17 @@
             <ul class="nav-dropdown-menu">
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Educatie Hub</a></li>
-              <li><a href="/faq.html">FAQ Centrum</a></li>
+              <li><a href="/nl/faq.html">FAQ Centrum</a></li>
             </ul>
           </li>
 
           <li><a href="#pricing">Prijzen</a></li>
 
-          <li><a href="/affiliates.html">Partners</a></li>
+          <li><a href="/nl/affiliates.html">Partners</a></li>
 
         </ul>
 
       </nav>
-
-
-
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Taal selectie" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text)">
-          <span>🇺🇸</span>
-        </button>
-      </div>
 
       <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Thema selectie" style="padding:.5rem .7rem;color:var(--text)">
         <span id="theme-icon">
@@ -3680,7 +3474,7 @@
               <input type="checkbox" id="trialConsent" required>
               <span>
                 Ik begrijp dat <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> alleen educatief is. Geen financieel advies.
-                <a href="/terms.html" style="color:var(--brand)">Voorwaarden</a>
+                <a href="/nl/terms.html" style="color:var(--brand)">Voorwaarden</a>
               </span>
             </label>
 
@@ -5718,7 +5512,7 @@
 
     <!-- View All FAQs Link -->
     <div style="text-align:center;margin-top:2.5rem">
-      <a href="/faq.html" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+      <a href="/nl/faq.html" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
         Bekijk Volledige FAQ (30+ Vragen) →
       </a>
       <p style="color:var(--muted-2);font-size:.85rem;margin-top:.8rem">Setup handleidingen, strategieën en technische details</p>
@@ -5801,8 +5595,8 @@
           <ul style="list-style:none;padding:0;margin:0">
             <li style="margin-bottom:.4rem"><a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">GitHub</a></li>
             <li style="margin-bottom:.4rem"><a href="mailto:support@signalpilot.io" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">support@signalpilot.io</a></li>
-            <li style="margin-bottom:.4rem"><a href="/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Routekaart</a></li>
-            <li style="margin-bottom:.4rem"><a href="/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Partnerprogramma</a></li>
+            <li style="margin-bottom:.4rem"><a href="/nl/roadmap.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Routekaart</a></li>
+            <li style="margin-bottom:.4rem"><a href="/nl/affiliates.html" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Partnerprogramma</a></li>
           </ul>
         </div>
 
@@ -5869,13 +5663,6 @@
     </div>
 
   </div>
-
-
-
-  <!-- Hidden Google Translate container -->
-  <div id="google_translate_container" style="position:absolute;left:-9999px;" aria-hidden="true"></div>
-
-
 
   <!-- =======================================================================
        SCRIPT: CONFIG + UTILITIES
@@ -6015,9 +5802,9 @@
         <a href="#inside">Wat zit erin</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Educatie Hub</a>
-        <a href="/faq.html">FAQ Centrum</a>
+        <a href="/nl/faq.html">FAQ Centrum</a>
         <a href="#pricing">Prijzen</a>
-        <a href="/affiliates.html">Partners</a>
+        <a href="/nl/affiliates.html">Partners</a>
       `;
 
       // Assemble menu
@@ -6068,7 +5855,6 @@
 
     /* ======================== Resources Dropdown ======================== */
 
-    // Use event delegation for Google Translate compatibility
     (function() {
       let dropdownOpen = false;
 
@@ -6120,160 +5906,6 @@
         }
       });
     })();
-
-
-    /* ======================== Language Dropdown - Direct child of body ======================== */
-
-    // Language dropdown - create as direct child of body to escape stacking context
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
-
-      // Create language dropdown menu
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      // Create language buttons
-      const languages = [
-        { code: 'en', name: 'English', flag: '🇺🇸' },
-        { code: 'de', name: 'Deutsch', flag: '🇩🇪' },
-        { code: 'fr', name: 'Français', flag: '🇫🇷' },
-        { code: 'es', name: 'Español', flag: '🇪🇸' },
-        { code: 'it', name: 'Italiano', flag: '🇮🇹' },
-        { code: 'zh', name: '中文', flag: '🇨🇳' },
-        { code: 'ru', name: 'Русский', flag: '🇷🇺' },
-        { code: 'ar', name: 'العربية', flag: '🇸🇦' },
-        { code: 'pt', name: 'Português', flag: '🇵🇹' },
-        { code: 'tr', name: 'Türkçe', flag: '🇹🇷' },
-        { code: 'ja', name: '日本語', flag: '🇯🇵' },
-        { code: 'ko', name: '한국어', flag: '🇰🇷' },
-        { code: 'vi', name: 'Tiếng Việt', flag: '🇻🇳' },
-        { code: 'th', name: 'ไทย', flag: '🇹🇭' },
-        { code: 'hi', name: 'हिन्दी', flag: '🇮🇳' },
-        { code: 'id', name: 'Bahasa Indonesia', flag: '🇮🇩' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.setAttribute('data-lang', lang.code);
-        btn.textContent = lang.flag + ' ' + lang.name;
-        btn.addEventListener('click', function() {
-          // Helper functions
-          function baseDomain(host) {
-            const p = host.split('.');
-            return p.length > 2 ? p.slice(-2).join('.') : host;
-          }
-
-          function setCookie(name, value, days, domain) {
-            let expires = '';
-            if (days) {
-              const d = new Date();
-              d.setTime(d.getTime() + days * 864e5);
-              expires = '; expires=' + d.toUTCString();
-            }
-            const dom = domain ? '; domain=' + domain : '';
-            document.cookie = name + '=' + value + expires + '; path=/' + dom;
-          }
-
-          function setGoogTrans(langCode) {
-            const target = (langCode === 'zh') ? 'zh-CN' : langCode;
-            const val = '/en/' + target;
-            setCookie('googtrans', val, 365);
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            setCookie('googtrans', val, 365, root);
-          }
-
-          function applyDirLang(langCode) {
-            document.documentElement.lang = (langCode === 'zh') ? 'zh-CN' : langCode;
-            document.documentElement.dir = (langCode === 'ar') ? 'rtl' : 'ltr';
-          }
-
-          // Save to localStorage
-          localStorage.setItem('sp_lang', lang.code);
-
-          // Set cookies and attributes
-          if (lang.code === 'en') {
-            // For English: Set googtrans to /en/en (English to English = no translation)
-            const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-            const expires = new Date(Date.now() + 365 * 864e5).toUTCString();
-
-            // Set to /en/en which tells Google Translate "English to English" (no translation)
-            document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/';
-            document.cookie = 'googtrans=/en/en; expires=' + expires + '; path=/; domain=' + root;
-
-            applyDirLang('en');
-
-            // Track event if analytics available
-            if (typeof trackEvent === 'function') {
-              trackEvent('language_change', {
-                language: 'en',
-                language_name: lang.name
-              });
-            }
-
-            console.log('[GT] Switching to English - setting googtrans=/en/en');
-
-            // Use location.replace for a true hard reload without history
-            setTimeout(() => {
-              location.replace(location.pathname + '?lang=en&t=' + Date.now());
-            }, 50);
-          } else {
-            setGoogTrans(lang.code);
-            applyDirLang(lang.code);
-
-            // Track event if analytics available
-            if (typeof trackEvent === 'function') {
-              trackEvent('language_change', {
-                language: lang.code,
-                language_name: lang.name
-              });
-            }
-
-            console.log('[GT] Language changed to:', lang.code);
-            location.reload();
-          }
-        });
-        langMenu.appendChild(btn);
-      });
-
-      // CRITICAL: Append directly to body (escapes header's stacking context)
-      document.body.appendChild(langMenu);
-
-      // Open/close functions
-      function open() {
-        langMenu.classList.add('active');
-        langBtn.setAttribute('aria-expanded', 'true');
-      }
-
-      function close() {
-        langMenu.classList.remove('active');
-        langBtn.setAttribute('aria-expanded', 'false');
-      }
-
-      function toggle() {
-        if (langMenu.classList.contains('active')) {
-          close();
-        } else {
-          open();
-        }
-      }
-
-      // Event listeners
-      langBtn.addEventListener('click', function(e) {
-        toggle();
-      });
-
-      // Close when clicking outside
-      document.addEventListener('click', function(e) {
-        if (langMenu.classList.contains('active')) {
-          if (!langMenu.contains(e.target) && !langBtn.contains(e.target)) {
-            close();
-          }
-        }
-      });
-    })();
-
-
 
     /* ======================== Copy to clipboard (wallets) ======================== */
 
@@ -6345,247 +5977,6 @@
       window.addEventListener('hashchange',show); show();})();
 
 
-
-    /* ======================== Google Translate (on demand) ======================== */
-
-    // Google Translate Initialization with robust error handling
-    window.googleTranslateElementInit = function() {
-      console.log('[GT] Init called');
-      if (!window.google || !google.translate || !google.translate.TranslateElement) {
-        console.warn('[GT] Google Translate API not ready');
-        return;
-      }
-
-      const container = document.getElementById('google_translate_container');
-      if (!container) {
-        console.error('[GT] Container not found');
-        return;
-      }
-
-      try {
-        new google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'ar,de,es,fr,it,ru,zh-CN,pt,tr,ja,ko,vi,th,hi,id',
-          autoDisplay: false
-        }, 'google_translate_container');
-        console.log('[GT] Widget created successfully');
-        window.__gte_initialized = true;
-      } catch (error) {
-        console.error('[GT] Failed to create widget:', error);
-      }
-    };
-
-    // Load saved language on page load with robust polling
-    (function() {
-      const LANG_KEY = 'sp_lang';
-
-      function baseDomain(host) {
-        const p = host.split('.');
-        return p.length > 2 ? p.slice(-2).join('.') : host;
-      }
-
-      function setCookie(name, value, days, domain) {
-        let expires = '';
-        if (days) {
-          const d = new Date();
-          d.setTime(d.getTime() + days * 864e5);
-          expires = '; expires=' + d.toUTCString();
-        }
-        const dom = domain ? '; domain=' + domain : '';
-        document.cookie = name + '=' + value + expires + '; path=/' + dom;
-      }
-
-      function setGoogTrans(lang) {
-        const target = (lang === 'zh') ? 'zh-CN' : lang;
-        const val = '/en/' + target;
-        setCookie('googtrans', val, 365);
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        setCookie('googtrans', val, 365, root);
-      }
-
-      function clearGoogTrans() {
-        // Clear all Google Translate cookies thoroughly and aggressively
-        const root = '.' + baseDomain(location.hostname.replace(/^www\./, ''));
-        const cookieNames = ['googtrans', 'googtrans(2)', 'googtrans(0)', 'googtrans(1)'];
-        const domains = ['', '; domain=' + root, '; domain=' + location.hostname, '; domain=.signalpilot.io'];
-        const paths = ['/', '/en', '/en/'];
-
-        // Nuclear option: clear every possible cookie variation
-        cookieNames.forEach(name => {
-          domains.forEach(domain => {
-            paths.forEach(path => {
-              // Try deleting with empty value
-              document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
-              // Try setting to /en/en and deleting
-              document.cookie = name + '=/en/en; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=' + path + domain;
-              // Try with max-age
-              document.cookie = name + '=; max-age=0; path=' + path + domain;
-            });
-          });
-        });
-
-        // Also clear localStorage and sessionStorage
-        if (window.localStorage) {
-          localStorage.removeItem('googtrans');
-          localStorage.removeItem('googtrans(2)');
-        }
-        if (window.sessionStorage) {
-          sessionStorage.removeItem('googtrans');
-          sessionStorage.removeItem('googtrans(2)');
-        }
-
-        // Remove any Google Translate elements from DOM
-        const gtElements = [
-          '.skiptranslate',
-          '.goog-te-banner-frame',
-          '#goog-gt-tt',
-          '.goog-te-balloon-frame',
-          'iframe[src*="translate.google.com"]',
-          'iframe.goog-te-menu-frame',
-          '.goog-te-menu2'
-        ];
-        gtElements.forEach(selector => {
-          document.querySelectorAll(selector).forEach(el => el.remove());
-        });
-
-        console.log('[GT] Cleared all Google Translate cookies and elements');
-      }
-
-      function applyDirLang(lang) {
-        document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : lang;
-        document.documentElement.dir = (lang === 'ar') ? 'rtl' : 'ltr';
-      }
-
-      function loadGTE() {
-        if (window.__gte_loading) {
-          console.log('[GT] Already loading');
-          return;
-        }
-        if (window.google && window.google.translate) {
-          console.log('[GT] Already loaded');
-          googleTranslateElementInit();
-          return;
-        }
-
-        console.log('[GT] Loading script...');
-        window.__gte_loading = true;
-
-        const s = document.createElement('script');
-        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-        s.async = true;
-        s.onerror = function() {
-          console.error('[GT] Script failed to load');
-          window.__gte_loading = false;
-          // Retry after 2 seconds
-          setTimeout(function() {
-            if (!window.google) {
-              console.log('[GT] Retrying...');
-              loadGTE();
-            }
-          }, 2000);
-        };
-        s.onload = function() {
-          console.log('[GT] Script loaded');
-          // Poll for initialization
-          let attempts = 0;
-          const checkInit = setInterval(function() {
-            attempts++;
-            if (window.__gte_initialized || attempts > 50) {
-              clearInterval(checkInit);
-              if (!window.__gte_initialized) {
-                console.warn('[GT] Init timeout after ' + attempts + ' attempts');
-              }
-            }
-          }, 100);
-        };
-        document.head.appendChild(s);
-      }
-
-      const sel = document.getElementById('langSel');
-
-      // Check URL parameter for forced language
-      const urlParams = new URLSearchParams(window.location.search);
-      const urlLang = urlParams.get('lang');
-
-      let saved = localStorage.getItem(LANG_KEY) || 'en';
-
-      // If URL says lang=en, force English and clear localStorage
-      if (urlLang === 'en') {
-        saved = 'en';
-        localStorage.setItem(LANG_KEY, 'en');
-        console.log('[GT] URL forced English language');
-      }
-
-      const code = saved.toLowerCase().startsWith('zh') ? 'zh' : saved.slice(0, 2);
-
-      console.log('[GT] Saved language:', code);
-
-      if (sel) sel.value = code;
-
-      // Only set translation cookies for non-English languages
-      if (code !== 'en') {
-        setGoogTrans(code);
-        applyDirLang(code);
-      } else {
-        // For English: cookie already set to /en/en by early script
-        // Just ensure HTML attributes are correct
-        applyDirLang('en');
-
-        // Remove Google Translate font wrappers that might be lingering in the DOM
-        setTimeout(() => {
-          document.querySelectorAll('font').forEach(font => {
-            const parent = font.parentNode;
-            while (font.firstChild) {
-              parent.insertBefore(font.firstChild, font);
-            }
-            parent.removeChild(font);
-          });
-        }, 100);
-
-        // Clean URL after processing
-        if (urlLang === 'en') {
-          setTimeout(() => {
-            const cleanUrl = window.location.pathname;
-            window.history.replaceState({}, '', cleanUrl);
-          }, 200);
-        }
-      }
-
-      // Update language button text to show current language
-      const langBtn = document.getElementById('langToggle');
-      if (langBtn) {
-        const langText = langBtn.querySelector('span');
-        if (langText) {
-          const flagMap = {
-            'en': '🇺🇸', 'de': '🇩🇪', 'fr': '🇫🇷', 'es': '🇪🇸',
-            'it': '🇮🇹', 'zh': '🇨🇳', 'ru': '🇷🇺', 'ar': '🇸🇦',
-            'pt': '🇵🇹', 'tr': '🇹🇷', 'ja': '🇯🇵', 'ko': '🇰🇷',
-            'vi': '🇻🇳', 'th': '🇹🇭', 'hi': '🇮🇳', 'id': '🇮🇩'
-          };
-          langText.textContent = flagMap[code] || '🌐';
-        }
-      }
-
-      // Load on DOMContentLoaded to ensure page is ready
-      if (code !== 'en') {
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(loadGTE, 500); // Small delay to let page settle
-          });
-        } else {
-          setTimeout(loadGTE, 500);
-        }
-      }
-
-      sel.addEventListener('change', e => {
-        const v = e.target.value;
-        localStorage.setItem(LANG_KEY, v);
-        setGoogTrans(v);
-        applyDirLang(v);
-        if (v !== 'en') loadGTE();
-        location.reload();
-      });
-    })();
 
 
 
@@ -7368,17 +6759,7 @@ if ('serviceWorker' in navigator) {
       });
     });
 
-    // 6. TRACK LANGUAGE SELECTOR
-    const langToggle = document.getElementById('langToggle');
-    if (langToggle) {
-      langToggle.addEventListener('click', function() {
-        trackEvent('language_selector_open', {});
-      });
-    }
-
-    // Language dropdown analytics now integrated into the language dropdown JavaScript above
-
-    // 7. TRACK THEME TOGGLE
+    // 6. TRACK THEME TOGGLE
     const themeToggle = document.getElementById('themeToggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', function() {
@@ -7641,7 +7022,7 @@ if ('serviceWorker' in navigator) {
     <div class="cookie-consent-text">
       <h3>🍪 Cookies</h3>
       <p>
-        We gebruiken analyse cookies (Clarity & GA4) om uw ervaring te verbeteren. <a href="/privacy.html">Privacybeleid</a>
+        We gebruiken analyse cookies (Clarity & GA4) om uw ervaring te verbeteren. <a href="/nl/privacy.html">Privacybeleid</a>
       </p>
     </div>
     <div class="cookie-consent-actions">

--- a/nl/manage-subscription.html
+++ b/nl/manage-subscription.html
@@ -332,7 +332,7 @@
       </ul>
 
       <div class="warning-box">
-        <p><strong>Restitutiebeleid:</strong> We bieden een 7-dagen geld-terug-garantie voor nieuwe abonnees. Na 7 dagen kunt u annuleren om toekomstige kosten te voorkomen, maar er worden geen gedeeltelijke restituties verleend. Zie ons <a href="refund.html">restitutiebeleid</a> voor details.</p>
+        <p><strong>Restitutiebeleid:</strong> We bieden een 7-dagen geld-terug-garantie voor nieuwe abonnees. Na 7 dagen kunt u annuleren om toekomstige kosten te voorkomen, maar er worden geen gedeeltelijke restituties verleend. Zie ons <a href="/nl/refund.html">restitutiebeleid</a> voor details.</p>
       </div>
 
       <!-- CANCELLATION DETAILS -->
@@ -351,9 +351,9 @@
       <h2>Snelle links</h2>
 
       <ul>
-        <li><a href="refund.html">Restitutiebeleid</a> — Details over de 7-dagen geld-terug-garantie</li>
-        <li><a href="terms.html">Gebruiksvoorwaarden</a> — Volledige abonnementsvoorwaarden</li>
-        <li><a href="privacy.html">Privacybeleid</a> — Hoe we uw gegevens behandelen</li>
+        <li><a href="/nl/refund.html">Restitutiebeleid</a> — Details over de 7-dagen geld-terug-garantie</li>
+        <li><a href="/nl/terms.html">Gebruiksvoorwaarden</a> — Volledige abonnementsvoorwaarden</li>
+        <li><a href="/nl/privacy.html">Privacybeleid</a> — Hoe we uw gegevens behandelen</li>
         <li><a href="/#faq">Veelgestelde Vragen</a> — Veelgestelde vragen</li>
       </ul>
 
@@ -364,9 +364,9 @@
     <div class="container">
       <div>© 2025 Signal Pilot Labs. Alle rechten voorbehouden.</div>
       <div>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Voorwaarden</a>
-        <a href="refund.html">Restituties</a>
+        <a href="/nl/privacy.html">Privacy</a>
+        <a href="/nl/terms.html">Voorwaarden</a>
+        <a href="/nl/refund.html">Restituties</a>
       </div>
     </div>
   </footer>

--- a/nl/privacy.html
+++ b/nl/privacy.html
@@ -195,7 +195,7 @@
 
   <header>
     <div class="container">
-      <a href="../index.html" class="logo">Signal Pilot</a>
+      <a href="/" class="logo">Signal Pilot</a>
       <button id="themeToggle" class="theme-toggle">Thema</button>
     </div>
   </header>
@@ -378,10 +378,10 @@
     <div class="container">
       <div>© <span id="year"></span> Signal Pilot Labs. Alle rechten voorbehouden.</div>
       <div>
-        <a href="privacy.html">Privacy</a>
-        <a href="../terms.html">Voorwaarden</a>
-        <a href="../refund.html">Restitutiebeleid</a>
-        <a href="../index.html">Home</a>
+        <a href="/nl/privacy.html">Privacy</a>
+        <a href="/nl/terms.html">Voorwaarden</a>
+        <a href="/nl/refund.html">Restitutiebeleid</a>
+        <a href="/">Home</a>
       </div>
     </div>
   </footer>

--- a/nl/refund.html
+++ b/nl/refund.html
@@ -271,7 +271,7 @@
 
   <header>
     <div class="container">
-      <a href="index.html" class="logo">Signal Pilot</a>
+      <a href="/" class="logo">Signal Pilot</a>
       <button id="themeToggle" class="theme-toggle">Thema</button>
     </div>
   </header>
@@ -400,7 +400,7 @@
       <h3>4.3 Annuleringsproces</h3>
       <p><strong>PayPal abonnementen:</strong></p>
       <ul>
-        <li>Bereikbaar via PayPal → Instellingen → Betalingen → Automatische betalingen beheren</li>
+        <li>Bereikbaar via <a href="/nl/manage-subscription.html">PayPal → Instellingen → Betalingen → Automatische betalingen beheren</a></li>
         <li>Vermeld onder "Signal Pilot Labs" met annuleringsoptie</li>
         <li>Annuleringsverzoeken kunnen worden gestuurd naar <a href="mailto:support@signalpilot.io">support@signalpilot.io</a></li>
       </ul>
@@ -571,10 +571,10 @@
     <div class="container">
       <div>© <span id="year"></span> Signal Pilot Labs. Alle rechten voorbehouden.</div>
       <div>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Voorwaarden</a>
-        <a href="refund.html">Restitutiebeleid</a>
-        <a href="index.html">Home</a>
+        <a href="/nl/privacy.html">Privacy</a>
+        <a href="/nl/terms.html">Voorwaarden</a>
+        <a href="/nl/refund.html">Restitutiebeleid</a>
+        <a href="/">Home</a>
       </div>
     </div>
   </footer>

--- a/nl/roadmap.html
+++ b/nl/roadmap.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Roadmap — Signal Pilot</title>
-  <meta name="description" content="Signal Pilot Roadmap — Wat live is, wat komt en waar we naartoe gaan. Transparente Entwicklung, kontinuierliche Verbesserung.">
+  <meta name="description" content="Signal Pilot Roadmap — Wat live is, wat komt en waar we naartoe gaan. Transparante ontwikkeling, continue verbetering.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
@@ -140,7 +140,7 @@
       z-index: 1;
     }
 
-    
+
 
       display: none !important;
     }
@@ -148,15 +148,10 @@
       color: inherit !important;
     }
 
-    /* Prevent Google Translate from blocking clicks */
-    nav font,
-    nav span:not(.dropdown-arrow),
-    
-
     /* Ensure buttons always work */
     nav a,
     nav button,
-    
+
 
     /* Screen reader only utility */
     .sr-only {
@@ -398,17 +393,6 @@
       background: rgba(59,130,246,.12);
       color: #0f172a;
     }
-
-    /* Language Dropdown */
-    
-
-    
-
-    
-
-    
-
-    
 
     .btn {
       background: var(--bg-soft);
@@ -1029,7 +1013,7 @@
             </div>
             <div class="feature-item">
               <span class="feature-icon">📚</span>
-              <div class="feature-text"><strong>Gratis onderwijscentrum</strong>82 interactieve lessen (kostenlos für alle), 4 progressieve niveaus, 250.000 Wörter, Quizze, voortgangsregistratie</div>
+              <div class="feature-text"><strong>Gratis onderwijscentrum</strong>82 interactieve lessen (gratis voor iedereen), 4 progressieve niveaus, 250.000 woorden, Quizzen, voortgangsregistratie</div>
             </div>
             <div class="feature-item">
               <span class="feature-icon">📖</span>
@@ -1065,7 +1049,7 @@
             </div>
             <div class="feature-item">
               <span class="feature-icon" style="color: var(--accent);">✓</span>
-              <div class="feature-text"><strong>Nieuwe indicatoren (2-3)</strong>Optie flow Optionsfluss & Gamma-Wände Gamma walls, Correlatiematrix, Seizoenaliteitmachine</div>
+              <div class="feature-text"><strong>Nieuwe indicatoren (2-3)</strong>Optie flow & Gamma walls, Correlatiematrix, Seizoenaliteitmachine</div>
             </div>
             <div class="feature-item">
               <span class="feature-icon" style="color: var(--accent);">✓</span>
@@ -1077,7 +1061,7 @@
             </div>
             <div class="feature-item">
               <span class="feature-icon" style="color: var(--accent);">✓</span>
-              <div class="feature-text"><strong>Voorinstellingen bibliotheek</strong>Vooraf geconfigureerde setups für Cryptocurrencies, Forex, Aandelen</div>
+              <div class="feature-text"><strong>Voorinstellingen bibliotheek</strong>Vooraf geconfigureerde setups voor Cryptocurrencies, Forex, Aandelen</div>
             </div>
             <div class="feature-item">
               <span class="feature-icon" style="color: var(--accent);">✓</span>
@@ -1105,7 +1089,7 @@
           <div class="phase-content">
             <div class="feature-item">
               <span class="feature-icon" style="color: var(--muted);">○</span>
-              <div class="feature-text"><strong>Mobiele Apps</strong>iOS + Android mit Push notificaties</div>
+              <div class="feature-text"><strong>Mobiele Apps</strong>iOS + Android met Push notificaties</div>
             </div>
             <div class="feature-item">
               <span class="feature-icon" style="color: var(--muted);">○</span>
@@ -1129,7 +1113,7 @@
         <div class="commitment-grid">
           <div class="commitment-item">
             <strong>🔄 Continue verbetering</strong><br>
-            318 Commits aan onderwijs, 153 zur Documentatie — actieve ontwikkeling, geen opgave. Elke indicator ontvangt regelmatige updates.
+            318 Commits aan onderwijs, 153 naar Documentatie — actieve ontwikkeling, geen opgave. Elke indicator ontvangt regelmatige updates.
           </div>
           <div class="commitment-item">
             <strong>💰 Alle toekomstige releases inbegrepen</strong><br>

--- a/nl/terms.html
+++ b/nl/terms.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Algemene Voorwaarden — Signal Pilot</title>
-  <meta name="description" content="Algemene Voorwaarden von Signal Pilot — Regeln und Richtlinien für die Nutzung unserer Trading-Indikatoren.">
+  <meta name="description" content="Algemene Voorwaarden van Signal Pilot — Regels en richtlijnen voor het gebruik van onze handelsindicatoren.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
@@ -208,7 +208,7 @@
 
   <header>
     <div class="container">
-      <a href="index.html" class="logo">Signal Pilot</a>
+      <a href="/" class="logo">Signal Pilot</a>
       <button id="themeToggle" class="theme-toggle">Design</button>
     </div>
   </header>
@@ -220,9 +220,9 @@
 
       <p class="subtitle">Juridische overeenkomst voor het gebruik van de Signal Pilot indicatoren.</p>
 
-      <div class="updated">Laatst bijgewerkt: 23. Oktober 2025</div>
+      <div class="updated">Laatst bijgewerkt: 23 oktober 2025</div>
 
-      <p>Welkom bij Signal Pilot. Door toegang te krijgen tot of gebruik te maken van onze dienst, gaat u akkoord met deze Algemene Voorwaarden („Voorwaarden") gebunden. Personen die niet akkoord gaan, mogen de dienst niet gebruiken.</p>
+      <p>Welkom bij Signal Pilot. Door toegang te krijgen tot of gebruik te maken van onze dienst, gaat u akkoord met deze Algemene Voorwaarden („Voorwaarden") gebonden. Personen die niet akkoord gaan, mogen de dienst niet gebruiken.</p>
 
       <div class="warning-box">
         <p><strong>⚠️ BELANGRIJKE OPMERKING:</strong> Signal Pilot indicatoren zijn alleen voor educatieve en informatieve doeleinden. Handelen brengt aanzienlijke risico's met zich mee. We bieden geen financieel advies, beleggingsaanbevelingen of winstgaranties.</p>
@@ -230,7 +230,7 @@
 
       <h2>1. Dienst omschrijving</h2>
 
-      <p>Signal Pilot Labs („wir", „uns" oder „unser") biedt TradingView indicatoren voor technische analyse. Onze dienst omvat:</p>
+      <p>Signal Pilot Labs („wij", „ons" of „onze") biedt TradingView indicatoren voor technische analyse. Onze dienst omvat:</p>
       <ul>
         <li>Toegang tot proprietary Pine Script indicatoren</li>
         <li>Non-repainting signaallogica</li>
@@ -246,7 +246,7 @@
       <p>Gebruikers moeten ten minste 18 jaar oud zijn (of de wettelijke meerderjarigheidsleeftijd in hun jurisdictie), om Signal Pilot te gebruiken.</p>
 
       <h3>2.2 TradingView account</h3>
-      <p>Ein gültiges TradingView account ist erforderlich, um unsere Indikatoren zu nutzen. Signal Pilot is een onafhankelijke derde partij en is niet aangesloten bij TradingView.</p>
+      <p>Een geldig TradingView account is vereist om onze indicatoren te gebruiken. Signal Pilot is een onafhankelijke derde partij en is niet aangesloten bij TradingView.</p>
 
       <h3>2.3 Account beveiliging</h3>
       <ul>
@@ -284,22 +284,22 @@
 
       <h2>4. Annulering en restituties</h2>
 
-      <p>Volledige details vindt u in het <a href="refund.html">restitutiebeleid</a>. Samenvatting:</p>
+      <p>Volledige details vindt u in het <a href="/nl/refund.html">restitutiebeleid</a>. Samenvatting:</p>
       <ul>
         <li><strong>7-dagen restitutie periode:</strong> Volledige restitutie als u niet tevreden bent (alleen nieuwe kopers)</li>
         <li><strong>Na 7 dagen:</strong> Geen restituties, maar u kunt annuleren, om toekomstige kosten te voorkomen</li>
         <li><strong>Levenslange toegang:</strong> Na 7 dagen geen restituties (beschouwd als definitieve aankoop)</li>
       </ul>
 
-      <p>Om te annuleren stuurt u een e-mail naar <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> of beheer uw PayPal abonnement.</p>
+      <p>Om te annuleren stuurt u een e-mail naar <a href="mailto:support@signalpilot.io">support@signalpilot.io</a> of beheer uw <a href="/nl/manage-subscription.html">PayPal abonnement</a>.</p>
 
       <h2>5. Beleid voor acceptabel gebruik</h2>
 
       <p>U gaat ermee akkoord om NIET:</p>
       <ul>
         <li><strong>Toegang delen:</strong> Uw indicator toegang te herdistribueren, door te verkopen of te delen</li>
-        <li><strong>Reverse Engineering:</strong> Zu dekompilieren, zu zerlegen oder den Quellcode zu extrahieren</li>
-        <li><strong>Frauduleuze activiteit:</strong> Gestohlene Betalingsmethoden oder falsche Identitäten zu verwenden</li>
+        <li><strong>Reverse Engineering:</strong> Te decompileren, te demonteren of de broncode te extraheren</li>
+        <li><strong>Frauduleuze activiteit:</strong> Gestolen betaalmethoden of valse identiteiten te gebruiken</li>
         <li><strong>Support misbruik:</strong> Support te lastigvallen, spammen of buitensporige support verzoeken in te dienen</li>
         <li><strong>Commerciële wederverkoop:</strong> Signal Pilot indicatoren zonder schriftelijke toestemming aan te bieden als onderdeel van een betaalde dienst</li>
       </ul>
@@ -309,7 +309,7 @@
       <h2>6. Intellectueel eigendom</h2>
 
       <h3>6.1 Eigendom</h3>
-      <p>Alle Signal-Pilot-Indikatoren, Code, Designs, Marken und Inhalte sind Eigendom von Signal Pilot Labs. Uw abonnement verleent een beperkte, niet-exclusieve, niet-overdraagbare licentie voor het gebruik van onze indicatoren.</p>
+      <p>Alle Signal Pilot indicatoren, code, ontwerpen, merken en inhoud zijn eigendom van Signal Pilot Labs. Uw abonnement verleent een beperkte, niet-exclusieve, niet-overdraagbare licentie voor het gebruik van onze indicatoren.</p>
 
       <h3>6.2 Gebruikersbeperkingen</h3>
       <p>U mag NIET:</p>
@@ -371,7 +371,7 @@
         <li>Wij zijn NIET aansprakelijk voor indirecte, gevolg- of punitieve schade</li>
       </ul>
 
-      <p>Einige Gerichtsbarkeiten erlauben keine Beperking van aansprakelijkheiden, daarom zijn deze mogelijk niet op u van toepassing.</p>
+      <p>Sommige rechtsgebieden staan geen beperking van aansprakelijkheid toe, daarom zijn deze mogelijk niet op u van toepassing.</p>
 
       <h2>9. Vrijwaring</h2>
 
@@ -386,17 +386,17 @@
       <h2>10. Dienst beschikbaarheid</h2>
 
       <h3>10.1 Beschikbaarheid</h3>
-      <p>Wir streben nach hoher Beschikbaarheid, garantieren aber keinen ununterbrochenen Dienst. Onderhoud, updates of technische problemen kunnen leiden tot tijdelijke downtime.</p>
+      <p>We streven naar hoge beschikbaarheid, maar garanderen geen ononderbroken dienst. Onderhoud, updates of technische problemen kunnen leiden tot tijdelijke downtime.</p>
 
       <h3>10.2 TradingView afhankelijkheid</h3>
-      <p>Onze indicatoren vereisen het TradingView platform. Wir sind nicht verantwortlich für TradingViews Dienst beschikbaarheid, beleidswijzigingen of technische problemen.</p>
+      <p>Onze indicatoren vereisen het TradingView platform. Wij zijn niet verantwoordelijk voor TradingViews dienst beschikbaarheid, beleidswijzigingen of technische problemen.</p>
 
       <h3>10.3 Wijzigingen aan indicatoren</h3>
       <p>Wij kunnen indicatoren op elk moment bijwerken, wijzigen of stopzetten. We informeren gebruikers over grote wijzigingen.</p>
 
       <h2>11. Privacy en gegevens</h2>
 
-      <p>Uw gebruik van Signal Pilot is onderworpen aan ons <a href="privacy.html">Privacybeleid</a>. Belangrijkste punten:</p>
+      <p>Uw gebruik van Signal Pilot is onderworpen aan ons <a href="/nl/privacy.html">Privacybeleid</a>. Belangrijkste punten:</p>
       <ul>
         <li>Wij verzamelen minimale gegevens (TradingView gebruikersnaam, betalingsinformatie)</li>
         <li>Wij volgen NIET uw handelsactiviteit of posities</li>
@@ -416,11 +416,11 @@
         <li>Indicator toegang deelt of overdraagt</li>
       </ul>
 
-      <h3>12.3 Auswirkung der Beëindiging</h3>
+      <h3>12.3 Gevolgen van beëindiging</h3>
       <ul>
         <li>Uw indicator toegang wordt ingetrokken</li>
-        <li>Keine Rückerstattung bei vorzeitiger Beëindiging (behalve binnen 7 dagen)</li>
-        <li>Blijvend: Intellectueel eigendom, Beperking van aansprakelijkheiden, Vrijwaring bleiben gültig</li>
+        <li>Geen restitutie bij voortijdige beëindiging (behalve binnen 7 dagen)</li>
+        <li>Blijvend: Intellectueel eigendom, Beperking van aansprakelijkheid, Vrijwaring blijven geldig</li>
       </ul>
 
       <h2>13. Geschillenbeslechting</h2>
@@ -429,21 +429,21 @@
       <p>Deze voorwaarden zijn onderworpen aan de wetten van [Your Jurisdiction] zonder inachtneming van wetsconflicten.</p>
 
       <h3>13.2 Arbitrage</h3>
-      <p>Alle Streitigkeiten werden durch verbindliches Arbitrage statt Gerichtsverfahren beigelegt (behalve wanneer wettelijk verboden).</p>
+      <p>Alle geschillen worden opgelost door bindende arbitrage in plaats van gerechtelijke procedures (behalve wanneer wettelijk verboden).</p>
 
       <h3>13.3 Informele beslechting</h3>
       <p>Voordat u een claim indient, neem contact met ons op via <a href="mailto:legal@signalpilot.io">legal@signalpilot.io</a>, om een informele beslechting te proberen.</p>
 
       <h2>14. Wijzigingen van de voorwaarden</h2>
 
-      <p>Wij kunnen deze voorwaarden op elk moment bijwerken. Wijzigingen worden op deze pagina geplaatst met een nieuwe datum „Zuletzt aktualisiert" veröffentlicht. Belangrijke wijzigingen worden per e-mail gecommuniceerd.</p>
+      <p>Wij kunnen deze voorwaarden op elk moment bijwerken. Wijzigingen worden op deze pagina geplaatst met een nieuwe datum „Laatst bijgewerkt". Belangrijke wijzigingen worden per e-mail gecommuniceerd.</p>
 
       <p>Uw voortgezet gebruik na wijzigingen betekent instemming. Ontevredenheid vereist annulering van het abonnement voordat de wijzigingen van kracht worden.</p>
 
       <h2>15. Diversen</h2>
 
       <h3>15.1 Volledige overeenkomst</h3>
-      <p>Diese Voorwaarden zusammen mit unseren Datenschutz- und restitutiebeleidn stellen die gesamte Vereinbarung tussen u en Signal Pilot Labs.</p>
+      <p>Deze voorwaarden samen met ons privacy- en restitutiebeleid vormen de volledige overeenkomst tussen u en Signal Pilot Labs.</p>
 
       <h3>15.2 Scheidbaarheidsclausule</h3>
       <p>Als een bepaling ongeldig wordt bevonden, blijven de overige bepalingen geldig.</p>
@@ -484,12 +484,12 @@
 
   <footer>
     <div class="container">
-      <div>© <span id="year"></span> Signal Pilot Labs. Alle Rechte vorbehalten.</div>
+      <div>© <span id="year"></span> Signal Pilot Labs. Alle rechten voorbehouden.</div>
       <div>
-        <a href="privacy.html">Datenschutz</a>
-        <a href="terms.html">Voorwaarden</a>
-        <a href="refund.html">restitutiebeleid</a>
-        <a href="index.html">Startseite</a>
+        <a href="/nl/privacy.html">Privacy</a>
+        <a href="/nl/terms.html">Voorwaarden</a>
+        <a href="/nl/refund.html">Restitutiebeleid</a>
+        <a href="/">Home</a>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
Complete overhaul of Dutch (/nl/) directory to ensure proper Dutch language support:

## Changes Made:

### 1. Removed Google Translate Features
- Removed Google Translate initialization code and cookie management
- Removed language dropdown button and all associated JavaScript
- Removed all CSS rules for .lang-dropdown and #langToggle
- Cleaned up all Google Translate related comments

### 2. Fixed Mixed German/Dutch Text
- Converted all German text to proper Dutch across all files
- Fixed terms.html: "Oktober" → "oktober", "von" → "van", etc.
- Fixed faq.html: Extensive German → Dutch conversion
- Fixed roadmap.html: German phrases → Dutch
- Fixed JSON-LD schema questions to Dutch

### 3. Fixed Internal Links
- Changed all internal page links from root (e.g., /faq.html) to Dutch versions (/nl/faq.html)
- Fixed 35 internal links across 8 files to ensure Dutch pages link to Dutch pages
- Preserved external links to docs/education subdomains

### 4. Files Modified (8 total)
- nl/index.html - Google Translate code, language dropdown, links fixed
- nl/faq.html - German text converted, links fixed
- nl/terms.html - German text converted, links fixed
- nl/refund.html - Links fixed
- nl/privacy.html - Links fixed
- nl/affiliates.html - Links fixed
- nl/roadmap.html - Google Translate remnants removed, German text fixed
- nl/manage-subscription.html - Links fixed

All Dutch pages now contain only Dutch text with no Google Translate features and correctly link to other Dutch pages within the /nl/ directory.