### PR TITLE
Improve video performance + mobile visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -3410,18 +3410,22 @@
         muted
         playsinline
         disablepictureinpicture
+        preload="auto"
         style="
           position: absolute;
           top: -70px;
           left: 0;
           height: calc(100% + 70px);
-          width: auto;
+          width: 50vw;
+          min-width: 400px;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
           object-position: 50% 30%;
-          opacity: 0.9;
-          mix-blend-mode: screen;
+          opacity: 0.85;
+          will-change: transform;
+          transform: translateZ(0);
+          backface-visibility: hidden;
         "
       >
         <source src="assets/videos/signal-conduit-4k.mp4" type="video/mp4">


### PR DESCRIPTION
Performance:
- Remove mix-blend-mode (expensive)
- Add will-change: transform for GPU optimization
- Add translateZ(0) for hardware acceleration
- Add backface-visibility: hidden
- Add preload="auto"

Mobile:
- Set width: 50vw with min-width: 400px
- Ensures beam visible on all screen sizes