### PR TITLE
Fix animated text overflow in Arabic hero section

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -3271,7 +3271,7 @@ html[lang="ar"] [style*="text-align:center"] {
             الميزة ليست في رؤية المزيد. بل في رؤية ما يهم.
           </h1>
 
-          <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
+          <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;min-height:3.5rem">
             كشف الدورات بدون إعادة رسم • 7 مؤشرات متميزة لـ <span id="typed-text" style="color:var(--brand);font-weight:600">المتداولين الجادين</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
           </p>
 


### PR DESCRIPTION
- Removed white-space:nowrap that was preventing text wrapping
- Added min-height:3.5rem to maintain consistent layout
- Prevents hero-demo.mp4 from shifting when animated text changes to longer Arabic phrases