### PR TITLE
Fix video blending by making body::before transparent on desktop

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4060,6 +4060,15 @@ html[lang="ar"] [style*="text-align:center"] {
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
   </style>
 

--- a/de/index.html
+++ b/de/index.html
@@ -3986,6 +3986,15 @@
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
 
   </style>

--- a/es/index.html
+++ b/es/index.html
@@ -4224,6 +4224,15 @@
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
   </style>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -3622,6 +3622,15 @@
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
 
   </style>

--- a/hu/index.html
+++ b/hu/index.html
@@ -3478,6 +3478,15 @@
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
 
   </style>

--- a/it/index.html
+++ b/it/index.html
@@ -3906,6 +3906,15 @@
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
   </style>
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -3741,6 +3741,15 @@
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
 
   </style>

--- a/nl/index.html
+++ b/nl/index.html
@@ -8415,6 +8415,15 @@ if ('serviceWorker' in navigator) {
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
 </style>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -3789,6 +3789,15 @@
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
 
   </style>

--- a/ru/index.html
+++ b/ru/index.html
@@ -8344,6 +8344,15 @@ if ('serviceWorker' in navigator) {
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
 </style>
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -3476,6 +3476,15 @@
         background: transparent !important;
         background-color: transparent !important;
       }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
+      }
     }
 
   </style>
@@ -4010,6 +4019,15 @@
       .hero, #main-content, main, main > section:first-child {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* Remove solid background from body::before so starfield blends through */
+      body::before {
+        background:
+          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
+          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
+          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
+          transparent !important;
       }
     }
   </style>


### PR DESCRIPTION
- Remove solid var(--bg) background from body::before for desktop
- Keep only the subtle gradient overlays, make base transparent
- This allows starfield to blend through properly with energy-beam video
- mix-blend-mode: screen now correctly shows starfield through the video