### PR TITLE
Fix dropdown menu alignment with !important overrides

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -3049,13 +3049,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/de/index.html
+++ b/de/index.html
@@ -2880,13 +2880,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/es/index.html
+++ b/es/index.html
@@ -3268,13 +3268,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -3141,13 +3141,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -3066,13 +3066,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/index.html
+++ b/index.html
@@ -2068,13 +2068,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/it/index.html
+++ b/it/index.html
@@ -2866,13 +2866,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -3292,13 +3292,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -3053,13 +3053,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -3001,13 +3001,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -2838,13 +2838,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -3051,13 +3051,13 @@
     .nav-dropdown-menu a{
       position:relative;
       padding:.6rem .9rem;
-      display:flex;
+      display:flex !important;
       align-items:center;
-      justify-content:flex-start;
+      justify-content:flex-start !important;
       gap:.5rem;
       border-radius:8px;
       width:100%;
-      text-align:left;
+      text-align:left !important;
     }
 
 


### PR DESCRIPTION
Added !important to dropdown menu link alignment properties to override any conflicting nav a styles:
- display: flex !important
- justify-content: flex-start !important
- text-align: left !important

This ensures all dropdown items are left-aligned consistently.