### PR TITLE
Disable shimmer effect on mobile completely

### DIFF
--- a/index.html
+++ b/index.html
@@ -1213,35 +1213,15 @@
       animation: shimmerGradient 15s linear infinite;
     }
 
-    /* Mobile shimmer optimization - prevent flickering */
+    /* Mobile - disable shimmer completely due to Safari rendering issues */
     @media (max-width:768px) {
       .shimmer-text {
-        /* Force hardware acceleration */
-        transform: translateZ(0);
-        -webkit-transform: translateZ(0);
-        will-change: auto;
-
-        /* Slower animation on mobile */
-        animation-duration: 20s !important;
-
-        /* Simpler gradient to reduce rendering load */
-        background: linear-gradient(
-          90deg,
-          #9cc0ff 0%,
-          #ffffff 50%,
-          #9cc0ff 100%
-        ) !important;
-        background-size: 200% auto !important;
-      }
-
-      html[data-theme="light"] .shimmer-text {
-        background: linear-gradient(
-          90deg,
-          #3b82f6 0%,
-          #0c4a6e 50%,
-          #3b82f6 100%
-        ) !important;
-        background-size: 200% auto !important;
+        animation: none !important;
+        background: none !important;
+        -webkit-background-clip: unset !important;
+        background-clip: unset !important;
+        -webkit-text-fill-color: inherit !important;
+        color: var(--fg) !important;
       }
     }
 


### PR DESCRIPTION
Mobile Safari has rendering issues with background-clip: text causing white box overlay glitches. Shimmer is now disabled on mobile devices to ensure clean text rendering.

Desktop shimmer animation remains unchanged.