### PR TITLE
Fix pricing card overflow on Portuguese site mobile

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2230,7 +2230,7 @@
         gap: 2rem !important;
         max-width: 100% !important;
         padding: 0 1rem !important;
-        margin: 0 auto !important;
+        margin: 2rem auto 0 auto !important; /* Add top margin for absolute badges */
         box-sizing: border-box !important;
         align-items: center !important;
         justify-content: center !important;


### PR DESCRIPTION
Added 2rem top margin to pricing-grid on mobile to prevent badges from being cut off at the top. The absolute positioned badges at top:-12px and top:-14px were overflowing and making content unreadable.

Mobile pricing grid now has proper spacing to accommodate all badge content.