### PR TITLE
Use circle gradients with pixel values for truly round aurora on mobile

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1316,10 +1316,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/de/index.html
+++ b/de/index.html
@@ -1231,10 +1231,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/es/index.html
+++ b/es/index.html
@@ -1400,10 +1400,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/fr/index.html
+++ b/fr/index.html
@@ -1353,10 +1353,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/hu/index.html
+++ b/hu/index.html
@@ -1324,10 +1324,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/index.html
+++ b/index.html
@@ -1210,14 +1210,13 @@
     /* MOBILE ENHANCEMENT: Full desktop-style aurora experience on mobile! */
 
     @media (max-width: 1024px) {
-      /* Beautiful aurora on mobile - adjusted for narrow viewport to avoid vertical strips */
+      /* Force truly ROUND gradients using circle keyword and pixels */
       .bg-aurora{
-        /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/it/index.html
+++ b/it/index.html
@@ -1224,10 +1224,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/ja/index.html
+++ b/ja/index.html
@@ -1433,10 +1433,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/nl/index.html
+++ b/nl/index.html
@@ -1317,10 +1317,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/pt/index.html
+++ b/pt/index.html
@@ -1241,10 +1241,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/ru/index.html
+++ b/ru/index.html
@@ -1210,10 +1210,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;

--- a/tr/index.html
+++ b/tr/index.html
@@ -1317,10 +1317,10 @@
       .bg-aurora{
         /* Larger, rounder gradients optimized for mobile aspect ratio */
         background:
-          radial-gradient(80% 60% at 15% 15%, rgba(125,200,255,.40), transparent 62%),
-          radial-gradient(70% 55% at 85% 20%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(85% 65% at 75% 85%, rgba(118,221,255,.28), transparent 70%),
-          radial-gradient(60% 50% at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
+          radial-gradient(circle 300px at 15% 15%, rgba(125,200,255,.40), transparent 62%),
+          radial-gradient(circle 250px at 85% 20%, rgba(155,140,255,.38), transparent 65%),
+          radial-gradient(circle 320px at 75% 85%, rgba(118,221,255,.28), transparent 70%),
+          radial-gradient(circle 200px at 10% 70%, rgba(151,124,255,.22), transparent 66%) !important;
 
         mix-blend-mode:screen !important;
         opacity:.75 !important;


### PR DESCRIPTION
ISSUE: Aurora still appeared as vertical strips on mobile despite increasing percentages to 80%, 70%, etc.

ROOT CAUSE: Percentage-based gradients scale with viewport dimensions. On mobile portrait (390px × 844px):
- 80% width × 60% height = 312px × 506px = vertical ellipse!
- Percentages create ovals on portrait screens, not circles

FIX: Use 'circle' keyword with pixel values instead of percentages
- circle 300px = perfectly round 300px radius, any aspect ratio
- circle 250px, 320px, 200px for different gradient sizes
- Guarantees round blobs on any screen orientation

BEFORE: radial-gradient(80% 60% at 15% 15%, ...)
AFTER:  radial-gradient(circle 300px at 15% 15%, ...)

RESULT: Truly circular aurora gradients on mobile, matching desktop aesthetic

Applied to all 12 HTML files