### PR TITLE
Fix badge overflow with inset constraint strategy

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2263,15 +2263,19 @@
       /* Fix absolute positioned badges on pricing cards */
       .pricing-grid .card.plan > div[style*="position:absolute"] {
         position: absolute !important;
-        max-width: calc(100% - 3rem) !important;
-        left: 50% !important;
-        transform: translateX(-50%) !important;
+        left: 1rem !important;
+        right: 1rem !important;
+        top: -12px !important;
+        width: auto !important;
+        max-width: none !important;
+        transform: none !important;
         font-size: 0.6rem !important;
         padding: 0.3rem 0.5rem !important;
         white-space: nowrap !important;
         overflow: hidden !important;
         text-overflow: ellipsis !important;
         box-sizing: border-box !important;
+        text-align: center !important;
       }
 
       /* Ensure all card content wraps */


### PR DESCRIPTION
Changed badge positioning approach to prevent overflow:
- Use left: 1rem and right: 1rem together to constrain width
- Remove transform-based centering that was causing issues
- Set width: auto to fit within left/right boundaries
- Add text-align: center to center text within constrained badge
- Maintain reduced font-size (0.6rem) and padding (0.3rem 0.5rem)

This ensures badges stay within card borders by constraining them between left and right margins instead of trying to center them.