### PR TITLE
Mobile starfield - overlay approach with mix-blend-mode screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,15 +517,10 @@
       transition:all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
-    /* MOBILE: Simple, clean mobile setup - NO forced positioning */
+    /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
-      /* HTML and body MUST be transparent for starfield to show through */
-      html, body {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Starfield video - lowest layer at z-index 0 */
+      /* Starfield video - ON TOP as overlay with low opacity */
+      /* Content shows through it instead of other way around */
       #starfield-bg {
         position: fixed !important;
         top: 0 !important;
@@ -534,27 +529,21 @@
         height: 100vh !important;
         height: 100dvh !important;
         object-fit: cover !important;
-        z-index: 0 !important;
+        z-index: 9998 !important;
         pointer-events: none !important;
-        opacity: 0.5 !important;
+        opacity: 0.25 !important;
+        mix-blend-mode: screen !important;
       }
 
-      /* Energy beam above starfield */
+      /* Energy beam stays where it is */
       #energy-beam-video {
         z-index: 1 !important;
       }
 
-      /* Main content above both videos */
+      /* Main content normal */
       main {
         position: relative !important;
-        z-index: 2 !important;
-        background: transparent !important;
-      }
-
-      /* ALL sections must be transparent to see starfield through */
-      section, .section, .container, .stack {
-        background: transparent !important;
-        background-color: transparent !important;
+        z-index: 1 !important;
       }
 
       /* Background layers BEHIND everything */


### PR DESCRIPTION
Instead of starfield behind transparent content (which mobile browsers block), put starfield ON TOP with:
- z-index: 9998 (above content)
- opacity: 0.25 (low so content visible through it)
- mix-blend-mode: screen (stars glow, dark areas transparent)
- pointer-events: none (clicks pass through)