### PR TITLE
EXPERIMENT: Move constellations above bg-aurora layer

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -871,7 +871,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1707,7 +1707,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3698,7 +3698,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/de/index.html
+++ b/de/index.html
@@ -786,7 +786,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1538,7 +1538,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3539,7 +3539,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/es/index.html
+++ b/es/index.html
@@ -856,7 +856,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1778,7 +1778,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3912,7 +3912,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/fr/index.html
+++ b/fr/index.html
@@ -908,7 +908,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1784,7 +1784,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3882,7 +3882,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/hu/index.html
+++ b/hu/index.html
@@ -879,7 +879,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1724,7 +1724,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3711,7 +3711,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/index.html
+++ b/index.html
@@ -764,7 +764,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -2785,7 +2785,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/it/index.html
+++ b/it/index.html
@@ -779,7 +779,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1524,7 +1524,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3511,7 +3511,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/ja/index.html
+++ b/ja/index.html
@@ -931,7 +931,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1885,7 +1885,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -4007,7 +4007,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/nl/index.html
+++ b/nl/index.html
@@ -872,7 +872,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1711,7 +1711,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3697,7 +3697,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/pt/index.html
+++ b/pt/index.html
@@ -742,7 +742,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1526,7 +1526,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3867,7 +3867,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/ru/index.html
+++ b/ru/index.html
@@ -765,7 +765,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1496,7 +1496,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3482,7 +3482,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;

--- a/tr/index.html
+++ b/tr/index.html
@@ -872,7 +872,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -1709,7 +1709,7 @@
     @media (max-width: 768px) {
       /* Background layers BEHIND everything */
       .bg-stars, .sp-constellations, .bg-aurora {
-        z-index: -1 !important;
+        z-index: -2 !important;
         position: fixed !important;
       }
 
@@ -3696,7 +3696,7 @@
 .sp-constellations{
   position:fixed;
   inset:0;
-  z-index:-2;
+  z-index:0;
   pointer-events:none;
   width:100%;
   height:100%;


### PR DESCRIPTION
Testing hypothesis that bg-aurora (z-index:-1) is washing out the constellations (previously z-index:-2). The aurora has opacity:.85 and mix-blend-mode:screen which might be making the subtle constellation lines invisible.

Change:
- Moved .sp-constellations from z-index:-2 to z-index:0
- This places constellations ABOVE bg-aurora layer
- Still below main content (z-index:1) so won't interfere with text

New layer stack (bottom to top):
- body::before: z-index:-4 (solid background)
- bg-stars: z-index:-3 (star field)
- bg-aurora: z-index:-1 (aurora gradients)
- constellations: z-index:0 (NOW HERE - above aurora!)
- main: z-index:1 (content)

If this works, constellations should now be visible throughout the page.