### PR TITLE
Move badges inside card borders to fix overflow

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -2245,7 +2245,7 @@
         max-width: 100% !important;
         width: 100% !important;
         margin: 0 !important;
-        padding: 3.5rem 1rem 1.5rem 1rem !important;
+        padding: 3rem 1rem 1.5rem 1rem !important;
         box-sizing: border-box !important;
         overflow: visible !important;
         transform: none !important; /* Remove any scale transforms */
@@ -2265,7 +2265,7 @@
         position: absolute !important;
         left: 1rem !important;
         right: 1rem !important;
-        top: -12px !important;
+        top: 0.75rem !important;
         width: auto !important;
         max-width: none !important;
         transform: none !important;


### PR DESCRIPTION
Changed badge positioning from top: -12px (above card) to top: 0.75rem (inside card at the top). This keeps badges within the card borders instead of floating above them. Also adjusted top padding to 3rem to accommodate the badges plus content below.

This fixes the overflow issue by positioning badges inside the card's visible area rather than outside its borders.