### PR TITLE
Fix pricing card badge overflow on Portuguese site mobile

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2263,11 +2263,11 @@
       /* Fix absolute positioned badges on pricing cards */
       .pricing-grid .card.plan > div[style*="position:absolute"] {
         position: absolute !important;
-        max-width: calc(100% - 4rem) !important;
+        max-width: calc(100% - 2rem) !important;
         left: 50% !important;
         transform: translateX(-50%) !important;
-        font-size: 0.7rem !important;
-        padding: 0.35rem 0.7rem !important;
+        font-size: 0.65rem !important;
+        padding: 0.35rem 0.6rem !important;
         white-space: nowrap !important;
         overflow: hidden !important;
         text-overflow: ellipsis !important;


### PR DESCRIPTION
Adjusted badge positioning CSS to prevent badges like "ECONOMIZE" and "LIMITADO • 150 VAGAS" from overflowing card borders on mobile:
- Increased max-width from calc(100% - 4rem) to calc(100% - 2rem)
- Reduced font-size from 0.7rem to 0.65rem
- Reduced padding from 0.35rem 0.7rem to 0.35rem 0.6rem