### PR TITLE
Fix interactive demo for mobile Turkish

### DIFF
--- a/tr/index.html
+++ b/tr/index.html
@@ -4821,37 +4821,6 @@
 
       /* Smooth transition for non-dragging movements */
       .smooth-transition { transition: left 0.3s ease, width 0.3s ease !important; }
-
-      /* Mobile responsive for comparison slider */
-      @media (max-width: 768px) {
-        #comparison-slider {
-          border-radius: 12px !important;
-          border-width: 2px !important;
-        }
-        .comparison-image {
-          min-height: 300px !important;
-        }
-        #slider-handle {
-          width: 40px !important;
-        }
-        #handle-circle {
-          width: 40px !important;
-          height: 40px !important;
-        }
-      }
-
-      @media (max-width: 480px) {
-        .comparison-image {
-          min-height: 250px !important;
-        }
-        #slider-handle {
-          width: 36px !important;
-        }
-        #handle-circle {
-          width: 36px !important;
-          height: 36px !important;
-        }
-      }
     </style>
 
     <script>


### PR DESCRIPTION
The mobile responsive styles were incorrectly added only to the Turkish version, breaking the interactive demo slider. Other language directories don't have these styles and work correctly. This reverts the Turkish version to match the working behavior of all other language directories.