### PR TITLE
Fix hero heading to use shimmer-text class

### DIFF
--- a/index.html
+++ b/index.html
@@ -3356,7 +3356,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professional TradingView Indicators</span>
-            <span data-text-stagger data-stagger-delay="300" data-stagger-speed="30">The edge isn't seeing more. It's seeing what matters.</span>
+            <span class="shimmer-text">The edge isn't seeing more. It's seeing what matters.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">


### PR DESCRIPTION
Changed from data-text-stagger to class='shimmer-text' to match other headings on the page like 'Try All 7 Indicators' and 'See It In Action'.

Uses CSS gradient animation for consistent shimmer effect.