### PR TITLE
Add preload link for hero video to improve load time

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
+  <!-- Preload hero video for faster initial display -->
+  <link rel="preload" href="assets/videos/hero-demo.mp4" as="video" type="video/mp4" fetchpriority="high">
+
   <!-- Prevent aggressive caching on mobile browsers -->
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
   <meta http-equiv="Pragma" content="no-cache" />


### PR DESCRIPTION
Adds <link rel="preload"> with fetchpriority="high" to start downloading the 8.3MB hero-demo.mp4 video immediately when the page loads, before the browser encounters the video element.