### PR TITLE
FORCE particles canvas to be visible with inline styles 💪✨

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1362,6 +1362,12 @@
     resize();
     start();
 
+    // FORCE canvas to be visible - override any CSS hiding it!
+    canvas.style.display = 'block';
+    canvas.style.visibility = 'visible';
+    canvas.style.opacity = '1';
+    console.log('🎨 Forced canvas visibility!');
+
     // Debug log for all devices to verify initialization and visibility
     setTimeout(() => {
       const computedStyle = window.getComputedStyle(canvas);


### PR DESCRIPTION
Debug output showed canvas was hidden by CSS:
- computedDisplay: "none"
- computedVisibility: "hidden"
- computedOpacity: "0"

Even though data-particles="true" was set correctly!

SOLUTION: Force visibility with inline styles:
- canvas.style.display = 'block'
- canvas.style.visibility = 'visible'
- canvas.style.opacity = '1'

Inline styles override CSS rules (except !important). This should finally make particles visible on mobile!

Added console.log to confirm force was applied.