### PR TITLE
Slow down mobile shimmer animation significantly

### DIFF
--- a/index.html
+++ b/index.html
@@ -1242,8 +1242,8 @@
         /* Hint browser about what will change */
         will-change: background-position;
 
-        /* Slower animation on mobile for smoother performance */
-        animation-duration: 20s;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 40s !important;
 
         /* Ensure proper layering */
         z-index: 1;

--- a/index.html
+++ b/index.html
@@ -3592,8 +3592,8 @@
       <div class="container" style="max-width:800px">
 
         <div style="text-align:center;margin-bottom:3rem">
-          <h2 class="headline lg shimmer-text" style="margin-bottom:1rem">
-            Try All 7 Indicators Free for 7 Days
+          <h2 class="headline lg" style="margin-bottom:1rem">
+            <span class="shimmer-text">Try All 7 Indicators Free for 7 Days</span>
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
@@ -4642,7 +4642,7 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg shimmer-text" style="text-align:center;margin-bottom:1rem">Why Traders Switch (And Don't Look Back)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Why Traders Switch (And Don't Look Back)</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
             The complete system vs buying indicators one at a time.


### PR DESCRIPTION
Changed mobile animation from 20s to 40s to make it more subtle and prevent the extremely fast movement on mobile devices.

Desktop remains at 15s for appropriate speed.