### PR TITLE
Fix Q4 2025 roadmap goal checkmarks to match 40% progress

### DIFF
--- a/de/roadmap.html
+++ b/de/roadmap.html
@@ -1068,19 +1068,19 @@
               <div class="feature-text"><strong>Neue Indikatoren (2-3)</strong>Optionsfluss & Gamma-Wände, Korrelationsmatrix, Saisonalitätsmaschine</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Bildungserweiterung</strong>Tier-5-Start — institutioneller Orderflow & Optionsmarktanalyse</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Videoinhalt</strong>Anleitungen, Live-Analyse</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Voreinstellungsbibliothek</strong>Vorkonfigurierte Setups für Kryptowährungen, Devisen, Aktien</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Community-Funktionen</strong>Mitgliederdiskussionen (Plattform TBD basierend auf Nachfrage)</div>
             </div>
           </div>

--- a/de/roadmap.html
+++ b/de/roadmap.html
@@ -999,8 +999,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Live jetzt</a>
-    <a href="#q4">Q4 2025</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1043,11 +1043,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">Q4 2025</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">Verfeinerung</h2>
           </div>
 
@@ -1087,11 +1087,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Zukunftsvision</h2>
           </div>
 

--- a/de/roadmap.html
+++ b/de/roadmap.html
@@ -1060,11 +1060,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Verbesserte Genauigkeit</strong>Algorithmus-Updates, weniger falsche Signale</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Neue Indikatoren (2-3)</strong>Optionsfluss & Gamma-Wände, Korrelationsmatrix, Saisonalitätsmaschine</div>
             </div>
             <div class="feature-item">

--- a/es/roadmap.html
+++ b/es/roadmap.html
@@ -1049,11 +1049,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Precisión Mejorada</strong>Actualizaciones de algoritmos, reducción de señales falsas</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Nuevos Indicadores (2-3)</strong>Flujo de opciones y muros gamma, matriz de correlación, motor de estacionalidad</div>
             </div>
             <div class="feature-item">

--- a/es/roadmap.html
+++ b/es/roadmap.html
@@ -988,8 +988,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Disponible Ahora</a>
-    <a href="#q4">Q4 2025</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1032,11 +1032,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">Q4 2025</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">Refinamiento</h2>
           </div>
 
@@ -1076,11 +1076,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Visión Futura</h2>
           </div>
 

--- a/es/roadmap.html
+++ b/es/roadmap.html
@@ -1057,19 +1057,19 @@
               <div class="feature-text"><strong>Nuevos Indicadores (2-3)</strong>Flujo de opciones y muros gamma, matriz de correlación, motor de estacionalidad</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Expansión Educativa</strong>Lanzamiento del Nivel 5—flujo de órdenes institucionales y análisis del mercado de opciones</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Contenido en Video</strong>Tutoriales, análisis en vivo</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Biblioteca de Preajustes</strong>Configuraciones preconfiguradas para criptomonedas, forex, acciones</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Funciones Comunitarias</strong>Discusiones de miembros (plataforma por determinar según la demanda)</div>
             </div>
           </div>

--- a/fr/roadmap.html
+++ b/fr/roadmap.html
@@ -1085,19 +1085,19 @@
               <div class="feature-text"><strong>Nouveaux Indicateurs (2-3)</strong>Flux d'options et murs gamma, matrice de corrélation, moteur de saisonnalité</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Expansion Éducative</strong>Lancement du Niveau 5 — flux d'ordres institutionnels et analyse du marché des options</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Contenu Vidéo</strong>Tutoriels étape par étape, analyse en direct</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Bibliothèque de Préréglages</strong>Configurations préconfigurées pour crypto, forex, actions</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Fonctionnalités Communautaires</strong>Discussions entre membres (plateforme à déterminer selon la demande)</div>
             </div>
           </div>

--- a/fr/roadmap.html
+++ b/fr/roadmap.html
@@ -1077,11 +1077,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Précision Améliorée</strong>Mises à jour d'algorithmes, réduction des faux signaux</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Nouveaux Indicateurs (2-3)</strong>Flux d'options et murs gamma, matrice de corrélation, moteur de saisonnalité</div>
             </div>
             <div class="feature-item">

