### PR TITLE
Remove blue border from hero video container on desktop

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1245,6 +1245,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2598,6 +2603,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2659,6 +2669,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2716,6 +2731,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/de/index.html
+++ b/de/index.html
@@ -1160,6 +1160,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2516,6 +2521,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2577,6 +2587,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2634,6 +2649,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/es/index.html
+++ b/es/index.html
@@ -1328,6 +1328,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2716,6 +2721,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2777,6 +2787,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2834,6 +2849,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/fr/index.html
+++ b/fr/index.html
@@ -1282,6 +1282,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2730,6 +2735,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2791,6 +2801,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2859,6 +2874,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/hu/index.html
+++ b/hu/index.html
@@ -1253,6 +1253,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2602,6 +2607,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2663,6 +2673,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2720,6 +2735,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/index.html
+++ b/index.html
@@ -2616,6 +2616,11 @@
         top:0 !important;
         left:0 !important;
       }
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
     }
 
     @media (max-width:480px){

--- a/it/index.html
+++ b/it/index.html
@@ -1153,6 +1153,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2502,6 +2507,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2563,6 +2573,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2620,6 +2635,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/ja/index.html
+++ b/ja/index.html
@@ -1351,6 +1351,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2778,6 +2783,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2839,6 +2849,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2897,6 +2912,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/nl/index.html
+++ b/nl/index.html
@@ -1246,6 +1246,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2594,6 +2599,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2655,6 +2665,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2712,6 +2727,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/pt/index.html
+++ b/pt/index.html
@@ -1170,6 +1170,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2743,6 +2748,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2824,6 +2834,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2881,6 +2896,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/ru/index.html
+++ b/ru/index.html
@@ -1139,6 +1139,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2487,6 +2492,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2548,6 +2558,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2605,6 +2620,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */

--- a/tr/index.html
+++ b/tr/index.html
@@ -1246,6 +1246,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2595,6 +2600,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container - maintain 16:9 aspect ratio */
@@ -2656,6 +2666,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
     }
 
@@ -2713,6 +2728,11 @@
         position:absolute !important;
         top:0 !important;
         left:0 !important;
+
+      /* Remove border from video container on desktop */
+      .hero > div > div:nth-child(2) > div{
+        border:none !important;
+      }
       }
 
       /* Video container maintains aspect ratio */


### PR DESCRIPTION
Added CSS rule to remove the border from the video container on desktop screens (min-width: 1025px). This eliminates the blue border that was appearing around the video when using object-fit: contain.