### PR TITLE
Fix SVG icons not rendering on Windows Chrome

### DIFF
--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -44,7 +44,12 @@
     .sp-theme-toggle svg {
       width: 24px;
       height: 24px;
-      stroke: currentColor;
+      stroke: #9fdcff;
+      fill: none;
+    }
+
+    html[data-theme="light"] .sp-theme-toggle svg {
+      stroke: #0f1524;
     }
 
     /* Light mode support */


### PR DESCRIPTION
Theme toggle SVG used 'currentColor' which didn't inherit properly on Windows Chrome in dark mode. Added explicit stroke colors.