### PR TITLE
Fix chronicle article links to use correct language paths

### DIFF
--- a/ar/chronicle/index.html
+++ b/ar/chronicle/index.html
@@ -473,7 +473,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/ar/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">مميز</span>
@@ -491,7 +491,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/ar/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -508,7 +508,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/ar/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -525,7 +525,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/ar/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -542,7 +542,7 @@
         </a>
 
         <!-- Article 5: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/ar/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -559,7 +559,7 @@
         </a>
 
         <!-- Article 6: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/ar/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -576,7 +576,7 @@
         </a>
 
         <!-- Article 7: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/ar/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -593,7 +593,7 @@
         </a>
 
         <!-- Article 8: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/ar/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -610,7 +610,7 @@
         </a>
 
         <!-- Article 9: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/ar/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -627,7 +627,7 @@
         </a>
 
         <!-- Article 10: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/ar/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -644,7 +644,7 @@
         </a>
 
         <!-- Article 11: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/ar/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -661,7 +661,7 @@
         </a>
 
         <!-- Article 12: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/ar/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/de/chronicle/index.html
+++ b/de/chronicle/index.html
@@ -465,7 +465,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/de/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Empfohlen</span>
@@ -483,7 +483,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/de/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -500,7 +500,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/de/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -517,7 +517,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/de/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -534,7 +534,7 @@
         </a>
 
         <!-- Article 5: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/de/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -551,7 +551,7 @@
         </a>
 
         <!-- Article 6: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/de/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -568,7 +568,7 @@
         </a>
 
         <!-- Article 7: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/de/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -585,7 +585,7 @@
         </a>
 
         <!-- Article 8: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/de/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -602,7 +602,7 @@
         </a>
 
         <!-- Article 9: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/de/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -619,7 +619,7 @@
         </a>
 
         <!-- Article 10: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/de/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -636,7 +636,7 @@
         </a>
 
         <!-- Article 11: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/de/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -653,7 +653,7 @@
         </a>
 
         <!-- Article 12: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/de/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/es/chronicle/index.html
+++ b/es/chronicle/index.html
@@ -465,7 +465,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/es/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Destacado</span>
@@ -483,7 +483,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/es/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -500,7 +500,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/es/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -517,7 +517,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/es/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -534,7 +534,7 @@
         </a>
 
         <!-- Article 5: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/es/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -551,7 +551,7 @@
         </a>
 
         <!-- Article 6: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/es/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -568,7 +568,7 @@
         </a>
 
         <!-- Article 7: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/es/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -585,7 +585,7 @@
         </a>
 
         <!-- Article 8: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/es/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -602,7 +602,7 @@
         </a>
 
         <!-- Article 9: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/es/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -619,7 +619,7 @@
         </a>
 
         <!-- Article 10: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/es/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -636,7 +636,7 @@
         </a>
 
         <!-- Article 11: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/es/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -653,7 +653,7 @@
         </a>
 
         <!-- Article 12: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/es/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/fr/chronicle/index.html
+++ b/fr/chronicle/index.html
@@ -465,7 +465,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/fr/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">À la une</span>
@@ -483,7 +483,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/fr/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -500,7 +500,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/fr/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -517,7 +517,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/fr/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -534,7 +534,7 @@
         </a>
 
         <!-- Article 5: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/fr/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -551,7 +551,7 @@
         </a>
 
         <!-- Article 6: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/fr/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -568,7 +568,7 @@
         </a>
 
         <!-- Article 7: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/fr/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -585,7 +585,7 @@
         </a>
 
         <!-- Article 8: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/fr/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -602,7 +602,7 @@
         </a>
 
         <!-- Article 9: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/fr/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -619,7 +619,7 @@
         </a>
 
         <!-- Article 10: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/fr/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -636,7 +636,7 @@
         </a>
 
         <!-- Article 11: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/fr/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -653,7 +653,7 @@
         </a>
 
         <!-- Article 12: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/fr/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/hu/chronicle/index.html
