### PR TITLE
Translate remaining English text in Hungarian site

### DIFF
--- a/hu/index.html
+++ b/hu/index.html
@@ -108,7 +108,7 @@
       {
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#monthly-plan",
-        "name": "Signal Pilot Elite Seven - Monthly Subscription",
+        "name": "Signal Pilot Elit Seven - Havi Előfizetés",
         "description": "Professzionális TradingView indikátorok Pentarch™ ciklus detektálással. Mind a 7 elit indikátor plusz jövőbeli frissítések. 100% nem átrajzoló, auditált. Működik részvényeken, kriptón, forexen, indexeken és nyersanyagokon.",
         "brand": {
           "@type": "Brand",
@@ -176,7 +176,7 @@
       {
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
-        "name": "Signal Pilot Elite Seven - Yearly Subscription (Best Value)",
+        "name": "Signal Pilot Elit Seven - Éves Előfizetés (Legjobb Érték)",
         "description": "Professzionális TradingView indikátorok Pentarch™ ciklus detektálással. Spórolj 489$/év. Mind a 7 elit indikátor plusz jövőbeli frissítések. 100% nem átrajzoló, auditált. Prioritás támogatás és haladó képzés mellékelve.",
         "brand": {
           "@type": "Brand",
@@ -249,7 +249,7 @@
       {
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#lifetime-plan",
-        "name": "Signal Pilot Elite Seven - Lifetime Access (Limited Founding 100)",
+        "name": "Signal Pilot Elit Seven - Élethosszig Tartó Hozzáférés (Korlátozott Alapító 100)",
         "description": "Professzionális TradingView indikátorok élethosszig tartó hozzáféréssel. Pentarch™ ciklus detektálás. Mind a 7 elit indikátor plusz minden jövőbeli kiadás örökre. 100% nem átrajzoló, auditált. Privát Discord közösség, 200+ előre beállított konfiguráció, béta hozzáférés, prioritás támogatás.",
         "brand": {
           "@type": "Brand",
@@ -2816,7 +2816,7 @@
         "priceValidUntil": "2025-12-31",
         "availability": "https://schema.org/InStock",
         "url": "https://www.signalpilot.io/#pricing",
-        "name": "Monthly Subscription",
+        "name": "Havi Előfizetés",
         "seller": {
           "@type": "Organization",
           "name": "Signal Pilot"
@@ -2829,7 +2829,7 @@
         "priceValidUntil": "2025-12-31",
         "availability": "https://schema.org/InStock",
         "url": "https://www.signalpilot.io/#pricing",
-        "name": "Yearly Subscription",
+        "name": "Éves Előfizetés",
         "seller": {
           "@type": "Organization",
           "name": "Signal Pilot"
@@ -2963,17 +2963,17 @@
         "offers": [
           {
             "@type": "Offer",
-            "name": "Monthly Plan",
+            "name": "Havi Csomag",
             "price": "99.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2025-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Flexible month-to-month billing with all 7 elite indicators"
+            "description": "Rugalmas havi számlázás mind a 7 elit indikátorral"
           },
           {
             "@type": "Offer",
-            "name": "Yearly Plan",
+            "name": "Éves Csomag",
             "price": "699.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2025-12-31",
@@ -2983,7 +2983,7 @@
           },
           {
             "@type": "Offer",
-            "name": "Lifetime Plan",
+            "name": "Élethosszig Tartó Csomag",
             "price": "1799.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2025-12-31",
@@ -4739,17 +4739,17 @@
 
 
 
-    <!-- INTERACTIVE DEMO -->
+    <!-- INTERAKTÍV DEMÓ -->
 
     <section class="section">
 
       <div class="container stack">
 
         <div style="text-align:center;max-width:800px;margin:0 auto 1.5rem">
-          <span class="badge" style="margin-bottom:1rem">INTERACTIVE DEMO</span>
-          <h2 class="headline lg">The Difference</h2>
+          <span class="badge" style="margin-bottom:1rem">INTERAKTÍV DEMÓ</span>
+          <h2 class="headline lg">A Különbség</h2>
           <p style="color:var(--muted);font-size:1.1rem;line-height:1.6;margin-top:1rem">
-            <strong style="color:var(--brand)">👆 Drag the slider</strong> to compare trading with and without <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>. Same chart. Same timeframe. Completely different clarity.
+            <strong style="color:var(--brand)">👆 Húzd a csúszkát</strong>, hogy összehasonlítsd a kereskedést <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span> nélkül és vele. Ugyanaz a grafikon. Ugyanaz az időkeret. Teljesen más átláthatóság.
           </p>
         </div>
 
@@ -4773,10 +4773,10 @@
           <div class="comparison-image" style="position:relative;width:100%;min-height:600px;aspect-ratio:16/9;background:#0a0e18">
             <img
               src="assets/showcase/chart-without.jpg"
-              alt="Chart without Signal Pilot"
+              alt="Grafikon Signal Pilot nélkül"
               loading="eager"
               style="width:100%;height:100%;object-fit:contain;display:block"
-              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
+              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>Signal Pilot NÉLKÜL</span><span style=\'font-size:.9rem;opacity:.7\'>Grafikon kép hozzáadása:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
 
@@ -4785,15 +4785,15 @@
             <img
               id="overlay-image"
               src="assets/showcase/chart-with.jpg"
-              alt="Chart with Signal Pilot"
+              alt="Grafikon Signal Pilot-tal"
               loading="eager"
               style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
-              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
+              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>Signal Pilot-TAL</span><span style=\'font-size:.9rem;opacity:.7\'>Grafikon kép hozzáadása:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>
 
           <!-- Slider Handle with Pulse Animation -->
-          <div id="slider-handle" role="slider" aria-label="Comparison slider position" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0" style="position:absolute;top:0;left:50%;width:48px;height:100%;transform:translateX(-50%);z-index:100;cursor:ew-resize;touch-action:pan-x">
+          <div id="slider-handle" role="slider" aria-label="Összehasonlító csúszka pozíció" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0" style="position:absolute;top:0;left:50%;width:48px;height:100%;transform:translateX(-50%);z-index:100;cursor:ew-resize;touch-action:pan-x">
             <!-- Hit area (wider for easier grabbing) -->
             <div style="position:absolute;top:0;left:50%;transform:translateX(-50%);width:48px;height:100%;cursor:ew-resize"></div>
             <!-- Visual line -->
@@ -4926,7 +4926,7 @@
       }
 
       // Update overlay width when images load
-      const backgroundImage = slider.querySelector('img[alt="Chart without Signal Pilot"]');
+      const backgroundImage = slider.querySelector('img[alt="Grafikon Signal Pilot nélkül"]');
       const foregroundImage = overlayImage;
 
       if (backgroundImage) {


### PR DESCRIPTION
Fixed English text found in hu/index.html:
- Interactive demo section: "INTERACTIVE DEMO" → "INTERAKTÍV DEMÓ"
- Headline: "The Difference" → "A Különbség"
- Description: "Drag the slider..." → "Húzd a csúszkát..."
- Image alt texts: "Chart without/with Signal Pilot" → Hungarian
- Aria labels: "Comparison slider position" → Hungarian
- Schema.org product names: Translated to Hungarian
- Schema.org offer names: "Monthly Plan" → "Havi Csomag", etc.
- Error handler messages: "WITHOUT/WITH Signal Pilot" → Hungarian
- HTML comments: Translated to Hungarian

All user-facing text in the Hungarian directory is now fully in Hungarian.