### PR TITLE
Remove old bg-aurora CSS and add desktop video override for all langu…

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -814,9 +814,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1052,45 +1049,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -1227,8 +1186,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1248,47 +1205,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1589,9 +1508,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1826,45 +1742,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -2001,8 +1879,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -2022,47 +1898,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2083,10 +1921,7 @@
     }
 
     /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* html[data-theme="light"] .bg-aurora REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -4196,6 +4031,29 @@ html[lang="ar"] [style*="text-align:center"] {
         background: transparent !important;
         background-color: transparent !important;
         background-image: none !important;
+      }
+    }
+
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
       }
     }
   </style>

--- a/de/index.html
+++ b/de/index.html
@@ -798,10 +798,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
-
       /* Header needs high z-index for dropdown menus */
       header {
         position: relative;
@@ -1036,55 +1032,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
@@ -1211,8 +1159,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1232,47 +1178,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1558,10 +1466,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
-
       /* Header needs high z-index for dropdown menus */
       header {
         position: relative;
@@ -1795,55 +1699,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
@@ -1970,8 +1826,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1991,47 +1845,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2052,10 +1868,7 @@
     }
 
     /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* bg-aurora light mode rules REMOVED - using video background */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -4141,6 +3954,35 @@
       }
 
     }
+
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+
+      /* Ensure transparent backgrounds for blend mode to work */
+      .hero,
+      #main-content,
+      main,
+      main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/es/index.html
+++ b/es/index.html
@@ -1135,55 +1135,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
@@ -1310,8 +1262,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1331,47 +1281,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1991,55 +1903,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
@@ -2166,8 +2030,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -2187,47 +2049,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2248,10 +2072,7 @@
     }
 
     /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* html[data-theme="light"] .bg-aurora rule REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -4370,6 +4191,34 @@
         background-image: none !important;
       }
 
+    }
+
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+
+      /* Ensure transparent backgrounds for blend mode to work */
+      .hero,
+      #main-content,
+      main,
+      main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
     }
   </style>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -850,9 +850,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1087,56 +1084,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      /* DISABLED: animation causing flickering */
-      /* animation:aurora 36s linear infinite alternate; */
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:auto;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* REMOVED: Smooth theme transitions - causes flickering */
-      /* transition:opacity 0.3s ease, filter 0.3s ease; */
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
@@ -1263,8 +1211,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1284,47 +1230,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1661,9 +1569,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1897,56 +1802,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      /* DISABLED: animation causing flickering */
-      /* animation:aurora 36s linear infinite alternate; */
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:auto;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* REMOVED: Smooth theme transitions - causes flickering */
-      /* transition:opacity 0.3s ease, filter 0.3s ease; */
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1)}
@@ -2073,8 +1929,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -2094,47 +1948,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2155,10 +1971,7 @@
     }
 
     /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* bg-aurora light mode rule REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -3778,6 +3591,33 @@
   transform: translateZ(0);
 }
 
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+
+      /* Ensure transparent backgrounds for blend mode to work */
+      .hero,
+      #main-content,
+      main,
+      main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+    }
 
   </style>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -819,9 +819,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1057,45 +1054,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -1232,7 +1191,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
 
       #typing-cursor{animation:none;opacity:1}
 
@@ -1253,46 +1211,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
 
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
@@ -1600,9 +1521,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1837,45 +1755,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -2012,7 +1892,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
 
       #typing-cursor{animation:none;opacity:1}
 
@@ -2033,46 +1912,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
 
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
@@ -2094,10 +1936,7 @@
     }
 
     /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* html[data-theme="light"] .bg-aurora - REMOVED, using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -3613,6 +3452,28 @@
   transform: translateZ(0);
 }
 
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+    }
 
   </style>
 

--- a/it/index.html
+++ b/it/index.html
@@ -1029,55 +1029,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
@@ -1204,8 +1156,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1225,47 +1175,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1781,55 +1693,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
@@ -1956,8 +1820,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1977,47 +1839,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2038,10 +1862,7 @@
     }
 
     /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* bg-aurora rule REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -4055,6 +3876,30 @@
         background: transparent !important;
         background-color: transparent !important;
         background-image: none !important;
+      }
+    }
+
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
       }
     }
   </style>

