### PR TITLE
Add on-screen debug info for mobile constellation troubleshooting

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1368,6 +1368,24 @@
     canvas.style.setProperty('opacity', '1', 'important');
     console.log('💪 Forced canvas visibility with !important!');
 
+    // ADD VISIBLE DEBUG INFO ON SCREEN FOR MOBILE DEBUGGING
+    const debugDiv = document.createElement('div');
+    debugDiv.id = 'particle-debug';
+    debugDiv.style.cssText = 'position:fixed;top:10px;left:10px;background:rgba(0,0,0,0.8);color:#0f0;padding:10px;z-index:9999;font-size:12px;font-family:monospace;max-width:90vw;word-wrap:break-word;';
+    debugDiv.innerHTML = `
+      ✅ Particles.js loaded!<br>
+      Canvas: ${canvas.id}<br>
+      Size: ${canvas.width}x${canvas.height}<br>
+      Particles: ${particles.length}<br>
+      Display: ${canvas.style.display}<br>
+      Visibility: ${canvas.style.visibility}<br>
+      Position: ${window.getComputedStyle(canvas).position}<br>
+      Z-Index: ${window.getComputedStyle(canvas).zIndex}
+    `;
+    document.body.appendChild(debugDiv);
+    // Remove debug after 5 seconds
+    setTimeout(() => debugDiv.remove(), 5000);
+
     // Debug log for all devices to verify initialization and visibility
     setTimeout(() => {
       const computedStyle = window.getComputedStyle(canvas);


### PR DESCRIPTION
Added visible debug div that appears for 5 seconds showing:
- Canvas ID and dimensions
- Number of particles
- CSS display/visibility/position/z-index values

This will help diagnose if particles.js is loading on mobile and what the actual computed styles are on real devices (not just DevTools).

Debug info appears as green text on black background in top-left corner.