### PR TITLE
Make shimmer text animation more white

### DIFF
--- a/index.html
+++ b/index.html
@@ -1183,13 +1183,13 @@
 
       background: linear-gradient(
         90deg,
-        #9cc0ff 0%,
-        #86a8ff 20%,
-        #7ccaff 40%,
-        #c5dbff 50%,
-        #7ccaff 60%,
-        #86a8ff 80%,
-        #9cc0ff 100%
+        #c4d9ff 0%,
+        #d4e6ff 20%,
+        #e8f2ff 40%,
+        #ffffff 50%,
+        #e8f2ff 60%,
+        #d4e6ff 80%,
+        #c4d9ff 100%
       );
       background-size: 200% auto;
 
@@ -1214,13 +1214,13 @@
     html[data-theme="light"] .shimmer-text {
       background: linear-gradient(
         90deg,
-        #1e40af 0%,
-        #3b82f6 20%,
-        #0ea5e9 40%,
-        #0c4a6e 50%,
-        #0ea5e9 60%,
-        #3b82f6 80%,
-        #1e40af 100%
+        #2563eb 0%,
+        #60a5fa 20%,
+        #93c5fd 40%,
+        #ffffff 50%,
+        #93c5fd 60%,
+        #60a5fa 80%,
+        #2563eb 100%
       );
       background-size: 200% auto;
       -webkit-background-clip: text;


### PR DESCRIPTION
Update the shimmer gradient to have a pure white highlight at the 50% position and lighter/whiter blues throughout. This creates a brighter, more prominent shimmer effect on the text.