### PR TITLE
Fix nav CSS and Italian oath across all chronicle articles

### DIFF
--- a/de/chronicle/the-hierarchy-of-signals/index.html
+++ b/de/chronicle/the-hierarchy-of-signals/index.html
@@ -162,6 +162,24 @@
 
     .header-nav a:hover { color: var(--text); }
 
+    nav ul {
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+    }
+
+    nav a {
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav a:hover { color: var(--text); }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/de/chronicle/the-pilots-oath/index.html
+++ b/de/chronicle/the-pilots-oath/index.html
@@ -163,6 +163,24 @@
 
     .header-nav a:hover { color: var(--text); }
 
+    nav ul {
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+    }
+
+    nav a {
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav a:hover { color: var(--text); }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/de/chronicle/why-non-repainting-matters/index.html
+++ b/de/chronicle/why-non-repainting-matters/index.html
@@ -167,6 +167,24 @@
 
     .header-nav a:hover { color: var(--text); }
 
+    nav ul {
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+    }
+
+    nav a {
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav a:hover { color: var(--text); }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/hu/chronicle/the-cartographer/index.html
+++ b/hu/chronicle/the-cartographer/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--warn),var(--gold));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-commander/index.html
+++ b/hu/chronicle/the-commander/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--brand),var(--accent));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-hierarchy-of-signals/index.html
+++ b/hu/chronicle/the-hierarchy-of-signals/index.html
@@ -194,6 +194,24 @@
 
     .header-nav a:hover { color: var(--text); }
 
+    nav ul {
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+    }
+
+    nav a {
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav a:hover { color: var(--text); }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/hu/chronicle/the-pilots-oath/index.html
+++ b/hu/chronicle/the-pilots-oath/index.html
@@ -197,6 +197,24 @@
 
     .header-nav a:hover { color: var(--text); }
 
+    nav ul {
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+    }
+
+    nav a {
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav a:hover { color: var(--text); }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/hu/chronicle/the-prophet/index.html
+++ b/hu/chronicle/the-prophet/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-scales/index.html
+++ b/hu/chronicle/the-scales/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--good),var(--bad));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-watchman/index.html
+++ b/hu/chronicle/the-watchman/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/why-non-repainting-matters/index.html
+++ b/hu/chronicle/why-non-repainting-matters/index.html
@@ -167,6 +167,24 @@
 
     .header-nav a:hover { color: var(--text); }
 
+    nav ul {
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+    }
+
+    nav a {
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav a:hover { color: var(--text); }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/it/chronicle/birth-of-the-elite-seven/index.html
+++ b/it/chronicle/birth-of-the-elite-seven/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/meet-the-sovereign/index.html
+++ b/it/chronicle/meet-the-sovereign/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/the-arbiter/index.html
+++ b/it/chronicle/the-arbiter/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/the-cartographer/index.html
+++ b/it/chronicle/the-cartographer/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/the-commander/index.html
+++ b/it/chronicle/the-commander/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/the-hierarchy-of-signals/index.html
+++ b/it/chronicle/the-hierarchy-of-signals/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/the-pilots-oath/index.html
+++ b/it/chronicle/the-pilots-oath/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */
@@ -80,9 +83,11 @@
     .article-content h2{font-family:'EB Garamond',Georgia,serif;font-size:1.75rem;font-weight:600;color:var(--text);margin:3rem 0 1.5rem;line-height:1.3}
     .drop-cap::first-letter{float:left;font-size:4.5rem;line-height:0.8;padding-right:0.15em;padding-top:0.1em;color:var(--accent);font-weight:500}
     .divider{text-align:center;margin:3rem 0;color:var(--muted-2);font-size:1.5rem;letter-spacing:0.5em}
-    .oath-container{background:linear-gradient(135deg,rgba(244,208,63,.08),rgba(244,208,63,.02));border:2px solid rgba(244,208,63,.3);border-radius:var(--radius);padding:2.5rem;margin:2rem 0;text-align:center}
-    .oath-container h3{font-family:'EB Garamond',Georgia,serif;font-size:1.5rem;color:var(--gold);margin-bottom:1.5rem;font-style:italic}
-    .oath-container p{font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;color:var(--text);line-height:1.8;margin-bottom:0}
+    .oath-container{background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(91,138,255,.03));border:1px solid rgba(91,138,255,.2);border-radius:var(--radius);padding:3rem;margin:3rem 0;text-align:center}
+    .oath-container h3{font-family:'Space Grotesk',system-ui,sans-serif;font-size:0.85rem;font-weight:700;text-transform:uppercase;letter-spacing:0.2em;color:var(--accent);margin-bottom:2rem}
+    .oath-lines{font-size:1.4rem;line-height:2.2;color:var(--text);font-style:italic}
+    .oath-lines .section{margin-bottom:1.5rem}
+    .oath-lines .emphasis{font-size:1.6rem;color:var(--gold);font-weight:500}
     .lesson-card{background:linear-gradient(135deg,rgba(255,255,255,.04),rgba(255,255,255,.02));border:1px solid var(--border);border-radius:var(--radius);padding:1.5rem 2rem;margin:1.5rem 0}
     .lesson-card h4{font-family:'Space Grotesk',system-ui,sans-serif;font-size:0.9rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--accent);margin-bottom:0.75rem}
     .lesson-card p{margin-bottom:0;font-size:1.1rem}
