### PR TITLE
Fix remaining Turkish translation issues in tr/index.html

### DIFF
--- a/tr/index.html
+++ b/tr/index.html
@@ -3098,7 +3098,7 @@
 
 
 
-      <a href="/" class="brand">
+      <a href="/tr/" class="brand">
 
         <span>Signal Pilot</span>
 
@@ -5440,7 +5440,7 @@
 
     <section id="faq" class="section" role="region" aria-labelledby="faq-heading" style="padding-top:1.5rem">
   <div class="container stack">
-    <h2 id="faq-heading" class="headline lg" style="text-align:center">FAQ</h2>
+    <h2 id="faq-heading" class="headline lg" style="text-align:center">SSS</h2>
     <p style="text-align:center;color:var(--muted);margin:-0.5rem 0 1.5rem 0;font-size:.9rem">Satın alma öncesi sorular yanıtlandı. Kurulum kılavuzları için: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokümantasyon</a> veya <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Eğitim Merkezi</a>.</p>
 
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;max-width:1100px;margin:0 auto">


### PR DESCRIPTION
- Change FAQ heading from 'FAQ' to 'SSS' (Turkish acronym for Frequently Asked Questions)
- Fix brand logo link to point to /tr/ instead of / to keep users on Turkish site

These were the last two English text issues found during final verification.