### PR TITLE
Remove badgePulse animation from lifetime badge across all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6375,7 +6375,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               محدود • <span data-count="150">150</span> مقعد متبقي
             </div>
 

--- a/de/index.html
+++ b/de/index.html
@@ -6129,7 +6129,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               BEGRENZT • <span data-count="150">150</span> PLÄTZE ÜBRIG
             </div>
 

--- a/es/index.html
+++ b/es/index.html
@@ -6570,7 +6570,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               LIMITADO • <span data-count="150">150</span> RESTANTES
             </div>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -6476,7 +6476,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               LIMITÉ • <span class="no-animate">150</span> PLACES RESTANTES
             </div>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -6301,7 +6301,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               LIMITED • <span data-count="150">150</span> SLOTS LEFT
             </div>
 

--- a/index.html
+++ b/index.html
@@ -5375,7 +5375,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               LIMITED • <span data-count="150">150</span> SLOTS LEFT
             </div>
 

--- a/it/index.html
+++ b/it/index.html
@@ -6101,7 +6101,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               LIMITED • <span data-count="150">150</span> SLOTS LEFT
             </div>
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -6599,7 +6599,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               限定 • <span data-count="150">150</span> 残り枠
             </div>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -6286,7 +6286,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               BEPERKT • <span data-count="150">150</span> PLAATSEN OVER
             </div>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -6376,7 +6376,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledpor="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.75rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.75rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               LIMITADO • <span class="no-animate">150</span> VAGAS
             </div>
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -6074,7 +6074,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               ОГРАНИЧЕНО • <span data-count="150">150</span> МЕСТ ОСТАЛОСЬ
             </div>
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -6288,7 +6288,7 @@
 
           <article class="card plan" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="position:relative;border:2px solid rgba(249,162,60,0.3)">
 
-            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%;animation:badgePulse 2s ease-in-out infinite">
+            <div style="position:absolute;top:-14px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#f9a23c,#ff8c42);color:#fff;padding:.5rem 1.1rem;border-radius:999px;font-weight:800;font-size:.82rem;box-shadow:0 4px 16px rgba(249,162,60,.5);white-space:nowrap;max-width:90%">
               SINIRLI • <span data-count="150">150</span> KOTA KALDI
             </div>
 


### PR DESCRIPTION
This commit completely removes the badgePulse animation from the "LIMITED • 150 SLOTS LEFT" badge on the lifetime pricing card to eliminate flickering on all devices.

The pulsing animation was causing visual flicker and performance issues. The badge now has a static appearance with the gradient background and shadow, without any animation effects.

Changes:
- Removed 'animation:badgePulse 2s ease-in-out infinite' from lifetime badge inline styles
- Applied to: ar, de, es, fr, hu, index.html (en), it, ja, nl, pt, ru, tr (12 languages)

This completes the comprehensive fix for ALL animation flickering issues across the entire pricing section on all devices and languages.