### PR TITLE
Fix mobile animated text: Reserve min-width to prevent text shifting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1160,8 +1160,8 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
+      /* Reduce typing text on mobile - set min-width to prevent line shift when text changes */
+      #typed-text{font-size:0.95rem !important;display:inline-block !important;min-width:9em !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}

--- a/pt/index.html
+++ b/pt/index.html
@@ -1163,8 +1163,8 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
+      /* Reduce typing text on mobile - set min-width to prevent line shift when text changes */
+      #typed-text{font-size:0.95rem !important;display:inline-block !important;min-width:9em !important}
 
       /* Smaller progress bar on mobile - with fixes for mobile browsers */
       .scroll-progress{
@@ -1961,8 +1961,8 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:none !important;width:fit-content !important;margin-left:auto !important;margin-right:auto !important;overflow-wrap:break-word;word-break:break-word;text-align:center !important}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
+      /* Reduce typing text on mobile - set min-width to prevent line shift when text changes */
+      #typed-text{font-size:0.95rem !important;display:inline-block !important;min-width:9em !important}
 
       /* Smaller progress bar on mobile - with fixes for mobile browsers */
       .scroll-progress{


### PR DESCRIPTION
When typed text changes from long words like "position traders" to short words like "scalpers", the line width would change and cause the centered text to shift position.

Solution: Set min-width:9em on #typed-text span so it always takes the same width regardless of word length. This keeps the text block stable.