### PR TITLE
Remove all backdrop-filter blur - use solid backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,10 +671,9 @@
         box-shadow: 0 4px 12px rgba(91,138,255,.15) !important; /* Remove heavy glow, use subtle shadow */
       }
 
-      /* Make pricing cards semi-transparent on mobile so constellations show through */
+      /* Make pricing cards solid on mobile - no backdrop-filter */
       .card.plan {
-        background: linear-gradient(180deg,rgba(5,7,13,.95),rgba(5,7,13,.90)) !important;
-        backdrop-filter: blur(10px);
+        background: linear-gradient(180deg,rgba(5,7,13,.97),rgba(5,7,13,.95)) !important;
       }
 
       /* Override inline background styles on specific sections - they block particles! */
@@ -812,38 +811,30 @@
 
     .success-check{animation:checkPop 0.4s cubic-bezier(0.4, 0, 0.2, 1)}
 
-    /* ==================== GLASSMORPHISM EFFECTS ==================== */
+    /* ==================== CARD EFFECTS - NO BACKDROP-FILTER ==================== */
 
-    /* Glassmorphism for cards */
+    /* Solid backgrounds instead of expensive backdrop-filter blur */
     .glassmorphic {
-      background: rgba(10, 14, 24, 0.6) !important;
-      backdrop-filter: blur(20px) saturate(180%);
-      -webkit-backdrop-filter: blur(20px) saturate(180%);
+      background: rgba(10, 14, 24, 0.92) !important;
       border: 1px solid rgba(139, 178, 255, 0.18) !important;
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.37) !important;
     }
 
-    /* Apply glassmorphism to cards */
     .card {
-      background: rgba(10, 14, 24, 0.6) !important;
-      backdrop-filter: blur(20px) saturate(180%);
-      -webkit-backdrop-filter: blur(20px) saturate(180%);
+      background: rgba(10, 14, 24, 0.92) !important;
       border: 1px solid rgba(139, 178, 255, 0.15) !important;
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.37) !important;
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
     }
 
     .card:hover {
-      backdrop-filter: blur(24px) saturate(200%);
-      -webkit-backdrop-filter: blur(24px) saturate(200%);
       border-color: rgba(139, 178, 255, 0.3) !important;
       box-shadow: 0 12px 48px rgba(91, 138, 255, 0.2) !important;
     }
 
-    /* Glassmorphism for navigation */
+    /* Header - solid background instead of expensive backdrop-filter */
     header {
-      backdrop-filter: blur(12px) saturate(180%);
-      -webkit-backdrop-filter: blur(12px) saturate(180%);
+      background: rgba(5, 7, 13, 0.95);
     }
 
     /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */


### PR DESCRIPTION
Major performance improvement:
- Header: backdrop-filter blur(12px) → solid rgba background
- Cards: backdrop-filter blur(20-24px) → solid rgba(10,14,24,0.92)
- Mobile pricing cards: backdrop-filter blur(10px) → solid gradient
- Also fixed transition: all → specific properties on .card