### PR TITLE
Fix mobile scroll performance: pause particles animation during scroll

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1450,6 +1450,28 @@
   }
 
   // Event listeners
+  let scrollTimeout;
+  let isScrolling = false;
+  const isMobile = () => window.innerWidth <= 768;
+
+  // Pause particles during scroll on mobile for better performance
+  function handleScroll() {
+    if (!isMobile()) return; // Only pause on mobile
+
+    if (!isScrolling) {
+      isScrolling = true;
+      stop(); // Pause animation during scroll
+    }
+
+    clearTimeout(scrollTimeout);
+    scrollTimeout = setTimeout(() => {
+      isScrolling = false;
+      start(); // Resume animation after scrolling stops
+    }, 150); // Resume 150ms after scroll ends
+  }
+
+  window.addEventListener('scroll', handleScroll, { passive: true });
+
   window.addEventListener('resize', () => {
     stop();
     resize();

--- a/index.html
+++ b/index.html
@@ -766,10 +766,13 @@
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important; /* Remove expensive drop-shadow on mobile for better scroll performance */
+        will-change: transform; /* GPU acceleration hint */
       }
       .sp-constellations {
         z-index: 1 !important;
         position: fixed !important;
+        will-change: transform; /* GPU acceleration for smoother scrolling */
       }
       .bg-aurora {
         z-index: -1 !important;


### PR DESCRIPTION
Performance optimizations for smoother mobile scrolling:
- Pause particle/constellation animations during scroll on mobile (≤768px)
- Resume animation 150ms after scrolling stops
- Remove expensive drop-shadow filter from .bg-stars on mobile
- Add will-change: transform for GPU acceleration on mobile
- Use passive scroll listeners for better performance

This eliminates lag/glitching when scrolling on mobile devices