### PR TITLE
Investigate FAQ anchor link scrolling issue

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -7627,18 +7627,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/de/index.html
+++ b/de/index.html
@@ -7385,18 +7385,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/es/index.html
+++ b/es/index.html
@@ -7824,18 +7824,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/fr/index.html
+++ b/fr/index.html
@@ -7730,18 +7730,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/hu/index.html
+++ b/hu/index.html
@@ -7547,18 +7547,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/index.html
+++ b/index.html
@@ -6871,18 +6871,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/it/index.html
+++ b/it/index.html
@@ -7345,18 +7345,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/ja/index.html
+++ b/ja/index.html
@@ -7850,18 +7850,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/nl/index.html
+++ b/nl/index.html
@@ -7534,18 +7534,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/pt/index.html
+++ b/pt/index.html
@@ -7642,18 +7642,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/ru/index.html
+++ b/ru/index.html
@@ -7320,18 +7320,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);

--- a/tr/index.html
+++ b/tr/index.html
@@ -7538,18 +7538,27 @@ if ('serviceWorker' in navigator) {
 
 <script>
 // Force scroll to top on page load/refresh (Mobile fix)
+// But respect URL hash anchors for direct linking (e.g., /#faq)
 (function() {
-  // Immediately scroll to top
+  var hasHash = window.location.hash && window.location.hash.length > 1;
+
   if ('scrollRestoration' in history) {
-    history.scrollRestoration = 'manual';
+    // Only disable scroll restoration if no hash anchor
+    history.scrollRestoration = hasHash ? 'auto' : 'manual';
   }
-  window.scrollTo(0, 0);
-  
-  // Also on page load
-  window.addEventListener('load', function() {
+
+  // Only scroll to top if no hash anchor
+  if (!hasHash) {
     window.scrollTo(0, 0);
+  }
+
+  // Also on page load (but respect hash)
+  window.addEventListener('load', function() {
+    if (!window.location.hash || window.location.hash.length <= 1) {
+      window.scrollTo(0, 0);
+    }
   });
-  
+
   // And on beforeunload (catches refresh)
   window.addEventListener('beforeunload', function() {
     window.scrollTo(0, 0);


### PR DESCRIPTION
The "Force scroll to top on page load/refresh (Mobile fix)" script was unconditionally scrolling to top, which overrode the anchor link handler's scroll to #faq (or other hash anchors). This broke external links like signalpilot.io/?t=dark#faq - the page would briefly scroll to #faq then immediately jump back to top.

Fixed by checking for URL hash before force-scrolling to top. When a hash anchor is present in the URL:
- Skip immediate scrollTo(0,0)
- Skip scrollTo on load event
- Set scrollRestoration to 'auto' to let anchor handler work

Applied to all 12 index.html files (main + 11 localized versions).