### PR TITLE
Increase top padding to 3.5rem for better badge clearance

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2245,7 +2245,7 @@
         max-width: 100% !important;
         width: 100% !important;
         margin: 0 !important;
-        padding: 2rem 1rem 1.5rem 1rem !important;
+        padding: 3.5rem 1rem 1.5rem 1rem !important;
         box-sizing: border-box !important;
         overflow: visible !important;
         transform: none !important; /* Remove any scale transforms */


### PR DESCRIPTION
Increased top padding from 2rem to 3.5rem to provide more vertical space for the absolute-positioned badges, ensuring they don't overflow or overlap with the card content below.