### PR TITLE
Make signal legend boxes neutral grayscale for placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -3544,29 +3544,29 @@
                 <strong>Five signals map the complete market cycle—from early accumulation to late-stage breakdown.</strong>
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
-                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(62,213,152,.08);border:1px solid rgba(62,213,152,.2);border-radius:8px;min-width:0">
-                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6);flex-shrink:0"></span>
-                  <strong style="color:#3ed598;font-size:.9rem;white-space:nowrap;flex-shrink:0">TD</strong>
+                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(107,114,128,.08);border:1px solid rgba(107,114,128,.2);border-radius:8px;min-width:0">
+                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#6b7280;box-shadow:0 0 8px rgba(107,114,128,.4);flex-shrink:0"></span>
+                  <strong style="color:#9ca3af;font-size:.9rem;white-space:nowrap;flex-shrink:0">TD</strong>
                   <span style="color:rgba(255,255,255,.7);font-size:.85rem;white-space:nowrap">→ Touchdown (early-cycle)</span>
                 </div>
-                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(62,213,152,.08);border:1px solid rgba(62,213,152,.2);border-radius:8px;min-width:0">
-                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6);flex-shrink:0"></span>
-                  <strong style="color:#3ed598;font-size:.9rem;white-space:nowrap;flex-shrink:0">IGN</strong>
+                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(107,114,128,.08);border:1px solid rgba(107,114,128,.2);border-radius:8px;min-width:0">
+                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#6b7280;box-shadow:0 0 8px rgba(107,114,128,.4);flex-shrink:0"></span>
+                  <strong style="color:#9ca3af;font-size:.9rem;white-space:nowrap;flex-shrink:0">IGN</strong>
                   <span style="color:rgba(255,255,255,.7);font-size:.85rem;white-space:nowrap">→ Ignition (momentum)</span>
                 </div>
-                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(118,221,255,.08);border:1px solid rgba(118,221,255,.2);border-radius:8px;min-width:0">
-                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#76ddff;box-shadow:0 0 8px rgba(118,221,255,.6);flex-shrink:0"></span>
-                  <strong style="color:#76ddff;font-size:.9rem;white-space:nowrap;flex-shrink:0">CAP</strong>
+                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(107,114,128,.08);border:1px solid rgba(107,114,128,.2);border-radius:8px;min-width:0">
+                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#6b7280;box-shadow:0 0 8px rgba(107,114,128,.4);flex-shrink:0"></span>
+                  <strong style="color:#9ca3af;font-size:.9rem;white-space:nowrap;flex-shrink:0">CAP</strong>
                   <span style="color:rgba(255,255,255,.7);font-size:.85rem;white-space:nowrap">→ Climax (late-cycle)</span>
                 </div>
-                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(249,162,60,.08);border:1px solid rgba(249,162,60,.2);border-radius:8px;min-width:0">
-                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#f9a23c;box-shadow:0 0 8px rgba(249,162,60,.6);flex-shrink:0"></span>
-                  <strong style="color:#f9a23c;font-size:.9rem;white-space:nowrap;flex-shrink:0">WRN</strong>
+                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(107,114,128,.08);border:1px solid rgba(107,114,128,.2);border-radius:8px;min-width:0">
+                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#6b7280;box-shadow:0 0 8px rgba(107,114,128,.4);flex-shrink:0"></span>
+                  <strong style="color:#9ca3af;font-size:.9rem;white-space:nowrap;flex-shrink:0">WRN</strong>
                   <span style="color:rgba(255,255,255,.7);font-size:.85rem;white-space:nowrap">→ Warning (weakening)</span>
                 </div>
-                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(255,107,157,.08);border:1px solid rgba(255,107,157,.2);border-radius:8px;min-width:0">
-                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#ff6b9d;box-shadow:0 0 8px rgba(255,107,157,.6);flex-shrink:0"></span>
-                  <strong style="color:#ff6b9d;font-size:.9rem;white-space:nowrap;flex-shrink:0">BDN</strong>
+                <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(107,114,128,.08);border:1px solid rgba(107,114,128,.2);border-radius:8px;min-width:0">
+                  <span class="signal-icon" style="width:8px;height:8px;border-radius:50%;background:#6b7280;box-shadow:0 0 8px rgba(107,114,128,.4);flex-shrink:0"></span>
+                  <strong style="color:#9ca3af;font-size:.9rem;white-space:nowrap;flex-shrink:0">BDN</strong>
                   <span style="color:rgba(255,255,255,.7);font-size:.85rem;white-space:nowrap">→ Breakdown (bearish)</span>
                 </div>
               </div>


### PR DESCRIPTION
- Change all 5 signal boxes (TD, IGN, CAP, WRN, BDN) to grayscale
- Replace bright colors (green, blue, orange, pink) with muted grays
- Use #6b7280 for icons and #9ca3af for text
- Reduce glow intensity to indicate placeholder status