### PR TITLE
Add final CSS override to force video blending with starfield

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4034,6 +4034,22 @@ html[lang="ar"] [style*="text-align:center"] {
       }
     }
 
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/de/index.html
+++ b/de/index.html
@@ -3956,6 +3956,21 @@
     }
 
 
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/es/index.html
+++ b/es/index.html
@@ -4193,6 +4193,22 @@
 
     }
 
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/fr/index.html
+++ b/fr/index.html
@@ -4154,6 +4154,23 @@
       }
 
     }
+
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/hu/index.html
+++ b/hu/index.html
@@ -3959,6 +3959,23 @@
         background-image: none !important;
       }
     }
+
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/it/index.html
+++ b/it/index.html
@@ -3879,6 +3879,22 @@
       }
     }
 
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/ja/index.html
+++ b/ja/index.html
@@ -4221,6 +4221,23 @@
         background-image: none !important;
       }
     }
+
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/nl/index.html
+++ b/nl/index.html
@@ -3933,6 +3933,23 @@
         background-image: none !important;
       }
     }
+
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/pt/index.html
+++ b/pt/index.html
@@ -4270,6 +4270,23 @@
         background-image: none !important;
       }
     }
+
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/ru/index.html
+++ b/ru/index.html
@@ -3864,6 +3864,23 @@
         background-image: none !important;
       }
     }
+
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->

--- a/tr/index.html
+++ b/tr/index.html
@@ -3958,6 +3958,22 @@
       }
     }
 
+
+    /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
+    #energy-beam-video {
+      mix-blend-mode: screen !important;
+      background: transparent !important;
+    }
+
+    /* Ensure ALL parent elements up to body are transparent for blend to work */
+    .hero,
+    #main-content,
+    main#main,
+    main {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
   </style>
 
 <!-- Scroll Reveal Animations (async) -->


### PR DESCRIPTION
- Add explicit mix-blend-mode: screen on #energy-beam-video
- Add background: transparent on video element
- Force transparent backgrounds on all parent elements (.hero, #main-content, main)
- Placed at END of CSS to ensure highest precedence over duplicate CSS blocks