### PR TITLE
Fix shimmer effect on section headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -3718,7 +3718,7 @@
 
         <!-- Section Header -->
         <div style="text-align:center;margin-bottom:3rem">
-          <h2 class="headline lg shimmer-text" style="margin-bottom:1rem">See It In Action</h2>
+          <h2 class="headline lg" style="margin-bottom:1rem"><span class="shimmer-text">See It In Action</span></h2>
           <p class="note" style="max-width:55ch;margin:0 auto;color:var(--muted)">
             The edge, visualized.
           </p>
@@ -4933,7 +4933,7 @@
 
         <div style="text-align:center;max-width:800px;margin:0 auto 1.5rem">
           <span class="badge" style="margin-bottom:1rem">INTERACTIVE DEMO</span>
-          <h2 class="headline lg shimmer-text">The Difference</h2>
+          <h2 class="headline lg"><span class="shimmer-text">The Difference</span></h2>
           <p style="color:var(--muted);font-size:1.1rem;line-height:1.6;margin-top:1rem">
             <strong style="color:var(--brand)">👆 Drag the slider</strong> to compare trading with and without <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>. Same chart. Same timeframe. Completely different clarity.
           </p>
@@ -5337,7 +5337,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg shimmer-text" style="text-align:center">Plans & Pricing</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Plans & Pricing</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Trusted by <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>
@@ -5639,7 +5639,7 @@
 
     <section id="faq" class="section" role="region" aria-labelledby="faq-heading" style="padding-top:1.5rem">
   <div class="container stack">
-    <h2 id="faq-heading" class="headline lg shimmer-text" style="text-align:center">FAQ</h2>
+    <h2 id="faq-heading" class="headline lg" style="text-align:center"><span class="shimmer-text">FAQ</span></h2>
     <p style="text-align:center;color:var(--muted);margin:-0.5rem 0 1.5rem 0;font-size:.9rem">Pre-purchase questions answered. For setup guides: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a> or <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a>.</p>
 
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;max-width:1100px;margin:0 auto">


### PR DESCRIPTION
Move shimmer-text class from h2 to inner span element. This ensures the gradient only spans the text width (not full block), allowing background-clip: text to work properly.

Fixed headings:
- See It In Action
- The Difference
- Plans & Pricing
- FAQ