### PR TITLE
Chronicle audit fixes: hero images, SEO metadata, OpenGraph images

### DIFF
--- a/chronicle/birth-of-the-elite-seven/index.html
+++ b/chronicle/birth-of-the-elite-seven/index.html
@@ -15,8 +15,8 @@
   <meta property="og:title" content="The Birth of The Elite Seven">
   <meta property="og:description" content="Before the markets had names, before the candles told stories, there was only noise. This is the origin story of The Elite Seven.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
-  <meta property="article:published_time" content="2024-12-24">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council.png">
+  <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="The Birth of The Elite Seven">
@@ -436,6 +436,28 @@
       font-style: italic;
     }
 
+    /* Hero Image */
+    .article-hero {
+      max-width: 900px;
+      margin: 0 auto 3rem;
+      padding: 0 1.5rem;
+    }
+
+    .article-hero-image {
+      width: 100%;
+      max-height: 500px;
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+
+    .article-hero-image img {
+      width: 100%;
+      height: 100%;
+      max-height: 500px;
+      object-fit: cover;
+      object-position: center top;
+    }
+
     /* Share Section */
     .share-section {
       max-width: 720px;
@@ -603,7 +625,13 @@
     </div>
   </div>
 
-  <!-- Article Content -->
+  <!-- Hero Image -->
+  <div class="article-hero">
+    <div class="article-hero-image">
+      <img src="/chronicle/elite-seven-council.png" alt="The Elite Seven Council" loading="lazy">
+    </div>
+  </div>
+
   <article class="article-content">
 
     <p class="drop-cap">Before the markets had names, before the candles told stories, there was only noise. Traders wandered the charts like ships without stars—guessing, hoping, losing. The void of uncertainty consumed them. Fortunes vanished into the darkness between support and resistance. Generations of capital, erased.</p>

--- a/chronicle/meet-the-sovereign/index.html
+++ b/chronicle/meet-the-sovereign/index.html
@@ -15,9 +15,12 @@
   <meta property="og:title" content="Meet The Sovereign: Pentarch Explained">
   <meta property="og:description" content="A deep dive into Pentarch, the flagship indicator that maps the five phases of market cycles.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
-  <meta property="article:published_time" content="2024-12-24">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Meet The Sovereign: Pentarch">
+  <meta name="twitter:description" content="A deep dive into Pentarch, the flagship indicator that maps the five phases of market cycles.">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/chronicle/the-arbiter/index.html
+++ b/chronicle/the-arbiter/index.html
@@ -13,8 +13,12 @@
   <meta property="og:title" content="The Arbiter: Harmonic Oscillator">
   <meta property="og:description" content="Four voices. One verdict. I decide when the trigger is pulled.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Arbiter: Harmonic Oscillator">
+  <meta name="twitter:description" content="Four voices. One verdict. I decide when the trigger is pulled.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/chronicle/the-cartographer/index.html
+++ b/chronicle/the-cartographer/index.html
@@ -13,8 +13,12 @@
   <meta property="og:title" content="The Cartographer: Janus Atlas">
   <meta property="og:description" content="Every battlefield has its terrain. Janus Atlas maps where the wars will be fought.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Cartographer: Janus Atlas">
+  <meta name="twitter:description" content="Every battlefield has its terrain. Janus Atlas maps where the wars will be fought.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/chronicle/the-commander/index.html
+++ b/chronicle/the-commander/index.html
@@ -13,8 +13,12 @@
   <meta property="og:title" content="The Commander: OmniDeck">
   <meta property="og:description" content="Ten systems. One vision. Total clarity.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Commander: OmniDeck">
+  <meta name="twitter:description" content="Ten systems. One vision. Total clarity.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/chronicle/the-council-assembles/index.html
+++ b/chronicle/the-council-assembles/index.html
@@ -13,8 +13,12 @@
   <meta property="og:title" content="The Council Assembles">
   <meta property="og:description" content="You've met each member. Now watch them work as one.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Council Assembles">
+  <meta name="twitter:description" content="When The Elite Seven unite, chaos becomes clarity and noise becomes signal.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/chronicle/the-hierarchy-of-signals/index.html
+++ b/chronicle/the-hierarchy-of-signals/index.html
@@ -15,10 +15,12 @@
   <meta property="og:title" content="The Hierarchy of Signals">
   <meta property="og:description" content="The Seven do not exist in isolation. They form a constellation—a hierarchy of purpose.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
-  <meta property="article:published_time" content="2024-12-24">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals.png">
+  <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Hierarchy of Signals">
+  <meta name="twitter:description" content="The Seven do not exist in isolation. They form a constellation—a hierarchy of purpose.">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -472,6 +474,28 @@
     strong { color: var(--text); font-weight: 600; }
     em { font-style: italic; }
 
+    /* Hero Image */
+    .article-hero {
+      max-width: 900px;
+      margin: 0 auto 3rem;
+      padding: 0 1.5rem;
+    }
+
+    .article-hero-image {
+      width: 100%;
+      max-height: 500px;
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+
+    .article-hero-image img {
+      width: 100%;
+      height: 100%;
+      max-height: 500px;
+      object-fit: cover;
+      object-position: center top;
+    }
+
     .share-section {
       max-width: 720px;
       margin: 0 auto;
@@ -626,6 +650,13 @@
       <span>December 24, 2025</span>
       <span>·</span>
       <span>6 min read</span>
+    </div>
+  </div>
+
+  <!-- Hero Image -->
+  <div class="article-hero">
+    <div class="article-hero-image">
+      <img src="/chronicle/hierarchy-of-signals.png" alt="The Hierarchy of Signals" loading="lazy">
     </div>
   </div>
 

--- a/chronicle/the-pilots-oath/index.html
+++ b/chronicle/the-pilots-oath/index.html
@@ -15,10 +15,12 @@
   <meta property="og:title" content="The Pilot's Oath">
   <meta property="og:description" content="You who wield The Elite Seven are not a trader. You are a Pilot. This is the oath that separates those who navigate from those who gamble.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
-  <meta property="article:published_time" content="2024-12-24">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath.png">
+  <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Pilot's Oath">
+  <meta name="twitter:description" content="You who wield The Elite Seven are not a trader. You are a Pilot.">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -410,6 +412,28 @@
       font-style: italic;
     }
 
+    /* Hero Image */
+    .article-hero {
+      max-width: 900px;
+      margin: 0 auto 3rem;
+      padding: 0 1.5rem;
+    }
+
+    .article-hero-image {
+      width: 100%;
+      max-height: 500px;
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+
+    .article-hero-image img {
+      width: 100%;
+      height: 100%;
+      max-height: 500px;
+      object-fit: cover;
+      object-position: center top;
+    }
+
     /* Share Section */
     .share-section {
       max-width: 720px;
@@ -578,7 +602,13 @@
     </div>
   </div>
 
-  <!-- Article Content -->
+  <!-- Hero Image -->
+  <div class="article-hero">
+    <div class="article-hero-image">
+      <img src="/chronicle/pilots-oath.png" alt="The Pilot's Oath" loading="lazy">
+    </div>
+  </div>
+
   <article class="article-content">
 
     <p class="drop-cap">You who wield The Elite Seven are not a trader. You are a <strong>Pilot</strong>. You navigate the void between fear and greed, between accumulation and distribution, between the lies price tells and the truth volume whispers.</p>

--- a/chronicle/the-prophet/index.html
+++ b/chronicle/the-prophet/index.html
@@ -13,8 +13,12 @@
   <meta property="og:title" content="The Prophet: Volume Oracle">
   <meta property="og:description" content="Volume Oracle hears what retail cannot—the footsteps of institutions moving in darkness.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Prophet: Volume Oracle">
+  <meta name="twitter:description" content="Volume Oracle hears what retail cannot—the footsteps of institutions moving in darkness.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/chronicle/the-scales/index.html
+++ b/chronicle/the-scales/index.html
@@ -13,8 +13,12 @@
   <meta property="og:title" content="The Scales: Plutus Flow">
   <meta property="og:description" content="I weigh the invisible. Pressure does not lie.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Scales: Plutus Flow">
+  <meta name="twitter:description" content="I weigh the invisible. Pressure does not lie.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/chronicle/the-watchman/index.html
+++ b/chronicle/the-watchman/index.html
@@ -13,8 +13,12 @@
   <meta property="og:title" content="The Watchman: Augury Grid">
   <meta property="og:description" content="While you watch one chart, I watch them all.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Watchman: Augury Grid">
+  <meta name="twitter:description" content="While you watch one chart, I watch them all.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/chronicle/why-non-repainting-matters/index.html
+++ b/chronicle/why-non-repainting-matters/index.html
@@ -15,9 +15,12 @@
   <meta property="og:title" content="Why Non-Repainting Matters">
   <meta property="og:description" content="Most indicators lie to you by changing their historical signals. Here's why non-repainting is non-negotiable.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
-  <meta property="article:published_time" content="2024-12-24">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters.png">
+  <meta property="article:published_time" content="2025-12-24">
+  <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Why Non-Repainting Matters">
+  <meta name="twitter:description" content="Most indicators lie to you by changing their historical signals. Here's why non-repainting is non-negotiable.">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -454,6 +457,28 @@
     strong { color: var(--text); font-weight: 600; }
     em { font-style: italic; }
 
+    /* Hero Image */
+    .article-hero {
+      max-width: 900px;
+      margin: 0 auto 3rem;
+      padding: 0 1.5rem;
+    }
+
+    .article-hero-image {
+      width: 100%;
+      max-height: 500px;
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+
+    .article-hero-image img {
+      width: 100%;
+      height: 100%;
+      max-height: 500px;
+      object-fit: cover;
+      object-position: center top;
+    }
+
     .share-section {
       max-width: 720px;
       margin: 0 auto;
@@ -607,6 +632,13 @@
       <span>December 24, 2025</span>
       <span>·</span>
       <span>7 min read</span>
+    </div>
+  </div>
+
+  <!-- Hero Image -->
+  <div class="article-hero">
+    <div class="article-hero-image">
+      <img src="/chronicle/non-repainting-matters.png" alt="Why Non-Repainting Matters" loading="lazy">
     </div>
   </div>
 


### PR DESCRIPTION
- Added hero images to 4 missing articles (birth-of-the-elite-seven, the-pilots-oath, the-hierarchy-of-signals, why-non-repainting-matters)
- Fixed SEO metadata across all 12 articles (article:author, article:published_time, twitter:title, twitter:description)
- Updated og:image from generic preview.png to article-specific images