### PR TITLE
Fix pricing card flickering on non-English sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2379,7 +2379,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6301,7 +6303,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               وفّر <span data-count="489" data-prefix="$">489</span>

--- a/de/index.html
+++ b/de/index.html
@@ -2210,7 +2210,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6055,7 +6057,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SPARE <span data-count="489" data-prefix="$">489</span>

--- a/es/index.html
+++ b/es/index.html
@@ -2561,7 +2561,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6496,7 +6498,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               AHORRA <span data-count="489" data-prefix="$">489</span>

--- a/fr/index.html
+++ b/fr/index.html
@@ -2456,7 +2456,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }

--- a/hu/index.html
+++ b/hu/index.html
@@ -2396,7 +2396,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6227,7 +6229,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SPÓROLJ <span data-count="489" data-prefix="$">489</span>

--- a/index.html
+++ b/index.html
@@ -1090,8 +1090,8 @@
     }
 
     @keyframes badgePulse{
-      0%,100%{transform:translateX(-50%) translateZ(0) scale(1);box-shadow:0 4px 16px rgba(249,162,60,.5)}
-      50%{transform:translateX(-50%) translateZ(0) scale(1.05);box-shadow:0 6px 24px rgba(249,162,60,.7)}
+      0%,100%{transform:translateX(-50%) scale(1);box-shadow:0 4px 16px rgba(249,162,60,.5)}
+      50%{transform:translateX(-50%) scale(1.05);box-shadow:0 6px 24px rgba(249,162,60,.7)}
     }
 
     @keyframes floatOrb1{
@@ -5374,7 +5374,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%) translateZ(0);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite;will-change:transform;backface-visibility:hidden;-webkit-font-smoothing:antialiased">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
               LIMITED • <span data-count="150">150</span> SLOTS LEFT
             </div>
 

--- a/it/index.html
+++ b/it/index.html
@@ -2196,7 +2196,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6027,7 +6029,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SAVE <span data-count="489" data-prefix="$">489</span>

--- a/ja/index.html
+++ b/ja/index.html
@@ -2617,7 +2617,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6525,7 +6527,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               節約： <span data-count="489" data-prefix="$">489</span>

--- a/nl/index.html
+++ b/nl/index.html
@@ -2383,7 +2383,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6212,7 +6214,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               SAVE <span data-count="489" data-prefix="$">489</span>

--- a/pt/index.html
+++ b/pt/index.html
@@ -2252,7 +2252,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6302,7 +6304,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledpor="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledpor="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.75rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               ECONOMIZE <span data-count="489" data-prefix="$">489</span>

--- a/ru/index.html
+++ b/ru/index.html
@@ -2168,7 +2168,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6000,7 +6002,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               ЭКОНОМИЯ <span data-count="489" data-prefix="$">489</span>

--- a/tr/index.html
+++ b/tr/index.html
@@ -2381,7 +2381,9 @@
       }
 
       /* Override yearly card scale on mobile */
+      /* Stop pricing card glow animation on mobile - causes flickering with aurora */
       #plan-yearly {
+        animation: none !important;
         transform: none !important;
         z-index: 1 !important;
       }
@@ -6214,7 +6216,7 @@
 
           <!-- YEARLY -->
 
-          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05) translateZ(0);z-index:2;will-change:box-shadow;backface-visibility:hidden">
+          <article class="card plan" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="position:relative;border:3px solid var(--brand);box-shadow:0 0 60px rgba(91,138,255,.35);animation:pricingGlow 3s ease-in-out infinite;transform:scale(1.05);z-index:2">
 
             <div style="position:absolute;top:-12px;right:1rem;background:linear-gradient(135deg,#3ed598,#2ec98a);color:#fff;padding:.4rem .9rem;border-radius:999px;font-weight:800;font-size:.8rem;box-shadow:0 4px 12px rgba(62,213,152,.4);white-space:nowrap">
               <span data-count="489" data-prefix="$">$489</span> TASARRUF


### PR DESCRIPTION
This commit resolves mobile flickering issues for pricing cards and badges:

1. Fixed yearly pricing card flickering (all language directories):
   - Added `animation: none !important` to disable pricingGlow animation on mobile
   - Removed problematic CSS properties from yearly card inline styles:
     - translateZ(0)
     - will-change:box-shadow - backface-visibility:hidden
   - These properties caused hardware acceleration conflicts with background animations

2. Fixed "LIMITED • 150 SLOTS LEFT" badge flickering (English site):
   - Removed translateZ(0) from badgePulse keyframes animation
   - Removed problematic inline styles:
     - translateZ(0)
     - will-change:transform - backface-visibility:hidden - -webkit-font-smoothing:antialiased

The English site already had the correct yearly card implementation - this fix brings all other languages (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr) in line with that working solution.

All changes manually applied using Edit tool as requested.