### PR TITLE
Add marketing copy translations to all language files

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4265,7 +4265,7 @@ html[lang="ar"] [style*="text-align:center"] {
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>خمس إشارات ترسم دورة السوق الكاملة—من التراكم المبكر إلى الانهيار في المرحلة المتأخرة.</strong>
+                <strong>خمس إشارات ترسم دورة السوق الكاملة.</strong> يظهر TD عندما ينفد البيع. يظهر CAP عندما يصل الشراء للذروة. أنت لا تخمن الانعكاس، بل ترى تغير البنية. استعد للتحولات. لا تلاحقها.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4313,6 +4313,18 @@ html[lang="ar"] [style*="text-align:center"] {
 
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">أنت لا تتنبأ. أنت تتعرف.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          صعودي أو هبوطي: الدورات تنتهي بنفس الطريقة. عندما يظهر TD بعد بيع مطول، هذا إرهاق. عندما يُشعل CAP بعد صعود ممتد، هذه ذروة. السوق يتحدث بالدورات.
+        </p>
+      </div>
     </section>
 
     <!-- قسم التجربة المجانية -->
@@ -5091,7 +5103,7 @@ html[lang="ar"] [style*="text-align:center"] {
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">النخبة <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          كشف الدورة رباعي الطبقات (Pentarch™) بالإضافة إلى ستة أدوات تحليل متخصصة. تحليل <span data-quality="elite">نخبوي</span> لهيكل السوق.
+          Pentarch™ يرسم الدورات الكاملة. ستة أدوات نخبوية توفر السياق. البنية بدلاً من الضوضاء.
         </p>
 
 
@@ -5354,10 +5366,10 @@ html[lang="ar"] [style*="text-align:center"] {
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">لماذا يتحول المتداولون (ولا ينظرون إلى الوراء)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">لماذا يتحول المتداولون</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            النظام الكامل مقابل شراء المؤشرات واحداً تلو الآخر.
+            نهجان. واحد يمنحك التحكم.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5371,15 +5383,15 @@ html[lang="ar"] [style*="text-align:center"] {
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = إشارات متضاربة</span>
+                  <span>مؤشرات متضاربة، لا تعرف أبداً أيها تثق</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>يعيد الرسم بشكل متكرر، مما يُبطل الاختبارات التاريخية</span>
+                  <span>الإشارات تعيد الرسم، "الدخول المثالي" بالأمس يختفي اليوم</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>تحتاج من 3 إلى 5 مؤشرات منفصلة تزدحم بها رسمك البياني</span>
+                  <span>مراقبة الآخرين، انتظار إشارتهم قبل التصرف</span>
                 </li>
               </ul>
             </div>
@@ -5392,19 +5404,19 @@ html[lang="ar"] [style*="text-align:center"] {
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>عرض متكامل واحد</strong> — خريطة دورة موحدة</span>
+                  <span><strong>شاهد الإرهاق بنفسك</strong>، TD/IGN يظهران عندما يجف البيع</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% بدون إعادة رسم</strong> (تم التدقيق، تحدي $100)</span>
+                  <span><strong>شاهد الذروة بنفسك</strong>، CAP/WRN يظهران عندما يبلغ الشراء ذروته</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 أنظمة نخبوية مضمنة</strong> — مجموعة أدوات كاملة</span>
+                  <span><strong>ثق بما تراه</strong>، 100% بدون إعادة رسم، تم التدقيق، مكافأة $100</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> درساً + وثائق 50+ صفحة</strong> — أتقن رحلتك</span>
+                  <span><strong>أتقن القراءة</strong>، <span data-count="82">82</span> درساً + 50+ صفحة توثيق لبناء القناعة</span>
                 </li>
               </ul>
             </div>
@@ -6049,7 +6061,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">الخطط والأسعار</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">اختر ميزتك</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           موثوق به من قبل <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/de/index.html
+++ b/de/index.html
@@ -4157,7 +4157,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Fünf Signale bilden den kompletten Marktzyklus ab—von früher Akkumulation bis zum späten Zusammenbruch.</strong>
+                <strong>Fünf Signale bilden den kompletten Marktzyklus ab.</strong> TD erscheint, wenn der Verkaufsdruck nachlässt. CAP erscheint, wenn der Kaufdruck seinen Höhepunkt erreicht. Du rätst nicht die Wende, du siehst den Strukturwandel. Bereite dich auf Übergänge vor. Jage ihnen nicht hinterher.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4188,23 +4188,20 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> bildet vollständige Marktzyklen mit fünf Ereignissignalen ab.
-
-            Jede Phase vom Frühzyklus bis zum Spätzyklus ist sichtbar—kein Repaint, bei Schluss bestätigt.
-
-            Sechs Elite-Begleitindikatoren liefern Kontext, Filter und Timing-Daten.
-
-          </p>
-
-        </div>
-
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">Du prognostizierst nicht. Du erkennst.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Bullen- oder Bärenmarkt: Zyklen enden gleich. Wenn TD nach längerem Verkauf erscheint, ist das Erschöpfung. Wenn CAP nach einem ausgedehnten Anstieg feuert, ist das Höhepunkt. Der Markt spricht in Zyklen.
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -4983,7 +4980,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Die Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Vierschichtige Zyklus-Erkennung (Pentarch™) plus sechs spezialisierte Analyse-Tools. <span data-quality="elite">Elite</span> Marktstruktur-Analyse.
+          Pentarch™ bildet komplette Zyklen ab. Sechs Elite-Tools liefern Kontext. Struktur statt Rauschen.
         </p>
 
 
@@ -5246,10 +5243,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Warum Trader wechseln (und nicht zurückblicken)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Warum Trader wechseln</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            Das vollständige System vs. Kauf einzelner Indikatoren.
+            Zwei Ansätze. Einer gibt dir die Kontrolle.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5263,15 +5260,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = widersprüchliche Signale</span>
+                  <span>Widersprüchliche Indikatoren — du weißt nie, welchem du vertrauen sollst</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Repainted häufig, macht Backtests ungültig</span>
+                  <span>Signale repainen — der "perfekte Einstieg" von gestern verschwindet heute</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Benötigt 3-5 separate Indikatoren, die Ihren Chart überladen</span>
+                  <span>Anderen zuschauen — auf ihren Aufruf warten, bevor du handelst</span>
                 </li>
               </ul>
             </div>
@@ -5284,19 +5281,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Eine integrierte Ansicht</strong> — einheitliche Zykluskarte</span>
+                  <span><strong>Sieh Erschöpfung selbst</strong> — TD/IGN erscheinen, wenn der Verkaufsdruck nachlässt</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% nicht-repaintierend</strong> (geprüft, $100-Challenge)</span>
+                  <span><strong>Sieh den Höhepunkt selbst</strong> — CAP/WRN erscheinen, wenn der Kaufdruck peakt</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 Elite-Systeme enthalten</strong> — komplettes Toolkit</span>
+                  <span><strong>Vertraue dem, was du siehst</strong> — 100% nicht-repaintierend, geprüft, $100 Belohnung</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> Lektionen + 50+ Seiten Dokumentation</strong> — meistern Sie Ihre Reise</span>
+                  <span><strong>Meistere das Lesen</strong> — <span data-count="82">82</span> Lektionen + 50+ Seiten Doku für Überzeugung</span>
                 </li>
               </ul>
             </div>
@@ -5941,7 +5938,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Pläne & Preise</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Wähle deinen Vorteil</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Vertraut von <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/es/index.html
+++ b/es/index.html
@@ -4384,7 +4384,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Cinco señales mapean el ciclo completo del mercado—desde la acumulación temprana hasta el colapso tardío.</strong>
+                <strong>Cinco señales mapean el ciclo completo del mercado.</strong> TD aparece cuando las ventas se agotan. CAP aparece cuando las compras alcanzan su clímax. No adivinas el giro, ves el cambio de estructura. Prepárate para las transiciones. No las persigas.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%, 250px),1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4415,23 +4415,20 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> mapea ciclos completos del mercado con cinco señales de eventos.
-
-            Cada fase desde el ciclo temprano hasta el ciclo tardío es visible—sin repintado, confirmado al cierre.
-
-            Seis indicadores complementarios élite proporcionan contexto, filtros y datos de sincronización.
-
-          </p>
-
-        </div>
-
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">No estás prediciendo. Estás reconociendo.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Alcista o bajista: los ciclos terminan igual. Cuando TD aparece después de ventas prolongadas, eso es agotamiento. Cuando CAP dispara después de una subida extendida, eso es clímax. El mercado habla en ciclos.
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -5255,7 +5252,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Los <span data-count="7" data-text-mode>7</span> Élite</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Detección de ciclos de cuatro capas (Pentarch™) más seis herramientas de análisis especializadas. Análisis de estructura de mercado <span data-quality="elite">élite</span>.
+          Pentarch™ mapea ciclos completos. Seis herramientas élite proporcionan contexto. Estructura sobre ruido.
         </p>
 
 
@@ -5529,10 +5526,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Por Qué Los Traders Cambian (Y No Miran Atrás)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Por Qué Los Traders Cambian</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            El sistema completo vs comprar indicadores de uno en uno.
+            Dos enfoques. Uno te da el control.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5546,15 +5543,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Estocástico = señales contradictorias</span>
+                  <span>Indicadores contradictorios — nunca sabes en cuál confiar</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Se repintan frecuentemente, invalidando backtests</span>
+                  <span>Las señales se repintan — la "entrada perfecta" de ayer desaparece hoy</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Necesitas 3-5 indicadores separados saturando tu gráfico</span>
+                  <span>Observando a otros — esperando su señal antes de actuar</span>
                 </li>
               </ul>
             </div>
@@ -5567,19 +5564,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Una vista integrada</strong> — mapa de ciclo unificado</span>
+                  <span><strong>Ve el agotamiento tú mismo</strong> — TD/IGN aparecen cuando las ventas se agotan</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% sin repintado</strong> (auditado, desafío de $100)</span>
+                  <span><strong>Ve el clímax tú mismo</strong> — CAP/WRN aparecen cuando las compras alcanzan su pico</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 sistemas élite incluidos</strong> — conjunto completo de herramientas</span>
+                  <span><strong>Confía en lo que ves</strong> — 100% sin repintado, auditado, recompensa de $100</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> lecciones + más de 50 páginas de docs</strong> — domina tu camino</span>
+                  <span><strong>Domina la lectura</strong> — <span data-count="82">82</span> lecciones + más de 50 páginas para convicción</span>
                 </li>
               </ul>
             </div>
@@ -6236,7 +6233,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Planes y Precios</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Elige Tu Ventaja</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Con la confianza de <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/fr/index.html
+++ b/fr/index.html
@@ -4357,7 +4357,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Cinq signaux cartographient le cycle de marché complet—de l'accumulation précoce à l'effondrement tardif.</strong>
+                <strong>Cinq signaux cartographient le cycle de marché complet.</strong> TD apparaît quand les ventes s'épuisent. CAP apparaît quand les achats atteignent leur apogée. Vous ne devinez pas le tournant, vous voyez le changement de structure. Préparez-vous aux transitions. Ne les poursuivez pas.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4388,23 +4388,20 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> cartographie les cycles de marché complets avec cinq signaux d'événements.
-
-            Chaque phase du cycle précoce au cycle tardif est visible—sans repeinture, confirmée à la clôture.
-
-            Six indicateurs d'élite complémentaires fournissent le contexte, les filtres et les données de timing.
-
-          </p>
-
-        </div>
-
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">Vous ne prédisez pas. Vous reconnaissez.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Haussier ou baissier : les cycles finissent de la même façon. Quand TD apparaît après des ventes prolongées, c'est l'épuisement. Quand CAP se déclenche après une hausse prolongée, c'est l'apogée. Le marché parle en cycles.
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -5183,7 +5180,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Les <span data-count="7" data-text-mode>7</span> Élite</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.
+          Pentarch™ cartographie les cycles complets. Six outils élite fournissent le contexte. La structure plutôt que le bruit.
         </p>
 
 
@@ -5446,10 +5443,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Pourquoi Les Traders Changent (Et Ne Regardent Pas en Arrière)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Pourquoi Les Traders Changent</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            Le système complet vs l'achat d'indicateurs un par un.
+            Deux approches. L'une vous donne le contrôle.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5463,15 +5460,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastique = signaux contradictoires</span>
+                  <span>Indicateurs conflictuels, vous n'êtes jamais sûr duquel faire confiance</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Se repeint fréquemment, invalidant les backtests</span>
+                  <span>Les signaux se repeignent, l'entrée "parfaite" d'hier disparaît aujourd'hui</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Besoin de 3-5 indicateurs séparés encombrant votre graphique</span>
+                  <span>Observer les autres, attendre leur signal avant d'agir</span>
                 </li>
               </ul>
             </div>
@@ -5484,19 +5481,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Une vue intégrée</strong> — carte de cycle unifiée</span>
+                  <span><strong>Voyez l'épuisement vous-même</strong>, TD/IGN apparaissent quand la vente se tarit</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% sans repeinture</strong> (audité, défi de $100)</span>
+                  <span><strong>Voyez le climax vous-même</strong>, CAP/WRN apparaissent quand l'achat atteint son pic</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 systèmes élite inclus</strong> — boîte à outils complète</span>
+                  <span><strong>Faites confiance à ce que vous voyez</strong>, 100% sans repeinture, audité, prime de $100</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> leçons + plus de 50 pages de docs</strong> — maîtrisez votre parcours</span>
+                  <span><strong>Maîtrisez la lecture</strong>, <span data-count="82">82</span> leçons + 50+ pages de docs pour construire la conviction</span>
                 </li>
               </ul>
             </div>
@@ -6142,7 +6139,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Plans & Tarifs</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Choisissez Votre Avantage</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Utilisé par <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/hu/index.html
+++ b/hu/index.html
@@ -4192,7 +4192,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Öt jelzés térképezi fel a teljes piaci ciklust—a korai akkumulációtól a késői összeomlásig.</strong>
+                <strong>Öt jelzés térképezi fel a teljes piaci ciklust.</strong> TD akkor jelenik meg, amikor az eladás kimerül. CAP akkor jelenik meg, amikor a vásárlás csúcsra ér. Nem találgatod a fordulót, hanem látod a struktúra változását. Készülj fel az átmenetekre. Ne kergesd őket.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4240,6 +4240,18 @@
 
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">Nem jósolgatsz. Felismersz.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Bika vagy medve: a ciklusok ugyanúgy érnek véget. Amikor TD jelenik meg hosszú eladás után, az kimerülés. Amikor CAP aktiválódik hosszú emelkedés után, az csúcs. A piac ciklusokban beszél.
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -5015,10 +5027,10 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">The Elite <span data-count="7" data-text-mode>7</span></span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Az Elit <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.
+          Pentarch™ feltérképezi a teljes ciklusokat. Hat elit eszköz biztosít kontextust. Struktúra a zaj helyett.
         </p>
 
 
@@ -5281,10 +5293,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Miért Váltanak a Kereskedők (És Nem Néznek Vissza)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Miért Váltanak a Kereskedők</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            A teljes rendszer vs. indikátorok vásárlása egyenként.
+            Két megközelítés. Az egyik irányítást ad neked.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5298,15 +5310,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = ellentmondó jelzések</span>
+                  <span>Ellentmondó indikátorok, sosem tudod melyikben bízz</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Gyakran átrajzol, érvényteleníti a backteszteket</span>
+                  <span>Jelzések átfestnek, a tegnapi "tökéletes belépő" ma eltűnik</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>3-5 külön indikátor kell, ami telezsúfolja a grafikonod</span>
+                  <span>Másokat figyelni, várni az ő jelzésükre cselekvés előtt</span>
                 </li>
               </ul>
             </div>
@@ -5319,19 +5331,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Egy integrált nézet</strong> — egységes ciklus térkép</span>
+                  <span><strong>Lásd magad a kimerülést</strong>, TD/IGN megjelenik amikor az eladás elapad</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% nem átfestő</strong> (auditált, $100 kihívás)</span>
+                  <span><strong>Lásd magad a csúcsot</strong>, CAP/WRN megjelenik amikor a vásárlás tetőzik</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 elit rendszer tartalmazza</strong> — teljes eszköztár</span>
+                  <span><strong>Bízz abban amit látsz</strong>, 100% nem átfestő, auditált, $100 jutalom</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> lecke + 50+ oldal dokumentáció</strong> — sajátítsd el az utad</span>
+                  <span><strong>Sajátítsd el az olvasást</strong>, <span data-count="82">82</span> lecke + 50+ oldal dokumentáció a meggyőződéshez</span>
                 </li>
               </ul>
             </div>
@@ -5976,7 +5988,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Csomagok és Árazás</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Válaszd Ki Az Előnyöd</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Megbíznak bennünk <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/it/index.html
+++ b/it/index.html
@@ -4129,7 +4129,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Cinque segnali mappano il ciclo di mercato completo—dall'accumulazione iniziale al crollo finale.</strong>
+                <strong>Cinque segnali mappano il ciclo di mercato completo.</strong> TD appare quando la vendita si esaurisce. CAP appare quando l'acquisto raggiunge il climax. Non indovini il cambio, vedi la struttura che cambia. Preparati alle transizioni. Non inseguirle.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4177,6 +4177,18 @@
 
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">Non stai prevedendo. Stai riconoscendo.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Bull o bear: i cicli finiscono allo stesso modo. Quando TD appare dopo una vendita prolungata, quello è esaurimento. Quando CAP scatta dopo una corsa estesa, quello è climax. Il mercato parla in cicli.
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -4955,7 +4967,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">I <span data-count="7" data-text-mode>7</span> Elite</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Rilevamento del ciclo a quattro strati (Pentarch™) più sei strumenti di analisi specializzati. Analisi <span data-quality="elite">elite</span> della struttura di mercato.
+          Pentarch™ mappa i cicli completi. Sei strumenti elite forniscono contesto. La struttura piuttosto che il rumore.
         </p>
 
 
@@ -5218,10 +5230,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Perché i Trader Passano (E Non Tornano Indietro)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Perché i Trader Cambiano</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            Il sistema completo vs l'acquisto di indicatori uno alla volta.
+            Due approcci. Uno ti dà il controllo.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5235,15 +5247,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = segnali contrastanti</span>
+                  <span>Indicatori in conflitto, non sei mai sicuro di quale fidarti</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Si ridipinge frequentemente, invalidando i backtest</span>
+                  <span>I segnali si ridipingono, l'entrata "perfetta" di ieri scompare oggi</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Servono 3-5 indicatori separati che ingombrano il grafico</span>
+                  <span>Guardare gli altri, aspettare il loro segnale prima di agire</span>
                 </li>
               </ul>
             </div>
@@ -5256,19 +5268,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Una vista integrata</strong> — mappa del ciclo unificata</span>
+                  <span><strong>Vedi l'esaurimento tu stesso</strong>, TD/IGN appaiono quando la vendita si esaurisce</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% senza ridipintura</strong> (verificato, sfida $100)</span>
+                  <span><strong>Vedi il climax tu stesso</strong>, CAP/WRN appaiono quando l'acquisto raggiunge il picco</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 sistemi elite inclusi</strong> — toolkit completo</span>
+                  <span><strong>Fidati di ciò che vedi</strong>, 100% senza ridipintura, verificato, premio di $100</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> lezioni + documentazione di oltre 50 pagine</strong> — padroneggia il tuo percorso</span>
+                  <span><strong>Padroneggia la lettura</strong>, <span data-count="82">82</span> lezioni + 50+ pagine di docs per costruire convinzione</span>
                 </li>
               </ul>
             </div>
@@ -5913,7 +5925,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Piani e Prezzi</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Scegli il Tuo Vantaggio</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Trusted by <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/ja/index.html
+++ b/ja/index.html
@@ -4481,7 +4481,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>5つのシグナルが完全なマーケットサイクルをマッピング—初期の蓄積から後期の崩壊まで。</strong>
+                <strong>5つのシグナルが完全なマーケットサイクルをマッピング。</strong> TDは売りが枯渇した時に出現。CAPは買いがクライマックスに達した時に出現。転換を予測するのではなく、構造の変化を見る。転換に備える。追いかけない。
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4529,6 +4529,18 @@
 
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">予測ではない。認識している。</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          強気でも弱気でも、サイクルは同じように終わる。長期の売りの後にTDが出現したら、それは枯渇。長期の上昇の後にCAPが発火したら、それはクライマックス。市場はサイクルで語る。
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -5307,7 +5319,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">エリート<span data-count="7" data-text-mode>7</span>種類</span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          4層サイクル検出（Pentarch™）と6つの専門分析ツール。<span data-quality="elite">エリート</span>級の市場構造分析。
+          Pentarch™が完全なサイクルをマッピング。6つのエリートツールがコンテキストを提供。ノイズより構造。
         </p>
 
 
@@ -5570,10 +5582,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">トレーダーが乗り換える理由（そして振り返らない理由）</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">トレーダーが乗り換える理由</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            インジケーターを個別に購入するのと完全なシステムとの比較。
+            2つのアプローチ。1つはあなたにコントロールを与える。
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5587,15 +5599,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + ストキャスティクス = 矛盾するシグナル</span>
+                  <span>矛盾するインジケーター、どれを信じるか分からない</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>頻繁にリペイント、バックテストを無効化</span>
+                  <span>シグナルがリペイント、昨日の「完璧なエントリー」が今日消える</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>3〜5個の別々のインジケーターが必要でチャートが散らかる</span>
+                  <span>他の人を見て、彼らのシグナルを待ってから行動</span>
                 </li>
               </ul>
             </div>
@@ -5608,19 +5620,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>統合ビュー</strong> — 統一されたサイクルマップ</span>
+                  <span><strong>自分で枯渇を見る</strong>、売りが枯れた時にTD/IGNが出現</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100%ノンリペイント</strong>（監査済み、$100チャレンジ）</span>
+                  <span><strong>自分でクライマックスを見る</strong>、買いがピークに達した時にCAP/WRNが出現</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>エリート7システム含む</strong> — 完全なツールキット</span>
+                  <span><strong>見たものを信じる</strong>、100%ノンリペイント、監査済み、$100報奨金</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span>レッスン + 50ページ以上のドキュメント</strong> — あなたの学習をマスター</span>
+                  <span><strong>読み方をマスター</strong>、<span data-count="82">82</span>レッスン + 50+ページのドキュメントで確信を構築</span>
                 </li>
               </ul>
             </div>
@@ -6265,7 +6277,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">プラン＆料金</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">あなたの優位性を選ぶ</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           利用されています： <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4168,7 +4168,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Vijf signalen brengen de complete marktcyclus in kaart—van vroege accumulatie tot late-fase afbraak.</strong>
+                <strong>Vijf signalen brengen de complete marktcyclus in kaart.</strong> TD verschijnt wanneer verkopen uitgeput raakt. CAP verschijnt wanneer kopen zijn climax bereikt. Je gokt niet op de wending, je ziet de structuur verschuiven. Bereid je voor op transities. Jaag ze niet na.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4216,6 +4216,18 @@
 
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">Je voorspelt niet. Je herkent.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Bull of bear: cycli eindigen op dezelfde manier. Wanneer TD verschijnt na langdurig verkopen, dat is uitputting. Wanneer CAP afgaat na een uitgebreide rally, dat is climax. De markt spreekt in cycli.
+        </p>
+      </div>
     </section>
 
     <!-- GRATIS PROEFPERIODE SECTIE -->
@@ -4994,7 +5006,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">De Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Vier-laagse cyclusdetectie (Pentarch™) plus zes gespecialiseerde analysetools. <span data-quality="elite">Elite</span> marktstructuuranalyse.
+          Pentarch™ brengt complete cycli in kaart. Zes elite tools bieden context. Structuur boven ruis.
         </p>
 
 
@@ -5257,10 +5269,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Waarom Traders Overstappen (En Nooit Terugkijken)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Waarom Traders Overstappen</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            Het complete systeem vs indicatoren één voor één kopen.
+            Twee benaderingen. Eén geeft jou de controle.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5274,15 +5286,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = tegenstrijdige signalen</span>
+                  <span>Tegenstrijdige indicatoren, je weet nooit welke te vertrouwen</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Herschildert regelmatig, maakt backtests ongeldig</span>
+                  <span>Signalen herschilderen, de "perfecte entry" van gisteren verdwijnt vandaag</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Nodig: 3-5 aparte indicatoren die je grafiek vol maken</span>
+                  <span>Anderen volgen, wachten op hun signaal voordat je handelt</span>
                 </li>
               </ul>
             </div>
@@ -5295,19 +5307,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Eén geïntegreerd overzicht</strong> — verenigde cyclus kaart</span>
+                  <span><strong>Zie uitputting zelf</strong>, TD/IGN verschijnen wanneer verkopen opdroogt</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% niet-herschilderend</strong> (geauditeerd, $100 uitdaging)</span>
+                  <span><strong>Zie climax zelf</strong>, CAP/WRN verschijnen wanneer kopen piekt</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 elite systemen inbegrepen</strong> — complete toolkit</span>
+                  <span><strong>Vertrouw wat je ziet</strong>, 100% niet-herschilderend, geauditeerd, $100 beloning</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> lessen + 50+ pagina's documentatie</strong> — beheers je reis</span>
+                  <span><strong>Beheers de lezing</strong>, <span data-count="82">82</span> lessen + 50+ pagina's docs om overtuiging op te bouwen</span>
                 </li>
               </ul>
             </div>
@@ -5952,7 +5964,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Pakketten & Prijzen</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Kies Je Voorsprong</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Vertrouwd door <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/pt/index.html
+++ b/pt/index.html
@@ -4506,7 +4506,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Cinco sinais mapeiam o ciclo completo do mercado—desde acumulação inicial até colapso final.</strong>
+                <strong>Cinco sinais mapeiam o ciclo completo do mercado.</strong> TD aparece quando a venda se esgota. CAP aparece quando a compra atinge o clímax. Você não adivinha a virada, você vê a estrutura mudar. Prepare-se para as transições. Não as persiga.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4554,6 +4554,18 @@
 
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">Você não está prevendo. Você está reconhecendo.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Alta ou baixa: os ciclos terminam da mesma forma. Quando TD aparece após venda prolongada, isso é exaustão. Quando CAP dispara após uma corrida estendida, isso é clímax. O mercado fala em ciclos.
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -5332,7 +5344,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Os Elite <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Detecção de ciclo de quatro camadas (Pentarch™) mais seis ferramentas especializadas de análise. Elite análise de estrutura de mercado.
+          Pentarch™ mapeia ciclos completos. Seis ferramentas elite fornecem contexto. Estrutura em vez de ruído.
         </p>
 
 
@@ -5595,10 +5607,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Por Que Traders Mudam (E Não Voltam Atrás)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Por Que Traders Mudam</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            O sistema completo vs comprar indicadores um de cada vez.
+            Duas abordagens. Uma te dá o controle.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5612,15 +5624,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = conflicting signals</span>
+                  <span>Indicadores conflitantes, você nunca sabe em qual confiar</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Repinta frequentemente, invalidando backtests</span>
+                  <span>Sinais repintam, a entrada "perfeita" de ontem desaparece hoje</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Precisa de 3-5 indicadores separados bagunçando seu gráfico</span>
+                  <span>Seguir outros, esperar o sinal deles antes de agir</span>
                 </li>
               </ul>
             </div>
@@ -5633,19 +5645,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Uma visão integrada</strong> — mapa de ciclo unificado</span>
+                  <span><strong>Veja a exaustão você mesmo</strong>, TD/IGN aparecem quando a venda seca</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% sem repintura</strong> (auditado, desafio de $100)</span>
+                  <span><strong>Veja o clímax você mesmo</strong>, CAP/WRN aparecem quando a compra atinge o pico</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 sistemas elite incluídos</strong> — kit completo</span>
+                  <span><strong>Confie no que você vê</strong>, 100% sem repintura, auditado, recompensa de $100</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> lições + docs de 50+ páginas</strong> — domine sua jornada</span>
+                  <span><strong>Domine a leitura</strong>, <span data-count="82">82</span> lições + 50+ páginas de docs para construir convicção</span>
                 </li>
               </ul>
             </div>
@@ -6207,7 +6219,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Plans & Preços</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Escolha Sua Vantagem</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Trusted por <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/ru/index.html
+++ b/ru/index.html
@@ -4102,7 +4102,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Пять сигналов отображают полный рыночный цикл — от ранней накопления до поздней стадии пробоя.</strong>
+                <strong>Пять сигналов отображают полный рыночный цикл.</strong> TD появляется, когда продажи истощаются. CAP появляется, когда покупки достигают кульминации. Вы не угадываете разворот, вы видите изменение структуры. Готовьтесь к переходам. Не гонитесь за ними.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4150,6 +4150,18 @@
 
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">Вы не предсказываете. Вы распознаёте.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Бычий или медвежий: циклы заканчиваются одинаково. Когда TD появляется после длительных продаж, это истощение. Когда CAP срабатывает после длительного роста, это кульминация. Рынок говорит циклами.
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -4928,7 +4940,7 @@
         <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Элитная <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Четырёхслойное определение циклов (Pentarch™) плюс шесть специализированных инструментов анализа. <span data-quality="elite">Элитный</span> анализ рыночной структуры.
+          Pentarch™ отображает полные циклы. Шесть элитных инструментов обеспечивают контекст. Структура вместо шума.
         </p>
 
 
@@ -5191,10 +5203,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Почему трейдеры переходят (и не оглядываются назад)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Почему трейдеры переходят</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            Полная система против покупки индикаторов по одному.
+            Два подхода. Один даёт вам контроль.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5208,15 +5220,15 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = конфликтующие сигналы</span>
+                  <span>Конфликтующие индикаторы, никогда не знаешь какому доверять</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Часто перерисовывается, делая бэктесты недействительными</span>
+                  <span>Сигналы перерисовываются, «идеальный вход» вчера исчезает сегодня</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Нужно 3-5 отдельных индикаторов, загромождающих график</span>
+                  <span>Следить за другими, ждать их сигнала перед действием</span>
                 </li>
               </ul>
             </div>
@@ -5229,19 +5241,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>Единый интегрированный вид</strong> — унифицированная карта циклов</span>
+                  <span><strong>Видите истощение сами</strong>, TD/IGN появляются, когда продажи иссякают</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% без перерисовки</strong> (проверено, вызов $100)</span>
+                  <span><strong>Видите кульминацию сами</strong>, CAP/WRN появляются, когда покупки достигают пика</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 элитных систем включены</strong> — полный инструментарий</span>
+                  <span><strong>Доверяйте тому, что видите</strong>, 100% без перерисовки, проверено, награда $100</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> урока + документация 50+ страниц</strong> — овладейте своим путём</span>
+                  <span><strong>Овладейте чтением</strong>, <span data-count="82">82</span> урока + 50+ страниц документации для уверенности</span>
                 </li>
               </ul>
             </div>
@@ -5886,7 +5898,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Планы и цены</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Выберите своё преимущество</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           Доверяют <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span>
         </p>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4178,7 +4178,7 @@
             <!-- Signal Legend - Improved Readability -->
             <div class="video-caption" style="padding:2rem 1rem;text-align:center;max-width:1000px;margin:0 auto">
               <p style="margin:0 0 1.5rem 0;font-size:1rem;line-height:1.7;color:rgba(255,255,255,0.9)">
-                <strong>Five signals map the complete market cycle—from early accumulation to late-stage breakdown.</strong>
+                <strong>Beş sinyal tam piyasa döngüsünü haritalıyor.</strong> TD satış tükendiğinde ortaya çıkar. CAP alım zirveye ulaştığında ortaya çıkar. Dönüşü tahmin etmiyorsunuz, yapının değişimini görüyorsunuz. Geçişlere hazırlanın. Peşlerinden koşmayın.
               </p>
               <div class="signal-legend" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;max-width:1200px;margin:0 auto">
                 <div class="signal-item" style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.2);border-radius:8px;min-width:0">
@@ -4226,6 +4226,18 @@
 
       </div>
 
+    </section>
+
+    <!-- CYCLE PHILOSOPHY SECTION -->
+    <section class="section" style="padding:3rem 0;">
+      <div class="container" style="max-width:800px;text-align:center">
+        <h2 class="headline lg" style="margin-bottom:1.5rem">
+          <span class="shimmer-text">Tahmin etmiyorsunuz. Tanıyorsunuz.</span>
+        </h2>
+        <p style="color:var(--muted);font-size:1.15rem;line-height:1.7;max-width:650px;margin:0 auto">
+          Boğa veya ayı: döngüler aynı şekilde sona erer. TD uzun süreli satıştan sonra ortaya çıktığında, bu tükenmedir. CAP uzun bir yükselişten sonra tetiklendiğinde, bu zirvedir. Piyasa döngülerle konuşur.
+        </p>
+      </div>
     </section>
 
     <!-- FREE TRIAL SECTION -->
@@ -5001,10 +5013,10 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">The Elite <span data-count="7" data-text-mode>7</span></span></h2>
+        <h2 class="headline lg" style="text-align:center;max-width:20ch;margin-left:auto;margin-right:auto;margin-top:3rem"><span class="shimmer-text">Elit <span data-count="7" data-text-mode>7</span></span></h2>
 
         <p class="note" style="text-align:center;max-width:68ch;margin:0 auto 1.5rem">
-          Four-layer cycle detection (Pentarch™) plus six specialized analysis tools. Elite market structure analysis.
+          Pentarch™ tam döngüleri haritalıyor. Altı elit araç bağlam sağlıyor. Gürültü yerine yapı.
         </p>
 
 
@@ -5267,10 +5279,10 @@
 
         <div style="max-width:900px;margin:0 auto">
 
-          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem">Yatırımcılar Neden Geçiş Yapıyor (Ve Geri Bakmıyorlar)</h2>
+          <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Yatırımcılar Neden Geçiş Yapıyor</span></h2>
 
           <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
-            Komple sistem vs göstergeleri birer birer satın almak.
+            İki yaklaşım. Biri size kontrolü verir.
           </p>
 
           <!-- Two-column bullet comparison format -->
@@ -5279,20 +5291,20 @@
             <!-- Left Column: Traditional -->
             <div class="comparison-column">
               <h3 class="comparison-heading comparison-heading-negative">
-                ❌ Traditional Approach
+                ❌ Geleneksel Yaklaşım
               </h3>
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>RSI + MACD + Stochastic = conflicting signals</span>
+                  <span>Çelişkili göstergeler, hangisine güveneceğinizi asla bilemezsiniz</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Repaints frequently, invalidating backtests</span>
+                  <span>Sinyaller yeniden çiziliyor, dünkü "mükemmel giriş" bugün kayboluyor</span>
                 </li>
                 <li class="comparison-item comparison-item-negative">
                   <span class="comparison-bullet comparison-bullet-negative">•</span>
-                  <span>Need 3-5 separate indicators cluttering your chart</span>
+                  <span>Başkalarını izlemek, harekete geçmeden önce onların sinyalini beklemek</span>
                 </li>
               </ul>
             </div>
@@ -5305,19 +5317,19 @@
               <ul class="comparison-list">
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>One integrated view</strong> — unified cycle map</span>
+                  <span><strong>Tükenmeyi kendiniz görün</strong>, satış kuruduğunda TD/IGN ortaya çıkar</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>100% non-repainting</strong> (audited, $100 challenge)</span>
+                  <span><strong>Zirveyi kendiniz görün</strong>, alım zirve yaptığında CAP/WRN ortaya çıkar</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong>7 elite systems included</strong> — complete toolkit</span>
+                  <span><strong>Gördüğünüze güvenin</strong>, 100% yeniden çizilmez, denetlenmiş, $100 ödül</span>
                 </li>
                 <li class="comparison-item comparison-item-positive">
                   <span class="comparison-bullet comparison-bullet-positive">•</span>
-                  <span><strong><span data-count="82">82</span> lessons + 50+ page docs</strong> — master your journey</span>
+                  <span><strong>Okumayı ustalaşın</strong>, <span data-count="82">82</span> ders + 50+ sayfa belge ile güven oluşturun</span>
                 </li>
               </ul>
             </div>
@@ -5962,7 +5974,7 @@
 
       <div class="container stack">
 
-        <h2 class="headline lg" style="text-align:center">Planlar ve Fiyatlandırma</h2>
+        <h2 class="headline lg" style="text-align:center"><span class="shimmer-text">Avantajınızı Seçin</span></h2>
         <p style="text-align:center;font-size:1.1rem;color:var(--muted);margin-top:1rem;margin-bottom:2rem">
           <span class="typewriter-pricing" style="color:var(--brand);font-weight:600"></span> tarafından güveniliyor
         </p>


### PR DESCRIPTION
Updates to all 11 language versions (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr):
- Video caption: Added TD/CAP exhaustion/climax messaging
- Philosophy section: Added "You're not predicting. You're recognizing."
- Comparison headline: Updated to "Why Traders Switch" (shimmer)
- Comparison subtitle: "Two approaches. One puts you in control."
- Comparison bullets: New outcome-focused messaging
- Elite Seven intro: "Pentarch™ maps complete cycles. Structure over noise."
- Pricing headline: "Choose Your Edge" (shimmer)