### PR TITLE
Fix starfield video zoom: use object-fit contain for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -543,15 +543,13 @@
 
       #starfield-bg {
         position: absolute !important;
-        top: 50% !important;
-        left: 50% !important;
-        min-width: 100% !important;
-        min-height: 100% !important;
-        width: auto !important;
-        height: auto !important;
-        -webkit-transform: translate3d(-50%, -50%, 0) !important;
-        transform: translate3d(-50%, -50%, 0) !important;
-        object-fit: cover !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+        -webkit-transform: translate3d(0, 0, 0) !important;
+        transform: translate3d(0, 0, 0) !important;
+        object-fit: contain !important;
         opacity: 0.5 !important;
       }
 


### PR DESCRIPTION
Landscape video on portrait mobile screen was causing massive zoom with object-fit: cover. Changed to contain so the full starfield is visible - black letterboxing blends with dark background.