### PR TITLE
Try plus-lighter blend mode for mobile starfield

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@
 
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
-      /* Starfield video - BEHIND content like desktop, just with lower opacity */
+      /* Starfield video - ON TOP as overlay */
       #starfield-bg {
         position: fixed !important;
         top: 0 !important;
@@ -532,27 +532,28 @@
         height: 100vh !important;
         height: 100dvh !important;
         object-fit: cover !important;
-        z-index: -1 !important;
+        z-index: 9998 !important;
         pointer-events: none !important;
-        opacity: 0.35 !important;
+        opacity: 0.5 !important;
+        mix-blend-mode: plus-lighter !important;
       }
 
-      /* Energy beam stays where it is */
+      /* Energy beam hidden on mobile for performance */
       #energy-beam-video {
-        z-index: 1 !important;
+        display: none !important;
       }
 
-      /* Main content - NO z-index to allow starfield to show through */
+      /* Main content */
       main {
         position: relative !important;
-        background: transparent !important;
+        z-index: 1 !important;
       }
 
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
-        filter: none !important; /* Remove expensive drop-shadow on mobile for better scroll performance */
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;


### PR DESCRIPTION
Reverted to overlay approach (z-index 9998) with plus-lighter blend mode instead of screen. Additive blending should make stars visible on any background.