### PR TITLE
Remove translateZ(0) from pricingGlow keyframes across all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1166,8 +1166,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -2009,8 +2009,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/de/index.html
+++ b/de/index.html
@@ -1081,8 +1081,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -1840,8 +1840,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/es/index.html
+++ b/es/index.html
@@ -1250,8 +1250,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -2179,8 +2179,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/hu/index.html
+++ b/hu/index.html
@@ -1174,8 +1174,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -2026,8 +2026,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/it/index.html
+++ b/it/index.html
@@ -1074,8 +1074,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -1826,8 +1826,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/ja/index.html
+++ b/ja/index.html
@@ -1234,8 +1234,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -2195,8 +2195,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/nl/index.html
+++ b/nl/index.html
@@ -1167,8 +1167,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -2013,8 +2013,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/pt/index.html
+++ b/pt/index.html
@@ -1064,8 +1064,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -1855,8 +1855,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/ru/index.html
+++ b/ru/index.html
@@ -1060,8 +1060,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -1798,8 +1798,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{

--- a/tr/index.html
+++ b/tr/index.html
@@ -1167,8 +1167,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{
@@ -2011,8 +2011,8 @@
     }
 
     @keyframes pricingGlow{
-      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05) translateZ(0)}
-      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05) translateZ(0)}
+      0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
+      50%{box-shadow:0 0 60px rgba(91,138,255,.4),0 0 120px rgba(91,138,255,.2);transform:scale(1.05)}
     }
 
     @keyframes badgePulse{


### PR DESCRIPTION
This commit fixes the root cause of pricing card flickering on mobile by removing translateZ(0) from the @keyframes pricingGlow animation across all language directories.

The pricingGlow animation is applied to the yearly pricing card and was causing hardware acceleration conflicts with background animations on mobile devices.

Changes made:
- Removed translateZ(0) from both pricingGlow keyframe definitions in each file
- Updated transform property from "scale(1.05) translateZ(0)" to "scale(1.05)"
- Applied to 10 language directories: ar, de, es, hu, it, ja, nl, pt, ru, tr
- French (fr) and English (index.html) already had clean implementations

This completes the comprehensive fix for all pricing component flickering issues across all languages on mobile devices.