### PR TITLE
Optimize mobile constellation performance for smooth scrolling

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1178,9 +1178,9 @@
 
   // Update particle position
   function updateParticle(p, config) {
-    // Mobile gets 2.5x faster movement for more dynamic effect
+    // Mobile gets faster movement for more dynamic effect (balanced for smooth scrolling)
     const isMobile = window.innerWidth <= 768;
-    const speedBoost = isMobile ? 2.5 : 1;
+    const speedBoost = isMobile ? 1.8 : 1;
 
     p.x += p.vx * speedBoost;
     p.y += p.vy * speedBoost;
@@ -1273,11 +1273,11 @@
     let targetCount;
 
     if (currentConfig.count === 'auto') {
-      // More particles on mobile for richer constellation experience
+      // More particles on mobile for richer constellation experience (balanced for performance)
       const isMobile = vw <= 768;
-      const maxParticles = isMobile ? 200 : 120;
-      const minParticles = isMobile ? 100 : 50;
-      const divisor = isMobile ? 8000 : 12000;
+      const maxParticles = isMobile ? 150 : 120;
+      const minParticles = isMobile ? 80 : 50;
+      const divisor = isMobile ? 10000 : 12000;
       targetCount = Math.min(maxParticles, Math.max(minParticles, Math.floor(area / divisor)));
     } else {
       targetCount = currentConfig.count;


### PR DESCRIPTION
Reduced particle count and speed to prevent glitching during scroll:

Particle Count (mobile):
- maxParticles: 200 → 150 (still 25% more than desktop)
- minParticles: 100 → 80
- divisor: 8000 → 10000 (less dense but smoother)

Movement Speed (mobile):
- speedBoost: 2.5x → 1.8x (80% faster than desktop)

The combination of 200 particles + 2.5x speed was overwhelming mobile GPU during scroll events, causing glitchy/jittery movement. These values provide a good balance between visual richness and scroll performance.

Desktop remains unchanged (smooth as silk).