### PR TITLE
Add dynamic blog carousel and indicator links to all language versions

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5159,9 +5159,10 @@ html[lang="ar"] [style*="text-align:center"] {
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">تفاصيل ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">الوثائق</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>مثل إشارة المرور للسوق</strong> — يُظهر لك بالضبط أين أنت في الدورة مع 5 إشارات رئيسية:</p>
@@ -5193,9 +5194,10 @@ html[lang="ar"] [style*="text-align:center"] {
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">تفاصيل ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">الوثائق</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> أدوات قوية في طبقة واحدة نظيفة.</strong> بدلاً من ازدحام الرسم البياني، احصل على كل ما تحتاجه في مؤشر واحد:</p>
@@ -5228,9 +5230,10 @@ html[lang="ar"] [style*="text-align:center"] {
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">تفاصيل ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">الوثائق</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>اتبع الأموال الذكية.</strong> يتتبع أنماط التراكم/التوزيع المؤسسي مع مستويات الثقة:</p>
@@ -5263,9 +5266,10 @@ html[lang="ar"] [style*="text-align:center"] {
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">تفاصيل ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">الوثائق</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>مقياس شد الحبل.</strong> يتتبع الطلب التراكمي مقابل ضغط العرض مع مرور الوقت:</p>
@@ -5298,9 +5302,10 @@ html[lang="ar"] [style*="text-align:center"] {
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">تفاصيل ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">الوثائق</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>رسم تلقائي للمستويات الرئيسية.</strong> يوقفك عن رسم مئات الخطوط يدوياً:</p>
@@ -5333,9 +5338,10 @@ html[lang="ar"] [style*="text-align:center"] {
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">تفاصيل ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">الوثائق</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>لوحة التحكم.</strong> تتبع 8+ أسواق في وقت واحد وشاهد أنظف الإعدادات أولاً:</p>
@@ -5367,9 +5373,10 @@ html[lang="ar"] [style*="text-align:center"] {
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">تفاصيل ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">الوثائق</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> مذبذبات تصوت.</strong> تظهر الإشارات فقط عندما تتفق مؤشرات الزخم المتعددة:</p>
@@ -6407,7 +6414,7 @@ html[lang="ar"] [style*="text-align:center"] {
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">هل تُعيد الإشارات الرسم؟</strong>
-        <p id="faq-answer-1" class="note"><strong>بدون إعادة رسم. مضمون.</strong><br>جميع الإشارات تتأكد عند إغلاق الشمعة.<br>نراجع كل مؤشر بحثاً عن تحيز استباقي.<br>إذا أثبتّ أي إعادة رسم، ندفع لك <strong>$100 دولار أمريكي</strong>.<br>ما تراه في التاريخ هو بالضبط ما كنت ستراه مباشرة.</p>
+        <p id="faq-answer-1" class="note"><strong>بدون إعادة رسم. مضمون.</strong><br>جميع الإشارات تتأكد عند إغلاق الشمعة.<br>نراجع كل مؤشر بحثاً عن تحيز استباقي.<br>إذا أثبتّ أي إعادة رسم، ندفع لك <strong>$100 دولار أمريكي</strong>.<br>ما تراه في التاريخ هو بالضبط ما كنت ستراه مباشرة.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6446,12 +6453,12 @@ html[lang="ar"] [style*="text-align:center"] {
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">ما هي الأطر الزمنية الأفضل؟</strong>
-        <p id="faq-answer-8" class="note">جميع الأطر الزمنية مدعومة—من رسوم دقيقة واحدة إلى رسوم سنوية.<br><strong>الأكثر شعبية:</strong> 15 دقيقة-1 ساعة للتداول اليومي، 4 ساعات-يومي للتداول المتأرجح.<br>دورة Pentarch الخماسية المراحل تتكيف مع الإطار الزمني تلقائياً.<br>يغطي المركز التعليمي استراتيجيات تحسين الإطار الزمني.</p>
+        <p id="faq-answer-8" class="note">جميع الأطر الزمنية مدعومة—من رسوم دقيقة واحدة إلى رسوم سنوية.<br><strong>الأكثر شعبية:</strong> 15 دقيقة-1 ساعة للتداول اليومي، 4 ساعات-يومي للتداول المتأرجح.<br>دورة Pentarch الخماسية المراحل تتكيف مع الإطار الزمني تلقائياً.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">هل يمكنني استخدام عدة مؤشرات معاً؟</strong>
-        <p id="faq-answer-9" class="note"><strong>بالتأكيد!</strong><br>السبعة المميزة مصممة للعمل معاً.<br>المجموعات الشائعة: <strong>Pentarch + Volume Oracle</strong> لتوقيت الدورة مع تأكيد المال الذكي، أو <strong>OmniDeck + Janus Atlas</strong> لتحليل كامل لهيكل السوق مع المستويات الرئيسية.</p>
+        <p id="faq-answer-9" class="note"><strong>بالتأكيد!</strong><br>السبعة المميزة مصممة للعمل معاً.<br>المجموعات الشائعة: <strong>Pentarch + Volume Oracle</strong> لتوقيت الدورة مع تأكيد المال الذكي، أو <strong>OmniDeck + Janus Atlas</strong> لتحليل كامل لهيكل السوق مع المستويات الرئيسية.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See complete system breakdown →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6512,44 +6519,23 @@ html[lang="ar"] [style*="text-align:center"] {
         <p style="color:var(--muted);font-size:1rem;margin:0">رؤى التداول والاستراتيجيات وتحليل السوق</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6708,7 +6694,68 @@ html[lang="ar"] [style*="text-align:center"] {
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
 
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with backtesting.</p>
+            </a>
+          `;
+        });
+    })();
 
     // Capture ref/UTM
 

--- a/de/index.html
+++ b/de/index.html
@@ -5046,9 +5046,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Dokumentation</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener">See It In Action</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Like a traffic light for the market</strong> — shows you exactly where you are in the cycle with 5 key signals:</p>
@@ -5080,9 +5081,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Dokumentation</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener">See It In Action</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> powerful tools in one clean overlay.</strong> Instead of cluttering your chart, get everything you need in a single indicator:</p>
@@ -5115,9 +5117,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Dokumentation</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener">See It In Action</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Follow the smart money.</strong> Tracks institutional accumulation/distribution patterns with confidence levels:</p>
@@ -5150,9 +5153,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Dokumentation</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener">See It In Action</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>The tug-of-war meter.</strong> Tracks cumulative demand vs supply pressure over time:</p>
@@ -5185,9 +5189,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Dokumentation</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener">See It In Action</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Auto-plots key levels.</strong> Stops you from drawing hundreds of lines manually:</p>
@@ -5220,9 +5225,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Dokumentation</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener">See It In Action</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Mission control dashboard.</strong> Track 8+ markets simultaneously and see the cleanest setups first:</p>
@@ -5254,9 +5260,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Dokumentation</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener">See It In Action</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillators vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
@@ -6294,7 +6301,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">Werden die Signale neu gezeichnet?</strong>
-        <p id="faq-answer-1" class="note"><strong>Kein Repaint. Garantiert.</strong><br>Alle Signale werden beim Kerzenschluss finalisiert.<br>Wir prüfen jeden Indikator auf Lookahead-Bias.<br>Wenn Sie ein Repaint nachweisen können, zahlen wir Ihnen <strong>100 USD</strong>.<br>Was Sie im Verlauf sehen, hätten Sie live genauso gesehen.</p>
+        <p id="faq-answer-1" class="note"><strong>Kein Repaint. Garantiert.</strong><br>Alle Signale werden beim Kerzenschluss finalisiert.<br>Wir prüfen jeden Indikator auf Lookahead-Bias.<br>Wenn Sie ein Repaint nachweisen können, zahlen wir Ihnen <strong>100 USD</strong>.<br>Was Sie im Verlauf sehen, hätten Sie live genauso gesehen.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6333,12 +6340,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">Welche Zeitrahmen funktionieren am besten?</strong>
-        <p id="faq-answer-8" class="note">Alle Zeitrahmen werden unterstützt – von 1-Minuten- bis Jahres-Charts.<br><strong>Am beliebtesten:</strong> 15m-1H für Day Trading, 4H-Daily für Swing Trading.<br>Pentarchs 5-Phasen-Zyklus passt sich automatisch an Ihren Zeitrahmen an.<br>Das Bildungszentrum behandelt Strategien zur Zeitrahmen-Optimierung.</p>
+        <p id="faq-answer-8" class="note">Alle Zeitrahmen werden unterstützt – von 1-Minuten- bis Jahres-Charts.<br><strong>Am beliebtesten:</strong> 15m-1H für Day Trading, 4H-Daily für Swing Trading.<br>Pentarchs 5-Phasen-Zyklus passt sich automatisch an Ihren Zeitrahmen an.<br>Das Bildungszentrum behandelt Strategien zur Zeitrahmen-Optimierung.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Kann ich mehrere Indikatoren zusammen verwenden?</strong>
-        <p id="faq-answer-9" class="note"><strong>Absolut!</strong><br>Die Elite Sieben sind darauf ausgelegt, zusammenzuarbeiten.<br>Beliebte Kombinationen: <strong>Pentarch + Volume Oracle</strong> für Zyklus-Timing mit Smart-Money-Bestätigung, oder <strong>OmniDeck + Janus Atlas</strong> für vollständige Marktstrukturanalyse mit Schlüsselniveaus.</p>
+        <p id="faq-answer-9" class="note"><strong>Absolut!</strong><br>Die Elite Sieben sind darauf ausgelegt, zusammenzuarbeiten.<br>Beliebte Kombinationen: <strong>Pentarch + Volume Oracle</strong> für Zyklus-Timing mit Smart-Money-Bestätigung, oder <strong>OmniDeck + Janus Atlas</strong> für vollständige Marktstrukturanalyse mit Schlüsselniveaus.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See how indicators work together →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6399,43 +6406,24 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Trading-Einblicke, Strategien und Marktanalysen</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
 
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
 
       </div>
 
@@ -6594,7 +6582,62 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
 
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+          `;
+        });
+    })();
 
     // Capture ref/UTM
 

--- a/es/index.html
+++ b/es/index.html
@@ -5321,9 +5321,10 @@
             <div class="title mod" style="justify-content:center">
               <h3>SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Detalles ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Documentación</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Como un semáforo para el mercado</strong> — te muestra exactamente dónde estás en el ciclo con 5 señales clave:</p>
@@ -5366,9 +5367,10 @@
             <div class="title mod" style="justify-content:center">
               <h3>SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Detalles ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Documentación</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> herramientas poderosas en una sola capa limpia.</strong> En lugar de saturar tu gráfico, obtén todo lo que necesitas en un solo indicador:</p>
@@ -5401,9 +5403,10 @@
             <div class="title mod" style="justify-content:center">
               <h3>SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Detalles ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Documentación</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Sigue al dinero inteligente.</strong> Rastrea patrones institucionales de acumulación/distribución con niveles de confianza:</p>
@@ -5436,9 +5439,10 @@
             <div class="title mod" style="justify-content:center">
               <h3>SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Detalles ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Documentación</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>El medidor de tira y afloja.</strong> Rastrea la demanda acumulativa vs presión de oferta a lo largo del tiempo:</p>
@@ -5471,9 +5475,10 @@
             <div class="title mod" style="justify-content:center">
               <h3>SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Detalles ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Documentación</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Dibuja niveles clave automáticamente.</strong> Te evita dibujar cientos de líneas manualmente:</p>
@@ -5506,9 +5511,10 @@
             <div class="title mod" style="justify-content:center">
               <h3>SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Detalles ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Documentación</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Panel de control de misión.</strong> Rastrea 8+ mercados simultáneamente y ve las configuraciones más limpias primero:</p>
@@ -5540,9 +5546,10 @@
             <div class="title mod" style="justify-content:center">
               <h3>SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Detalles ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Documentación</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> osciladores votan.</strong> Las señales solo aparecen cuando múltiples indicadores de impulso están de acuerdo:</p>
@@ -6592,7 +6599,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">¿Las señales se repintan?</strong>
-        <p id="faq-answer-1" class="note"><strong>Cero repintado. Garantizado.</strong><br>Todas las señales se finalizan al cierre de la vela.<br>Auditamos cada indicador en busca de sesgo de anticipación.<br>Si puedes probar cualquier repintado, te pagamos <strong>$100 USD</strong>.<br>Lo que ves en el historial es exactamente lo que habrías visto en vivo.</p>
+        <p id="faq-answer-1" class="note"><strong>Cero repintado. Garantizado.</strong><br>Todas las señales se finalizan al cierre de la vela.<br>Auditamos cada indicador en busca de sesgo de anticipación.<br>Si puedes probar cualquier repintado, te pagamos <strong>$100 USD</strong>.<br>Lo que ves en el historial es exactamente lo que habrías visto en vivo.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6631,12 +6638,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">¿Qué marcos temporales funcionan mejor?</strong>
-        <p id="faq-answer-8" class="note">Todos los marcos temporales soportados—gráficos de 1 minuto a anuales.<br><strong>Más populares:</strong> 15m-1H para day trading, 4H-Diario para swing trading.<br>El ciclo de 5 fases de Pentarch se adapta a tu marco temporal automáticamente.<br>El Centro Educativo cubre estrategias de optimización de marcos temporales.</p>
+        <p id="faq-answer-8" class="note">Todos los marcos temporales soportados—gráficos de 1 minuto a anuales.<br><strong>Más populares:</strong> 15m-1H para day trading, 4H-Diario para swing trading.<br>El ciclo de 5 fases de Pentarch se adapta a tu marco temporal automáticamente.<br>El Centro Educativo cubre estrategias de optimización de marcos temporales.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">¿Puedo usar múltiples indicadores juntos?</strong>
-        <p id="faq-answer-9" class="note"><strong>¡Absolutamente!</strong><br>Los Seven Élite están diseñados para funcionar juntos.<br>Combos populares: <strong>Pentarch + Volume Oracle</strong> para sincronización de ciclos con confirmación de dinero inteligente, o <strong>OmniDeck + Janus Atlas</strong> para análisis completo de estructura de mercado con niveles clave.</p>
+        <p id="faq-answer-9" class="note"><strong>¡Absolutamente!</strong><br>Los Seven Élite están diseñados para funcionar juntos.<br>Combos populares: <strong>Pentarch + Volume Oracle</strong> para sincronización de ciclos con confirmación de dinero inteligente, o <strong>OmniDeck + Janus Atlas</strong> para análisis completo de estructura de mercado con niveles clave.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See how indicators work together →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6697,44 +6704,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Perspectivas de trading, estrategias y análisis de mercado</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6890,6 +6876,74 @@
       fetch(SP_WEBHOOK,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain;charset=UTF-8'},body:JSON.stringify(p)}).catch(()=>{}); }
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
+
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
 
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -5249,9 +5249,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Détails ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Like a traffic light for the market</strong> — shows you exactly where you are in the cycle with 5 key signals:</p>
@@ -5283,9 +5284,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Détails ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> powerful tools in one clean overlay.</strong> Instead of cluttering your chart, get everything you need in a single indicator:</p>
@@ -5318,9 +5320,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Détails ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Suivez l'argent intelligent.</strong> Suit les modèles d'accumulation/distribution institutionnels avec niveaux de confiance :</p>
@@ -5353,9 +5356,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Détails ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>The tug-of-war meter.</strong> Tracks cumulative demand vs supply pressure over time:</p>
@@ -5388,9 +5392,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Détails ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Auto-plots key levels.</strong> Stops you from drawing hundreds of lines manually:</p>
@@ -5423,9 +5428,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Détails ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Mission control dashboard.</strong> Track 8+ markets simultaneously and see the cleanest setups first:</p>
@@ -5457,9 +5463,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Détails ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillators vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
@@ -6498,7 +6505,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">Les signaux se repeignent-ils ?</strong>
-        <p id="faq-answer-1" class="note"><strong>Zéro repeinture. Garanti.</strong><br>Tous les signaux se finalisent à la clôture de la bougie.<br>Nous auditons chaque indicateur pour les biais de lookahead.<br>Si vous pouvez prouver une repeinture, nous vous payons <strong>$100 USD</strong>.<br>Ce que vous voyez dans l'historique est exactement ce que vous auriez vu en direct.</p>
+        <p id="faq-answer-1" class="note"><strong>Zéro repeinture. Garanti.</strong><br>Tous les signaux se finalisent à la clôture de la bougie.<br>Nous auditons chaque indicateur pour les biais de lookahead.<br>Si vous pouvez prouver une repeinture, nous vous payons <strong>$100 USD</strong>.<br>Ce que vous voyez dans l'historique est exactement ce que vous auriez vu en direct.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6537,12 +6544,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">Quels timeframes fonctionnent le mieux ?</strong>
-        <p id="faq-answer-8" class="note">Tous les timeframes sont pris en charge—graphiques de 1 minute à annuels.<br><strong>Les plus populaires :</strong> 15m-1H pour le day trading, 4H-Journalier pour le swing trading.<br>Le cycle à 5 phases de Pentarch s'adapte automatiquement à votre timeframe.<br>Le Centre de Formation couvre les stratégies d'optimisation des timeframes.</p>
+        <p id="faq-answer-8" class="note">Tous les timeframes sont pris en charge—graphiques de 1 minute à annuels.<br><strong>Les plus populaires :</strong> 15m-1H pour le day trading, 4H-Journalier pour le swing trading.<br>Le cycle à 5 phases de Pentarch s'adapte automatiquement à votre timeframe.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Puis-je utiliser plusieurs indicateurs ensemble ?</strong>
-        <p id="faq-answer-9" class="note"><strong>Absolument !</strong><br>Les Sept Élite sont conçus pour fonctionner ensemble.<br>Combos populaires : <strong>Pentarch + Volume Oracle</strong> pour le timing de cycle avec confirmation du smart money, ou <strong>OmniDeck + Janus Atlas</strong> pour une analyse complète de la structure du marché avec niveaux clés.</p>
+        <p id="faq-answer-9" class="note"><strong>Absolument !</strong><br>Les Sept Élite sont conçus pour fonctionner ensemble.<br>Combos populaires : <strong>Pentarch + Volume Oracle</strong> pour le timing de cycle avec confirmation du smart money, ou <strong>OmniDeck + Janus Atlas</strong> pour une analyse complète de la structure du marché avec niveaux clés.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See how indicators work together →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6603,44 +6610,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Analyses de trading, stratégies et études de marché</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6800,6 +6786,74 @@
       fetch(SP_WEBHOOK,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain;charset=UTF-8'},body:JSON.stringify(p)}).catch(()=>{}); }
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
+
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
 
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -5081,9 +5081,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Részletek ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Dokumentáció</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Like a traffic light for the market</strong> — shows you exactly where you are in the cycle with 5 key signals:</p>
@@ -5115,9 +5116,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Részletek ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Dokumentáció</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> powerful tools in one clean overlay.</strong> Instead of cluttering your chart, get everything you need in a single indicator:</p>
@@ -5150,9 +5152,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Részletek ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Dokumentáció</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Follow the smart money.</strong> Tracks institutional accumulation/distribution patterns with confidence levels:</p>
@@ -5185,9 +5188,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Részletek ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Dokumentáció</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>The tug-of-war meter.</strong> Tracks cumulative demand vs supply pressure over time:</p>
@@ -5220,9 +5224,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Részletek ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Dokumentáció</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Automatikusan rajzolja a kulcsszinteket.</strong> Megállítja, hogy több száz vonalat rajzolj manuálisan:</p>
@@ -5255,9 +5260,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Részletek ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Dokumentáció</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Irányítóközpont vezérlőpult.</strong> Kövess 8+ piacot egyidejűleg és láthatod először a legtisztább beállításokat:</p>
@@ -5289,9 +5295,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Részletek ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Dokumentáció</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillators vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
@@ -6329,7 +6336,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">Átrajzolódnak a jelek?</strong>
-        <p id="faq-answer-1" class="note"><strong>Nulla átrajzolás. Garantált.</strong><br>Minden jel a gyertya zárásakor véglegesül.<br>Minden indikátort ellenőrzünk az előretekintési torzítás ellen.<br>Ha bármilyen átrajzolást tudsz bizonyítani, fizetünk <strong>$100 USD</strong>-t.<br>Amit a történelemben látsz, az pontosan az, amit élőben láttál volna.</p>
+        <p id="faq-answer-1" class="note"><strong>Nulla átrajzolás. Garantált.</strong><br>Minden jel a gyertya zárásakor véglegesül.<br>Minden indikátort ellenőrzünk az előretekintési torzítás ellen.<br>Ha bármilyen átrajzolást tudsz bizonyítani, fizetünk <strong>$100 USD</strong>-t.<br>Amit a történelemben látsz, az pontosan az, amit élőben láttál volna.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6368,12 +6375,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">Mely időkeretek működnek a legjobban?</strong>
-        <p id="faq-answer-8" class="note">Minden időkeret támogatott—1 perces grafikonoktól éves grafikonokig.<br><strong>Legnépszerűbb:</strong> 15p-1Ó napközbeni kereskedéshez, 4Ó-Napi swing kereskedéshez.<br>A Pentarch 5 fázisú ciklusa automatikusan alkalmazkodik az időkeretedhez.<br>Az Oktatási Központ lefedi az időkeret optimalizálási stratégiákat.</p>
+        <p id="faq-answer-8" class="note">Minden időkeret támogatott—1 perces grafikonoktól éves grafikonokig.<br><strong>Legnépszerűbb:</strong> 15p-1Ó napközbeni kereskedéshez, 4Ó-Napi swing kereskedéshez.<br>A Pentarch 5 fázisú ciklusa automatikusan alkalmazkodik az időkeretedhez.<br>Az Oktatási Központ lefedi az időkeret optimalizálási stratégiákat.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Használhatok több indikátort együtt?</strong>
-        <p id="faq-answer-9" class="note"><strong>Természetesen!</strong><br>Az Elite Seven indikátorok együtt használatra tervezték.<br>Népszerű kombók: <strong>Pentarch + Volume Oracle</strong> ciklus időzítéshez okos pénz megerősítéssel, vagy <strong>OmniDeck + Janus Atlas</strong> teljes piaci szerkezet elemzéshez kulcs szintekkel.</p>
+        <p id="faq-answer-9" class="note"><strong>Természetesen!</strong><br>Az Elite Seven indikátorok együtt használatra tervezték.<br>Népszerű kombók: <strong>Pentarch + Volume Oracle</strong> ciklus időzítéshez okos pénz megerősítéssel, vagy <strong>OmniDeck + Janus Atlas</strong> teljes piaci szerkezet elemzéshez kulcs szintekkel.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See indicator combinations in action →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6434,44 +6441,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Kereskedési betekintések, stratégiák és piacelemzés</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6625,6 +6611,74 @@
       fetch(SP_WEBHOOK,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain;charset=UTF-8'},body:JSON.stringify(p)}).catch(()=>{}); }
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
+
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
 
 

--- a/it/index.html
+++ b/it/index.html
@@ -5018,9 +5018,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Dettagli ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Documentazione</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Come un semaforo per il mercato</strong> — ti mostra esattamente dove ti trovi nel ciclo con 5 segnali chiave:</p>
@@ -5052,9 +5053,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Dettagli ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Documentazione</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> potenti strumenti in un'unica overlay pulita.</strong> Invece di ingombrare il tuo grafico, ottieni tutto ciò di cui hai bisogno in un singolo indicatore:</p>
@@ -5087,9 +5089,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Dettagli ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Documentazione</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Segui lo smart money.</strong> Traccia i pattern di accumulazione/distribuzione istituzionale con livelli di confidenza:</p>
@@ -5122,9 +5125,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Dettagli ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Documentazione</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Il misuratore del braccio di ferro.</strong> Traccia la pressione cumulativa di domanda vs offerta nel tempo:</p>
@@ -5157,9 +5161,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Dettagli ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Documentazione</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Traccia automaticamente livelli chiave.</strong> Ti evita di disegnare centinaia di linee manualmente:</p>
@@ -5192,9 +5197,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Dettagli ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Documentazione</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Dashboard di controllo missione.</strong> Traccia 8+ mercati simultaneamente e vedi i setup più puliti per primi:</p>
@@ -5226,9 +5232,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Dettagli ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Documentazione</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillatori votano.</strong> I segnali appaiono solo quando più indicatori di momentum concordano:</p>
@@ -6266,7 +6273,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">I segnali si ridisegnano?</strong>
-        <p id="faq-answer-1" class="note"><strong>Zero ridisegno. Garantito.</strong><br>Tutti i segnali si finalizzano alla chiusura della candela.<br>Verifichiamo ogni indicatore per bias di lookahead.<br>Se puoi dimostrare qualsiasi ridisegno, ti paghiamo <strong>$100 USD</strong>.<br>Ciò che vedi nella cronologia è esattamente ciò che avresti visto in tempo reale.</p>
+        <p id="faq-answer-1" class="note"><strong>Zero ridisegno. Garantito.</strong><br>Tutti i segnali si finalizzano alla chiusura della candela.<br>Verifichiamo ogni indicatore per bias di lookahead.<br>Se puoi dimostrare qualsiasi ridisegno, ti paghiamo <strong>$100 USD</strong>.<br>Ciò che vedi nella cronologia è esattamente ciò che avresti visto in tempo reale.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Scopri come funziona il ridisegno →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6305,12 +6312,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">Quali timeframe funzionano meglio?</strong>
-        <p id="faq-answer-8" class="note">Tutti i timeframe supportati—grafici da 1 minuto ad annuali.<br><strong>Più popolari:</strong> 15m-1H per day trading, 4H-Giornaliero per swing trading.<br>Il ciclo a 5 fasi di Pentarch si adatta automaticamente al tuo timeframe.<br>L'Hub Educativo copre le strategie di ottimizzazione del timeframe.</p>
+        <p id="faq-answer-8" class="note">Tutti i timeframe supportati—grafici da 1 minuto ad annuali.<br><strong>Più popolari:</strong> 15m-1H per day trading, 4H-Giornaliero per swing trading.<br>Il ciclo a 5 fasi di Pentarch si adatta automaticamente al tuo timeframe.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Padroneggia l'analisi multi-timeframe →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Posso usare più indicatori insieme?</strong>
-        <p id="faq-answer-9" class="note"><strong>Assolutamente!</strong><br>I Sette Elite sono progettati per funzionare insieme.<br>Combo popolari: <strong>Pentarch + Volume Oracle</strong> per timing del ciclo con conferma dello smart money, o <strong>OmniDeck + Janus Atlas</strong> per analisi completa della struttura di mercato con livelli chiave.</p>
+        <p id="faq-answer-9" class="note"><strong>Assolutamente!</strong><br>I Sette Elite sono progettati per funzionare insieme.<br>Combo popolari: <strong>Pentarch + Volume Oracle</strong> per timing del ciclo con conferma dello smart money, o <strong>OmniDeck + Janus Atlas</strong> per analisi completa della struttura di mercato con livelli chiave.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">Vedi come funzionano insieme →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6371,20 +6378,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Approfondimenti sul trading, strategie e analisi di mercato</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
         <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
           <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
           <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
@@ -6562,6 +6572,75 @@
       fetch(SP_WEBHOOK,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain;charset=UTF-8'},body:JSON.stringify(p)}).catch(()=>{}); }
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
+
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
+
 
 
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -5371,9 +5371,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">詳細 ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">ドキュメント</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">実際の動作を見る →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>市場の信号機のように</strong> — 5つの主要シグナルでサイクル内の正確な位置を表示：</p>
@@ -5405,9 +5406,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">詳細 ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">ドキュメント</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">実際の動作を見る →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span>の強力なツールを1つのクリーンなオーバーレイに集約。</strong> チャートを散らかす代わりに、必要なすべてを1つのインジケーターで：</p>
@@ -5440,9 +5442,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">詳細 ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">ドキュメント</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">実際の動作を見る →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>スマートマネーを追跡。</strong> 機関投資家の蓄積/分配パターンを信頼度レベルで追跡：</p>
@@ -5475,9 +5478,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">詳細 ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">ドキュメント</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">実際の動作を見る →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>綱引きメーター。</strong> 時間経過に伴う累積需要と供給圧力を追跡：</p>
@@ -5510,9 +5514,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">詳細 ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">ドキュメント</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">実際の動作を見る →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>重要レベルを自動プロット。</strong> 手動で何百本もラインを引く必要がなくなります：</p>
@@ -5545,9 +5550,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">詳細 ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">ドキュメント</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">実際の動作を見る →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>ミッションコントロールダッシュボード。</strong> 8つ以上の市場を同時追跡し、最もクリーンなセットアップを最初に確認：</p>
@@ -5579,9 +5585,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">詳細 ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">ドキュメント</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">実際の動作を見る →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span>つのオシレーターが投票。</strong> 複数のモメンタムインジケーターが一致した時のみシグナルが表示：</p>
@@ -6619,7 +6626,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">シグナルはリペイントしますか？</strong>
-        <p id="faq-answer-1" class="note"><strong>ノンリペイント。保証します。</strong><br>すべてのシグナルはローソク足のクローズ時に確定します。<br>各インジケーターをルックアヘッドバイアスについて監査しています。<br>リペイントを証明できれば<strong>$100 USD</strong>をお支払いします。<br>履歴で表示されるものは、リアルタイムで見たであろうものと正確に一致します。</p>
+        <p id="faq-answer-1" class="note"><strong>ノンリペイント。保証します。</strong><br>すべてのシグナルはローソク足のクローズ時に確定します。<br>各インジケーターをルックアヘッドバイアスについて監査しています。<br>リペイントを証明できれば<strong>$100 USD</strong>をお支払いします。<br>履歴で表示されるものは、リアルタイムで見たであろうものと正確に一致します。<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">リペイントの仕組みを学ぶ →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6658,12 +6665,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">どの時間足が最適ですか？</strong>
-        <p id="faq-answer-8" class="note">すべての時間足をサポート—1分足から年足チャートまで。<br><strong>最も人気：</strong> デイトレードは15分〜1時間足、スイングトレードは4時間〜日足。<br>Pentarchの5フェーズサイクルは時間足に自動的に適応します。<br>トレーニングセンターでは時間足最適化戦略をカバーしています。</p>
+        <p id="faq-answer-8" class="note">すべての時間足をサポート—1分足から年足チャートまで。<br><strong>最も人気：</strong> デイトレードは15分〜1時間足、スイングトレードは4時間〜日足。<br>Pentarchの5フェーズサイクルは時間足に自動的に適応します。<br>トレーニングセンターでは時間足最適化戦略をカバーしています。<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">マルチタイムフレーム分析をマスターする →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">複数のインジケーターを一緒に使えますか？</strong>
-        <p id="faq-answer-9" class="note"><strong>もちろんです！</strong><br>エリート7種類は連携して機能するように設計されています。<br>人気の組み合わせ： <strong>Pentarch + Volume Oracle</strong> でサイクルタイミングとスマートマネー確認、または <strong>OmniDeck + Janus Atlas</strong> で主要レベルと市場構造の完全な分析。</p>
+        <p id="faq-answer-9" class="note"><strong>もちろんです！</strong><br>エリート7種類は連携して機能するように設計されています。<br>人気の組み合わせ： <strong>Pentarch + Volume Oracle</strong> でサイクルタイミングとスマートマネー確認、または <strong>OmniDeck + Janus Atlas</strong> で主要レベルと市場構造の完全な分析。<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">インジケーターの連携を見る →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6724,43 +6731,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">トレーディングの洞察、戦略、市場分析</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
 
       </div>
 
@@ -6918,6 +6905,73 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
 
     // Capture ref/UTM

--- a/nl/index.html
+++ b/nl/index.html
@@ -5058,9 +5058,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Documentatie</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">Zie het in actie →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Als een verkeerslicht voor de markt</strong> — toont je precies waar je bent in de cyclus met 5 belangrijke signalen:</p>
@@ -5092,9 +5093,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Documentatie</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">Zie het in actie →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> krachtige tools in één schone overlay.</strong> In plaats van je grafiek te vervuilen, krijg je alles wat je nodig hebt in één indicator:</p>
@@ -5127,9 +5129,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Documentatie</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">Zie het in actie →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Volg het slimme geld.</strong> Volgt institutionele accumulatie/distributie patronen met vertrouwensniveaus:</p>
@@ -5162,9 +5165,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Documentatie</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">Zie het in actie →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>De touwtrekken meter.</strong> Volgt cumulatieve vraag vs aanbod druk in de tijd:</p>
@@ -5197,9 +5201,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Documentatie</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">Zie het in actie →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Auto-plot sleutelniveaus.</strong> Stopt je van handmatig honderden lijnen te tekenen:</p>
@@ -5232,9 +5237,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Documentatie</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Zie het in actie →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Missie controle dashboard.</strong> Volg 8+ markten tegelijkertijd en zie de schoonste setups eerst:</p>
@@ -5266,9 +5272,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Documentatie</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">Zie het in actie →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillatoren stemmen.</strong> Signalen verschijnen alleen wanneer meerdere momentum indicatoren het eens zijn:</p>
@@ -6306,7 +6313,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">Worden de signalen opnieuw geschilderd?</strong>
-        <p id="faq-answer-1" class="note"><strong>Nul herschildering. Gegarandeerd.</strong><br>Alle signalen worden definitief bij het sluiten van de candle.<br>We controleren elke indicator op lookahead bias.<br>Als je kunt bewijzen dat er herschildering plaatsvindt, betalen we je <strong>$100 USD</strong>.<br>Wat je in de geschiedenis ziet, is precies wat je live zou hebben gezien.</p>
+        <p id="faq-answer-1" class="note"><strong>Nul herschildering. Gegarandeerd.</strong><br>Alle signalen worden definitief bij het sluiten van de candle.<br>We controleren elke indicator op lookahead bias.<br>Als je kunt bewijzen dat er herschildering plaatsvindt, betalen we je <strong>$100 USD</strong>.<br>Wat je in de geschiedenis ziet, is precies wat je live zou hebben gezien.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener">Lees meer over het herschilderingsprobleem →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6345,12 +6352,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">Welke timeframes werken het beste?</strong>
-        <p id="faq-answer-8" class="note">Alle timeframes ondersteund—1-minuut tot jaarlijkse grafieken.<br><strong>Meest populair:</strong> 15m-1H voor day trading, 4H-Daily voor swing trading.<br>Pentarch's 5-fasen cyclus past zich automatisch aan jouw timeframe aan.<br>Education Hub behandelt timeframe optimalisatie strategieën.</p>
+        <p id="faq-answer-8" class="note">Alle timeframes ondersteund—1-minuut tot jaarlijkse grafieken.<br><strong>Meest populair:</strong> 15m-1H voor day trading, 4H-Daily voor swing trading.<br>Pentarch's 5-fasen cyclus past zich automatisch aan jouw timeframe aan.<br>Education Hub behandelt timeframe optimalisatie strategieën.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener">Lees over multi-timeframe bevestiging →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Kan ik meerdere indicatoren samen gebruiken?</strong>
-        <p id="faq-answer-9" class="note"><strong>Absoluut!</strong><br>De Elite Seven zijn ontworpen om samen te werken.<br>Populaire combinaties: <strong>Pentarch + Volume Oracle</strong> voor cyclus timing met smart money bevestiging, of <strong>OmniDeck + Janus Atlas</strong> voor complete marktstructuur analyse met sleutelniveaus.</p>
+        <p id="faq-answer-9" class="note"><strong>Absoluut!</strong><br>De Elite Seven zijn ontworpen om samen te werken.<br>Populaire combinaties: <strong>Pentarch + Volume Oracle</strong> voor cyclus timing met smart money bevestiging, of <strong>OmniDeck + Janus Atlas</strong> voor complete marktstructuur analyse met sleutelniveaus.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener">Lees een complete handleiding van Signal Pilot →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6411,44 +6418,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Handelsinzichten, strategieën en marktanalyse</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6602,6 +6588,74 @@
       fetch(SP_WEBHOOK,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain;charset=UTF-8'},body:JSON.stringify(p)}).catch(()=>{}); }
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
+
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
 
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -5398,9 +5398,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Detalhes ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Como um semáforo para o mercado</strong> — mostra exatamente onde você está no ciclo com 5 sinais-chave:</p>
@@ -5432,9 +5433,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Detalhes ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> ferramentas poderosas em uma sobreposição limpa.</strong> Em vez de poluir seu gráfico, obtenha tudo o que você precisa em um único indicador:</p>
@@ -5467,9 +5469,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Detalhes ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Siga o dinheiro inteligente.</strong> Rastreia padrões de acumulação/distribuição institucional com níveis de confiança:</p>
@@ -5502,9 +5505,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Detalhes ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>O medidor de cabo de guerra.</strong> Rastreia demanda cumulativa vs pressão de oferta ao longo do tempo:</p>
@@ -5537,9 +5541,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Detalhes ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Plota níveis-chave automaticamente.</strong> Evita que você desenhe centenas de linhas manualmente:</p>
@@ -5572,9 +5577,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Detalhes ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Painel de controle de missão.</strong> Rastreie 8+ mercados simultaneamente e veja as configurações mais limpas primeiro:</p>
@@ -5606,9 +5612,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Detalhes ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> osciladores votam.</strong> Sinais só aparecem quando múltiplos indicadores de momentum concordam:</p>
@@ -6563,7 +6570,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">Os sinais repintam?</strong>
-        <p id="faq-answer-1" class="note"><strong>Zero repintura. Garantido.</strong><br>Todos os sinais finalizam no fechamento da vela.<br>Auditamos cada indicador para viés de antecipação.<br>Se você provar qualquer repintura, pagamos <strong>$100 USD</strong>.<br>O que você vê no histórico é exatamente o que teria visto ao vivo.</p>
+        <p id="faq-answer-1" class="note"><strong>Zero repintura. Garantido.</strong><br>Todos os sinais finalizam no fechamento da vela.<br>Auditamos cada indicador para viés de antecipação.<br>Se você provar qualquer repintura, pagamos <strong>$100 USD</strong>.<br>O que você vê no histórico é exatamente o que teria visto ao vivo.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6602,12 +6609,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">Quais períodos funcionam melhor?</strong>
-        <p id="faq-answer-8" class="note">Todos os períodos suportados—gráficos de 1 minuto até anuais.<br><strong>Mais populares:</strong> 15m-1H para day trading, 4H-Diário para swing trading.<br>O ciclo de 5 fases do Pentarch se adapta ao seu período automaticamente.<br>O Centro de Educação cobre estratégias de otimização de períodos.</p>
+        <p id="faq-answer-8" class="note">Todos os períodos suportados—gráficos de 1 minuto até anuais.<br><strong>Mais populares:</strong> 15m-1H para day trading, 4H-Diário para swing trading.<br>O ciclo de 5 fases do Pentarch se adapta ao seu período automaticamente.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Posso usar múltiplos indicadores juntos?</strong>
-        <p id="faq-answer-9" class="note"><strong>Absolutamente!</strong><br>Os Sete de Elite são projetados para trabalhar juntos.<br>Combinações populares: <strong>Pentarch + Volume Oracle</strong> para timing de ciclo com confirmação de smart money, ou <strong>OmniDeck + Janus Atlas</strong> para análise completa de estrutura de mercado com níveis-chave.</p>
+        <p id="faq-answer-9" class="note"><strong>Absolutamente!</strong><br>Os Sete de Elite são projetados para trabalhar juntos.<br>Combinações populares: <strong>Pentarch + Volume Oracle</strong> para timing de ciclo com confirmação de smart money, ou <strong>OmniDeck + Janus Atlas</strong> para análise completa de estrutura de mercado com níveis-chave.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See how they work together →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6668,44 +6675,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Insights de trading, estratégias e análise de mercado</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6859,6 +6845,74 @@
       fetch(SP_WEBHOOK,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain;charset=UTF-8'},body:JSON.stringify(p)}).catch(()=>{}); }
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
+
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
 
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -4991,9 +4991,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Подробнее ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Документация</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Как светофор для рынка</strong> — показывает точно, где вы находитесь в цикле с 5 ключевыми сигналами:</p>
@@ -5025,9 +5026,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Подробнее ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Документация</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> мощных инструментов в одном чистом оверлее.</strong> Вместо загромождения графика получите всё необходимое в одном индикаторе:</p>
@@ -5060,9 +5062,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Подробнее ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Документация</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Следуйте за умными деньгами.</strong> Отслеживает паттерны институциональной аккумуляции/распределения с уровнями уверенности:</p>
@@ -5095,9 +5098,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Подробнее ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Документация</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Измеритель перетягивания каната.</strong> Отслеживает кумулятивное давление спроса и предложения со временем:</p>
@@ -5130,9 +5134,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Подробнее ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Документация</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Автоматически отображает ключевые уровни.</strong> Избавляет от необходимости рисовать сотни линий вручную:</p>
@@ -5165,9 +5170,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Подробнее ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Документация</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Панель управления миссией.</strong> Отслеживайте 8+ рынков одновременно и видьте самые чистые сетапы первыми:</p>
@@ -5199,9 +5205,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Подробнее ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Документация</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> осциллятора голосуют.</strong> Сигналы появляются только когда несколько индикаторов импульса согласны:</p>
@@ -6239,7 +6246,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">Перерисовываются ли сигналы?</strong>
-        <p id="faq-answer-1" class="note"><strong>Никакой перерисовки. Гарантировано.</strong><br>Все сигналы финализируются при закрытии свечи.<br>Мы проверяем каждый индикатор на опережающее смещение.<br>Если вы можете доказать любую перерисовку, мы заплатим вам <strong>$100 USD</strong>.<br>То, что вы видите в истории, это именно то, что вы бы увидели вживую.</p>
+        <p id="faq-answer-1" class="note"><strong>Никакой перерисовки. Гарантировано.</strong><br>Все сигналы финализируются при закрытии свечи.<br>Мы проверяем каждый индикатор на опережающее смещение.<br>Если вы можете доказать любую перерисовку, мы заплатим вам <strong>$100 USD</strong>.<br>То, что вы видите в истории, это именно то, что вы бы увидели вживую.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6278,12 +6285,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">Какие таймфреймы работают лучше всего?</strong>
-        <p id="faq-answer-8" class="note">Поддерживаются все таймфреймы—от 1-минутных до годовых графиков.<br><strong>Самые популярные:</strong> 15m-1H для дневной торговли, 4H-Daily для свинг-торговли.<br>5-фазный цикл Pentarch автоматически адаптируется к вашему таймфрейму.<br>Образовательный центр охватывает стратегии оптимизации таймфреймов.</p>
+        <p id="faq-answer-8" class="note">Поддерживаются все таймфреймы—от 1-минутных до годовых графиков.<br><strong>Самые популярные:</strong> 15m-1H для дневной торговли, 4H-Daily для свинг-торговли.<br>5-фазный цикл Pentarch автоматически адаптируется к вашему таймфрейму.<br>Образовательный центр охватывает стратегии оптимизации таймфреймов.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Могу ли я использовать несколько индикаторов вместе?</strong>
-        <p id="faq-answer-9" class="note"><strong>Конечно!</strong><br>Элитная 7 разработана для совместной работы.<br>Популярные комбинации: <strong>Pentarch + Volume Oracle</strong> для определения времени циклов с подтверждением умных денег, или <strong>OmniDeck + Janus Atlas</strong> для полного анализа структуры рынка с ключевыми уровнями.</p>
+        <p id="faq-answer-9" class="note"><strong>Конечно!</strong><br>Элитная 7 разработана для совместной работы.<br>Популярные комбинации: <strong>Pentarch + Volume Oracle</strong> для определения времени циклов с подтверждением умных денег, или <strong>OmniDeck + Janus Atlas</strong> для полного анализа структуры рынка с ключевыми уровнями.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See how they work together →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6344,44 +6351,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Торговые инсайты, стратегии и анализ рынка</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6536,7 +6522,73 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
 
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
     // Capture ref/UTM
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -5067,9 +5067,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Pentarch</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Detaylar ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Like a traffic light for the market</strong> — shows you exactly where you are in the cycle with 5 key signals:</p>
@@ -5101,9 +5102,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — OmniDeck</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Detaylar ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> powerful tools in one clean overlay.</strong> Instead of cluttering your chart, get everything you need in a single indicator:</p>
@@ -5136,9 +5138,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Volume Oracle</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Detaylar ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Akıllı parayı takip edin.</strong> Güven seviyeleriyle kurumsal birikim/dağıtım kalıplarını izler:</p>
@@ -5171,9 +5174,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Plutus Flow</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Detaylar ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>İp çekme ölçer.</strong> Zaman içinde kümülatif talep vs arz baskısını izler:</p>
@@ -5206,9 +5210,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Janus Atlas</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Detaylar ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Auto-plots key levels.</strong> Stops you from drawing hundreds of lines manually:</p>
@@ -5241,9 +5246,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Augury Grid</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Detaylar ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Mission control dashboard.</strong> Track 8+ markets simultaneously and see the cleanest setups first:</p>
@@ -5275,9 +5281,10 @@
             <div class="title mod" style="justify-content:center">
               <h3 style="white-space:nowrap">SP — Harmonic Oscillator</h3>
             </div>
-            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center">
+            <div style="display:flex;gap:.5rem;margin-top:.5rem;align-items:center;flex-wrap:wrap">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Detaylar ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Docs</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillators vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
@@ -6315,7 +6322,7 @@
       <!-- CORE VALUE PROP -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-1">
         <strong id="faq-question-1">Sinyaller yeniden çiziliyor mu?</strong>
-        <p id="faq-answer-1" class="note"><strong>Sıfır yeniden çizim. Garantili.</strong><br>Tüm sinyaller mum kapanışında kesinleşir.<br>Her göstergeyi ileriye bakma yanlılığı açısından denetleriz.<br>Herhangi bir yeniden çizim kanıtlarsanız, size <strong>$100 USD</strong> öderiz.<br>Geçmişte gördükleriniz, canlıda göreceğinizin tam olarak aynısıdır.</p>
+        <p id="faq-answer-1" class="note"><strong>Sıfır yeniden çizim. Garantili.</strong><br>Tüm sinyaller mum kapanışında kesinleşir.<br>Her göstergeyi ileriye bakma yanlılığı açısından denetleriz.<br>Herhangi bir yeniden çizim kanıtlarsanız, size <strong>$100 USD</strong> öderiz.<br>Geçmişte gördükleriniz, canlıda göreceğinizin tam olarak aynısıdır.<br><a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" style="color:var(--brand)">Learn how repainting works →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-2">
@@ -6354,12 +6361,12 @@
       <!-- TRADING & STRATEGY -->
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-8">
         <strong id="faq-question-8">Hangi zaman dilimleri en iyi çalışır?</strong>
-        <p id="faq-answer-8" class="note">Tüm zaman dilimleri desteklenir—1 dakikadan yıllık grafiklere kadar.<br><strong>En popüler:</strong> Günlük işlemler için 15m-1S, swing işlemleri için 4S-Günlük.<br>Pentarch'ın 5 aşamalı döngüsü zaman diliminize otomatik olarak uyum sağlar.<br>Eğitim Merkezi, zaman dilimi optimizasyon stratejilerini kapsar.</p>
+        <p id="faq-answer-8" class="note">Tüm zaman dilimleri desteklenir—1 dakikadan yıllık grafiklere kadar.<br><strong>En popüler:</strong> Günlük işlemler için 15m-1S, swing işlemleri için 4S-Günlük.<br>Pentarch'ın 5 aşamalı döngüsü zaman diliminize otomatik olarak uyum sağlar.<br><a href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">Master multi-timeframe analysis →</a></p>
       </div>
 
       <div class="card" role="button" aria-expanded="false" tabindex="0" aria-controls="faq-answer-9">
         <strong id="faq-question-9">Birden fazla göstergeyi birlikte kullanabilir miyim?</strong>
-        <p id="faq-answer-9" class="note"><strong>Kesinlikle!</strong><br>Elite Seven birlikte çalışacak şekilde tasarlandı.<br>Popüler kombinasyonlar: Akıllı para onayı ile döngü zamanlaması için <strong>Pentarch + Volume Oracle</strong> veya anahtar seviyelerle tam piyasa yapısı analizi için <strong>OmniDeck + Janus Atlas</strong>.</p>
+        <p id="faq-answer-9" class="note"><strong>Kesinlikle!</strong><br>Elite Seven birlikte çalışacak şekilde tasarlandı.<br>Popüler kombinasyonlar: Akıllı para onayı ile döngü zamanlaması için <strong>Pentarch + Volume Oracle</strong> veya anahtar seviyelerle tam piyasa yapısı analizi için <strong>OmniDeck + Janus Atlas</strong>.<br><a href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See how indicators work together →</a></p>
       </div>
 
       <!-- EDUCATION & SUPPORT -->
@@ -6420,44 +6427,23 @@
         <p style="color:var(--muted);font-size:1rem;margin:0">Ticaret içgörüleri, stratejiler ve piyasa analizi</p>
       </div>
 
-      <div class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-
-        <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing (And What Actually Works)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle with the rainbow-chart approach.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/psychology-of-getting-stopped-out/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(118,75,162,.15);color:#a78bfa;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PSYCHOLOGY</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Psychology of Getting Stopped Out</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Analyzes the emotional impact of exact stop-loss hits and price reversals.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
@@ -6613,6 +6599,74 @@
       fetch(SP_WEBHOOK,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain;charset=UTF-8'},body:JSON.stringify(p)}).catch(()=>{}); }
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
+
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {
+          // Fallback to static content on error
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
+    })();
 
 
 


### PR DESCRIPTION
Apply same changes as main index.html to all 11 language directories:
- Dynamic blog carousel fetching from /api/articles.json
- Loading skeleton placeholders while content loads
- FAQ links for repainting, timeframes, and indicators topics
- "See It In Action" buttons on all 7 indicator cards

Languages updated: ar, de, es, fr, hu, it, ja, nl, pt, ru, tr