### PR TITLE
Simplify character shuffle visibility logic

### DIFF
--- a/assets/character-shuffle.css
+++ b/assets/character-shuffle.css
@@ -9,31 +9,16 @@
   position: relative;
 }
 
-/* Individual character during shuffle */
+/* Individual character - always visible by default */
 .char-shuffle .char {
   display: inline-block;
-  opacity: 1;
+  opacity: 1 !important; /* Force visibility, never hide */
   transition: none;
 }
 
-/* Characters start hidden before shuffle begins */
-.char-shuffle:not(.shuffling):not([data-shuffle-init="true"]) .char {
-  opacity: 0;
-}
-
-/* Character visible state - ensure settled chars stay visible */
-.char-shuffle .char.settled {
-  opacity: 1 !important;
-}
-
-/* CRITICAL: ALL characters visible after shuffle completes */
-.char-shuffle[data-shuffle-init="true"] .char {
-  opacity: 1 !important;
-}
-
-/* Stop shuffle animation explicitly for settled chars */
-.char-shuffle.shuffling .char.settled {
-  animation: none;
+/* Pre-animation state: hide characters only before initialization */
+.char-shuffle.pre-shuffle .char {
+  opacity: 0 !important;
 }
 
 /* Preserve spaces */

--- a/assets/character-shuffle.js
+++ b/assets/character-shuffle.js
@@ -72,7 +72,9 @@
 
     // Split text into character spans
     element.innerHTML = splitText(originalText);
-    element.classList.add('char-shuffle');
+
+    // Add classes for initial state
+    element.classList.add('char-shuffle', 'pre-shuffle');
 
     // Mark as initialized
     element.dataset.shuffleInit = 'true';
@@ -92,6 +94,8 @@
 
     // Start shuffling after delay
     setTimeout(() => {
+      // Remove pre-shuffle class to make characters visible
+      element.classList.remove('pre-shuffle');
       element.classList.add('shuffling');
 
       let elapsed = 0;
@@ -127,6 +131,7 @@
         if (allSettled) {
           clearInterval(shuffleTimer);
           element.classList.remove('shuffling');
+          // Characters remain visible due to .char { opacity: 1 !important }
         }
       }, CONFIG.shuffleInterval);
 
@@ -215,9 +220,9 @@
         return;
       }
 
-      // Reset initialization flag
+      // Reset initialization flag and classes
       element.dataset.shuffleInit = 'false';
-      element.classList.remove('char-shuffle', 'shuffling');
+      element.classList.remove('char-shuffle', 'shuffling', 'pre-shuffle');
 
       shuffleElement(element);
     }


### PR DESCRIPTION
Replaced complex opacity cascade with simple state management:
- Characters now use opacity: 1 !important by default (always visible)
- Only hide with .pre-shuffle class before animation starts
- Remove .pre-shuffle when animation begins
- No competing CSS rules or specificity conflicts

This ensures text remains visible after animation completes.