### PR TITLE
FIX CSS specificity war blocking aurora on mobile! 🎯

### DIFF
--- a/index.html
+++ b/index.html
@@ -895,8 +895,10 @@
         background: transparent !important;
       }
 
-      /* Force aurora visible on mobile */
-      .bg-aurora {
+      /* Force aurora visible on mobile - higher specificity to override data-aurora="false" */
+      html .bg-aurora,
+      html[data-aurora="false"] .bg-aurora,
+      html[data-aurora="true"] .bg-aurora {
         display: block !important;
         visibility: visible !important;
         opacity: 0.85 !important;
@@ -1235,15 +1237,8 @@
 
     /* MOBILE OPTIMIZATION: Simplify animations for older devices */
 
-    @media (max-width: 1024px) {
-      /* Optimize animations for mobile devices */
-      .bg-aurora{
-        mix-blend-mode:normal !important;
-        opacity:.35 !important;
-        filter:blur(40px) saturate(100%) brightness(100%) !important;
-        animation:none !important;
-      }
-    }
+    /* REMOVED: This was making aurora invisible on mobile with opacity:.35 !important */
+    /* Aurora opacity is now controlled by the mobile media query at line 898-904 */
 
     /* Light mode background adjustments */
     html[data-theme="light"] .bg-aurora{


### PR DESCRIPTION
The issue: Two conflicting CSS rules were OVERRIDING the mobile aurora fix:

1. html[data-aurora="false"] .bg-aurora (line 1218) had HIGHER specificity than .bg-aurora (line 898), so it hid aurora even with !important

2. @media (max-width: 1024px) rule (line 1240) set opacity:.35 !important making aurora nearly invisible on mobile

The fix:
- Increased mobile selector specificity to match/override data-aurora rules
- Removed conflicting opacity:.35 rule on mobile
- Aurora now shows at opacity:0.85 on mobile as intended

This should FINALLY make aurora visible on mobile! 🌌✨