### PR TITLE
Fix mobile animated text: Use inline-block and left-align so both lin…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1158,7 +1158,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;display:inline-block !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:left !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}

--- a/pt/index.html
+++ b/pt/index.html
@@ -1161,7 +1161,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;display:inline-block !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:left !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}
@@ -1959,7 +1959,7 @@
       }
 
       /* Allow hero text to wrap on mobile */
-      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
+      #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;display:inline-block !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:left !important}
 
       /* Reduce typing text on mobile */
       #typed-text{font-size:0.95rem !important}


### PR DESCRIPTION
…es move together

- Changed from text-align:center to text-align:left
- Added display:inline-block to make paragraph behave as single unit
- Now when animated text changes width, entire block (both lines) shifts together
- Previous approach had each line centering independently, so only line 2 moved