### PR TITLE
Make shimmer sweep sequentially from first to last word

### DIFF
--- a/index.html
+++ b/index.html
@@ -1168,10 +1168,10 @@
 
     @keyframes shimmerGradient {
       0% {
-        background-position: 200% 50%;
+        background-position: 400% 50%;
       }
       100% {
-        background-position: -200% 50%;
+        background-position: -400% 50%;
       }
     }
 
@@ -1183,15 +1183,15 @@
 
       background: linear-gradient(
         90deg,
-        #9cc0ff 0%,
-        #86a8ff 20%,
-        #7ccaff 40%,
+        #86a8ff 0%,
+        #86a8ff 40%,
+        #7ccaff 45%,
         #c5dbff 50%,
-        #7ccaff 60%,
-        #86a8ff 80%,
-        #9cc0ff 100%
+        #7ccaff 55%,
+        #86a8ff 60%,
+        #86a8ff 100%
       );
-      background-size: 200% auto;
+      background-size: 400% auto;
 
       /* Safari-specific text rendering */
       -webkit-background-clip: text;
@@ -1214,15 +1214,15 @@
     html[data-theme="light"] .shimmer-text {
       background: linear-gradient(
         90deg,
-        #1e40af 0%,
-        #3b82f6 20%,
-        #0ea5e9 40%,
+        #3b82f6 0%,
+        #3b82f6 40%,
+        #0ea5e9 45%,
         #0c4a6e 50%,
-        #0ea5e9 60%,
-        #3b82f6 80%,
-        #1e40af 100%
+        #0ea5e9 55%,
+        #3b82f6 60%,
+        #3b82f6 100%
       );
-      background-size: 200% auto;
+      background-size: 400% auto;
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;


### PR DESCRIPTION
Change shimmer to act like a narrow spotlight that sweeps across the entire sentence from beginning to end, instead of illuminating all lines simultaneously. Increased gradient size to 400% with a narrower bright section for sequential word-by-word effect.