### PR TITLE
Fix mobile starfield: behind content approach (iOS compatible)

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,19 +521,19 @@
       transition:all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
-    /* MOBILE: Simple, clean mobile setup */
+    /* MOBILE: Starfield BEHIND content (like desktop) - iOS compatible */
     @media (max-width: 768px) {
-      /* Starfield container - ON TOP, blends with everything below */
+      /* Starfield container - BEHIND content, no blend mode (iOS friendly) */
       #starfield-container {
         position: fixed !important;
         top: 0 !important;
         left: 0 !important;
         width: 100vw !important;
         height: 100vh !important;
-        z-index: 9999 !important;
+        z-index: -1 !important;
         pointer-events: none !important;
-        overflow: visible !important;
-        mix-blend-mode: screen !important;
+        overflow: hidden !important;
+        /* No mix-blend-mode - stars show through transparent content */
       }
 
       #starfield-bg {
@@ -543,12 +543,16 @@
         width: 100% !important;
         height: 100% !important;
         object-fit: cover !important;
-        opacity: 0.6 !important;
+        opacity: 0.5 !important;
       }
 
-      /* Energy beam hidden on mobile for performance */
+      /* Energy beam - show in hero, blend with starfield behind */
       #energy-beam-video {
-        display: none !important;
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        z-index: 0 !important; /* Above starfield (-1), below content (1) */
+        mix-blend-mode: screen !important; /* Blend with starfield beautifully */
       }
 
       /* Main content */
@@ -692,24 +696,7 @@
         background:transparent !important; /* Let particles show through on mobile! */
       }
 
-      /* Energy beam video - show and blend with starfield */
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        left: 50% !important;
-        top: -80px !important; /* Extend into header area */
-        transform: translateX(-50%) scaleX(-1) !important;
-        width: 100vw !important;
-        height: calc(100% + 80px) !important; /* Compensate for negative top */
-        object-fit: cover !important;
-        object-position: center 50% !important;
-        /* Remove complex mask on mobile - too expensive */
-        -webkit-mask-image: none !important;
-        mask-image: none !important;
-        -webkit-mask-composite: unset !important;
-        mask-composite: unset !important;
-      }
+      /* Energy beam styles defined earlier - blends with starfield */
 
       /* Disable shimmer animation on mobile - saves GPU */
       .shimmer-text {
@@ -767,12 +754,14 @@
       #main,
       #main > *,
       .hero,
+      section,
       section.section,
       section#trial,
       section#inside,
       section#pricing,
       section#faq,
-      section#thanks {
+      section#thanks,
+      footer section {
         background: transparent !important;
         background-color: transparent !important;
         background-image: none !important;


### PR DESCRIPTION
- Change starfield from z-index 9999 (on top) to -1 (behind content)
- Remove mix-blend-mode from starfield container (causes iOS issues)
- Show energy beam and blend with starfield using mix-blend-mode: screen
- Expand NUCLEAR transparent backgrounds rule to cover all sections