### PR TITLE
Fix mobile menu: exclude from body > * transparent rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -752,7 +752,7 @@
       }
 
       /* NUCLEAR: Force starfield visible across ENTIRE page */
-      body > *:not(#starfield-bg):not(script):not(style),
+      body > *:not(#starfield-bg):not(script):not(style):not(.mobile-nav):not(.mobile-nav-backdrop),
       main,
       main > *,
       main section,


### PR DESCRIPTION
The NUCLEAR rule at line 755 was targeting all direct children of body, including the dynamically appended .mobile-nav element.