### PR TITLE
Fix yearly card flickering by adding transform to keyframes

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1166,8 +1166,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -2009,8 +2009,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/de/index.html
+++ b/de/index.html
@@ -1081,8 +1081,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -1840,8 +1840,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/es/index.html
+++ b/es/index.html
@@ -1250,8 +1250,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -2179,8 +2179,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/hu/index.html
+++ b/hu/index.html
@@ -1174,8 +1174,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -2026,8 +2026,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/it/index.html
+++ b/it/index.html
@@ -1074,8 +1074,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -1826,8 +1826,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/ja/index.html
+++ b/ja/index.html
@@ -1234,8 +1234,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -2195,8 +2195,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/nl/index.html
+++ b/nl/index.html
@@ -1167,8 +1167,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -2013,8 +2013,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/pt/index.html
+++ b/pt/index.html
@@ -1064,8 +1064,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -1855,8 +1855,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/ru/index.html
+++ b/ru/index.html
@@ -1060,8 +1060,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -1798,8 +1798,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{

--- a/tr/index.html
+++ b/tr/index.html
@@ -1167,8 +1167,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{
@@ -2011,8 +2011,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
     }
 
     @keyframes badgePulse{


### PR DESCRIPTION
Added transform:scale(1.05) translateZ(0) to all pricingGlow keyframes to ensure GPU acceleration is maintained throughout the entire animation cycle.

The box-shadow animation alone was causing flickering because it wasn't consistently hardware-accelerated. By including the transform property in every keyframe step, the browser keeps the element on the GPU layer throughout the animation.

Applied to all 10 language sites with yearly cards.