### PR TITLE
Apply speed multiplier during particle movement, not just creation

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1178,8 +1178,12 @@
 
   // Update particle position
   function updateParticle(p, config) {
-    p.x += p.vx;
-    p.y += p.vy;
+    // Mobile gets 2.5x faster movement for more dynamic effect
+    const isMobile = window.innerWidth <= 768;
+    const speedBoost = isMobile ? 2.5 : 1;
+
+    p.x += p.vx * speedBoost;
+    p.y += p.vy * speedBoost;
 
     // Special handling for matrix-rain
     if (config.type === 'matrix-rain') {


### PR DESCRIPTION
Fixed: Particles now actually move faster on mobile!

Previous issue: Speed multiplier was only applied when particles were created, but existing particles kept their original velocities.

Solution: Apply 2.5x speed boost during the UPDATE phase (when particles actually move), not just creation. This affects ALL particles in real-time.

Mobile: speedBoost = 2.5x
Desktop: speedBoost = 1x (no change)

Now stars truly move faster on mobile devices!