--- a/fr/roadmap.html
+++ b/fr/roadmap.html
@@ -1016,8 +1016,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Disponible Maintenant</a>
-    <a href="#q4">T4 2025</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1060,11 +1060,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">T4 2025</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">Perfectionnement</h2>
           </div>
 
@@ -1104,11 +1104,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Vision Future</h2>
           </div>
 

--- a/hu/roadmap.html
+++ b/hu/roadmap.html
@@ -1026,11 +1026,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Javított Pontosság</strong>Algoritmus frissítések, csökkentett téves jelek</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Új Indikátorok (2-3)</strong>Opciós áramlás & gamma falak, korrelációs mátrix, szezonalitási motor</div>
             </div>
             <div class="feature-item">

--- a/hu/roadmap.html
+++ b/hu/roadmap.html
@@ -1034,19 +1034,19 @@
               <div class="feature-text"><strong>Új Indikátorok (2-3)</strong>Opciós áramlás & gamma falak, korrelációs mátrix, szezonalitási motor</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Oktatási Bővítés</strong>5. szint indítása—intézményi megbízásáramlás & opciós piaci elemzés</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Videó Tartalom</strong>Áttekintések, élő elemzések</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Előre Beállított Könyvtár</strong>Előre konfigurált beállítások kriptóhoz, forexhez, részvényekhez</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Közösségi Funkciók</strong>Tagsági beszélgetések (platform igény alapján meghatározva)</div>
             </div>
           </div>

--- a/hu/roadmap.html
+++ b/hu/roadmap.html
@@ -965,8 +965,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Már Elérhető</a>
-    <a href="#q4">2025 Q4</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1009,11 +1009,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">2025 Q4</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">Finomítás</h2>
           </div>
 
@@ -1053,11 +1053,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Jövőkép</h2>
           </div>
 

--- a/it/roadmap.html
+++ b/it/roadmap.html
@@ -965,8 +965,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Attivo Ora</a>
-    <a href="#q4">Q4 2025</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1009,11 +1009,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">Q4 2025</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">Raffinamento</h2>
           </div>
 
@@ -1053,11 +1053,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Visione Futura</h2>
           </div>
 

--- a/it/roadmap.html
+++ b/it/roadmap.html
@@ -1034,19 +1034,19 @@
               <div class="feature-text"><strong>Nuovi Indicatori (2-3)</strong>Flusso opzioni & muri gamma, matrice di correlazione, motore di stagionalità</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Espansione Educativa</strong>Lancio Livello 5—flusso ordini istituzionali & analisi mercato opzioni</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Contenuti Video</strong>Tutorial, analisi dal vivo</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Libreria Preset</strong>Configurazioni preimpostate per crypto, forex, azioni</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Funzionalità Community</strong>Discussioni membri (piattaforma da definire in base alla domanda)</div>
             </div>
           </div>

--- a/it/roadmap.html
+++ b/it/roadmap.html
@@ -1026,11 +1026,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Precisione Migliorata</strong>Aggiornamenti degli algoritmi, riduzione dei falsi segnali</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Nuovi Indicatori (2-3)</strong>Flusso opzioni & muri gamma, matrice di correlazione, motore di stagionalità</div>
             </div>
             <div class="feature-item">

--- a/ja/roadmap.html
+++ b/ja/roadmap.html
@@ -981,7 +981,7 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">提供中</a>
-    <a href="#q4">2025年第4四半期</a>
+    <a href="#q4">2026</a>
     <a href="#future">2026年以降</a>
   </nav>
 
@@ -1025,11 +1025,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">2025年第4四半期</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">改良</h2>
           </div>
 
@@ -1069,7 +1069,7 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">

--- a/ja/roadmap.html
+++ b/ja/roadmap.html
@@ -1042,11 +1042,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>精度の向上</strong>アルゴリズムの更新、誤シグナルの削減</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>新インジケーター（2～3種）</strong>オプションフロー＆ガンマウォール、相関マトリックス、季節性エンジン</div>
             </div>
             <div class="feature-item">

