### PR TITLE
Remove desktop video overrides - use inline styles like English

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4034,42 +4034,6 @@ html[lang="ar"] [style*="text-align:center"] {
       }
     }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/de/index.html
+++ b/de/index.html
@@ -3955,47 +3955,6 @@
 
     }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-
-      /* Ensure transparent backgrounds for blend mode to work */
-      .hero,
-      #main-content,
-      main,
-      main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
 
   </style>
 

--- a/es/index.html
+++ b/es/index.html
@@ -4193,47 +4193,6 @@
 
     }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-
-      /* Ensure transparent backgrounds for blend mode to work */
-      .hero,
-      #main-content,
-      main,
-      main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/fr/index.html
+++ b/fr/index.html
@@ -3591,47 +3591,6 @@
   transform: translateZ(0);
 }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-
-      /* Ensure transparent backgrounds for blend mode to work */
-      .hero,
-      #main-content,
-      main,
-      main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
 
   </style>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -3452,42 +3452,6 @@
   transform: translateZ(0);
 }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
 
   </style>
 

--- a/it/index.html
+++ b/it/index.html
@@ -3879,43 +3879,6 @@
       }
     }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/ja/index.html
+++ b/ja/index.html
@@ -3715,43 +3715,6 @@
   transform: translateZ(0);
 }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
-
   </style>
 
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -8389,42 +8389,6 @@ if ('serviceWorker' in navigator) {
     }
   }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
 </style>
 
 <script>

--- a/pt/index.html
+++ b/pt/index.html
@@ -3763,42 +3763,6 @@
   transform: translateZ(0);
 }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
 
   </style>
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -8318,42 +8318,6 @@ if ('serviceWorker' in navigator) {
     }
   }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
 </style>
 
 <script>

--- a/tr/index.html
+++ b/tr/index.html
@@ -3450,42 +3450,6 @@
   transform: translateZ(0);
 }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
 
   </style>
 
@@ -3994,42 +3958,6 @@
       }
     }
 
-    /* ============================================
-       DESKTOP OVERRIDE: Ensure video blending works
-       Video must extend past viewport edges to avoid visible boundaries
-       ============================================ */
-    @media (min-width: 769px) {
-      #energy-beam-video {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        mix-blend-mode: screen !important;
-        position: absolute !important;
-        top: -140px !important;
-        left: 0 !important;
-        width: 100% !important;
-        min-width: 100vw !important;
-        height: auto !important;
-        min-height: calc(100% + 210px) !important;
-        z-index: 0 !important;
-        pointer-events: none !important;
-        object-fit: cover !important;
-        object-position: left center !important;
-      }
-      .hero, #main-content, main, main > section:first-child {
-        background: transparent !important;
-        background-color: transparent !important;
-      }
-
-      /* Remove solid background from body::before so starfield blends through */
-      body::before {
-        background:
-          radial-gradient(1200px 700px at -6% -8%, rgba(130,185,255,.18), transparent 60%),
-          radial-gradient(1100px 660px at 108% -10%, rgba(155,140,255,.18), transparent 62%),
-          radial-gradient(1200px 700px at 52% 118%, rgba(118,221,255,.12), transparent 64%),
-          transparent !important;
-      }
-    }
   </style>
 
 <!-- Scroll Reveal Animations (async) -->


### PR DESCRIPTION
English desktop works with NO CSS overrides, just inline styles on the video. Removing all desktop override blocks so language pages match English behavior. The mix-blend-mode: screen in inline styles should work naturally.