### PR TITLE
Increase mobile particle count: 60 → 65 particles

### DIFF
--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1306,7 +1306,7 @@
       if (currentConfig.count === 'auto') {
         // Original working values - don't change without testing!
         const maxParticles = 120;
-        const minParticles = 60;
+        const minParticles = 65;
         const divisor = 12000;
         targetCount = Math.min(maxParticles, Math.max(minParticles, Math.floor(calcArea / divisor)));
       } else {


### PR DESCRIPTION
Testing performance with slightly more particles to find the optimal balance between visual richness and smooth scrolling.