### PR TITLE
Add shimmer effect to Elite Seven heading across all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5226,7 +5226,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">النخبة <span data-count="7" data-text-mode>7</span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">النخبة <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           كشف الدورة رباعي الطبقات (Pentarch™) بالإضافة إلى ستة أدوات تحليل متخصصة. تحليل <span data-quality="elite">نخبوي</span> لهيكل السوق.

--- a/de/index.html
+++ b/de/index.html
@@ -4980,7 +4980,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">Die Elite <span data-count="7" data-text-mode>7</span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Die Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Vierschichtige Zyklus-Erkennung (Pentarch™) plus sechs spezialisierte Analyse-Tools. <span data-quality="elite">Elite</span> Marktstruktur-Analyse.

--- a/es/index.html
+++ b/es/index.html
@@ -5398,7 +5398,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">Los <span data-count="7" data-text-mode>7</span> Élite</h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Los <span data-count="7" data-text-mode>7</span> Élite</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Detección de ciclos de cuatro capas (Pentarch™) más seis herramientas de análisis especializadas. Análisis de estructura de mercado <span data-quality="elite">élite</span>.

--- a/fr/index.html
+++ b/fr/index.html
@@ -5326,7 +5326,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">Les <span data-count="7" data-text-mode>7</span> Élite</h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Les <span data-count="7" data-text-mode>7</span> Élite</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.

--- a/hu/index.html
+++ b/hu/index.html
@@ -5152,7 +5152,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">The Elite <span data-count="7" data-text-mode>7</span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">The Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.

--- a/index.html
+++ b/index.html
@@ -4364,7 +4364,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">The Elite <span data-count="7" data-text-mode>7</span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">The Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.

--- a/it/index.html
+++ b/it/index.html
@@ -4952,7 +4952,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">I <span data-count="7" data-text-mode>7</span> Elite</h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">I <span data-count="7" data-text-mode>7</span> Elite</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Rilevamento del ciclo a quattro strati (Pentarch™) più sei strumenti di analisi specializzati. Analisi <span data-quality="elite">elite</span> della struttura di mercato.

--- a/ja/index.html
+++ b/ja/index.html
@@ -5450,7 +5450,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">エリート<span data-count="7" data-text-mode>7</span>種類</h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">エリート<span data-count="7" data-text-mode>7</span>種類</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           4層サイクル検出（Pentarch™）と6つの専門分析ツール。<span data-quality="elite">エリート</span>級の市場構造分析。

--- a/nl/index.html
+++ b/nl/index.html
@@ -5137,7 +5137,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">De Elite <span data-count="7" data-text-mode>7</span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">De Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Vier-laagse cyclusdetectie (Pentarch™) plus zes gespecialiseerde analysetools. <span data-quality="elite">Elite</span> marktstructuuranalyse.

--- a/pt/index.html
+++ b/pt/index.html
@@ -5329,7 +5329,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">Os Elite <span data-count="7" data-text-mode>7</span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Os Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Detecção de ciclo de quatro camadas (Pentarch™) mais seis ferramentas especializadas de análise. Elite análise de estrutura de mercado.

--- a/ru/index.html
+++ b/ru/index.html
@@ -4925,7 +4925,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">Элитная <span data-count="7" data-text-mode>7</span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Элитная <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Четырёхслойное определение циклов (Pentarch™) плюс шесть специализированных инструментов анализа. <span data-quality="elite">Элитный</span> анализ рыночной структуры.

--- a/tr/index.html
+++ b/tr/index.html
@@ -5139,7 +5139,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem">The Elite <span data-count="7" data-text-mode>7</span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">The Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
           Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.


### PR DESCRIPTION
Wrap the Elite Seven section heading in shimmer-text class to match other hero headings that shimmer.