### PR TITLE
Fix shimmer animation consistency across pages

### DIFF
--- a/assets/micro-interactions.css
+++ b/assets/micro-interactions.css
@@ -197,7 +197,7 @@
   background: linear-gradient(
     90deg,
     transparent 0%,
-    rgba(118, 221, 255, 0.1) 50%,
+    #ffffff 50%,
     transparent 100%
   );
   background-size: 1000px 100%;

--- a/de/roadmap.html
+++ b/de/roadmap.html
@@ -682,7 +682,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/es/roadmap.html
+++ b/es/roadmap.html
@@ -676,7 +676,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/fr/roadmap.html
+++ b/fr/roadmap.html
@@ -695,7 +695,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/hu/roadmap.html
+++ b/hu/roadmap.html
@@ -653,7 +653,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/it/roadmap.html
+++ b/it/roadmap.html
@@ -653,7 +653,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/ja/roadmap.html
+++ b/ja/roadmap.html
@@ -669,7 +669,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/nl/roadmap.html
+++ b/nl/roadmap.html
@@ -666,7 +666,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/pt/roadmap.html
+++ b/pt/roadmap.html
@@ -653,7 +653,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -747,7 +747,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 

--- a/tr/roadmap.html
+++ b/tr/roadmap.html
@@ -663,7 +663,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+      background: linear-gradient(90deg, transparent, #ffffff, transparent);
       animation: shimmer 2s infinite;
     }
 


### PR DESCRIPTION
Update all shimmer effects to use #ffffff (100% white) shine to match the hero heading shimmer, replacing the dimmer rgba() opacity values.