### PR TITLE
Fix mobile pullback: Use fit-content width so entire text block moves…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1158,7 +1158,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}

--- a/pt/index.html
+++ b/pt/index.html
@@ -1161,7 +1161,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}
@@ -1959,7 +1959,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}


### PR DESCRIPTION
… together

- Changed #hero-description to width:fit-content on mobile
- Removed max-width constraint so paragraph shrinks to content size
- Now entire text block (both lines) shifts together when animated text changes
- Previous center-align alone didn't work because lines centered independently