### PR TITLE
Fix lifetime badge flickering on mobile across all languages

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -6475,7 +6475,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;will-change:transform;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
               LIMITÉ • <span class="no-animate">150</span> PLACES RESTANTES
             </div>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -6300,7 +6300,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%) translateZ(0);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite;will-change:transform;backface-visibility:hidden;-webkit-font-smoothing:antialiased">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
               LIMITED • <span data-count="150">150</span> SLOTS LEFT
             </div>
 

--- a/it/index.html
+++ b/it/index.html
@@ -6100,7 +6100,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%) translateZ(0);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite;will-change:transform;backface-visibility:hidden;-webkit-font-smoothing:antialiased">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
               LIMITED • <span data-count="150">150</span> SLOTS LEFT
             </div>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -6375,7 +6375,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledpor="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.75rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;will-change:transform;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.75rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
               LIMITADO • <span class="no-animate">150</span> VAGAS
             </div>
 


### PR DESCRIPTION
This commit removes problematic CSS properties from the "LIMITED • 150 SLOTS LEFT" badge on the lifetime pricing card that caused flickering on mobile devices.

Changes made to badge inline styles:
- it/index.html: Removed translateZ(0), will-change:transform, backface-visibility:hidden, -webkit-font-smoothing:antialiased
- hu/index.html: Removed translateZ(0), will-change:transform, backface-visibility:hidden, -webkit-font-smoothing:antialiased
- fr/index.html: Removed will-change:transform
- pt/index.html: Removed will-change:transform

The badgePulse keyframes animation already had translateZ(0) removed in previous commit. Other languages (ar, de, es, ja, nl, ru, tr) already had clean badge implementations and required no changes.

This completes the mobile flickering fix for all pricing components across all languages.