### PR TITLE
Fix energy-beam video sizing to cover full viewport width

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4036,6 +4036,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -4045,11 +4046,15 @@ html[lang="ar"] [style*="text-align:center"] {
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;

--- a/de/index.html
+++ b/de/index.html
@@ -3957,6 +3957,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -3966,11 +3967,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
 
       /* Ensure transparent backgrounds for blend mode to work */

--- a/es/index.html
+++ b/es/index.html
@@ -4195,6 +4195,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -4204,11 +4205,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
 
       /* Ensure transparent backgrounds for blend mode to work */

--- a/fr/index.html
+++ b/fr/index.html
@@ -3593,6 +3593,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -3602,11 +3603,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
 
       /* Ensure transparent backgrounds for blend mode to work */

--- a/hu/index.html
+++ b/hu/index.html
@@ -3454,6 +3454,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -3463,11 +3464,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;

--- a/it/index.html
+++ b/it/index.html
@@ -3881,6 +3881,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -3890,11 +3891,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
 
       .hero, #main-content, main, main > section:first-child {

--- a/ja/index.html
+++ b/ja/index.html
@@ -3717,6 +3717,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -3726,11 +3727,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;

--- a/nl/index.html
+++ b/nl/index.html
@@ -8391,6 +8391,7 @@ if ('serviceWorker' in navigator) {
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -8400,11 +8401,15 @@ if ('serviceWorker' in navigator) {
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;

--- a/pt/index.html
+++ b/pt/index.html
@@ -3765,6 +3765,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -3774,11 +3775,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;

--- a/ru/index.html
+++ b/ru/index.html
@@ -8320,6 +8320,7 @@ if ('serviceWorker' in navigator) {
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -8329,11 +8330,15 @@ if ('serviceWorker' in navigator) {
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;

--- a/tr/index.html
+++ b/tr/index.html
@@ -3452,6 +3452,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -3461,11 +3462,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;
@@ -3982,6 +3987,7 @@
 
     /* ============================================
        DESKTOP OVERRIDE: Ensure video blending works
+       Video must extend past viewport edges to avoid visible boundaries
        ============================================ */
     @media (min-width: 769px) {
       #energy-beam-video {
@@ -3991,11 +3997,15 @@
         mix-blend-mode: screen !important;
         position: absolute !important;
         top: -140px !important;
-        left: -70px !important;
-        height: calc(100% + 210px) !important;
-        width: auto !important;
+        left: 0 !important;
+        width: 100% !important;
+        min-width: 100vw !important;
+        height: auto !important;
+        min-height: calc(100% + 210px) !important;
         z-index: 0 !important;
         pointer-events: none !important;
+        object-fit: cover !important;
+        object-position: left center !important;
       }
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;


### PR DESCRIPTION
- Change video from width:auto to width:100% with min-width:100vw
- Add object-fit:cover to ensure video fills container without gaps
- Add object-position:left center for proper alignment
- Fixes visible edge/boundary issue on wide desktop screens