### PR TITLE
Fix mobile animated text: Center align so both lines pull back together

### DIFF
--- a/index.html
+++ b/index.html
@@ -1158,7 +1158,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}

--- a/pt/index.html
+++ b/pt/index.html
@@ -1161,7 +1161,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}
@@ -1959,7 +1959,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}


### PR DESCRIPTION
- Added text-align: center to #hero-description on mobile
- Now both lines shift together when animated text changes length
- Creates unified pullback effect instead of just second line moving
- Applied to both English and Portuguese versions