### PR TITLE
Fix animated text pullback on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1161,7 +1161,7 @@
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word}
 
       /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
+      #typed-text{font-size:0.95rem !important;display:inline-block;min-width:10.5em;text-align:left}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -3224,7 +3224,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Non-repainting cycle detection • 7 premium indicators for <span id="typed-text" style="color:var(--brand);font-weight:600">serious traders</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Non-repainting cycle detection • 7 premium indicators for <span id="typed-text" style="color:var(--brand);font-weight:600;display:inline-block;min-width:10.5em;text-align:left">serious traders</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
           </p>
 
         </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -1164,7 +1164,7 @@
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word}
 
       /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
+      #typed-text{font-size:0.95rem !important;display:inline-block;min-width:10.5em;text-align:left}
 
       /* Smaller progress bar on mobile - with fixes for mobile browsers */
       .scroll-progress{
@@ -1962,7 +1962,7 @@
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word}
 
       /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
+      #typed-text{font-size:0.95rem !important;display:inline-block;min-width:10.5em;text-align:left}
 
       /* Smaller progress bar on mobile - with fixes for mobile browsers */
       .scroll-progress{
@@ -4325,7 +4325,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0">
-            Detecção de ciclos sem repintura • 7 indicadores premium para <span id="typed-text" style="color:var(--brand);font-weight:600">traders sérios</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Detecção de ciclos sem repintura • 7 indicadores premium para <span id="typed-text" style="color:var(--brand);font-weight:600;display:inline-block;min-width:10.5em;text-align:left">traders sérios</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
           </p>
 
         </div>


### PR DESCRIPTION
- Added min-width: 10.5em to #typed-text span to prevent layout shifts
- Applied display: inline-block for consistent width behavior
- Fixes mobile issue where second line "pulls back" during text transitions
- Applied to both English and Portuguese versions