### PR TITLE
Make mobile video container transparent to blend with site background

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2599,7 +2599,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2612,8 +2612,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2741,6 +2741,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/de/index.html
+++ b/de/index.html
@@ -2517,7 +2517,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2530,8 +2530,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2659,6 +2659,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/es/index.html
+++ b/es/index.html
@@ -2717,7 +2717,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2730,8 +2730,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2859,6 +2859,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/fr/index.html
+++ b/fr/index.html
@@ -2731,7 +2731,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2744,8 +2744,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2884,6 +2884,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/hu/index.html
+++ b/hu/index.html
@@ -2603,7 +2603,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2616,8 +2616,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2745,6 +2745,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/index.html
+++ b/index.html
@@ -2550,7 +2550,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2558,8 +2558,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2682,6 +2682,8 @@
 
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;

--- a/it/index.html
+++ b/it/index.html
@@ -2503,7 +2503,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2516,8 +2516,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2645,6 +2645,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/ja/index.html
+++ b/ja/index.html
@@ -2779,7 +2779,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2792,8 +2792,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2922,6 +2922,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/nl/index.html
+++ b/nl/index.html
@@ -2595,7 +2595,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2608,8 +2608,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2737,6 +2737,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/pt/index.html
+++ b/pt/index.html
@@ -2744,7 +2744,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2757,8 +2757,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2906,6 +2906,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/ru/index.html
+++ b/ru/index.html
@@ -2488,7 +2488,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2501,8 +2501,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2630,6 +2630,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }

--- a/tr/index.html
+++ b/tr/index.html
@@ -2596,7 +2596,7 @@
         display:block !important;
         visibility:visible !important;
         opacity:1 !important;
-        background:#0a0e18 !important;
+        background:transparent !important;
         position:absolute !important;
         top:0 !important;
         left:0 !important;
@@ -2609,8 +2609,8 @@
 
       /* Video container - maintain 245:106 aspect ratio (2940x1272) */
       .hero > div > div:nth-child(2) > div{
-        background:#0a0e18 !important;
-        border:2px solid rgba(91,138,255,.35) !important;
+        background:transparent !important;
+        border:none !important;
         aspect-ratio:245/106 !important;
         width:100% !important;
         position:relative !important;
@@ -2738,6 +2738,7 @@
       /* Video container maintains aspect ratio */
       .hero > div > div:nth-child(2) > div{
         aspect-ratio:245/106 !important;
+        border:none !important;
         width:100% !important;
         position:relative !important;
       }


### PR DESCRIPTION
Changed mobile video container and video element backgrounds from solid colors to transparent. This allows any letterboxing bars to blend seamlessly with the site's background gradient, creating a cleaner professional appearance on mobile devices.

Changes:
- Mobile container background: transparent (was #0a0e18)
- Mobile video background: transparent (was #0a0e18)
- Removed blue border on mobile (was 2px solid rgba(91,138,255,.35))
- Maintains 245:106 aspect ratio with object-fit: contain
- Desktop unchanged (245:106 + cover for perfect fill)