### PR TITLE
Fix yearly card flickering on all language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6301,7 +6301,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               وفّر <span data-count="489" data-prefix="$">489</span>

--- a/de/index.html
+++ b/de/index.html
@@ -6055,7 +6055,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SPARE <span data-count="489" data-prefix="$">489</span>

--- a/es/index.html
+++ b/es/index.html
@@ -6496,7 +6496,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               AHORRA <span data-count="489" data-prefix="$">489</span>

--- a/hu/index.html
+++ b/hu/index.html
@@ -6227,7 +6227,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SPÓROLJ <span data-count="489" data-prefix="$">489</span>

--- a/it/index.html
+++ b/it/index.html
@@ -6027,7 +6027,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SAVE <span data-count="489" data-prefix="$">489</span>

--- a/ja/index.html
+++ b/ja/index.html
@@ -6525,7 +6525,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               節約： <span data-count="489" data-prefix="$">489</span>

--- a/nl/index.html
+++ b/nl/index.html
@@ -6212,7 +6212,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SAVE <span data-count="489" data-prefix="$">489</span>

--- a/pt/index.html
+++ b/pt/index.html
@@ -6302,7 +6302,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledpor="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledpor="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.75rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               ECONOMIZE <span data-count="489" data-prefix="$">489</span>

--- a/ru/index.html
+++ b/ru/index.html
@@ -6000,7 +6000,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               ЭКОНОМИЯ <span data-count="489" data-prefix="$">489</span>

--- a/tr/index.html
+++ b/tr/index.html
@@ -6214,7 +6214,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               <span data-count="489" data-prefix="$">$489</span> TASARRUF


### PR DESCRIPTION
Added hardware acceleration to yearly pricing card to eliminate flickering from pricingGlow animation:
- translateZ(0) for GPU rendering
- will-change: box-shadow
- backface-visibility: hidden

Applied to all 10 language sites with yearly cards:
- Arabic, German, Spanish, Hungarian, Italian
- Japanese, Dutch, Portuguese, Russian, Turkish

The pricingGlow box-shadow animation now renders smoothly without any flickering or visual glitches.