### PR TITLE
Fix comparison slider zoom in other languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4911,7 +4911,7 @@ html[lang="ar"] [style*="text-align:center"] {
               src="assets/showcase/chart-without.jpg"
               alt="رسم بياني بدون Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>بدون Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>أضف صورة الرسم البياني إلى:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -4923,7 +4923,7 @@ html[lang="ar"] [style*="text-align:center"] {
               src="assets/showcase/chart-with.jpg"
               alt="رسم بياني مع Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>مع Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>أضف صورة الرسم البياني إلى:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/de/index.html
+++ b/de/index.html
@@ -4749,7 +4749,7 @@
               src="assets/showcase/chart-without.jpg"
               alt="Chart ohne Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -4761,7 +4761,7 @@
               src="assets/showcase/chart-with.jpg"
               alt="Chart mit Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/es/index.html
+++ b/es/index.html
@@ -5010,7 +5010,7 @@
               src="assets/showcase/chart-without.jpg"
               alt="Gráfico sin Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>SIN Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Agrega tu imagen de gráfico a:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -5022,7 +5022,7 @@
               src="assets/showcase/chart-with.jpg"
               alt="Gráfico con Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>CON Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Agrega tu imagen de gráfico a:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -4971,7 +4971,7 @@
               src="/assets/showcase/chart-without.jpg"
               alt="Chart without Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -4983,7 +4983,7 @@
               src="/assets/showcase/chart-with.jpg"
               alt="Chart with Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/hu/index.html
+++ b/hu/index.html
@@ -4828,7 +4828,7 @@
               src="../assets/showcase/chart-without.jpg"
               alt="Grafikon Signal Pilot nélkül"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>Signal Pilot NÉLKÜL</span><span style=\'font-size:.9rem;opacity:.7\'>Grafikon kép hozzáadása:<br/>../assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -4840,7 +4840,7 @@
               src="../assets/showcase/chart-with.jpg"
               alt="Grafikon Signal Pilot-tal"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>Signal Pilot-TAL</span><span style=\'font-size:.9rem;opacity:.7\'>Grafikon kép hozzáadása:<br/>../assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/it/index.html
+++ b/it/index.html
@@ -4728,7 +4728,7 @@
               src="/assets/showcase/chart-without.jpg"
               alt="Grafico senza Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>SENZA Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Aggiungi la tua immagine grafico a:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -4740,7 +4740,7 @@
               src="/assets/showcase/chart-with.jpg"
               alt="Grafico con Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>CON Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Aggiungi la tua immagine grafico a:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/ja/index.html
+++ b/ja/index.html
@@ -5017,7 +5017,7 @@
               src="/assets/showcase/chart-without.jpg"
               alt="Chart without Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>/assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -5029,7 +5029,7 @@
               src="/assets/showcase/chart-with.jpg"
               alt="Chart with Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4819,7 +4819,7 @@
               src="assets/showcase/chart-without.jpg"
               alt="Grafiek zonder Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>ZONDER Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Voeg uw grafiekafbeelding toe aan:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -4831,7 +4831,7 @@
               src="assets/showcase/chart-with.jpg"
               alt="Grafiek met Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>MET Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Voeg uw grafiekafbeelding toe aan:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -5028,7 +5028,7 @@
               src="assets/showcase/chart-without.jpg"
               alt="Gráfico sem Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -5040,7 +5040,7 @@
               src="assets/showcase/chart-with.jpg"
               alt="Gráfico com Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -4715,7 +4715,7 @@
               src="assets/showcase/chart-without.jpg"
               alt="График без Signal Pilot"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>БЕЗ Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Добавьте изображение графика в:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -4727,7 +4727,7 @@
               src="assets/showcase/chart-with.jpg"
               alt="График с Signal Pilot"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>С Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Добавьте изображение графика в:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4823,7 +4823,7 @@
               src="assets/showcase/chart-without.jpg"
               alt="Signal Pilot olmayan grafik"
               loading="eager"
-              style="width:100%;height:100%;object-fit:cover;display:block"
+              style="width:100%;height:100%;object-fit:contain;display:block"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,12,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><rect x=\'3\' y=\'3\' width=\'18\' height=\'18\' rx=\'2\'/><path d=\'M3 9h18\'/><path d=\'M9 21V9\'/></svg><span style=\'font-size:1.1rem;font-weight:600\'>WITHOUT Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-without.jpg</span></div>'"
             />
           </div>
@@ -4835,7 +4835,7 @@
               src="assets/showcase/chart-with.jpg"
               alt="Signal Pilot ile grafik"
               loading="eager"
-              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:cover;display:block;pointer-events:none"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;max-width:none;object-fit:contain;display:block;pointer-events:none"
               onerror="this.parentElement.innerHTML='<div style=\'display:flex;align-items:center;justify-content:center;height:100%;background:rgba(10,30,20,1);color:rgba(255,255,255,.5);flex-direction:column;gap:1rem\'><svg width=\'64\' height=\'64\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'currentColor\' stroke-width=\'1.5\'><polyline points=\'20 6 9 17 4 12\'/></svg><span style=\'font-size:1.1rem;font-weight:600;color:#3ed598\'>WITH Signal Pilot</span><span style=\'font-size:.9rem;opacity:.7\'>Add your chart image to:<br/>assets/showcase/chart-with.jpg</span></div>'"
             />
           </div>


### PR DESCRIPTION
Changed object-fit from 'cover' to 'contain' in comparison slider images for all language versions to prevent images from being zoomed in. This applies the same fix that was successfully implemented for the English version to all other language directories (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr).