### PR TITLE
Fix desktop starfield blend and mobile menu background

### DIFF
--- a/index.html
+++ b/index.html
@@ -659,8 +659,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -2078,7 +2078,8 @@
         right: 0;
         bottom: 0;
         width: min(85vw, 380px);
-        background: #0a0c14;
+        background: #0a0c14 !important;
+        background-color: #0a0c14 !important;
         z-index: 99999;
         transform: translateX(100%);
         transition: transform 0.3s ease;
@@ -3007,7 +3008,7 @@
 
     <!-- HERO -->
 
-    <section id="main-content" class="hero" style="position:relative;overflow:visible;z-index:1">
+    <section id="main-content" class="hero" style="position:relative;overflow:visible">
 
       <!-- EPIC Energy Beam v2 -->
       <div id="energy-beam-container" style="position:absolute;top:-70px;left:0;width:100%;height:calc(100% + 70px);pointer-events:none;z-index:0;overflow:visible;display:none"></div>


### PR DESCRIPTION
- Removed z-index from hero section and main to allow mix-blend-mode: screen to work with starfield (stacking contexts were preventing blend)
- Added !important to mobile-nav background to ensure solid menu background