### PR TITLE
Fix asset paths in French site for hero demo and interactive demo

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -3345,7 +3345,7 @@
               <!-- Chart Video -->
               <video
                 id="heroVideo"
-                src="assets/videos/hero-demo.mp4"
+                src="/assets/videos/hero-demo.mp4"
                 autoplay
                 loop
                 muted
@@ -3357,7 +3357,7 @@
                 width="1200"
                 height="600"
               >
-                <source src="assets/videos/hero-demo.mp4" type="video/mp4">
+                <source src="/assets/videos/hero-demo.mp4" type="video/mp4">
                 Votre navigateur ne supporte pas la balise vidéo.
               </video>
               
@@ -4349,7 +4349,7 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4383,7 +4383,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/omnideck-screenshot.jpg" alt="Omnideck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="Omnideck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4418,7 +4418,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle institutional flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle institutional flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4453,7 +4453,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow cumulative delta tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow cumulative delta tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4488,7 +4488,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4523,7 +4523,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4557,7 +4557,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -4914,7 +4914,7 @@
           <!-- Without Signal Pilot (Background) -->
           <div class="comparison-image" style="position:relative;width:100%;min-height:600px;aspect-ratio:16/9;background:#0a0e18">
             <img
-              src="assets/showcase/chart-without.jpg"
+              src="/assets/showcase/chart-without.jpg"
               alt="Chart without Signal Pilot"
               loading="eager"
               style="width:100%;height:100%;object-fit:contain;display:block"
@@ -4926,7 +4926,7 @@
           <div id="slider-overlay" class="comparison-image" style="position:absolute;top:0;left:0;width:50%;height:100%;overflow:hidden;z-index:10">
             <img
               id="overlay-image"
-              src="assets/showcase/chart-with.jpg"
+              src="/assets/showcase/chart-with.jpg"
               alt="Chart with Signal Pilot"
               loading="eager"
               style="position:absolute;top:0;left:0;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"


### PR DESCRIPTION
Updated all asset paths from relative to absolute paths to ensure proper loading from the /fr/ subdirectory:
- Hero demo video: /assets/videos/hero-demo.mp4
- Interactive demo images: /assets/showcase/chart-with.jpg and chart-without.jpg
- Indicator screenshots: /assets/screenshots/*.jpg

This ensures the hero video and interactive demo work correctly on the French language site.