### PR TITLE
Fix FAQ structured data for Google Rich Results

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -3046,66 +3046,66 @@
     "@type": "FAQPage",
     "mainEntity": [
       {
-        "@type": "Pergunta",
+        "@type": "Question",
         "name": "Os sinais repintam?",
-        "acceptedResposta": {
-          "@type": "Resposta",
+        "acceptedAnswer": {
+          "@type": "Answer",
           "text": "Zero repintura. Garantido. Todos os sinais finalizam no fechamento da vela. Auditamos todos os indicadores para viés de antecipação. Se você conseguir provar qualquer repintura, pagamos $100 USD. O que você vê no histórico é exatamente o que você teria visto ao vivo."
         }
       },
       {
-        "@type": "Pergunta",
+        "@type": "Question",
         "name": "Isto é consultoria financeira?",
-        "acceptedResposta": {
-          "@type": "Resposta",
+        "acceptedAnswer": {
+          "@type": "Answer",
           "text": "Não. Signal Pilot é apenas um conjunto de ferramentas educacionais. Fornecemos ferramentas de análise técnica—não consultoria de investimentos, recomendações de operações ou retornos garantidos. Você é o único responsável por suas decisões de trading."
         }
       },
       {
-        "@type": "Pergunta",
+        "@type": "Question",
         "name": "Funciona no TradingView gratuito?",
-        "acceptedResposta": {
-          "@type": "Resposta",
+        "acceptedAnswer": {
+          "@type": "Answer",
           "text": "Sim! Você só precisa de slots de indicadores suficientes para sua configuração. Contas gratuitas têm 3 slots, o que é suficiente para Pentarch + 1-2 filtros. Contas Pro/Premium têm mais slots e alertas ilimitados."
         }
       },
       {
-        "@type": "Pergunta",
+        "@type": "Question",
         "name": "Qual a rapidez da ativação?",
-        "acceptedResposta": {
-          "@type": "Resposta",
+        "acceptedAnswer": {
+          "@type": "Answer",
           "text": "Normalmente 12-24 horas. O acesso por convite do TradingView chega por e-mail. As notificações do TradingView mostrarão o convite. Para solicitações urgentes, envie e-mail para support@signalpilot.io"
         }
       },
       {
-        "@type": "Pergunta",
+        "@type": "Question",
         "name": "O que está incluído no meu plano?",
-        "acceptedResposta": {
-          "@type": "Resposta",
+        "acceptedAnswer": {
+          "@type": "Answer",
           "text": "Todos os planos incluem: Os Elite Seven, todas as atualizações futuras, suporte contínuo, documentação, predefinições e acesso a novos indicadores conforme são lançados. O vitalício inclui tudo, para sempre."
         }
       },
       {
-        "@type": "Pergunta",
+        "@type": "Question",
         "name": "Quais períodos funcionam melhor?",
-        "acceptedResposta": {
-          "@type": "Resposta",
+        "acceptedAnswer": {
+          "@type": "Answer",
           "text": "Todos os períodos suportados—gráficos de 1 minuto a anuais. Mais populares: 15m-1H para day trading, 4H-Diário para swing trading. O ciclo de 5 fases do Pentarch se adapta automaticamente ao seu período."
         }
       },
       {
-        "@type": "Pergunta",
+        "@type": "Question",
         "name": "Posso usar vários indicadores juntos?",
-        "acceptedResposta": {
-          "@type": "Resposta",
+        "acceptedAnswer": {
+          "@type": "Answer",
           "text": "Absolutamente! Os Elite Seven são projetados para funcionar juntos. Combinações populares: Pentarch + Volume Oracle para temporização de ciclo com confirmação de dinheiro inteligente, ou OmniDeck + Janus Atlas para análise completa de estrutura de mercado com níveis-chave."
         }
       },
       {
-        "@type": "Pergunta",
+        "@type": "Question",
         "name": "Quais mercados são suportados?",
-        "acceptedResposta": {
-          "@type": "Resposta",
+        "acceptedAnswer": {
+          "@type": "Answer",
           "text": "Qualquer mercado no TradingView: Ações, índices, forex, cripto, commodities, títulos. Se tiver dados OHLC + volume, nossos indicadores funcionam. Testado em 100+ símbolos em todas as classes de ativos."
         }
       }


### PR DESCRIPTION
Corrected schema.org vocabulary to use required English type names instead of Portuguese translations in FAQPage structured data.

**The Problem:**
Google Search Console reported "Invalid object type for field 'mainEntity'" errors because schema.org types and property names were in Portuguese:
- "@type": "Pergunta" (incorrect)
- "@type": "Resposta" (incorrect)
- "acceptedResposta" (incorrect)

**The Fix:**
Changed all FAQ schema types to standard schema.org vocabulary:
- "Pergunta" → "Question" (8 instances)
- "Resposta" → "Answer" (8 instances)
- "acceptedResposta" → "acceptedAnswer" (8 instances)

**Important Note:**
Schema.org vocabulary (types and property names) must ALWAYS be in English, regardless of content language. Only the actual content (name, text fields) should be translated to Portuguese.

**Result:**
- ✓ Valid FAQPage with 8 Question/Answer pairs
- ✓ All schema.org types use English vocabulary
- ✓ Content remains in Portuguese (correct)
- ✓ Google Rich Results compatible

Validated with JSON-LD parser - all 8 FAQ items now valid.