### PR TITLE
Fix Italian site: Convert all asset paths from relative to absolute

### DIFF
--- a/it/index.html
+++ b/it/index.html
@@ -3103,7 +3103,7 @@
               <!-- Chart Video -->
               <video
                 id="heroVideo"
-                src="assets/videos/hero-demo.mp4"
+                src="/assets/videos/hero-demo.mp4"
                 autoplay
                 loop
                 muted
@@ -3115,7 +3115,7 @@
                 width="1200"
                 height="600"
               >
-                <source src="assets/videos/hero-demo.mp4" type="video/mp4">
+                <source src="/assets/videos/hero-demo.mp4" type="video/mp4">
                 Il tuo browser non supporta il tag video.
               </video>
               
@@ -4107,7 +4107,7 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="assets/screenshots/pentarch-screenshot.jpg" alt="Rilevamento ciclo Pentarch su grafico BTC" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Rilevamento ciclo Pentarch su grafico BTC" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4141,7 +4141,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/omnideck-screenshot.jpg" alt="Indicatore tutto-in-uno Omnideck" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="Indicatore tutto-in-uno Omnideck" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4176,7 +4176,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/volume-oracle-screenshot.jpg" alt="Tracciamento flusso istituzionale Volume Oracle" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Tracciamento flusso istituzionale Volume Oracle" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4211,7 +4211,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/plutus-flow-screenshot.jpg" alt="Tracciamento delta cumulativo Plutus Flow" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Tracciamento delta cumulativo Plutus Flow" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4246,7 +4246,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/janus-atlas-screenshot.jpg" alt="Livelli chiave multi-timeframe Janus Atlas" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Livelli chiave multi-timeframe Janus Atlas" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4281,7 +4281,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/augury-grid-screenshot.jpg" alt="Tabella tracciamento multi-simbolo Augury Grid" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Tabella tracciamento multi-simbolo Augury Grid" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4315,7 +4315,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Timing multi-conferma Harmonic Oscillator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Timing multi-conferma Harmonic Oscillator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4672,7 +4672,7 @@
           <!-- Without Signal Pilot (Background) -->
           <div class="comparison-image" style="position:relative;width:100%;min-height:600px;aspect-ratio:16/9;background:#0a0e18">
             <img
-              src="assets/showcase/chart-without.jpg"
+              src="/assets/showcase/chart-without.jpg"
               alt="Grafico senza Signal Pilot"
               loading="eager"
               style="width:100%;height:100%;object-fit:contain;display:block"
@@ -4684,7 +4684,7 @@
           <div id="slider-overlay" class="comparison-image" style="position:absolute;top:0;left:0;width:50%;height:100%;overflow:hidden;z-index:10">
             <img
               id="overlay-image"
-              src="assets/showcase/chart-with.jpg"
+              src="/assets/showcase/chart-with.jpg"
               alt="Grafico con Signal Pilot"
               loading="eager"
               style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"


### PR DESCRIPTION
CRITICAL BUG FIX: The Italian site (/it/) was using relative paths to assets, which caused broken images and videos since the browser was looking for files at /it/assets/ instead of /assets/.

Changes:
- Hero video: assets/videos/hero-demo.mp4 → /assets/videos/hero-demo.mp4 (2 occurrences)
- Interactive demo images:
  - assets/showcase/chart-without.jpg → /assets/showcase/chart-without.jpg
  - assets/showcase/chart-with.jpg → /assets/showcase/chart-with.jpg
- Screenshot images: assets/screenshots/*.jpg → /assets/screenshots/*.jpg (7 files)

Total: 11 asset path fixes

This ensures the hero video and interactive demo work correctly on /it/index.html