### PR TITLE
Fix mobile starfield: use same approach as desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,8 +523,7 @@
 
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
-      /* Starfield video - ON TOP as overlay with low opacity */
-      /* Content shows through it instead of other way around */
+      /* Starfield video - BEHIND content like desktop, just with lower opacity */
       #starfield-bg {
         position: fixed !important;
         top: 0 !important;
@@ -533,10 +532,9 @@
         height: 100vh !important;
         height: 100dvh !important;
         object-fit: cover !important;
-        z-index: 9998 !important;
+        z-index: -1 !important;
         pointer-events: none !important;
-        opacity: 0.4 !important;
-        mix-blend-mode: screen !important;
+        opacity: 0.35 !important;
       }
 
       /* Energy beam stays where it is */
@@ -544,10 +542,10 @@
         z-index: 1 !important;
       }
 
-      /* Main content normal */
+      /* Main content - NO z-index to allow starfield to show through */
       main {
         position: relative !important;
-        z-index: 1 !important;
+        background: transparent !important;
       }
 
       /* Background layers BEHIND everything */


### PR DESCRIPTION
Changed from overlay (z-index 9998 + blend mode) to behind (z-index -1) approach. Removed z-index from main to prevent stacking context issues. This matches the working desktop approach.