### PR TITLE
Fix text disappearing after Matrix shuffle animation completes

### DIFF
--- a/assets/character-shuffle.css
+++ b/assets/character-shuffle.css
@@ -16,8 +16,8 @@
   transition: none;
 }
 
-/* Characters start hidden until shuffling begins */
-.char-shuffle:not(.shuffling) .char:not(.settled) {
+/* Characters start hidden before shuffle begins */
+.char-shuffle:not(.shuffling):not([data-shuffle-init="true"]) .char {
   opacity: 0;
 }
 
@@ -26,8 +26,8 @@
   opacity: 1 !important;
 }
 
-/* Ensure ALL characters are visible after shuffle completes */
-.char-shuffle:not(.shuffling)[data-shuffle-init="true"] .char {
+/* CRITICAL: ALL characters visible after shuffle completes */
+.char-shuffle[data-shuffle-init="true"] .char {
   opacity: 1 !important;
 }
 


### PR DESCRIPTION
Rewrote CSS visibility logic to prevent text from disappearing:
- Only hide chars BEFORE animation initializes
- Once initialized, keep ALL characters visible permanently
- Prevents unsettled chars from being hidden after shuffle ends