### PR TITLE
Hide aurora background on mobile for all language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -879,8 +879,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1723,8 +1722,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/de/index.html
+++ b/de/index.html
@@ -794,8 +794,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1554,8 +1553,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/es/index.html
+++ b/es/index.html
@@ -864,8 +864,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1794,8 +1793,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/fr/index.html
+++ b/fr/index.html
@@ -916,8 +916,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1800,8 +1799,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/hu/index.html
+++ b/hu/index.html
@@ -887,8 +887,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1740,8 +1739,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/it/index.html
+++ b/it/index.html
@@ -787,8 +787,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1540,8 +1539,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/ja/index.html
+++ b/ja/index.html
@@ -939,8 +939,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1901,8 +1900,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/nl/index.html
+++ b/nl/index.html
@@ -880,8 +880,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1727,8 +1726,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/pt/index.html
+++ b/pt/index.html
@@ -750,8 +750,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1542,8 +1541,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/ru/index.html
+++ b/ru/index.html
@@ -773,8 +773,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1512,8 +1511,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */

--- a/tr/index.html
+++ b/tr/index.html
@@ -880,8 +880,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */
@@ -1725,8 +1724,7 @@
         position: fixed !important;
       }
       .bg-aurora {
-        z-index: -1 !important;
-        position: fixed !important;
+        display: none !important; /* Hide aurora on mobile */
       }
 
       /* Header needs high z-index for dropdown menus */


### PR DESCRIPTION
Replaced aurora z-index positioning with display:none on mobile devices (max-width: 768px) across all 11 language sites:
- Arabic (ar)
- German (de)
- Spanish (es)
- French (fr)
- Hungarian (hu)
- Italian (it)
- Japanese (ja)
- Dutch (nl)
- Portuguese (pt)
- Russian (ru)
- Turkish (tr)

Mobile now shows only stars/constellations without aurora overlay for cleaner appearance and better performance.