### PR TITLE
Fix Chronicle card images not loading on language sites

### DIFF
--- a/ar/chronicle/index.html
+++ b/ar/chronicle/index.html
@@ -474,7 +474,7 @@
 
         <!-- Featured Article -->
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">مميز</span>
             <div class="article-meta">
@@ -492,7 +492,7 @@
 
         <!-- Article 2 -->
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">الفلسفة</span>
@@ -509,7 +509,7 @@
 
         <!-- Article 3 -->
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">النظام</span>
@@ -526,7 +526,7 @@
 
         <!-- Article 4: Meet The Sovereign -->
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">الأول من السبعة</span>
@@ -543,7 +543,7 @@
 
         <!-- Article 5: Why Non-Repainting Matters -->
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">الثقة</span>
@@ -560,7 +560,7 @@
 
         <!-- Article 6: The Prophet -->
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">الثاني من السبعة</span>
@@ -577,7 +577,7 @@
 
         <!-- Article 7: The Cartographer -->
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">الثالث من السبعة</span>
@@ -594,7 +594,7 @@
 
         <!-- Article 8: The Scales -->
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">الرابع من السبعة</span>
@@ -611,7 +611,7 @@
 
         <!-- Article 9: The Commander -->
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">الخامس من السبعة</span>
@@ -628,7 +628,7 @@
 
         <!-- Article 10: The Watchman -->
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">السادس من السبعة</span>
@@ -645,7 +645,7 @@
 
         <!-- Article 11: The Arbiter -->
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">السابع من السبعة</span>
@@ -662,7 +662,7 @@
 
         <!-- Article 12: The Council Assembles -->
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">الختام</span>

--- a/de/chronicle/index.html
+++ b/de/chronicle/index.html
@@ -466,7 +466,7 @@
 
         <!-- Featured Article -->
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Empfohlen</span>
             <div class="article-meta">
@@ -484,7 +484,7 @@
 
         <!-- Article 2 -->
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Philosophie</span>
@@ -501,7 +501,7 @@
 
         <!-- Article 3 -->
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">System</span>
@@ -518,7 +518,7 @@
 
         <!-- Article 4: Meet The Sovereign -->
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Eins von Sieben</span>
@@ -535,7 +535,7 @@
 
         <!-- Article 5: Why Non-Repainting Matters -->
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Vertrauen</span>
@@ -552,7 +552,7 @@
 
         <!-- Article 6: The Prophet -->
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Zwei von Sieben</span>
@@ -569,7 +569,7 @@
 
         <!-- Article 7: The Cartographer -->
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Drei von Sieben</span>
@@ -586,7 +586,7 @@
 
         <!-- Article 8: The Scales -->
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Vier von Sieben</span>
@@ -603,7 +603,7 @@
 
         <!-- Article 9: The Commander -->
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Fünf von Sieben</span>
@@ -620,7 +620,7 @@
 
         <!-- Article 10: The Watchman -->
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sechs von Sieben</span>
@@ -637,7 +637,7 @@
 
         <!-- Article 11: The Arbiter -->
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sieben von Sieben</span>
@@ -654,7 +654,7 @@
 
         <!-- Article 12: The Council Assembles -->
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Finale</span>

--- a/es/chronicle/index.html
+++ b/es/chronicle/index.html
@@ -466,7 +466,7 @@
 
         <!-- Featured Article -->
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Destacado</span>
             <div class="article-meta">
@@ -484,7 +484,7 @@
 
         <!-- Article 2 -->
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Filosofía</span>
@@ -501,7 +501,7 @@
 
         <!-- Article 3 -->
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sistema</span>
@@ -518,7 +518,7 @@
 
         <!-- Article 4: Meet The Sovereign -->
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Uno de Siete</span>
@@ -535,7 +535,7 @@
 
         <!-- Article 5: Why Non-Repainting Matters -->
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Confianza</span>
@@ -552,7 +552,7 @@
 
         <!-- Article 6: The Prophet -->
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Dos de Siete</span>
@@ -569,7 +569,7 @@
 
         <!-- Article 7: The Cartographer -->
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Tres de Siete</span>
@@ -586,7 +586,7 @@
 
         <!-- Article 8: The Scales -->
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Cuatro de Siete</span>
@@ -603,7 +603,7 @@
 
         <!-- Article 9: The Commander -->
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Cinco de Siete</span>
@@ -620,7 +620,7 @@
 
         <!-- Article 10: The Watchman -->
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Seis de Siete</span>
@@ -637,7 +637,7 @@
 
         <!-- Article 11: The Arbiter -->
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Siete de Siete</span>
@@ -654,7 +654,7 @@
 
         <!-- Article 12: The Council Assembles -->
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Final</span>

