### PR TITLE
Make hero-demo video solid - no stars showing through

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,6 +557,16 @@
         z-index: 1 !important;
       }
 
+      /* Hero demo video - solid background, NO stars showing through */
+      #heroVideo,
+      #heroVideo ~ *,
+      .hero div[style*="aspect-ratio:245/106"],
+      .hero div[style*="border-radius:12px"][style*="overflow:hidden"] {
+        background: #0a0e18 !important;
+        position: relative !important;
+        z-index: 10 !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;


### PR DESCRIPTION
Add CSS rule to give heroVideo container solid background (#0a0e18) and higher z-index so starfield doesn't show through it