--- a/ja/index.html
+++ b/ja/index.html
@@ -871,9 +871,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1117,55 +1114,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
@@ -1341,8 +1290,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1362,47 +1309,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1760,9 +1669,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -2005,55 +1911,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
-
-
-
-    @keyframes aurora{
-
-      from{transform:translate3d(-2%,-1%,0) scale(1.02)}
-
-      to{transform:translate3d(2%,1%,0) scale(1.05)}
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
     @keyframes pricingGlow{
       0%,100%{box-shadow:0 0 40px rgba(91,138,255,.2),0 0 80px rgba(91,138,255,.1);transform:scale(1.05)}
@@ -2229,8 +2087,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -2250,47 +2106,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2310,11 +2128,7 @@
       }
     }
 
-    /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* Light mode bg-aurora REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -3901,6 +3715,28 @@
   transform: translateZ(0);
 }
 
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+    }
 
   </style>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -812,9 +812,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1050,45 +1047,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -1225,7 +1184,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
 
       #typing-cursor{animation:none;opacity:1}
 
@@ -1246,47 +1204,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1586,9 +1506,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1823,45 +1740,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -1998,7 +1877,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
 
       #typing-cursor{animation:none;opacity:1}
 
@@ -2019,47 +1897,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2079,11 +1919,7 @@
       }
     }
 
-    /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* Light mode bg-aurora REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -8552,6 +8388,29 @@ if ('serviceWorker' in navigator) {
       font-size: 2rem !important;
     }
   }
+
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+    }
 </style>
 
 <script>

--- a/pt/index.html
+++ b/pt/index.html
@@ -757,9 +757,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1022,45 +1019,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -1231,8 +1190,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1252,47 +1209,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1556,9 +1475,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1820,45 +1736,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -2029,8 +1907,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -2050,47 +1926,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2111,10 +1949,7 @@
     }
 
     /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* html[data-theme="light"] .bg-aurora REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -3928,6 +3763,28 @@
   transform: translateZ(0);
 }
 
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+    }
 
   </style>
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -777,9 +777,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1015,45 +1012,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -1190,7 +1149,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
 
       #typing-cursor{animation:none;opacity:1}
 
@@ -1211,47 +1169,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -1516,9 +1436,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1753,45 +1670,7 @@
 
 
 
-    /* CSS aurora background animation */
-
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
-      backface-visibility:hidden;
-
-      /* Smooth theme transitions */
-      transition:background 0.5s ease, opacity 0.3s ease, filter 0.3s ease;
-
-    }
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
 
 
 
@@ -1928,7 +1807,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
 
       #typing-cursor{animation:none;opacity:1}
 
@@ -1949,47 +1827,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
-
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
         animation: none !important;
@@ -2009,11 +1849,7 @@
       }
     }
 
-    /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* Light mode bg-aurora rules REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -8481,6 +8317,29 @@ if ('serviceWorker' in navigator) {
       font-size: 2rem !important;
     }
   }
+
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+    }
 </style>
 
 <script>

--- a/tr/index.html
+++ b/tr/index.html
@@ -815,9 +815,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1055,37 +1052,7 @@
 
     /* CSS aurora background animation */
 
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
       backface-visibility:hidden;
 
       /* Smooth theme transitions */
