### PR TITLE
Fix mobile menu: exclude from transparent div rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@
 
       /* Force all sections transparent on mobile so starfield shows through */
       html, body, main, header, section, .section, .container, .stack, #main-content, .nav-backdrop,
-      .hero, article, footer, aside, div:not(.card):not(.card *):not(.btn):not(.modal-card) {
+      .hero, article, footer, aside, div:not(.card):not(.card *):not(.btn):not(.modal-card):not(.mobile-nav):not(.mobile-nav *) {
         background: transparent !important;
         background-color: transparent !important;
       }


### PR DESCRIPTION
The div:not() selector was making all divs transparent including .mobile-nav. Added :not(.mobile-nav):not(.mobile-nav *) exclusion.