### PR TITLE
Fix SVG icons: use explicit colors inline instead of currentColor

### DIFF
--- a/assets/chatbot.js
+++ b/assets/chatbot.js
@@ -459,7 +459,7 @@ Email: support@signalpilot.io`;
     toggle.className = 'sp-chatbot-toggle';
     toggle.setAttribute('aria-label', 'Open chatbot');
     toggle.innerHTML = `
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#9fdcff" stroke-width="2" width="28" height="28">
         <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
       </svg>
     `;

--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -384,11 +384,11 @@
     const button = document.createElement('button');
     button.className = 'sp-theme-toggle';
     button.innerHTML = `
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/>
-        <circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/>
-        <circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/>
-        <circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/>
+      <svg viewBox="0 0 24 24" fill="none" stroke="#9fdcff" stroke-width="2" width="24" height="24">
+        <circle cx="13.5" cy="6.5" r="1.5" fill="#9fdcff"/>
+        <circle cx="17.5" cy="10.5" r="1.5" fill="#9fdcff"/>
+        <circle cx="8.5" cy="7.5" r="1.5" fill="#9fdcff"/>
+        <circle cx="6.5" cy="12.5" r="1.5" fill="#9fdcff"/>
         <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>
       </svg>
     `;


### PR DESCRIPTION
Windows Chrome doesn't properly inherit currentColor for SVGs. Added explicit #9fdcff color directly in SVG attributes.