--- a/fr/chronicle/index.html
+++ b/fr/chronicle/index.html
@@ -466,7 +466,7 @@
 
         <!-- Featured Article -->
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">À la une</span>
             <div class="article-meta">
@@ -484,7 +484,7 @@
 
         <!-- Article 2 -->
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Philosophie</span>
@@ -501,7 +501,7 @@
 
         <!-- Article 3 -->
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Système</span>
@@ -518,7 +518,7 @@
 
         <!-- Article 4: Meet The Sovereign -->
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Un sur Sept</span>
@@ -535,7 +535,7 @@
 
         <!-- Article 5: Why Non-Repainting Matters -->
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Confiance</span>
@@ -552,7 +552,7 @@
 
         <!-- Article 6: The Prophet -->
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Deux sur Sept</span>
@@ -569,7 +569,7 @@
 
         <!-- Article 7: The Cartographer -->
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Trois sur Sept</span>
@@ -586,7 +586,7 @@
 
         <!-- Article 8: The Scales -->
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Quatre sur Sept</span>
@@ -603,7 +603,7 @@
 
         <!-- Article 9: The Commander -->
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Cinq sur Sept</span>
@@ -620,7 +620,7 @@
 
         <!-- Article 10: The Watchman -->
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Six sur Sept</span>
@@ -637,7 +637,7 @@
 
         <!-- Article 11: The Arbiter -->
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sept sur Sept</span>
@@ -654,7 +654,7 @@
 
         <!-- Article 12: The Council Assembles -->
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Finale</span>

--- a/hu/chronicle/index.html
+++ b/hu/chronicle/index.html
@@ -474,7 +474,7 @@
 
         <!-- Featured Article -->
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Kiemelt</span>
             <div class="article-meta">
@@ -492,7 +492,7 @@
 
         <!-- Article 2 -->
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Filozófia</span>
@@ -509,7 +509,7 @@
 
         <!-- Article 3 -->
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Rendszer</span>
@@ -526,7 +526,7 @@
 
         <!-- Article 4: Meet The Sovereign -->
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Első a hétből</span>
@@ -543,7 +543,7 @@
 
         <!-- Article 5: Why Non-Repainting Matters -->
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Bizalom</span>
@@ -560,7 +560,7 @@
 
         <!-- Article 6: The Prophet -->
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Második a hétből</span>
@@ -577,7 +577,7 @@
 
         <!-- Article 7: The Cartographer -->
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Harmadik a hétből</span>
@@ -594,7 +594,7 @@
 
         <!-- Article 8: The Scales -->
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Negyedik a hétből</span>
@@ -611,7 +611,7 @@
 
         <!-- Article 9: The Commander -->
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Ötödik a hétből</span>
@@ -628,7 +628,7 @@
 
         <!-- Article 10: The Watchman -->
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Hatodik a hétből</span>
@@ -645,7 +645,7 @@
 
         <!-- Article 11: The Arbiter -->
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Hetedik a hétből</span>
@@ -662,7 +662,7 @@
 
         <!-- Article 12: The Council Assembles -->
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Finálé</span>

--- a/it/chronicle/index.html
+++ b/it/chronicle/index.html
@@ -110,7 +110,7 @@
       <div class="articles-grid">
 
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">In evidenza</span>
             <div class="article-meta">
@@ -127,7 +127,7 @@
         </a>
 
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Filosofia</span>
@@ -143,7 +143,7 @@
         </a>
 
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sistema</span>
@@ -159,7 +159,7 @@
         </a>
 
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Uno di Sette</span>
@@ -175,7 +175,7 @@
         </a>
 
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Fiducia</span>
@@ -191,7 +191,7 @@
         </a>
 
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Due di Sette</span>
@@ -207,7 +207,7 @@
         </a>
 
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Tre di Sette</span>
@@ -223,7 +223,7 @@
         </a>
 
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Quattro di Sette</span>
@@ -239,7 +239,7 @@
         </a>
 
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Cinque di Sette</span>
@@ -255,7 +255,7 @@
         </a>
 
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sei di Sette</span>
@@ -271,7 +271,7 @@
         </a>
 
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sette di Sette</span>
@@ -287,7 +287,7 @@
         </a>
 
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Finale</span>

