### PR TITLE
Add top padding to pricing cards to accommodate badges

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2245,7 +2245,7 @@
         max-width: 100% !important;
         width: 100% !important;
         margin: 0 !important;
-        padding: 1.5rem 1rem !important;
+        padding: 2rem 1rem 1.5rem 1rem !important;
         box-sizing: border-box !important;
         overflow: visible !important;
         transform: none !important; /* Remove any scale transforms */


### PR DESCRIPTION
Increased top padding from 1.5rem to 2rem to make room for the absolute-positioned badges at the top of each pricing card. This pushes the card content (price/plan/buttons) down, preventing the badges from overlapping with the card content and staying properly within the visible card area.