--- a/ja/roadmap.html
+++ b/ja/roadmap.html
@@ -1050,19 +1050,19 @@
               <div class="feature-text"><strong>新インジケーター（2～3種）</strong>オプションフロー＆ガンマウォール、相関マトリックス、季節性エンジン</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>教育コンテンツの拡充</strong>ティア5のローンチ — 機関投資家のオーダーフローとオプション市場分析</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>動画コンテンツ</strong>ウォークスルー、ライブ分析</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>プリセットライブラリ</strong>仮想通貨、外国為替、株式向けの事前設定済みセットアップ</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>コミュニティ機能</strong>メンバー間のディスカッション（需要に応じてプラットフォーム選定予定）</div>
             </div>
           </div>

--- a/nl/roadmap.html
+++ b/nl/roadmap.html
@@ -1052,19 +1052,19 @@
               <div class="feature-text"><strong>Nieuwe indicatoren (2-3)</strong>Optie flow & Gamma walls, Correlatiematrix, Seizoenaliteitmachine</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Onderwijsuitbreiding</strong>Tier-5 start — institutionele orderflow & Optiemarktanalyse</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Video-inhoud</strong>Handleidingen, Live analyse</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Voorinstellingen bibliotheek</strong>Vooraf geconfigureerde setups voor Cryptocurrencies, Forex, Aandelen</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Community functies</strong>Ledendiscussies (Platform TBD gebaseerd op vraag)</div>
             </div>
           </div>

--- a/nl/roadmap.html
+++ b/nl/roadmap.html
@@ -1044,11 +1044,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Verbeterde nauwkeurigheid</strong>Algoritme-updates, minder valse signalen</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Nieuwe indicatoren (2-3)</strong>Optie flow & Gamma walls, Correlatiematrix, Seizoenaliteitmachine</div>
             </div>
             <div class="feature-item">

--- a/nl/roadmap.html
+++ b/nl/roadmap.html
@@ -983,8 +983,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Live nu</a>
-    <a href="#q4">Q4 2025</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1027,11 +1027,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">Q4 2025</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">Verfijning</h2>
           </div>
 
@@ -1071,11 +1071,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Toekomstvisie</h2>
           </div>
 

--- a/pt/roadmap.html
+++ b/pt/roadmap.html
@@ -1034,19 +1034,19 @@
               <div class="feature-text"><strong>Novos Indicadores (2-3)</strong>Fluxo de opções e paredes gamma, matriz de correlação, motor de sazonalidade</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Expansão Educacional</strong>Lançamento do Nível 5 — fluxo de ordens institucionais e análise de mercado de opções</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Conteúdo em Vídeo</strong>Tutoriais passo a passo, análise ao vivo</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Biblioteca de Predefinições</strong>Configurações pré-definidas para cripto, forex, ações</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Recursos da Comunidade</strong>Discussões entre membros (plataforma a ser definida com base na demanda)</div>
             </div>
           </div>

--- a/pt/roadmap.html
+++ b/pt/roadmap.html
@@ -965,8 +965,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Ativo Agora</a>
-    <a href="#q4">T4 2025</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1009,11 +1009,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">T4 2025</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">Refinamento</h2>
           </div>
 
@@ -1053,11 +1053,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Visão Futura</h2>
           </div>
 

--- a/pt/roadmap.html
+++ b/pt/roadmap.html
@@ -1026,11 +1026,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Precisão Aprimorada</strong>Atualizações de algoritmo, redução de sinais falsos</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Novos Indicadores (2-3)</strong>Fluxo de opções e paredes gamma, matriz de correlação, motor de sazonalidade</div>
             </div>
             <div class="feature-item">

--- a/roadmap.html
+++ b/roadmap.html
@@ -1088,8 +1088,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Live Now</a>
-    <a href="#q4">Q4 2025</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1132,11 +1132,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">Q4 2025</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">Refinement</h2>
           </div>
 
