### PR TITLE
Fix article header formatting across languages

### DIFF
--- a/chronicle/the-council-assembles/index.html
+++ b/chronicle/the-council-assembles/index.html
@@ -38,6 +38,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
 
     /* Resources Dropdown */
     .nav-dropdown{position:relative;z-index:65}

--- a/hu/chronicle/the-council-assembles/index.html
+++ b/hu/chronicle/the-council-assembles/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--gold),var(--warn));z-index:99;transition:width 0.1s}

--- a/it/chronicle/the-council-assembles/index.html
+++ b/it/chronicle/the-council-assembles/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/ja/chronicle/the-council-assembles/index.html
+++ b/ja/chronicle/the-council-assembles/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--gold),var(--warn));z-index:99;transition:width 0.1s}


### PR DESCRIPTION
Add missing nav ul and nav a CSS rules that were causing navigation menu items to display incorrectly over article content. Fixed in English, Hungarian, Italian, and Japanese versions.