### PR TITLE
Fix mobile starfield zoom: use scale transform to shrink stars

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,14 +544,15 @@
 
       #starfield-bg {
         position: absolute !important;
-        top: 0 !important;
-        left: 0 !important;
-        width: 100% !important;
-        height: 100% !important;
-        -webkit-transform: translate3d(0, 0, 0) !important;
-        transform: translate3d(0, 0, 0) !important;
+        top: 50% !important;
+        left: 50% !important;
+        width: 300% !important;
+        height: 300% !important;
+        -webkit-transform: translate3d(-50%, -50%, 0) scale(0.5) !important;
+        transform: translate3d(-50%, -50%, 0) scale(0.5) !important;
+        -webkit-transform-origin: center center !important;
+        transform-origin: center center !important;
         object-fit: cover !important;
-        object-position: center center !important;
         opacity: 0.5 !important;
       }
 


### PR DESCRIPTION
Landscape video on portrait screen causes extreme zoom with object-fit: cover. Workaround: make video 300% size then scale(0.5) to show more of the video content with smaller apparent star size.