### PR TITLE
Fix Portuguese site pricing card badge overflow

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2263,14 +2263,15 @@
       /* Fix absolute positioned badges on pricing cards */
       .pricing-grid .card.plan > div[style*="position:absolute"] {
         position: absolute !important;
-        max-width: calc(100% - 2rem) !important;
+        max-width: calc(100% - 3rem) !important;
         left: 50% !important;
         transform: translateX(-50%) !important;
-        font-size: 0.65rem !important;
-        padding: 0.35rem 0.6rem !important;
+        font-size: 0.6rem !important;
+        padding: 0.3rem 0.5rem !important;
         white-space: nowrap !important;
         overflow: hidden !important;
         text-overflow: ellipsis !important;
+        box-sizing: border-box !important;
       }
 
       /* Ensure all card content wraps */


### PR DESCRIPTION
Further reduced badge sizing to prevent overflow on mobile:
- Increased margins: max-width from calc(100% - 2rem) to calc(100% - 3rem)
- Reduced font size from 0.65rem to 0.6rem
- Reduced padding from 0.35rem 0.6rem to 0.3rem 0.5rem
- Added box-sizing: border-box for proper width calculations

This ensures badges like "ECONOMIZE" and "LIMITADO • 150 VAGAS" stay within card borders on all mobile screen sizes.