### PR TITLE
Fix hero video display on desktop screens

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -3294,7 +3294,7 @@ html[lang="ar"] [style*="text-align:center"] {
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/de/index.html
+++ b/de/index.html
@@ -3132,7 +3132,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/es/index.html
+++ b/es/index.html
@@ -3325,7 +3325,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/fr/index.html
+++ b/fr/index.html
@@ -3353,7 +3353,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/hu/index.html
+++ b/hu/index.html
@@ -3211,7 +3211,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/index.html
+++ b/index.html
@@ -3185,7 +3185,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/it/index.html
+++ b/it/index.html
@@ -3111,7 +3111,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/ja/index.html
+++ b/ja/index.html
@@ -3390,7 +3390,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/nl/index.html
+++ b/nl/index.html
@@ -3202,7 +3202,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/pt/index.html
+++ b/pt/index.html
@@ -3401,7 +3401,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/ru/index.html
+++ b/ru/index.html
@@ -3098,7 +3098,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >

--- a/tr/index.html
+++ b/tr/index.html
@@ -3206,7 +3206,7 @@
                 webkit-playsinline
                 preload="auto"
                 poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 600'%3E%3Crect fill='%230a0e18' width='1200' height='600'/%3E%3C/svg%3E"
-                style="width:100%;height:100%;display:block;object-fit:cover;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
+                style="width:100%;height:100%;display:block;object-fit:contain;object-position:center;background:#0a0e18;pointer-events:none;position:absolute;top:0;left:0"
                 width="1200"
                 height="600"
               >


### PR DESCRIPTION
Changed object-fit from 'cover' to 'contain' for the hero-demo.mp4 video to ensure the entire video is visible on desktop screens. Mobile was already using 'contain' and working correctly. This change brings desktop display in line with mobile behavior.