### PR TITLE
Remove inline background styles from sections to show constellations

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4432,7 +4432,7 @@ html[lang="ar"] [style*="text-align:center"] {
     </section>
 
     <!-- قسم التجربة المجانية -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5465,7 +5465,7 @@ html[lang="ar"] [style*="text-align:center"] {
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/de/index.html
+++ b/de/index.html
@@ -4186,7 +4186,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5219,7 +5219,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/es/index.html
+++ b/es/index.html
@@ -4559,7 +4559,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5648,7 +5648,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/fr/index.html
+++ b/fr/index.html
@@ -4532,7 +4532,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5565,7 +5565,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/hu/index.html
+++ b/hu/index.html
@@ -4358,7 +4358,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5391,7 +5391,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/index.html
+++ b/index.html
@@ -3440,7 +3440,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -4473,7 +4473,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/it/index.html
+++ b/it/index.html
@@ -4158,7 +4158,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5191,7 +5191,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/ja/index.html
+++ b/ja/index.html
@@ -4656,7 +4656,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5689,7 +5689,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/nl/index.html
+++ b/nl/index.html
@@ -4343,7 +4343,7 @@
     </section>
 
     <!-- GRATIS PROEFPERIODE SECTIE -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5376,7 +5376,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/pt/index.html
+++ b/pt/index.html
@@ -4516,7 +4516,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5549,7 +5549,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/ru/index.html
+++ b/ru/index.html
@@ -4131,7 +4131,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5164,7 +5164,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">

--- a/tr/index.html
+++ b/tr/index.html
@@ -4345,7 +4345,7 @@
     </section>
 
     <!-- FREE TRIAL SECTION -->
-    <section id="trial" class="section" style="padding:4rem 0;background:var(--bg-base)">
+    <section id="trial" class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
@@ -5378,7 +5378,7 @@
     </section>
 
     <!-- FEATURE COMPARISON TABLE -->
-    <section class="section" style="background:linear-gradient(135deg,rgba(91,138,255,.03),rgba(118,221,255,.01))">
+    <section class="section" style="">
       <div class="container">
 
         <div style="max-width:900px;margin:0 auto">


### PR DESCRIPTION
The CSS transparency rules were being overridden by inline background styles on sections like `background:var(--bg-base)` and gradient backgrounds. Inline styles have higher specificity than CSS rules in some cases.

Solution: Removed all inline background styles from section elements across all language sites and English site. Sections now inherit transparent background from CSS rules, allowing constellations to show throughout the page.

Changes:
- Removed `background:var(--bg-base)` from trial sections
- Removed `background:linear-gradient(...)` from feature comparison sections
- All other inline background styles removed from section elements
- Sections now truly transparent, revealing constellation canvas below

Fixed on: de, es, fr, ar, hu, it, ja, nl, pt, ru, tr, and English site