@@ -1228,8 +1195,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -1249,46 +1214,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
 
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
@@ -1591,9 +1519,6 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      .bg-aurora {
-        display: none !important; /* Hide aurora on mobile */
-      }
 
       /* Header needs high z-index for dropdown menus */
       header {
@@ -1830,37 +1755,7 @@
 
     /* CSS aurora background animation */
 
-    .bg-aurora{
-
-      position:fixed;
-
-      inset:0;
-
-      z-index:-1;
-
-      pointer-events:none;
-
-      background:
-
-        radial-gradient(45% 35% at 12% 12%,rgba(125,200,255,.40),transparent 62%),
-
-        radial-gradient(36% 28% at 85% 14%,rgba(155,140,255,.38),transparent 65%),
-
-        radial-gradient(48% 36% at 78% 88%,rgba(118,221,255,.28),transparent 70%),
-
-        radial-gradient(26% 22% at 8% 72%,rgba(151,124,255,.22),transparent 66%);
-
-      filter:blur(60px) saturate(130%) brightness(110%);
-
-      mix-blend-mode:screen;
-
-      animation:aurora 36s linear infinite alternate;
-
-      opacity:.85;
-
-      /* Performance optimization */
-      will-change:transform;
-      transform:translateZ(0);
+    /* bg-aurora CSS REMOVED - element disabled, using video background instead */
       backface-visibility:hidden;
 
       /* Smooth theme transitions */
@@ -2003,8 +1898,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      .bg-aurora{animation:none}
-
       #typing-cursor{animation:none;opacity:1}
 
       /* Disable all animations for users who prefer reduced motion */
@@ -2024,46 +1917,9 @@
       #parallax-orb-1,#parallax-orb-2{display:none !important}
     }
 
-    /* CAPABILITY-BASED DISPLAY: Hide effects on devices that can't handle them */
-    html[data-aurora="false"] .bg-aurora{
-      display:none !important;
-      visibility:hidden !important;
-    }
-
-    /* Constellations now enabled on all devices for beautiful mobile experience!
-       Removed data-particles="false" hiding rule - particles.js and device-capability.js
-       handle performance optimization internally without CSS overrides */
-
-    html[data-blendmodes="false"] .bg-aurora{
-      mix-blend-mode:normal !important;
-    }
-
-    html[data-performance="low"] .bg-aurora{
-      animation:none !important;
-      opacity:.2 !important;
-    }
-
-    html[data-performance="medium"] .bg-aurora{
-      animation-duration:60s !important;
-    }
-
-    /* MOBILE ENHANCEMENT: Round aurora that fits mobile viewport */
+    /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Smaller, centered gradients that fit mobile screens (not cut off at edges) */
-      .bg-aurora{
-        background:
-          radial-gradient(circle 180px at 25% 20%, rgba(125,200,255,.42), transparent 65%),
-          radial-gradient(circle 160px at 75% 25%, rgba(155,140,255,.38), transparent 65%),
-          radial-gradient(circle 200px at 50% 50%, rgba(91,138,255,.35), transparent 70%),
-          radial-gradient(circle 170px at 30% 75%, rgba(118,221,255,.32), transparent 65%),
-          radial-gradient(circle 150px at 70% 80%, rgba(151,124,255,.28), transparent 65%) !important;
-
-        mix-blend-mode:screen !important;
-        opacity:.8 !important;
-        filter:blur(50px) saturate(120%) brightness(105%) !important;
-        animation:aurora 36s linear infinite alternate !important;
-      }
 
       /* Disable harsh blinking cursor on mobile */
       #typing-cursor {
@@ -2085,10 +1941,7 @@
     }
 
     /* Light mode background adjustments */
-    html[data-theme="light"] .bg-aurora{
-      opacity:.06 !important;
-      filter:blur(80px) saturate(60%) brightness(120%) !important;
-    }
+    /* html[data-theme="light"] .bg-aurora REMOVED - using video background instead */
 
     html[data-theme="light"] .bg-stars{
       opacity:.08 !important;
@@ -3597,6 +3450,28 @@
   transform: translateZ(0);
 }
 
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+    }
 
   </style>
 
@@ -4102,6 +3977,29 @@
         background: transparent !important;
         background-color: transparent !important;
         background-image: none !important;
+      }
+    }
+
+    /* ============================================
+       DESKTOP OVERRIDE: Ensure video blending works
+       ============================================ */
+    @media (min-width: 769px) {
+      #energy-beam-video {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        mix-blend-mode: screen !important;
+        position: absolute !important;
+        top: -140px !important;
+        left: -70px !important;
+        height: calc(100% + 210px) !important;
+        width: auto !important;
+        z-index: 0 !important;
+        pointer-events: none !important;
+      }
+      .hero, #main-content, main, main > section:first-child {
+        background: transparent !important;
+        background-color: transparent !important;
       }
     }
   </style>


### PR DESCRIPTION
…ages

- Remove deprecated bg-aurora CSS definitions and keyframes
- Remove bg-aurora rules from media queries (mobile, reduced-motion, capabilities)
- Remove light mode bg-aurora adjustments
- Add desktop override CSS to ensure energy-beam-video blending works
- Force transparent backgrounds on hero/main sections for proper mix-blend-mode
- All old aurora references now commented out, using video background instead