+++ b/hu/chronicle/index.html
@@ -473,7 +473,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/hu/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Kiemelt</span>
@@ -491,7 +491,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/hu/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -508,7 +508,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/hu/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -525,7 +525,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/hu/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -542,7 +542,7 @@
         </a>
 
         <!-- Article 5: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/hu/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -559,7 +559,7 @@
         </a>
 
         <!-- Article 6: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/hu/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -576,7 +576,7 @@
         </a>
 
         <!-- Article 7: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/hu/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -593,7 +593,7 @@
         </a>
 
         <!-- Article 8: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/hu/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -610,7 +610,7 @@
         </a>
 
         <!-- Article 9: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/hu/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -627,7 +627,7 @@
         </a>
 
         <!-- Article 10: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/hu/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -644,7 +644,7 @@
         </a>
 
         <!-- Article 11: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/hu/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -661,7 +661,7 @@
         </a>
 
         <!-- Article 12: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/hu/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/it/chronicle/index.html
+++ b/it/chronicle/index.html
@@ -109,7 +109,7 @@
     <div class="container">
       <div class="articles-grid">
 
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/it/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">In evidenza</span>
@@ -126,7 +126,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/it/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -142,7 +142,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/it/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -158,7 +158,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/it/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -174,7 +174,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/it/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -190,7 +190,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/it/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -206,7 +206,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/it/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -222,7 +222,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/it/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -238,7 +238,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/it/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -254,7 +254,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/it/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -270,7 +270,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/it/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -286,7 +286,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/it/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/ja/chronicle/index.html
+++ b/ja/chronicle/index.html
@@ -473,7 +473,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/ja/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">注目記事</span>
@@ -491,7 +491,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/ja/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -508,7 +508,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/ja/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -525,7 +525,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/ja/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -542,7 +542,7 @@
         </a>
 
         <!-- Article 5: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/ja/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -559,7 +559,7 @@
         </a>
 
         <!-- Article 6: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/ja/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -576,7 +576,7 @@
         </a>
 
         <!-- Article 7: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/ja/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -593,7 +593,7 @@
         </a>
 
         <!-- Article 8: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/ja/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -610,7 +610,7 @@
         </a>
 
         <!-- Article 9: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/ja/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -627,7 +627,7 @@
         </a>
 
         <!-- Article 10: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/ja/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -644,7 +644,7 @@
         </a>
 
         <!-- Article 11: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/ja/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -661,7 +661,7 @@
         </a>
 
         <!-- Article 12: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/ja/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/nl/chronicle/index.html
+++ b/nl/chronicle/index.html
@@ -109,7 +109,7 @@
     <div class="container">
       <div class="articles-grid">
 
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/nl/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Uitgelicht</span>
@@ -126,7 +126,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/nl/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -142,7 +142,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/nl/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -158,7 +158,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/nl/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -174,7 +174,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/nl/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -190,7 +190,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/nl/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -206,7 +206,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/nl/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -222,7 +222,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/nl/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -238,7 +238,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/nl/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -254,7 +254,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/nl/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -270,7 +270,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/nl/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -286,7 +286,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/nl/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/pt/chronicle/index.html
+++ b/pt/chronicle/index.html
@@ -109,7 +109,7 @@
     <div class="container">
       <div class="articles-grid">
 
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/pt/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Destaque</span>
@@ -126,7 +126,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/pt/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -142,7 +142,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/pt/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -158,7 +158,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/pt/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -174,7 +174,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/pt/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -190,7 +190,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/pt/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -206,7 +206,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/pt/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -222,7 +222,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/pt/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -238,7 +238,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/pt/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -254,7 +254,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/pt/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -270,7 +270,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/pt/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -286,7 +286,7 @@
           </div>
         </a>
 
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/pt/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/ru/chronicle/index.html
+++ b/ru/chronicle/index.html
@@ -473,7 +473,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/ru/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Избранное</span>
@@ -491,7 +491,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/ru/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -508,7 +508,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/ru/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -525,7 +525,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/ru/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -542,7 +542,7 @@
         </a>
 
         <!-- Article 5: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/ru/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -559,7 +559,7 @@
         </a>
 
         <!-- Article 6: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/ru/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -576,7 +576,7 @@
         </a>
 
         <!-- Article 7: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/ru/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -593,7 +593,7 @@
         </a>
 
         <!-- Article 8: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/ru/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -610,7 +610,7 @@
         </a>
 
         <!-- Article 9: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/ru/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -627,7 +627,7 @@
         </a>
 
         <!-- Article 10: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/ru/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -644,7 +644,7 @@
         </a>
 
         <!-- Article 11: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/ru/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -661,7 +661,7 @@
         </a>
 
         <!-- Article 12: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/ru/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">

