### PR TITLE
Remove stagger animation from hero headline

### DIFF
--- a/index.html
+++ b/index.html
@@ -3232,7 +3232,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professional TradingView Indicators</span>
-            <span data-text-stagger data-stagger-variant="slide-up" data-stagger-delay="30" data-stagger-trigger="load">The edge isn't seeing more. It's seeing what matters.</span>
+            <span>The edge isn't seeing more. It's seeing what matters.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">


### PR DESCRIPTION
The stagger animation was causing the hero text to disappear because:
1. No JavaScript implementation exists to handle the animation
2. The hero text is immediately visible on page load (no scroll trigger)
3. Text was left in a hidden state waiting for animation that never runs

Removed all data-text-stagger attributes to display text normally.