### PR TITLE
Remove animation from 'Elite' text in market structure description

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -5329,7 +5329,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">Les <span data-count="7" data-text-mode>7</span> Élite</h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. <span data-quality="elite">Elite</span> market structure analysis.
+          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.
         </p>
 
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -5155,7 +5155,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">The Elite <span data-count="7" data-text-mode>7</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. <span data-quality="elite">Elite</span> market structure analysis.
+          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.
         </p>
 
 

--- a/index.html
+++ b/index.html
@@ -4231,7 +4231,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">The Elite <span data-count="7" data-text-mode>7</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. <span data-quality="elite">Elite</span> market structure analysis.
+          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.
         </p>
 
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -5332,7 +5332,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">Os Elite <span data-count="7" data-text-mode>7</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Detecção de ciclo de quatro camadas (Pentarch™) mais seis ferramentas especializadas de análise. <span data-quality="elite">Elite</span> análise de estrutura de mercado.
+          Detecção de ciclo de quatro camadas (Pentarch™) mais seis ferramentas especializadas de análise. Elite análise de estrutura de mercado.
         </p>
 
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -5142,7 +5142,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">The Elite <span data-count="7" data-text-mode>7</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. <span data-quality="elite">Elite</span> market structure analysis.
+          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.
         </p>
 
 


### PR DESCRIPTION
The animated 'Elite' text was unnecessary and distracting. Removed the data-quality="elite" span wrapper to make it plain text across all language versions.