### PR TITLE
Fix mobile video display - use contain to show full video

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1935,7 +1935,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2594,7 +2594,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2647,7 +2647,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2726,7 +2726,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/de/index.html
+++ b/de/index.html
@@ -1850,7 +1850,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2512,7 +2512,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2565,7 +2565,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2644,7 +2644,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/es/index.html
+++ b/es/index.html
@@ -2040,7 +2040,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2712,7 +2712,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2765,7 +2765,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2844,7 +2844,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/fr/index.html
+++ b/fr/index.html
@@ -1986,7 +1986,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2726,7 +2726,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2779,7 +2779,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2869,7 +2869,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/hu/index.html
+++ b/hu/index.html
@@ -1943,7 +1943,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2598,7 +2598,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2651,7 +2651,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2730,7 +2730,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/index.html
+++ b/index.html
@@ -2545,7 +2545,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2593,7 +2593,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2673,7 +2673,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/it/index.html
+++ b/it/index.html
@@ -1843,7 +1843,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2498,7 +2498,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2551,7 +2551,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2630,7 +2630,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/ja/index.html
+++ b/ja/index.html
@@ -2050,7 +2050,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2774,7 +2774,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2827,7 +2827,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2907,7 +2907,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/nl/index.html
+++ b/nl/index.html
@@ -1936,7 +1936,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2590,7 +2590,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2643,7 +2643,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2722,7 +2722,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/pt/index.html
+++ b/pt/index.html
@@ -1887,7 +1887,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2739,7 +2739,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2812,7 +2812,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2891,7 +2891,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/ru/index.html
+++ b/ru/index.html
@@ -1829,7 +1829,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2483,7 +2483,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2536,7 +2536,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2615,7 +2615,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;

--- a/tr/index.html
+++ b/tr/index.html
@@ -1936,7 +1936,7 @@
 
     .lightbox-content{max-width:90vw;max-height:90vh;position:relative;animation:lightboxZoomIn 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    .lightbox-content img{width:100%;height:100%;object-fit:cover;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
+    .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
     .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
 
@@ -2591,7 +2591,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         display:block !important;
         visibility:visible !important;
@@ -2644,7 +2644,7 @@
       #heroVideo{
         width:100%;
         height:100%;
-        object-fit:cover;
+        object-fit:contain;
         object-position:center;
         position:absolute;
         top:0;
@@ -2723,7 +2723,7 @@
       #heroVideo{
         width:100% !important;
         height:100% !important;
-        object-fit:cover !important;
+        object-fit:contain !important;
         object-position:center !important;
         position:absolute !important;
         top:0 !important;


### PR DESCRIPTION
Changed mobile/tablet displays to use object-fit: contain instead of cover to prevent excessive zoom/cropping on smaller screens. Desktop continues to use object-fit: cover for a polished, full-bleed look.

Changes:
- Mobile (max-width: 768px): contain
- Tablet (769px-1024px): contain
- Desktop (min-width: 1025px): cover (unchanged)

This ensures mobile users can see the entire video without it being cut off, while desktop maintains the clean, borderless appearance.