### PR TITLE
Add mobile responsive styling for interactive demo slider

### DIFF
--- a/tr/index.html
+++ b/tr/index.html
@@ -4821,6 +4821,37 @@
 
       /* Smooth transition for non-dragging movements */
       .smooth-transition { transition: left 0.3s ease, width 0.3s ease !important; }
+
+      /* Mobile responsive for comparison slider */
+      @media (max-width: 768px) {
+        #comparison-slider {
+          border-radius: 12px !important;
+          border-width: 2px !important;
+        }
+        .comparison-image {
+          min-height: 300px !important;
+        }
+        #slider-handle {
+          width: 40px !important;
+        }
+        #handle-circle {
+          width: 40px !important;
+          height: 40px !important;
+        }
+      }
+
+      @media (max-width: 480px) {
+        .comparison-image {
+          min-height: 250px !important;
+        }
+        #slider-handle {
+          width: 36px !important;
+        }
+        #handle-circle {
+          width: 36px !important;
+          height: 36px !important;
+        }
+      }
     </style>
 
     <script>


### PR DESCRIPTION
- Reduce comparison image min-height from 600px to 300px on mobile (768px and below)
- Further reduce to 250px on small mobile devices (480px and below)
- Adjust slider handle size for better touch interaction on mobile
- Optimize border radius and width for mobile screens

This ensures the interactive before/after slider looks great and is easy to use on all mobile devices.