--- a/ja/chronicle/index.html
+++ b/ja/chronicle/index.html
@@ -474,7 +474,7 @@
 
         <!-- Featured Article -->
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">注目記事</span>
             <div class="article-meta">
@@ -492,7 +492,7 @@
 
         <!-- Article 2 -->
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">哲学</span>
@@ -509,7 +509,7 @@
 
         <!-- Article 3 -->
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">システム</span>
@@ -526,7 +526,7 @@
 
         <!-- Article 4: Meet The Sovereign -->
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">7つの1番目</span>
@@ -543,7 +543,7 @@
 
         <!-- Article 5: Why Non-Repainting Matters -->
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">信頼</span>
@@ -560,7 +560,7 @@
 
         <!-- Article 6: The Prophet -->
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">7つの2番目</span>
@@ -577,7 +577,7 @@
 
         <!-- Article 7: The Cartographer -->
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">7つの3番目</span>
@@ -594,7 +594,7 @@
 
         <!-- Article 8: The Scales -->
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">7つの4番目</span>
@@ -611,7 +611,7 @@
 
         <!-- Article 9: The Commander -->
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">7つの5番目</span>
@@ -628,7 +628,7 @@
 
         <!-- Article 10: The Watchman -->
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">7つの6番目</span>
@@ -645,7 +645,7 @@
 
         <!-- Article 11: The Arbiter -->
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">7つの7番目</span>
@@ -662,7 +662,7 @@
 
         <!-- Article 12: The Council Assembles -->
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">フィナーレ</span>

--- a/nl/chronicle/index.html
+++ b/nl/chronicle/index.html
@@ -110,7 +110,7 @@
       <div class="articles-grid">
 
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Uitgelicht</span>
             <div class="article-meta">
@@ -127,7 +127,7 @@
         </a>
 
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Filosofie</span>
@@ -143,7 +143,7 @@
         </a>
 
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Systeem</span>
@@ -159,7 +159,7 @@
         </a>
 
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Eén van Zeven</span>
@@ -175,7 +175,7 @@
         </a>
 
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Vertrouwen</span>
@@ -191,7 +191,7 @@
         </a>
 
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Twee van Zeven</span>
@@ -207,7 +207,7 @@
         </a>
 
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Drie van Zeven</span>
@@ -223,7 +223,7 @@
         </a>
 
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Vier van Zeven</span>
@@ -239,7 +239,7 @@
         </a>
 
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Vijf van Zeven</span>
@@ -255,7 +255,7 @@
         </a>
 
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Zes van Zeven</span>
@@ -271,7 +271,7 @@
         </a>
 
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Zeven van Zeven</span>
@@ -287,7 +287,7 @@
         </a>
 
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Finale</span>

--- a/pt/chronicle/index.html
+++ b/pt/chronicle/index.html
@@ -110,7 +110,7 @@
       <div class="articles-grid">
 
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Destaque</span>
             <div class="article-meta">
@@ -127,7 +127,7 @@
         </a>
 
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Filosofia</span>
@@ -143,7 +143,7 @@
         </a>
 
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sistema</span>
@@ -159,7 +159,7 @@
         </a>
 
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Um de Sete</span>
@@ -175,7 +175,7 @@
         </a>
 
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Confiança</span>
@@ -191,7 +191,7 @@
         </a>
 
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Dois de Sete</span>
@@ -207,7 +207,7 @@
         </a>
 
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Três de Sete</span>
@@ -223,7 +223,7 @@
         </a>
 
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Quatro de Sete</span>
@@ -239,7 +239,7 @@
         </a>
 
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Cinco de Sete</span>
@@ -255,7 +255,7 @@
         </a>
 
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Seis de Sete</span>
@@ -271,7 +271,7 @@
         </a>
 
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sete de Sete</span>
@@ -287,7 +287,7 @@
         </a>
 
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Final</span>

--- a/ru/chronicle/index.html
+++ b/ru/chronicle/index.html
@@ -474,7 +474,7 @@
 
         <!-- Featured Article -->
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Избранное</span>
             <div class="article-meta">
