### PR TITLE
Fix mobile UX issues: sticky buttons, cookie banner, particles

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1012,13 +1012,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1026,6 +1024,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1855,13 +1859,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1869,6 +1871,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4603,7 +4606,6 @@ html[lang="ar"] [style*="text-align:center"] {
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Chart examples carousel" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/assets/particles.js
+++ b/assets/particles.js
@@ -1304,13 +1304,15 @@
       let targetCount;
 
       if (currentConfig.count === 'auto') {
-        // Original working values - don't change without testing!
-        const maxParticles = 120;
-        const minParticles = 65;
-        const divisor = 12000;
+        // Mobile: slightly fewer particles for balanced performance
+        // Desktop: original values
+        const maxParticles = isMobile ? 100 : 120;
+        const minParticles = isMobile ? 50 : 65;
+        const divisor = isMobile ? 15000 : 12000;
         targetCount = Math.min(maxParticles, Math.max(minParticles, Math.floor(calcArea / divisor)));
       } else {
-        targetCount = currentConfig.count;
+        // For explicit counts, reduce by 50% on mobile
+        targetCount = isMobile ? Math.floor(currentConfig.count * 0.5) : currentConfig.count;
       }
 
       targetParticleCount = targetCount; // Lock this value permanently
@@ -1353,8 +1355,10 @@
     ].includes(currentConfig.type);
 
     if (!skipConnections) {
-      const linkDist = Math.min(W, H) * 0.12;
-      ctx.lineWidth = 1;
+      // Shorter connection distance on mobile for cleaner look
+      const isMobile = W <= 768;
+      const linkDist = Math.min(W, H) * (isMobile ? 0.08 : 0.12);
+      ctx.lineWidth = isMobile ? 0.5 : 1;
 
       for (let i = 0; i < particles.length; i++) {
         for (let j = i + 1; j < particles.length; j++) {

--- a/de/index.html
+++ b/de/index.html
@@ -927,13 +927,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -941,6 +939,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1686,13 +1690,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1700,6 +1702,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4357,7 +4360,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Karussell mit Diagrammbeispielen" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/es/index.html
+++ b/es/index.html
@@ -1096,13 +1096,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1110,6 +1108,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -2025,13 +2029,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -2039,6 +2041,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4730,7 +4733,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Carrusel de ejemplos de gráficos" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/fr/index.html
+++ b/fr/index.html
@@ -1048,13 +1048,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1062,6 +1060,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1931,13 +1935,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1945,6 +1947,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4703,7 +4706,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Chart examples carousel" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/hu/index.html
+++ b/hu/index.html
@@ -1020,13 +1020,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1034,6 +1032,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1872,13 +1876,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1886,6 +1888,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4529,7 +4532,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Chart examples carousel" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/index.html
+++ b/index.html
@@ -934,19 +934,19 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
-
       /* Smooth scrolling */
       scroll-behavior:smooth;
-
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
       -moz-osx-font-smoothing:grayscale;
       text-rendering:optimizeLegibility;
 
+    }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
     }
 
 

--- a/it/index.html
+++ b/it/index.html
@@ -920,13 +920,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -934,6 +932,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1672,13 +1676,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1686,6 +1688,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4329,7 +4332,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Carosello esempi grafici" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/ja/index.html
+++ b/ja/index.html
@@ -1080,13 +1080,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1094,6 +1092,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -2041,13 +2045,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -2055,6 +2057,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4827,7 +4830,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="チャート例のカルーセル" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/nl/index.html
+++ b/nl/index.html
@@ -1013,13 +1013,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1027,6 +1025,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1859,13 +1863,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1873,6 +1875,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4514,7 +4517,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Grafiek voorbeelden carrousel" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/pt/index.html
+++ b/pt/index.html
@@ -910,13 +910,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -924,6 +922,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1708,13 +1712,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1722,6 +1724,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4706,7 +4709,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Carrossel de exemplos de gráficos" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/ru/index.html
+++ b/ru/index.html
@@ -906,13 +906,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -920,6 +918,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1644,13 +1648,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1658,6 +1660,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4302,7 +4305,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Карусель примеров графиков" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">

--- a/tr/index.html
+++ b/tr/index.html
@@ -1013,13 +1013,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1027,6 +1025,12 @@
       text-rendering:optimizeLegibility;
 
     }
+
+    /* Isolation only on main content, not html/body - prevents breaking position:fixed on iOS */
+    main {
+      isolation: isolate;
+    }
+
 
 
 
@@ -1857,13 +1861,11 @@
 
       background:transparent; /* Let particles/aurora/bg-stars show through! */
 
-      isolation:isolate;
+
 
       /* Smooth scrolling */
       scroll-behavior:smooth;
 
-      /* Better touch scrolling on iOS */
-      -webkit-overflow-scrolling:touch;
 
       /* Performance optimizations */
       -webkit-font-smoothing:antialiased;
@@ -1871,6 +1873,7 @@
       text-rendering:optimizeLegibility;
 
     }
+
 
 
 
@@ -4516,7 +4519,6 @@
           </button>
 
           <!-- Scrollable Gallery -->
-          <div id="pentarch-carousel" role="region" aria-label="Grafik örnekleri galerisi" aria-live="polite" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none">
 
             <!-- Chart 1 -->
             <div class="carousel-item" style="flex:0 0 100%;scroll-snap-align:center;position:relative;border-radius:12px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 8px 32px rgba(0,0,0,0.3);background:var(--bg-soft)">


### PR DESCRIPTION
- Fix position:fixed not working on iOS Safari by moving isolation:isolate from html/body to main element (this was creating a stacking context that broke fixed positioning)
- Remove -webkit-overflow-scrolling:touch from html/body (can interfere with fixed elements on iOS)
- Reduce particle count on mobile: max 100 (was 120), min 50 (was 65)
- Shorter connection lines on mobile (0.08 vs 0.12) with thinner strokes
- Applied all fixes to all 11 language directories

This should fix:
- Theme selector button not sticky on mobile
- Chatbot button not sticky on mobile
- Back-to-top button not sticky on mobile
- Cookie consent banner only showing at page bottom