### PR TITLE
Add dynamic blog carousel and action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4640,9 +4640,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Like a traffic light for the market</strong> — shows you exactly where you are in the cycle with 5 key signals:</p>
@@ -4674,9 +4675,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> powerful tools in one clean overlay.</strong> Instead of cluttering your chart, get everything you need in a single indicator:</p>
@@ -4709,9 +4711,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Follow the smart money.</strong> Tracks institutional accumulation/distribution patterns with confidence levels:</p>
@@ -4744,9 +4747,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>The tug-of-war meter.</strong> Tracks cumulative demand vs supply pressure over time:</p>
@@ -4779,9 +4783,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Auto-plots key levels.</strong> Stops you from drawing hundreds of lines manually:</p>
@@ -4814,9 +4819,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Mission control dashboard.</strong> Track 8+ markets simultaneously and see the cleanest setups first:</p>
@@ -4848,9 +4854,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillators vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
@@ -5891,7 +5898,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">Do the signals repaint?</strong>
-        <p id="faq-answer-1" class="note"><strong>Zero repainting. Guaranteed.</strong><br>All signals finalize on candle close.<br>We audit every indicator for lookahead bias.<br>If you can prove any repaint, we pay you <strong>$100 USD</strong>.<br>What you see in history is exactly what you would have seen live.</p>
+        <p id="faq-answer-1" class="note"><strong>Zero repainting. Guaranteed.</strong><br>All signals finalize on candle close.<br>We audit every indicator for lookahead bias.<br>If you can prove any repaint, we pay you <strong>$100 USD</strong>.<br>What you see in history is exactly what you would have seen live.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -5930,12 +5937,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">What timeframes work best?</strong>
-        <p id="faq-answer-8" class="note">All timeframes supported—1-minute to yearly charts.<br><strong>Most popular:</strong> 15m-1H for day trading, 4H-Daily for swing trading.<br>Pentarch's 5-phase cycle adapts to your timeframe automatically.<br>Education Hub covers timeframe optimization strategies.</p>
+        <p id="faq-answer-8" class="note">All timeframes supported—1-minute to yearly charts.<br><strong>Most popular:</strong> 15m-1H for day trading, 4H-Daily for swing trading.<br>Pentarch's 5-phase cycle adapts to your timeframe automatically.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Can I use multiple indicators together?</strong>
-        <p id="faq-answer-9" class="note"><strong>Absolutely!</strong><br>The Elite Seven are designed to work together.<br>Popular combos: <strong>Pentarch + Volume Oracle</strong> for cycle timing with smart money confirmation, or <strong>OmniDeck + Janus Atlas</strong> for complete market structure analysis with key levels.</p>
+        <p id="faq-answer-9" class="note"><strong>Absolutely!</strong><br>The Elite Seven are designed to work together.<br>Popular combos: <strong>Pentarch + Volume Oracle</strong> for cycle timing with smart money confirmation, or <strong>OmniDeck + Janus Atlas</strong> for complete market structure analysis with key levels.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See how indicators work together →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -5996,44 +6003,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Trading insights, strategies, and market analysis</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6188,6 +6174,69 @@
       fetch(SP_WEBHOOK,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain;charset=UTF-8'},body:JSON.stringify(p)}).catch(()=>{}); }
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
+
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const categoryColors = {
+        'INDICATORS': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'PSYCHOLOGY': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'MARKET CYCLES': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'PRACTICAL': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'STRATEGY': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'EDUCATION': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' }
+      };
+
+      function createArticleCard(article) {
+        const cat = (article.category || 'INDICATORS').toUpperCase();
+        const colors = categoryColors[cat] || categoryColors['INDICATORS'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${cat}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
 
 


### PR DESCRIPTION
- Blog carousel now fetches from /api/articles.json with loading skeleton
- Add fallback to static content on API error
- Link repainting FAQ to the-repainting-problem article
- Link timeframes FAQ to multi-timeframe-confirmation article
- Link indicators FAQ to inside-signal-pilot article
- Add "See It In Action" buttons to all 7 indicator cards with relevant blog articles