### PR TITLE
Fix yearly card flickering + override inline section backgrounds 🔧✨

### DIFF
--- a/index.html
+++ b/index.html
@@ -867,6 +867,22 @@
       section, .section {
         background:transparent !important;
       }
+
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
+      #plan-yearly {
+        animation: none !important;
+      }
+
+      /* Make pricing cards more solid on mobile to prevent aurora bleed-through */
+      .card.plan {
+        background: linear-gradient(180deg,rgba(255,255,255,.1),rgba(255,255,255,.06)), #05070d !important;
+      }
+
+      /* Override inline background styles on specific sections - they block particles! */
+      #trial[style*="background"],
+      section[style*="background"] {
+        background: transparent !important;
+      }
     }
     
     /* Removed reveal animations - not needed */


### PR DESCRIPTION
THREE CRITICAL FIXES:

1. ⚡ STOP YEARLY CARD FLICKERING:
   - #plan-yearly had animation: pricingGlow (pulses box-shadow every 3s)
   - Combined with aurora behind = flickering effect
   - FIX: animation: none !important on mobile
   - Card still has border glow, just not animated

2. 🎨 MAKE PRICING CARDS MORE SOLID:
   - .card.plan now has solid background: #05070d
   - Prevents aurora from bleeding through semi-transparent gradient
   - Format: linear-gradient(...), #05070d for layered effect

3. 🌟 OVERRIDE INLINE SECTION BACKGROUNDS:
   - Found sections with inline styles: background:var(--bg-base)
   - Inline styles were blocking particles even with CSS !important
   - FIX: section[style*="background"] { background: transparent !important }
   - Uses attribute selector to target sections with inline backgrounds
   - Now particles should show through ALL sections!

Inline background blockers found:
- Line 3431: <section id="trial" style="background:var(--bg-base)">
- Line 4464: <section style="background:linear-gradient(...)">

These were completely blocking particles on those sections!