### PR TITLE
Add desktop-specific media query to ensure hero video displays 100%

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1235,6 +1235,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2633,6 +2646,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/de/index.html
+++ b/de/index.html
@@ -1150,6 +1150,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2551,6 +2564,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/es/index.html
+++ b/es/index.html
@@ -1318,6 +1318,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2751,6 +2764,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -1272,6 +1272,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2765,6 +2778,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -1243,6 +1243,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2637,6 +2650,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -2605,6 +2605,19 @@
       }
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}

--- a/it/index.html
+++ b/it/index.html
@@ -1143,6 +1143,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2537,6 +2550,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -1341,6 +1341,19 @@
       }
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2813,6 +2826,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -1236,6 +1236,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2629,6 +2642,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -1160,6 +1160,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2798,6 +2811,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -1129,6 +1129,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2522,6 +2535,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -1236,6 +1236,19 @@
       #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
     }
 
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
+      }
+    }
+
     @media (max-width:480px){
       /* Extra small screens - smaller text */
       #hero-description{font-size:0.85rem !important;padding:0 0.5rem;line-height:1.5 !important}
@@ -2630,6 +2643,19 @@
 
       .headline.xl{
         font-size:2.5rem;
+      }
+    }
+
+    /* Desktop optimizations - ensure video shows 100% */
+    @media (min-width:1025px){
+      #heroVideo{
+        width:100% !important;
+        height:100% !important;
+        object-fit:contain !important;
+        object-position:center !important;
+        position:absolute !important;
+        top:0 !important;
+        left:0 !important;
       }
     }
 


### PR DESCRIPTION
Added @media (min-width:1025px) rule with !important flags to force object-fit:contain on desktop screens. This ensures the entire video is visible without cropping on large screens.