@@ -492,7 +492,7 @@
 
         <!-- Article 2 -->
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Философия</span>
@@ -509,7 +509,7 @@
 
         <!-- Article 3 -->
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Система</span>
@@ -526,7 +526,7 @@
 
         <!-- Article 4: Meet The Sovereign -->
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Первый из Семи</span>
@@ -543,7 +543,7 @@
 
         <!-- Article 5: Why Non-Repainting Matters -->
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Доверие</span>
@@ -560,7 +560,7 @@
 
         <!-- Article 6: The Prophet -->
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Второй из Семи</span>
@@ -577,7 +577,7 @@
 
         <!-- Article 7: The Cartographer -->
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Третий из Семи</span>
@@ -594,7 +594,7 @@
 
         <!-- Article 8: The Scales -->
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Четвёртый из Семи</span>
@@ -611,7 +611,7 @@
 
         <!-- Article 9: The Commander -->
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Пятый из Семи</span>
@@ -628,7 +628,7 @@
 
         <!-- Article 10: The Watchman -->
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Шестой из Семи</span>
@@ -645,7 +645,7 @@
 
         <!-- Article 11: The Arbiter -->
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Седьмой из Семи</span>
@@ -662,7 +662,7 @@
 
         <!-- Article 12: The Council Assembles -->
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Финал</span>

--- a/tr/chronicle/index.html
+++ b/tr/chronicle/index.html
@@ -474,7 +474,7 @@
 
         <!-- Featured Article -->
         <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/elite-seven-council.png')"><span>★</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Öne Çıkan</span>
             <div class="article-meta">
@@ -492,7 +492,7 @@
 
         <!-- Article 2 -->
         <a href="/chronicle/the-pilots-oath" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/pilots-oath.png')"><span>⚔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Felsefe</span>
@@ -509,7 +509,7 @@
 
         <!-- Article 3 -->
         <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/hierarchy-of-signals.png')"><span>◇</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Sistem</span>
@@ -526,7 +526,7 @@
 
         <!-- Article 4: Meet The Sovereign -->
         <a href="/chronicle/meet-the-sovereign" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/sovereign-pentarch.png')"><span>♔</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Yedinin Birincisi</span>
@@ -543,7 +543,7 @@
 
         <!-- Article 5: Why Non-Repainting Matters -->
         <a href="/chronicle/why-non-repainting-matters" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/non-repainting-matters.png')"><span>◈</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Güven</span>
@@ -560,7 +560,7 @@
 
         <!-- Article 6: The Prophet -->
         <a href="/chronicle/the-prophet" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/prophet-volume-oracle.png')"><span>◎</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Yedinin İkincisi</span>
@@ -577,7 +577,7 @@
 
         <!-- Article 7: The Cartographer -->
         <a href="/chronicle/the-cartographer" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/cartographer-janus-atlas.png')"><span>◫</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Yedinin Üçüncüsü</span>
@@ -594,7 +594,7 @@
 
         <!-- Article 8: The Scales -->
         <a href="/chronicle/the-scales" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/scales-plutus-flow.png')"><span>⚖</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Yedinin Dördüncüsü</span>
@@ -611,7 +611,7 @@
 
         <!-- Article 9: The Commander -->
         <a href="/chronicle/the-commander" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/commander-omnideck.png')"><span>⌘</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Yedinin Beşincisi</span>
@@ -628,7 +628,7 @@
 
         <!-- Article 10: The Watchman -->
         <a href="/chronicle/the-watchman" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/watchman-augury-grid.png')"><span>◉</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Yedinin Altıncısı</span>
@@ -645,7 +645,7 @@
 
         <!-- Article 11: The Arbiter -->
         <a href="/chronicle/the-arbiter" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Yedinin Yedincisi</span>
@@ -662,7 +662,7 @@
 
         <!-- Article 12: The Council Assembles -->
         <a href="/chronicle/the-council-assembles" class="article-card">
-          <div class="article-image has-bg" style="background-image:url('/chronicle/images/council-assembles.png')"><span>⚡</span></div>
+          <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">
               <span class="article-category">Final</span>


### PR DESCRIPTION
The image paths were incorrectly pointing to /chronicle/images/*.png but the images are stored directly at /chronicle/*.png. Fixed all 11 language variants.