### PR TITLE
Fix mobile flickering by using consistent particle count

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1294,11 +1294,10 @@
     let targetCount;
 
     if (currentConfig.count === 'auto') {
-      // More particles on mobile for richer constellation experience (balanced for performance)
-      const isMobile = vw <= 768;
-      const maxParticles = isMobile ? 150 : 120;
-      const minParticles = isMobile ? 80 : 50;
-      const divisor = isMobile ? 10000 : 12000;
+      // Consistent particle count - no mobile/desktop difference to avoid flickering
+      const maxParticles = 120;
+      const minParticles = 60;
+      const divisor = 12000;
       targetCount = Math.min(maxParticles, Math.max(minParticles, Math.floor(area / divisor)));
     } else {
       targetCount = currentConfig.count;


### PR DESCRIPTION
Removed mobile-specific 150 particle limit that was causing flickering. Both mobile and desktop now use the same stable particle count (60-120).

The flickering was caused by particles being rapidly created/destroyed when hitting the 150 limit during resize or scroll events on mobile.

Smooth performance maintained with 1.8x speed boost still active on mobile.