### PR TITLE
Performance optimizations round 2

### DIFF
--- a/assets/deferred.css
+++ b/assets/deferred.css
@@ -371,7 +371,7 @@
 
     .cta-inner{max-width:var(--max);width:100%;margin:0 auto;padding-left:calc(clamp(14px,4vw,22px) + env(safe-area-inset-left));padding-right:calc(clamp(14px,4vw,22px) + env(safe-area-inset-right))}
 
-    .cta-inner .bar{display:flex;gap:.8rem;align-items:center;justify-content:center;background:rgba(10,12,20,.98);border:1px solid rgba(255,255,255,.16);backdrop-filter:blur(10px);border-radius:14px;padding:.6rem .9rem calc(.6rem + env(safe-area-inset-bottom))}
+    .cta-inner .bar{display:flex;gap:.8rem;align-items:center;justify-content:center;background:rgba(10,12,20,.98);border:1px solid rgba(255,255,255,.16);backdrop-filter:blur(4px);border-radius:14px;padding:.6rem .9rem calc(.6rem + env(safe-area-inset-bottom))}
 
     @media (max-width:1100px){ .cta-inner .bar{gap:.6rem;padding:.5rem .8rem calc(.5rem + env(safe-area-inset-bottom))} }
 

--- a/index.html
+++ b/index.html
@@ -1562,13 +1562,13 @@
 
     .lightbox-content img{width:100%;height:100%;object-fit:contain;border-radius:12px;box-shadow:0 40px 120px rgba(0,0,0,0.6)}
 
-    .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(10px);min-width:44px;min-height:44px}
+    .lightbox-close{position:absolute;top:-50px;right:0;background:rgba(255,255,255,0.1);border:2px solid rgba(255,255,255,0.2);color:#fff;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:1.5rem;font-weight:300;transition:all 0.2s ease;backdrop-filter:blur(4px);min-width:44px;min-height:44px}
 
     .lightbox-close:hover{background:rgba(255,255,255,0.2);border-color:rgba(255,255,255,0.4);transform:scale(1.1)}
 
     /* Mobile lightbox optimizations */
     @media (max-width:768px){
-      .lightbox-overlay{padding:1rem;backdrop-filter:blur(10px)}
+      .lightbox-overlay{padding:1rem;backdrop-filter:blur(4px)}
 
       .lightbox-content{max-width:95vw;max-height:85vh}
 
@@ -1732,7 +1732,7 @@
       align-items:stretch;
       gap:.25rem;
       z-index:66;
-      backdrop-filter:blur(12px);
+      backdrop-filter:blur(4px);
     }
 
     /* Invisible hover bridge */
@@ -3144,16 +3144,19 @@
                   }
                 }
 
-                // Run on load
+                // Run on load and after delay to override other scripts
                 forceVideoVisible();
-
-                // Run after delays to override other scripts
-                setTimeout(forceVideoVisible, 100);
-                setTimeout(forceVideoVisible, 500);
                 setTimeout(forceVideoVisible, 1000);
 
-                // Re-run on resize
-                window.addEventListener('resize', forceVideoVisible);
+                // Re-run on resize (throttled to prevent spam during drag)
+                let resizeTimeout;
+                window.addEventListener('resize', () => {
+                  if (resizeTimeout) return;
+                  resizeTimeout = setTimeout(() => {
+                    forceVideoVisible();
+                    resizeTimeout = null;
+                  }, 200);
+                });
 
                 // Aggressive play attempts
                 function tryPlay(source) {
@@ -3655,7 +3658,7 @@
               width: 100%;
               height: 100%;
               background: rgba(5, 7, 13, 0.95);
-              backdrop-filter: blur(10px);
+              backdrop-filter: blur(4px);
             }
 
             .lightbox-content {
@@ -5080,24 +5083,37 @@
         }
       }
 
+      let lastAutoplayTime = 0;
       function resumeAutoPlay() {
         if (autoplayInterval) return;
-        autoplayInterval = setInterval(() => {
-          autoplayPos += (autoplayDirection * 2);
-          if (autoplayPos >= 100) {
-            autoplayPos = 100;
-            autoplayDirection = -1;
-          } else if (autoplayPos <= 0) {
-            autoplayPos = 0;
-            autoplayDirection = 1;
+        lastAutoplayTime = performance.now();
+        function animateSlider(currentTime) {
+          if (!isAutoPlaying || !isSliderVisible || document.hidden) {
+            autoplayInterval = null;
+            return;
           }
-          setSliderPosition(autoplayPos, false);
-        }, 30);
+          // Move ~2% every 30ms (same speed as before)
+          const delta = currentTime - lastAutoplayTime;
+          if (delta >= 30) {
+            autoplayPos += (autoplayDirection * 2);
+            if (autoplayPos >= 100) {
+              autoplayPos = 100;
+              autoplayDirection = -1;
+            } else if (autoplayPos <= 0) {
+              autoplayPos = 0;
+              autoplayDirection = 1;
+            }
+            setSliderPosition(autoplayPos, false);
+            lastAutoplayTime = currentTime;
+          }
+          autoplayInterval = requestAnimationFrame(animateSlider);
+        }
+        autoplayInterval = requestAnimationFrame(animateSlider);
       }
 
       function pauseAutoPlay() {
         if (autoplayInterval) {
-          clearInterval(autoplayInterval);
+          cancelAnimationFrame(autoplayInterval);
           autoplayInterval = null;
         }
       }
@@ -7168,7 +7184,7 @@ if ('serviceWorker' in navigator) {
 </script>
 
 <!-- Cookie Consent System - Re-enabled after finding real issue (PayPal rendering) -->
-<script src="/assets/cookie-consent.js"></script>
+<script src="/assets/cookie-consent.js" defer></script>
 
 <!-- AI Chatbot - Re-enabled after finding real issue (PayPal rendering) -->
 <script src="/assets/chatbot.js" defer></script>


### PR DESCRIPTION
- Add defer to cookie-consent.js (was blocking HTML parsing)
- Replace comparison slider setInterval with requestAnimationFrame (smoother, auto-pauses)
- Throttle hero video resize listener (prevents 100s of calls during resize)
- Consolidate hero video setTimeout calls (3 -> 1)
- Reduce backdrop-filter blur from 10-12px to 4px (major GPU savings)