### PR TITLE
Remove obsolete hero description paragraphs from 8 language files

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4296,21 +4296,6 @@ html[lang="ar"] [style*="text-align:center"] {
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> ترسم دورات السوق الكاملة بخمس إشارات أحداث.
-
-            كل مرحلة من الدورة المبكرة إلى الدورة المتأخرة مرئية—بدون إعادة رسم، مؤكدة عند الإغلاق.
-
-            ستة مؤشرات مصاحبة نخبوية توفر السياق والمرشحات وبيانات التوقيت.
-
-          </p>
-
-        </div>
-
       </div>
 
     </section>

--- a/hu/index.html
+++ b/hu/index.html
@@ -4223,21 +4223,6 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> teljes piaci ciklusokat térképez fel öt eseményjelzéssel.
-
-            Minden fázis a korai ciklustól a késői ciklusig látható—nem átfestő, záróár-megerősített.
-
-            Hat elit kiegészítő indikátor biztosít kontextust, szűrőket és időzítési adatokat.
-
-          </p>
-
-        </div>
-
       </div>
 
     </section>

--- a/it/index.html
+++ b/it/index.html
@@ -4160,21 +4160,6 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> mappa cicli di mercato completi con cinque segnali.
-
-            Ogni fase dall'inizio alla fine del ciclo è visibile—senza ridipintura, confermato alla chiusura.
-
-            Sei indicatori complementari d'élite forniscono contesto, filtri e dati di timing.
-
-          </p>
-
-        </div>
-
       </div>
 
     </section>

--- a/ja/index.html
+++ b/ja/index.html
@@ -4512,21 +4512,6 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> が5つのイベントシグナルで完全なマーケットサイクルをマッピングします。
-
-            初期サイクルから後期サイクルまでのすべてのフェーズが可視化—ノンリペイント、クローズ時に確定。
-
-            6つの補完的なエリート・インジケーターがコンテキスト、フィルター、タイミングデータを提供。
-
-          </p>
-
-        </div>
-
       </div>
 
     </section>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4199,21 +4199,6 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> brengt complete marktcycli in kaart met vijf gebeurtenis signalen.
-
-            Elke fase van vroege cyclus tot late cyclus is zichtbaar—niet-herschilderend, close-bevestigd.
-
-            Zes elite begeleidende indicatoren bieden context, filters en timing data.
-
-          </p>
-
-        </div>
-
       </div>
 
     </section>

--- a/pt/index.html
+++ b/pt/index.html
@@ -4537,21 +4537,6 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> mapeia ciclos completos de mercado com cinco sinais de evento.
-
-            Todas as fases do início ao final do ciclo são visíveis—sem repintura, confirmado no fechamento.
-
-            Seis indicadores elite complementares fornecem contexto, filtros e dados de temporização.
-
-          </p>
-
-        </div>
-
       </div>
 
     </section>

--- a/ru/index.html
+++ b/ru/index.html
@@ -4133,21 +4133,6 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> отображает полные рыночные циклы с помощью пяти сигналов событий.
-
-            Каждая фаза от начала до конца цикла видна—без перерисовки, подтверждение на закрытии.
-
-            Шесть элитных дополнительных индикаторов обеспечивают контекст, фильтры и данные о времени.
-
-          </p>
-
-        </div>
-
       </div>
 
     </section>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4209,21 +4209,6 @@
               </div>
             </div>
 
-        <!-- HERO DESCRIPTION & CTA - Centered Below Video -->
-        <div style="text-align:center;max-width:800px;margin:0 auto">
-
-          <p style="color:var(--muted);font-size:1.15rem;line-height:1.65;margin-bottom:2rem">
-
-            <strong>Pentarch™</strong> maps complete market cycles with five event signals.
-
-            Every phase from early cycle to late cycle is visible—non-repainting, close-confirmed.
-
-            Six elite companion indicators provide context, filters and timing data.
-
-          </p>
-
-        </div>
-
       </div>
 
     </section>


### PR DESCRIPTION
These old paragraphs with em-dashes were redundant with the new CYCLE PHILOSOPHY section and Elite Seven intro.