### PR TITLE
Update philosophy section and comparison table with outcome-focused copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3598,13 +3598,10 @@
     <section class="section" style="padding:3rem 0;">
       <div class="container" style="max-width:800px;text-align:center">
         <h2 class="headline lg" style="margin-bottom:1.5rem">
-          <span class="shimmer-text">Stop asking "is this the bottom?"</span>
+          <span class="shimmer-text">You're not predicting. You're recognizing.</span>
         </h2>
         <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
-          When TD appears after prolonged selling, you're not predicting a reversal—you're recognizing exhaustion. When CAP fires after an extended run, you're not calling a top—you're seeing climax.
-        </p>
-        <p style="color:var(--text);font-size:1.1rem;font-weight:600;margin-top:1.5rem">
-          The market tells you. You just need to read it.
+          When TD appears after prolonged selling—that's exhaustion. When CAP fires after an extended run—that's climax. The market tells you. Cycles always do.
         </p>
       </div>
     </section>
@@ -4681,15 +4678,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = conflicting signals</span>
+                  <span>Conflicting indicators — you're never sure which to trust</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Repaints frequently, invalidating backtests</span>
+                  <span>Signals repaint — yesterday's "perfect entry" disappears today</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Need 3-5 separate indicators cluttering your chart</span>
+                  <span>Watching others — waiting for their call before you act</span>
                 </li>
               </ul>
             </div>
@@ -4702,19 +4699,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>One integrated view</strong> — unified cycle map</span>
+                  <span><strong>See exhaustion yourself</strong> — TD/IGN appear when selling dries up</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% non-repainting</strong> (audited, $100 challenge)</span>
+                  <span><strong>See climax yourself</strong> — CAP/WRN appear when buying peaks</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 elite systems included</strong> — complete toolkit</span>
+                  <span><strong>Trust what you see</strong> — 100% non-repainting, audited, $100 bounty</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> lessons + 50+ page docs</strong> — master your journey</span>
+                  <span><strong>Master the read</strong> — <span data-count="82">82</span> lessons + 50+ page docs to build conviction</span>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
Philosophy section:
- Change headline to "You're not predicting. You're recognizing."
- Simplify body copy focusing on exhaustion/climax recognition

Comparison table:
- Traditional: Focus on pain (conflicting signals, repainting, dependency)
- Signal Pilot: Pair outcomes with proof (see exhaustion/climax + features)