### PR TITLE
Make spotlight x-ray much more subtle

### DIFF
--- a/assets/spotlight-xray.css
+++ b/assets/spotlight-xray.css
@@ -25,20 +25,16 @@
   /* Smooth transitions for size changes */
   transition: clip-path 0.1s ease-out, -webkit-clip-path 0.1s ease-out;
 
-  /* Dark overlay with slight transparency */
-  background: radial-gradient(
-    circle at var(--spotlight-x) var(--spotlight-y),
-    rgba(5, 10, 20, 0.92) 0%,
-    rgba(5, 10, 20, 0.97) 100%
-  );
+  /* NO background - fully see-through */
+  background: transparent;
 }
 
 /* Active state when hovering hero */
 .xray-layer.active {
-  --spotlight-size: 180px;
+  --spotlight-size: 80px;
 }
 
-/* Glow ring around spotlight edge */
+/* Subtle glow ring around spotlight edge */
 .xray-layer::before {
   content: '';
   position: absolute;
@@ -47,11 +43,11 @@
   width: 100%;
   height: 100%;
   background: radial-gradient(
-    circle 200px at var(--spotlight-x) var(--spotlight-y),
-    transparent 150px,
-    rgba(0, 212, 255, 0.15) 170px,
-    rgba(0, 212, 255, 0.05) 190px,
-    transparent 220px
+    circle 100px at var(--spotlight-x) var(--spotlight-y),
+    transparent 60px,
+    rgba(0, 212, 255, 0.06) 75px,
+    rgba(0, 212, 255, 0.02) 90px,
+    transparent 110px
   );
   pointer-events: none;
 }
@@ -69,39 +65,39 @@
   overflow: hidden;
 }
 
-/* Individual code column */
+/* Individual code column - very subtle */
 .xray-code-column {
   flex: 1;
   display: flex;
   flex-direction: column;
   animation: scrollCodeUp var(--scroll-duration, 30s) linear infinite;
   font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
-  font-size: 11px;
-  line-height: 1.6;
-  color: rgba(0, 212, 255, 0.7);
+  font-size: 9px;
+  line-height: 1.5;
+  color: rgba(0, 212, 255, 0.18);
   white-space: pre;
-  text-shadow: 0 0 10px rgba(0, 212, 255, 0.5);
+  text-shadow: 0 0 8px rgba(0, 212, 255, 0.1);
 }
 
 .xray-code-column:nth-child(2) {
   animation-duration: 35s;
   animation-delay: -10s;
-  color: rgba(0, 255, 170, 0.6);
-  text-shadow: 0 0 10px rgba(0, 255, 170, 0.4);
+  color: rgba(0, 255, 170, 0.15);
+  text-shadow: 0 0 8px rgba(0, 255, 170, 0.08);
 }
 
 .xray-code-column:nth-child(3) {
   animation-duration: 28s;
   animation-delay: -5s;
-  color: rgba(150, 120, 255, 0.6);
-  text-shadow: 0 0 10px rgba(150, 120, 255, 0.4);
+  color: rgba(150, 120, 255, 0.15);
+  text-shadow: 0 0 8px rgba(150, 120, 255, 0.08);
 }
 
 .xray-code-column:nth-child(4) {
   animation-duration: 32s;
   animation-delay: -15s;
-  color: rgba(255, 180, 100, 0.5);
-  text-shadow: 0 0 10px rgba(255, 180, 100, 0.3);
+  color: rgba(255, 180, 100, 0.12);
+  text-shadow: 0 0 8px rgba(255, 180, 100, 0.06);
 }
 
 @keyframes scrollCodeUp {
@@ -156,21 +152,21 @@
   }
 }
 
-/* Scan line effect */
+/* Scan line effect - very subtle */
 .xray-scanline {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
-  height: 2px;
+  height: 1px;
   background: linear-gradient(90deg,
     transparent,
-    rgba(0, 212, 255, 0.3),
-    rgba(0, 212, 255, 0.6),
-    rgba(0, 212, 255, 0.3),
+    rgba(0, 212, 255, 0.08),
+    rgba(0, 212, 255, 0.15),
+    rgba(0, 212, 255, 0.08),
     transparent
   );
-  animation: scanDown 4s linear infinite;
+  animation: scanDown 6s linear infinite;
   pointer-events: none;
 }
 


### PR DESCRIPTION
- Reduce spotlight size from 180px to 80px
- Lower code opacity to 12-18% (barely visible)
- Remove dark background - now fully see-through
- Tone down glow ring and scanline
- Smaller font size (9px)