### PR TITLE
Add new site to mobile hamburger menu

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6870,6 +6870,7 @@ html[lang="ar"] [style*="text-align:center"] {
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">جربها مجاناً لمدة 7 أيام ←</a>
         <a href="#inside">ما بالداخل</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">الوثائق</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">مركز التعليم</a>
         <a href="/ar/faq.html">مركز الأسئلة الشائعة</a>

--- a/de/index.html
+++ b/de/index.html
@@ -6757,6 +6757,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">7 Tage kostenlos testen →</a>
         <a href="#inside">Was ist enthalten</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Bildungszentrum</a>
         <a href="/faq.html">FAQ-Center</a>

--- a/es/index.html
+++ b/es/index.html
@@ -7055,6 +7055,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Prueba Gratis 7 Días →</a>
         <a href="#inside">Qué incluye</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro Educativo</a>
         <a href="/es/faq.html">Centro de Preguntas</a>

--- a/fr/index.html
+++ b/fr/index.html
@@ -6965,6 +6965,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Essai Gratuit 7 Jours →</a>
         <a href="#inside">Contenu inclus</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centre de Formation</a>
         <a href="/fr/faq.html">Centre FAQ</a>

--- a/hu/index.html
+++ b/hu/index.html
@@ -6790,6 +6790,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Próbáld 7 Napig Ingyen →</a>
         <a href="#inside">Mi van benne</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Oktatási Központ</a>
         <a href="/hu/faq.html">GYIK Központ</a>

--- a/index.html
+++ b/index.html
@@ -5941,6 +5941,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Try Free 7 Days →</a>
         <a href="#inside">What's inside</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a>
         <a href="/faq.html">FAQ Center</a>

--- a/it/index.html
+++ b/it/index.html
@@ -6728,6 +6728,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Prova Gratis 7 Giorni →</a>
         <a href="#inside">Cosa c'è dentro</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Hub Educativo</a>
         <a href="/it/faq.html">Centro FAQ</a>

--- a/ja/index.html
+++ b/ja/index.html
@@ -7082,6 +7082,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">7日間無料トライアル →</a>
         <a href="#inside">アドベントカレンダー</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">トレーニングセンター</a>
         <a href="/ja/faq.html">FAQセンター</a>

--- a/nl/index.html
+++ b/nl/index.html
@@ -6767,6 +6767,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Probeer 7 Dagen Gratis →</a>
         <a href="#inside">Wat zit erin</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Educatie Hub</a>
         <a href="/nl/faq.html">FAQ Centrum</a>

--- a/pt/index.html
+++ b/pt/index.html
@@ -7024,6 +7024,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Teste Grátis 7 Dias →</a>
         <a href="#inside">O que está incluído</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro de Educação</a>
         <a href="/pt/faq.html">Central de FAQ</a>

--- a/ru/index.html
+++ b/ru/index.html
@@ -6698,6 +6698,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">7 Дней Бесплатно →</a>
         <a href="#inside">Что внутри</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Образовательный центр</a>
         <a href="/faq.html">Центр FAQ</a>

--- a/tr/index.html
+++ b/tr/index.html
@@ -6778,6 +6778,7 @@
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">7 Gün Ücretsiz Dene →</a>
         <a href="#inside">İçerik</a>
+        <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokümantasyon</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Eğitim Merkezi</a>
         <a href="/tr/faq.html">SSS Merkezi</a>


### PR DESCRIPTION
The mobile menu was missing the Chronicle link that exists in the desktop nav dropdown. Added it to all 12 language variants.