### PR TITLE
Fix asset paths in Hungarian site for hero video and interactive demo

### DIFF
--- a/hu/index.html
+++ b/hu/index.html
@@ -3203,7 +3203,7 @@
               <!-- Chart Video -->
               <video
                 id="heroVideo"
-                src="assets/videos/hero-demo.mp4"
+                src="../assets/videos/hero-demo.mp4"
                 autoplay
                 loop
                 muted
@@ -3215,7 +3215,7 @@
                 width="1200"
                 height="600"
               >
-                <source src="assets/videos/hero-demo.mp4" type="video/mp4">
+                <source src="../assets/videos/hero-demo.mp4" type="video/mp4">
                 Your browser does not support the video tag.
               </video>
               
@@ -4772,11 +4772,11 @@
           <!-- Without Signal Pilot (Background) -->
           <div class="comparison-image" style="position:relative;width:100%;min-height:600px;aspect-ratio:16/9;background:#0a0e18">
             <img
-              src="assets/showcase/chart-without.jpg"
+              src="../assets/showcase/chart-without.jpg"
               alt="Grafikon Signal Pilot nélkül"
               loading="eager"
               style="width:100%;height:100%;object-fit:contain;display:block"
-              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>Signal Pilot NÉLKÜL</span><span style=\'font-size:.9rem;opacity:.7\'>Grafikon kép hozzáadása:<br/>assets/showcase/chart-without.jpg</span></div>'"
+              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>Signal Pilot NÉLKÜL</span><span style=\'font-size:.9rem;opacity:.7\'>Grafikon kép hozzáadása:<br/>../assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
 
@@ -4784,11 +4784,11 @@
           <div id="slider-overlay" class="comparison-image" style="position:absolute;top:0;left:0;width:50%;height:100%;overflow:hidden;z-index:10">
             <img
               id="overlay-image"
-              src="assets/showcase/chart-with.jpg"
+              src="../assets/showcase/chart-with.jpg"
               alt="Grafikon Signal Pilot-tal"
               loading="eager"
               style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
-              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>Signal Pilot-TAL</span><span style=\'font-size:.9rem;opacity:.7\'>Grafikon kép hozzáadása:<br/>assets/showcase/chart-with.jpg</span></div>'"
+              onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>Signal Pilot-TAL</span><span style=\'font-size:.9rem;opacity:.7\'>Grafikon kép hozzáadása:<br/>../assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>
 


### PR DESCRIPTION
Updated relative paths to use ../ prefix for:
- Hero demo video (assets/videos/hero-demo.mp4)
- Interactive demo images (assets/showcase/chart-*.jpg)

These files are in the root assets directory, not in /hu/assets, so the Hungarian page at /hu/index.html needs ../ to access them correctly.