@@ -1176,11 +1176,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Future Vision</h2>
           </div>
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -1157,19 +1157,19 @@
               <div class="feature-text"><strong>New Indicators (2-3)</strong>Options flow & gamma walls, correlation matrix, seasonality engine</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Education Expansion</strong>Tier 5 launch—institutional order flow & options market analysis</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Video Content</strong>Walkthroughs, live analysis</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Preset Library</strong>Pre-configured setups for crypto, forex, stocks</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Community Features</strong>Member discussions (platform TBD based on demand)</div>
             </div>
           </div>

--- a/roadmap.html
+++ b/roadmap.html
@@ -1149,11 +1149,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Enhanced Accuracy</strong>Algorithm updates, reduced false signals</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>New Indicators (2-3)</strong>Options flow & gamma walls, correlation matrix, seasonality engine</div>
             </div>
             <div class="feature-item">

--- a/tr/roadmap.html
+++ b/tr/roadmap.html
@@ -1036,11 +1036,11 @@
 
           <div class="phase-content">
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Gelişmiş Doğruluk</strong>Algoritma güncellemeleri, azaltılmış yanlış sinyaller</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Yeni Göstergeler (2-3)</strong>Opsiyon akışı ve gama duvarları, korelasyon matrisi, mevsimsellik motoru</div>
             </div>
             <div class="feature-item">

--- a/tr/roadmap.html
+++ b/tr/roadmap.html
@@ -1044,19 +1044,19 @@
               <div class="feature-text"><strong>Yeni Göstergeler (2-3)</strong>Opsiyon akışı ve gama duvarları, korelasyon matrisi, mevsimsellik motoru</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Eğitim Genişletme</strong>Seviye 5 lansmanı—kurumsal emir akışı ve opsiyon piyasası analizi</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Video İçerik</strong>Adım adım kılavuzlar, canlı analiz</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Hazır Ayar Kütüphanesi</strong>Kripto, forex, hisse senetleri için önceden yapılandırılmış kurulumlar</div>
             </div>
             <div class="feature-item">
-              <span class="feature-icon" style="color: var(--accent);">✓</span>
+              <span class="feature-icon" style="color: var(--accent);">○</span>
               <div class="feature-text"><strong>Topluluk Özellikleri</strong>Üye tartışmaları (talebe göre platform belirlenecek)</div>
             </div>
           </div>

--- a/tr/roadmap.html
+++ b/tr/roadmap.html
@@ -975,8 +975,8 @@
   <!-- Sticky Nav -->
   <nav class="sticky-nav">
     <a href="#live">Şimdi Yayında</a>
-    <a href="#q4">2025 4. Çeyrek</a>
-    <a href="#future">2026+</a>
+    <a href="#q4">2026</a>
+    <a href="#future">2027+</a>
   </nav>
 
   <!-- Timeline -->
@@ -1019,11 +1019,11 @@
         </div>
       </div>
 
-      <!-- Phase 2: Q4 2025 -->
+      <!-- Phase 2: 2026 -->
       <div class="phase" id="q4">
         <div class="phase-card phase-active">
           <div class="phase-header">
-            <span class="phase-badge badge-active">2025 4. Çeyrek</span>
+            <span class="phase-badge badge-active">2026</span>
             <h2 class="phase-title" style="color: var(--accent);">İyileştirme</h2>
           </div>
 
@@ -1063,11 +1063,11 @@
         </div>
       </div>
 
-      <!-- Phase 3: 2026+ -->
+      <!-- Phase 3: 2027+ -->
       <div class="phase" id="future">
         <div class="phase-card phase-future">
           <div class="phase-header">
-            <span class="phase-badge badge-future">2026+</span>
+            <span class="phase-badge badge-future">2027+</span>
             <h2 class="phase-title">Gelecek Vizyonu</h2>
           </div>
 


### PR DESCRIPTION
Changed items 3-6 in the Q4 2025 "Refinement" phase from checkmarks (✓) to pending circles (○) to accurately reflect the 40% completion status. The first 2 items (Enhanced Accuracy, New Indicators) remain marked as complete.

Updated across all 10 localized versions (de, es, fr, hu, it, ja, nl, pt, tr) plus the main English roadmap. Arabic version uses a different card-based layout with status badges that was already correct.