### PR TITLE
Make mobile video the default, only switch to desktop if wide screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -2934,7 +2934,7 @@
       opacity: 0.5;
     "
   >
-    <source src="assets/videos/starfield-bg.mp4?v=17" type="video/mp4">
+    <source src="assets/videos/starfield-bg-mobile.mp4?v=23" type="video/mp4">
   </video>
 </div>
 <script>
@@ -2943,16 +2943,13 @@
   const video = document.getElementById('starfield-bg');
   const source = video.querySelector('source');
 
-  // Use multiple checks for mobile detection
-  const isMobile = window.innerWidth <= 768 ||
-                   screen.width <= 768 ||
-                   /Android|iPhone|iPad|iPod|webOS|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+  // Default is mobile video (set in HTML). Only switch to desktop if screen is wide.
+  const isDesktop = window.innerWidth > 768 && screen.width > 768;
 
-  // Load mobile or desktop video
-  source.src = isMobile
-    ? 'assets/videos/starfield-bg-mobile.mp4?v=22'
-    : 'assets/videos/starfield-bg.mp4?v=17';
-  video.load();
+  if (isDesktop) {
+    source.src = 'assets/videos/starfield-bg.mp4?v=17';
+    video.load();
+  }
   video.play();
 
   // Pause when tab hidden, resume when visible


### PR DESCRIPTION
Mobile video now loads by default from HTML. JS only switches to desktop video if screen > 768px. This ensures mobile users get the correct video even before JS executes.