### PR TITLE
Fix CSS !important blocking particles + force with !important 💥

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1362,11 +1362,11 @@
     resize();
     start();
 
-    // FORCE canvas to be visible - override any CSS hiding it!
-    canvas.style.display = 'block';
-    canvas.style.visibility = 'visible';
-    canvas.style.opacity = '1';
-    console.log('🎨 Forced canvas visibility!');
+    // FORCE canvas to be visible with !important to override CSS !important rules!
+    canvas.style.setProperty('display', 'block', 'important');
+    canvas.style.setProperty('visibility', 'visible', 'important');
+    canvas.style.setProperty('opacity', '1', 'important');
+    console.log('💪 Forced canvas visibility with !important!');
 
     // Debug log for all devices to verify initialization and visibility
     setTimeout(() => {

--- a/index.html
+++ b/index.html
@@ -1163,7 +1163,8 @@
 
     /* Performance: Disable heavy effects on low-end devices */
     @media (prefers-reduced-data: reduce){
-      .bg-aurora,.bg-stars,.sp-constellations{display:none !important}
+      .bg-aurora,.bg-stars{display:none !important}
+      /* Particles are lightweight - keep them even in reduced data mode! */
 
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }


### PR DESCRIPTION
THE PROBLEM:
CSS rule with !important was overriding inline styles:
  @media (prefers-reduced-data: reduce) {
    .sp-constellations {display:none !important}
  }

Even mobile browsers trigger this media query!

DUAL FIX:
1. JavaScript: Use setProperty() with 'important' flag
   - canvas.style.setProperty('display', 'block', 'important')
   - This creates inline style with !important
   - Can override CSS !important rules

2. CSS: Remove .sp-constellations from reduced-data media query
   - Particles are lightweight (only 50-120 particles)
   - They're essential visual identity - keep even in data saver mode
   - Still hide heavy effects (aurora, videos, orbs)

Result: Particles will be visible even with:
- Data saver mode enabled
- Reduced data preference
- CSS trying to hide them

This MUST work! 🎄✨