### PR TITLE
Fix blog carousel consistency across language files

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6751,7 +6751,12 @@ html[lang="ar"] [style*="text-align:center"] {
             <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
               <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
-              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with backtesting.</p>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
             </a>
           `;
         });

--- a/de/index.html
+++ b/de/index.html
@@ -5049,7 +5049,7 @@
             <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="pentarch-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener">Dokumentation</a>
-              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener">See It In Action</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-to-trade-cycles-with-pentarch/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="pentarch-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Like a traffic light for the market</strong> — shows you exactly where you are in the cycle with 5 key signals:</p>
@@ -5084,7 +5084,7 @@
             <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="omnideck-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener">Dokumentation</a>
-              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener">See It In Action</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/inside-signal-pilot/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="omnideck-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="10" data-text-mode>10</span> powerful tools in one clean overlay.</strong> Instead of cluttering your chart, get everything you need in a single indicator:</p>
@@ -5120,7 +5120,7 @@
             <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="oracle-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener">Dokumentation</a>
-              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener">See It In Action</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="oracle-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Follow the smart money.</strong> Tracks institutional accumulation/distribution patterns with confidence levels:</p>
@@ -5156,7 +5156,7 @@
             <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="plutus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener">Dokumentation</a>
-              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener">See It In Action</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/accumulation-vs-distribution/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="plutus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>The tug-of-war meter.</strong> Tracks cumulative demand vs supply pressure over time:</p>
@@ -5192,7 +5192,7 @@
             <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="janus-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener">Dokumentation</a>
-              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener">See It In Action</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="janus-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Auto-plots key levels.</strong> Stops you from drawing hundreds of lines manually:</p>
@@ -5228,7 +5228,7 @@
             <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="augury-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener">Dokumentation</a>
-              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener">See It In Action</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/multi-timeframe-confirmation/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="augury-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong>Mission control dashboard.</strong> Track 8+ markets simultaneously and see the cleanest setups first:</p>
@@ -5263,7 +5263,7 @@
             <div style="display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem;align-items:center">
               <button class="btn btn-ghost btn-sm toggle-details" data-target="harmonic-details">Details ▼</button>
               <a class="btn btn-ghost btn-sm" href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener">Dokumentation</a>
-              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener">See It In Action</a>
+              <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
               <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="4" data-text-mode>4</span> oscillators vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
@@ -6634,6 +6634,16 @@
               <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
             </a>
           `;
         });

--- a/it/index.html
+++ b/it/index.html
@@ -6395,30 +6395,6 @@
           <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
           <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
         </div>
-        <a href="https://blog.signalpilot.io/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves (And How to See It)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodes institutional movement patterns and detection methods.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/3-questions-before-every-trade/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(251,191,36,.15);color:#fbbf24;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PRACTICAL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The 3 Questions to Ask Before Every Trade</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Essential decision framework before executing any trade.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/why-markets-move-in-cycles/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Markets Move in Cycles (And How to Profit)</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Markets trend about 20-30% of the time. The rest? Cycles.</p>
-        </a>
-
-        <a href="https://blog.signalpilot.io/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem: How Most Indicators Cheat</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Reveals deceptive indicator backtesting practices that create false confidence.</p>
-        </a>
-
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">


### PR DESCRIPTION
- de: Add button styling and missing fallback articles
- it: Remove leftover static article cards from carousel
- ar: Add missing 3rd fallback article (how-smart-money-moves)

All language files now have 18 blog references matching English.