### PR TITLE
Fix Italian directory language and remove translation

### DIFF
--- a/it/index.html
+++ b/it/index.html
@@ -3005,7 +3005,7 @@
 
 
 
-      <a href="/" class="brand">
+      <a href="/it/" class="brand">
 
         <span>Signal Pilot</span>
 
@@ -3036,7 +3036,7 @@
 
           <li><a href="#pricing">Prezzi</a></li>
 
-          <li><a href="/affiliates.html">Affiliati</a></li>
+          <li><a href="/it/affiliates.html">Affiliati</a></li>
 
         </ul>
 
@@ -3056,7 +3056,7 @@
 
 
 
-      <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="mainnav">Menu ☰</button>
+      <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="mainnav">Menù ☰</button>
 
     </div>
 
@@ -5699,7 +5699,7 @@
       const header = document.createElement('div');
       header.className = 'mobile-nav-header';
       header.innerHTML = `
-        <span style="color:#fff;font-weight:700;font-size:1.1rem">Menu</span>
+        <span style="color:#fff;font-weight:700;font-size:1.1rem">Menù</span>
         <button class="mobile-nav-close">&times;</button>
       `;
 
@@ -5711,9 +5711,9 @@
         <a href="#inside">Cosa c'è dentro</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Hub Educativo</a>
-        <a href="/faq.html">Centro FAQ</a>
+        <a href="/it/faq.html">Centro FAQ</a>
         <a href="#pricing">Prezzi</a>
-        <a href="/affiliates.html">Affiliati</a>
+        <a href="/it/affiliates.html">Affiliati</a>
       `;
 
       // Assemble menu
@@ -6927,7 +6927,7 @@ if ('serviceWorker' in navigator) {
     <div class="cookie-consent-text">
       <h3>🍪 Cookies</h3>
       <p>
-        Utilizziamo cookie analitici (Clarity e GA4) per migliorare la tua esperienza. <a href="/privacy.html">Politica sulla Privacy</a>
+        Utilizziamo cookie analitici (Clarity e GA4) per migliorare la tua esperienza. <a href="/it/privacy.html">Politica sulla Privacy</a>
       </p>
     </div>
     <div class="cookie-consent-actions">


### PR DESCRIPTION
Changes made:
- Verified NO Google Translate features or widgets present
- Fixed brand/logo link to point to /it/ instead of /
- Fixed all navigation links to point to Italian pages (/it/affiliates.html, /it/faq.html)
- Fixed privacy policy link in cookie consent banner (/it/privacy.html)
- Translated UI text: "Menu" -> "Menù" (2 occurrences in mobile navigation)

All internal links now correctly point to Italian language pages. All UI text is now in Italian.
No translation widgets or language toggle buttons present.