### PR TITLE
Fix mobile animated text: Reserve fixed 16ch width for typed text span

### DIFF
--- a/index.html
+++ b/index.html
@@ -1160,8 +1160,13 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
+      /* Fix animated text shifting: Reserve fixed width for longest word */
+      #typed-text{
+        font-size:0.95rem !important;
+        display:inline-block !important;
+        min-width:16ch !important; /* Fits "position traders" (longest word) */
+        text-align:center !important;
+      }
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}


### PR DESCRIPTION
Instead of controlling parent container, directly fix the animated span's width using CSS ch units. The span gets min-width: 16ch to fit "position traders" (longest phrase) and text-align: center to center words within.

This prevents layout shift when the typewriter animation cycles through words of different lengths on mobile devices.