@@ -233,13 +238,27 @@
     <p>Questo giuramento definisce cosa significa essere un Pilota.</p>
 
     <div class="oath-container">
-      <h3>Il Giuramento</h3>
-      <p>Navigo attraverso il rumore, non reagisco ad esso.<br>
-      Rispetto la gerarchia. Ogni segnale ha il suo posto.<br>
-      Non inseguo trade. Lascio che i trade vengano da me.<br>
-      Proteggo il capitale prima. I profitti vengono da quelli che sopravvivono.<br>
-      Ascolto il consiglio, anche quando la sua guida contraddice il mio desiderio.<br>
-      Sono un Pilota. La costellazione è la mia luce.</p>
+      <h3>Il Giuramento del Pilota</h3>
+      <div class="oath-lines">
+        <div class="section">
+          Non inseguirò.<br>
+          Non indovinerò.<br>
+          Non spererò.
+        </div>
+        <div class="section">
+          Leggerò il ciclo.<br>
+          Seguirò le istituzioni.<br>
+          Rispetterò i livelli.<br>
+          Peserò la pressione.<br>
+          Unificherò i miei sistemi.<br>
+          Scannerizzerò l'orizzonte.<br>
+          Aspetterò il consenso.
+        </div>
+        <div class="emphasis">
+          Non sono un giocatore d'azzardo. Sono un Pilota.<br>
+          E I Sette sono le mie stelle.
+        </div>
+      </div>
     </div>
 
     <div class="divider">✧ ✧ ✧</div>

--- a/it/chronicle/the-prophet/index.html
+++ b/it/chronicle/the-prophet/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/the-scales/index.html
+++ b/it/chronicle/the-scales/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/the-watchman/index.html
+++ b/it/chronicle/the-watchman/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/it/chronicle/why-non-repainting-matters/index.html
+++ b/it/chronicle/why-non-repainting-matters/index.html
@@ -38,6 +38,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/ja/chronicle/birth-of-the-elite-seven/index.html
+++ b/ja/chronicle/birth-of-the-elite-seven/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/ja/chronicle/meet-the-sovereign/index.html
+++ b/ja/chronicle/meet-the-sovereign/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/ja/chronicle/the-arbiter/index.html
+++ b/ja/chronicle/the-arbiter/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/ja/chronicle/the-cartographer/index.html
+++ b/ja/chronicle/the-cartographer/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     /* Resources Dropdown */

--- a/ja/chronicle/the-commander/index.html
+++ b/ja/chronicle/the-commander/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--brand),var(--accent));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-hierarchy-of-signals/index.html
+++ b/ja/chronicle/the-hierarchy-of-signals/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-pilots-oath/index.html
+++ b/ja/chronicle/the-pilots-oath/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--gold),var(--warn));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-prophet/index.html
+++ b/ja/chronicle/the-prophet/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-scales/index.html
+++ b/ja/chronicle/the-scales/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--good),var(--bad));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-watchman/index.html
+++ b/ja/chronicle/the-watchman/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/why-non-repainting-matters/index.html
+++ b/ja/chronicle/why-non-repainting-matters/index.html
@@ -33,6 +33,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--good),var(--accent));z-index:99;transition:width 0.1s}


### PR DESCRIPTION
- Add missing nav ul and nav a CSS rules to 33 chronicle articles across de, hu, it, ja language versions
- Fix Italian pilots-oath article:
  - Replace incomplete/different oath content with proper translation
  - Update oath CSS to match English version styling
- Affected languages: German (3), Hungarian (8), Italian (12), Japanese (11)