--- a/tr/chronicle/index.html
+++ b/tr/chronicle/index.html
@@ -473,7 +473,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article">
+        <a href="/tr/chronicle/birth-of-the-elite-seven/" class="article-card featured-article">
           <div class="article-image has-bg" style="background-image:url('/chronicle/elite-seven-council.png')"><span>★</span></div>
           <div class="article-content">
             <span class="featured-badge">Öne Çıkan</span>
@@ -491,7 +491,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card">
+        <a href="/tr/chronicle/the-pilots-oath/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/pilots-oath.png')"><span>⚔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -508,7 +508,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card">
+        <a href="/tr/chronicle/the-hierarchy-of-signals/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/hierarchy-of-signals.png')"><span>◇</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -525,7 +525,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card">
+        <a href="/tr/chronicle/meet-the-sovereign/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/sovereign-pentarch.png')"><span>♔</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -542,7 +542,7 @@
         </a>
 
         <!-- Article 5: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card">
+        <a href="/tr/chronicle/why-non-repainting-matters/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/non-repainting-matters.png')"><span>◈</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -559,7 +559,7 @@
         </a>
 
         <!-- Article 6: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card">
+        <a href="/tr/chronicle/the-prophet/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/prophet-volume-oracle.png')"><span>◎</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -576,7 +576,7 @@
         </a>
 
         <!-- Article 7: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card">
+        <a href="/tr/chronicle/the-cartographer/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"><span>◫</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -593,7 +593,7 @@
         </a>
 
         <!-- Article 8: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card">
+        <a href="/tr/chronicle/the-scales/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/scales-plutus-flow.png')"><span>⚖</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -610,7 +610,7 @@
         </a>
 
         <!-- Article 9: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card">
+        <a href="/tr/chronicle/the-commander/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/commander-omnideck.png')"><span>⌘</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -627,7 +627,7 @@
         </a>
 
         <!-- Article 10: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card">
+        <a href="/tr/chronicle/the-watchman/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/watchman-augury-grid.png')"><span>◉</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -644,7 +644,7 @@
         </a>
 
         <!-- Article 11: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card">
+        <a href="/tr/chronicle/the-arbiter/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"><span>⬡</span></div>
           <div class="article-content">
             <div class="article-meta">
@@ -661,7 +661,7 @@
         </a>
 
         <!-- Article 12: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card">
+        <a href="/tr/chronicle/the-council-assembles/" class="article-card">
           <div class="article-image has-bg" style="background-image:url('/chronicle/council-assembles.png')"><span>⚡</span></div>
           <div class="article-content">
             <div class="article-meta">


### PR DESCRIPTION
All language versions of the chronicle index page were incorrectly linking to English article paths (/chronicle/...) instead of their respective language paths (e.g., /es/chronicle/...). This caused users to be redirected to the English site when clicking articles.

Fixed all 12 article links in 11 language versions:
- Arabic, German, Spanish, French, Hungarian, Italian
- Japanese, Dutch, Portuguese, Russian, Turkish