### PR TITLE
Fix mobile aurora appearance and constellation full-page display

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1312,12 +1312,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/de/index.html
+++ b/de/index.html
@@ -1227,12 +1227,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/es/index.html
+++ b/es/index.html
@@ -1396,12 +1396,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -1349,12 +1349,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -1320,12 +1320,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -1210,12 +1210,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/it/index.html
+++ b/it/index.html
@@ -1220,12 +1220,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -1429,12 +1429,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -1313,12 +1313,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -1237,12 +1237,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -1206,12 +1206,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -1313,12 +1313,35 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - matches desktop experience */
+      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
       .bg-aurora{
+        /* Larger, rounder gradients optimized for mobile aspect ratio */
+        background:
+          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+
         mix-blend-mode:screen !important;
         opacity:.75 !important;
         filter:blur(50px) saturate(120%) brightness(105%) !important;
         animation:aurora 36s linear infinite alternate !important;
+      }
+
+      /* Fix constellation display on mobile - prevent stacking context isolation */
+      .sp-constellations, #constellations {
+        z-index: -1 !important;
+        position: fixed !important;
+      }
+
+      /* Remove relative positioning on sections that creates stacking contexts trapping the canvas */
+      section, .section {
+        position: static !important;
+      }
+
+      /* But keep relative positioning on hero for the parallax orbs */
+      .hero {
+        position: relative !important;
       }
     }
 


### PR DESCRIPTION
USER FEEDBACK:
1. Aurora looked like vertical strips on mobile (not round like desktop)
2. Constellations still only showing in hero section (not full page)

ROOT CAUSES:
1. Aurora: Desktop gradients use percentages (45% width). On mobile's 390px viewport, 45% = 175px = narrow vertical strips instead of round blobs
2. Constellations: Sections with position:relative create stacking contexts that trap the fixed-position constellation canvas

FIXES:

1. AURORA - Adjusted gradients for mobile aspect ratio:
   - Increased gradient sizes: 80%, 70%, 85%, 60% (was 45%, 36%, 48%, 26%)
   - Creates rounder, fuller coverage on narrow mobile screens
   - Maintains beautiful blended appearance with screen blend mode

2. CONSTELLATIONS - Removed stacking context isolation:
   - Set sections to position:static on mobile (removes stacking contexts)
   - Keeps .hero as position:relative (needed for parallax orbs)
   - Allows fixed-position canvas to display across entire page

RESULT: Mobile now has full desktop-quality visuals
- ✨ Round, beautiful aurora gradients (not vertical strips)
- 🌌 Constellations visible across entire site (not just hero)
- 🎨 True parity with desktop experience

Applied to all 12 HTML files (main + 11 languages)