### PR TITLE
Fix image preview for non-English articles

### DIFF
--- a/ar/chronicle/birth-of-the-elite-seven/index.html
+++ b/ar/chronicle/birth-of-the-elite-seven/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="ولادة النخبة السبعة">
   <meta property="og:description" content="قبل أن تحمل الأسواق أسماءً، قبل أن تروي الشموع قصصاً، لم يكن هناك سوى الضوضاء. هذه قصة أصل النخبة السبعة.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ولادة النخبة السبعة">
+  <meta name="twitter:description" content="قبل أن تحمل الأسواق أسماءً، قبل أن تروي الشموع قصصاً، لم يكن هناك سوى الضوضاء. هذه قصة أصل النخبة السبعة.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:title" content="ولادة النخبة السبعة">
   <meta name="twitter:description" content="قصة أصل سبع إشارات سماوية ظهرت لتبحر في الفراغ.">
 

--- a/ar/chronicle/meet-the-sovereign/index.html
+++ b/ar/chronicle/meet-the-sovereign/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="تعرف على الحاكم: شرح Pentarch">
   <meta property="og:description" content="نظرة عميقة في Pentarch، المؤشر الرئيسي الذي يرسم المراحل الخمس لدورات السوق.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="تعرف على الحاكم: شرح Pentarch">
+  <meta name="twitter:description" content="نظرة عميقة في Pentarch، المؤشر الرئيسي الذي يرسم المراحل الخمس لدورات السوق.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+Arabic:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ar/chronicle/the-arbiter/index.html
+++ b/ar/chronicle/the-arbiter/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="الحَكَم: Harmonic Oscillator">
   <meta property="og:description" content="أربعة أصوات. حكم واحد. أنا أقرر متى يُضغط الزناد.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="الحَكَم: Harmonic Oscillator">
+  <meta name="twitter:description" content="أربعة أصوات. حكم واحد. أنا أقرر متى يُضغط الزناد.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:title" content="الحَكَم: Harmonic Oscillator">
   <meta name="twitter:description" content="أربعة أصوات. حكم واحد. أنا أقرر متى يُضغط الزناد.">
 

--- a/ar/chronicle/the-cartographer/index.html
+++ b/ar/chronicle/the-cartographer/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="رسام الخرائط: Janus Atlas">
   <meta property="og:description" content="لكل ساحة معركة تضاريسها. أنا أرسم خريطة أين ستُخاض الحروب.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="رسام الخرائط: Janus Atlas">
+  <meta name="twitter:description" content="لكل ساحة معركة تضاريسها. أنا أرسم خريطة أين ستُخاض الحروب.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:title" content="رسام الخرائط: Janus Atlas">
   <meta name="twitter:description" content="لكل ساحة معركة تضاريسها. أنا أرسم خريطة أين ستُخاض الحروب.">
 

--- a/ar/chronicle/the-commander/index.html
+++ b/ar/chronicle/the-commander/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="القائد: OmniDeck">
   <meta property="og:description" content="عشرة أنظمة. رؤية واحدة. وضوح تام.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="القائد: OmniDeck">
+  <meta name="twitter:description" content="عشرة أنظمة. رؤية واحدة. وضوح تام.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:title" content="القائد: OmniDeck">
   <meta name="twitter:description" content="عشرة أنظمة. رؤية واحدة. وضوح تام.">
 

--- a/ar/chronicle/the-council-assembles/index.html
+++ b/ar/chronicle/the-council-assembles/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="المجلس يجتمع">
   <meta property="og:description" content="قابلت كل عضو. الآن شاهدهم يعملون كواحد.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="المجلس يجتمع">
+  <meta name="twitter:description" content="قابلت كل عضو. الآن شاهدهم يعملون كواحد.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:title" content="المجلس يجتمع">
   <meta name="twitter:description" content="قابلت كل عضو. الآن شاهدهم يعملون كواحد.">
 

--- a/ar/chronicle/the-hierarchy-of-signals/index.html
+++ b/ar/chronicle/the-hierarchy-of-signals/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="التسلسل الهرمي للإشارات">
   <meta property="og:description" content="السبعة لا يوجدون في عزلة. يشكلون كوكبة—تسلسل هرمي من الغرض.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="التسلسل الهرمي للإشارات">
+  <meta name="twitter:description" content="السبعة لا يوجدون في عزلة. يشكلون كوكبة—تسلسل هرمي من الغرض.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ar/chronicle/the-pilots-oath/index.html
+++ b/ar/chronicle/the-pilots-oath/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="قسم الطيار">
   <meta property="og:description" content="أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار. هذا هو القسم الذي يفصل بين أولئك الذين يبحرون وأولئك الذين يقامرون.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="قسم الطيار">
+  <meta name="twitter:description" content="أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار. هذا هو القسم الذي يفصل بين أولئك الذين يبحرون وأولئك الذين يقامرون.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ar/chronicle/the-prophet/index.html
+++ b/ar/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="النبي: Volume Oracle">
   <meta property="og:description" content="Volume Oracle يسمع ما لا يستطيع المتداولون العاديون سماعه—خطوات المؤسسات وهي تتحرك في الظلام.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="النبي: Volume Oracle">
+  <meta name="twitter:description" content="Volume Oracle يسمع ما لا يستطيع المتداولون العاديون سماعه—خطوات المؤسسات وهي تتحرك في الظلام.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+Arabic:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ar/chronicle/the-scales/index.html
+++ b/ar/chronicle/the-scales/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="الميزان: Plutus Flow">
   <meta property="og:description" content="أزن ما لا يُرى. الضغط لا يكذب.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="الميزان: Plutus Flow">
+  <meta name="twitter:description" content="أزن ما لا يُرى. الضغط لا يكذب.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:title" content="الميزان: Plutus Flow">
   <meta name="twitter:description" content="أزن ما لا يُرى. الضغط لا يكذب.">
 

--- a/ar/chronicle/the-watchman/index.html
+++ b/ar/chronicle/the-watchman/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="الحارس: Augury Grid">
   <meta property="og:description" content="بينما تراقب رسماً بيانياً واحداً، أنا أراقبها كلها.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="الحارس: Augury Grid">
+  <meta name="twitter:description" content="بينما تراقب رسماً بيانياً واحداً، أنا أراقبها كلها.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:title" content="الحارس: Augury Grid">
   <meta name="twitter:description" content="بينما تراقب رسماً بيانياً واحداً، أنا أراقبها كلها.">
 

--- a/ar/chronicle/why-non-repainting-matters/index.html
+++ b/ar/chronicle/why-non-repainting-matters/index.html
@@ -15,9 +15,12 @@
   <meta property="og:title" content="لماذا عدم إعادة الرسم مهم">
   <meta property="og:description" content="معظم المؤشرات تكذب عليك بتغيير إشاراتها التاريخية. إليك لماذا عدم إعادة الرسم غير قابل للتفاوض.">
   <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="لماذا عدم إعادة الرسم مهم">
+  <meta name="twitter:description" content="معظم المؤشرات تكذب عليك بتغيير إشاراتها التاريخية. إليك لماذا عدم إعادة الرسم غير قابل للتفاوض.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/de/chronicle/birth-of-the-elite-seven/index.html
+++ b/de/chronicle/birth-of-the-elite-seven/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="Die Geburt der Elite Sieben">
   <meta property="og:description" content="Bevor die Märkte Namen hatten, bevor die Kerzen Geschichten erzählten, gab es nur Rauschen. Dies ist die Entstehungsgeschichte der Elite Sieben.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Die Geburt der Elite Sieben">
+  <meta name="twitter:description" content="Bevor die Märkte Namen hatten, bevor die Kerzen Geschichten erzählten, gab es nur Rauschen. Dies ist die Entstehungsgeschichte der Elite Sieben.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:title" content="Die Geburt der Elite Sieben">
   <meta name="twitter:description" content="Die Entstehungsgeschichte von sieben himmlischen Signalen, die entstanden, um durch die Leere zu navigieren.">
 

--- a/de/chronicle/meet-the-sovereign/index.html
+++ b/de/chronicle/meet-the-sovereign/index.html
@@ -14,8 +14,11 @@
   <meta property="og:title" content="Lerne den Herrscher kennen: Pentarch erklärt">
   <meta property="og:description" content="Ein tiefer Einblick in Pentarch, den Flaggschiff-Indikator, der die fünf Phasen der Marktzyklen kartiert.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Lerne den Herrscher kennen: Pentarch erklärt">
+  <meta name="twitter:description" content="Ein tiefer Einblick in Pentarch, den Flaggschiff-Indikator, der die fünf Phasen der Marktzyklen kartiert.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/de/chronicle/the-arbiter/index.html
+++ b/de/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Der Schiedsrichter: Harmonic Oscillator">
   <meta property="og:description" content="Vier Stimmen. Ein Urteil. Ich entscheide, wann der Abzug gedrückt wird.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Der Schiedsrichter: Harmonic Oscillator">
+  <meta name="twitter:description" content="Vier Stimmen. Ein Urteil. Ich entscheide, wann der Abzug gedrückt wird.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/de/chronicle/the-cartographer/index.html
+++ b/de/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Der Kartograph: Janus Atlas">
   <meta property="og:description" content="Jedes Schlachtfeld hat sein Terrain. Janus Atlas kartiert, wo die Kriege geführt werden.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Der Kartograph: Janus Atlas">
+  <meta name="twitter:description" content="Jedes Schlachtfeld hat sein Terrain. Janus Atlas kartiert, wo die Kriege geführt werden.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/de/chronicle/the-commander/index.html
+++ b/de/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Der Kommandant: OmniDeck">
   <meta property="og:description" content="Zehn Systeme. Eine Vision. Totale Klarheit.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Der Kommandant: OmniDeck">
+  <meta name="twitter:description" content="Zehn Systeme. Eine Vision. Totale Klarheit.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/de/chronicle/the-council-assembles/index.html
+++ b/de/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Der Rat versammelt sich">
   <meta property="og:description" content="Sie haben jedes Mitglied kennengelernt. Jetzt sehen Sie, wie sie als Einheit arbeiten.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Der Rat versammelt sich">
+  <meta name="twitter:description" content="Sie haben jedes Mitglied kennengelernt. Jetzt sehen Sie, wie sie als Einheit arbeiten.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/de/chronicle/the-hierarchy-of-signals/index.html
+++ b/de/chronicle/the-hierarchy-of-signals/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="Die Hierarchie der Signale">
   <meta property="og:description" content="Die Sieben existieren nicht isoliert. Sie bilden ein Sternbild—eine Hierarchie des Zwecks.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Die Hierarchie der Signale">
+  <meta name="twitter:description" content="Die Sieben existieren nicht isoliert. Sie bilden ein Sternbild—eine Hierarchie des Zwecks.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/de/chronicle/the-pilots-oath/index.html
+++ b/de/chronicle/the-pilots-oath/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="Der Eid des Piloten">
   <meta property="og:description" content="Du, der die Elite Sieben führst, bist kein Händler. Du bist ein Pilot. Dies ist der Eid, der diejenigen, die navigieren, von denen trennt, die spielen.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Der Eid des Piloten">
+  <meta name="twitter:description" content="Du, der die Elite Sieben führst, bist kein Händler. Du bist ein Pilot. Dies ist der Eid, der diejenigen, die navigieren, von denen trennt, die spielen.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/de/chronicle/the-prophet/index.html
+++ b/de/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Der Prophet: Volume Oracle">
   <meta property="og:description" content="Volume Oracle hört, was der Retail nicht kann – die Schritte der Institutionen, die sich im Dunkeln bewegen.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Der Prophet: Volume Oracle">
+  <meta name="twitter:description" content="Volume Oracle hört, was der Retail nicht kann – die Schritte der Institutionen, die sich im Dunkeln bewegen.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/de/chronicle/the-scales/index.html
+++ b/de/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Die Waage: Plutus Flow">
   <meta property="og:description" content="Ich wiege das Unsichtbare. Druck lügt nicht.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Die Waage: Plutus Flow">
+  <meta name="twitter:description" content="Ich wiege das Unsichtbare. Druck lügt nicht.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/de/chronicle/the-watchman/index.html
+++ b/de/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Der Wächter: Augury Grid">
   <meta property="og:description" content="Während Sie einen Chart beobachten, beobachte ich alle.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Der Wächter: Augury Grid">
+  <meta name="twitter:description" content="Während Sie einen Chart beobachten, beobachte ich alle.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/de/chronicle/why-non-repainting-matters/index.html
+++ b/de/chronicle/why-non-repainting-matters/index.html
@@ -15,9 +15,12 @@
   <meta property="og:title" content="Warum Non-Repainting wichtig ist">
   <meta property="og:description" content="Die meisten Indikatoren belügen Sie, indem sie ihre historischen Signale ändern. Hier erfahren Sie, warum Non-Repainting unverzichtbar ist.">
   <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Warum Non-Repainting wichtig ist">
+  <meta name="twitter:description" content="Die meisten Indikatoren belügen Sie, indem sie ihre historischen Signale ändern. Hier erfahren Sie, warum Non-Repainting unverzichtbar ist.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/es/chronicle/birth-of-the-elite-seven/index.html
+++ b/es/chronicle/birth-of-the-elite-seven/index.html
@@ -13,9 +13,12 @@
   <meta property="og:title" content="El Nacimiento de Los Siete de Élite">
   <meta property="og:description" content="Antes de que los mercados tuvieran nombres, antes de que las velas contaran historias, solo había ruido. Esta es la historia del origen de Los Siete de Élite.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Nacimiento de Los Siete de Élite">
+  <meta name="twitter:description" content="Antes de que los mercados tuvieran nombres, antes de que las velas contaran historias, solo había ruido. Esta es la historia del origen de Los Siete de Élite.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/es/chronicle/meet-the-sovereign/index.html
+++ b/es/chronicle/meet-the-sovereign/index.html
@@ -15,9 +15,12 @@
   <meta property="og:title" content="Conoce al Soberano: Pentarch Explicado">
   <meta property="og:description" content="Una inmersión profunda en Pentarch, el indicador insignia que mapea las cinco fases de los ciclos de mercado.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Conoce al Soberano: Pentarch Explicado">
+  <meta name="twitter:description" content="Una inmersión profunda en Pentarch, el indicador insignia que mapea las cinco fases de los ciclos de mercado.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/es/chronicle/the-arbiter/index.html
+++ b/es/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="El Árbitro: Harmonic Oscillator">
   <meta property="og:description" content="Cuatro voces. Un veredicto. Yo decido cuándo se aprieta el gatillo.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Árbitro: Harmonic Oscillator">
+  <meta name="twitter:description" content="Cuatro voces. Un veredicto. Yo decido cuándo se aprieta el gatillo.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/es/chronicle/the-cartographer/index.html
+++ b/es/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="El Cartógrafo: Janus Atlas">
   <meta property="og:description" content="Cada campo de batalla tiene su terreno. Janus Atlas mapea dónde se librarán las guerras.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Cartógrafo: Janus Atlas">
+  <meta name="twitter:description" content="Cada campo de batalla tiene su terreno. Janus Atlas mapea dónde se librarán las guerras.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/es/chronicle/the-commander/index.html
+++ b/es/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="El Comandante: OmniDeck">
   <meta property="og:description" content="Diez sistemas. Una visión. Claridad total.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Comandante: OmniDeck">
+  <meta name="twitter:description" content="Diez sistemas. Una visión. Claridad total.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/es/chronicle/the-council-assembles/index.html
+++ b/es/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="El Consejo Se Reúne">
   <meta property="og:description" content="Has conocido a cada miembro. Ahora obsérvalos trabajar como uno.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Consejo Se Reúne">
+  <meta name="twitter:description" content="Has conocido a cada miembro. Ahora obsérvalos trabajar como uno.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/es/chronicle/the-hierarchy-of-signals/index.html
+++ b/es/chronicle/the-hierarchy-of-signals/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="La Jerarquía de Señales">
   <meta property="og:description" content="Los Siete no existen en aislamiento. Forman una constelación—una jerarquía de propósito.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Jerarquía de Señales">
+  <meta name="twitter:description" content="Los Siete no existen en aislamiento. Forman una constelación—una jerarquía de propósito.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/es/chronicle/the-pilots-oath/index.html
+++ b/es/chronicle/the-pilots-oath/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="El Juramento del Piloto">
   <meta property="og:description" content="Tú que empuñas a Los Siete de Élite no eres un trader. Eres un Piloto. Este es el juramento que separa a quienes navegan de quienes apuestan.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Juramento del Piloto">
+  <meta name="twitter:description" content="Tú que empuñas a Los Siete de Élite no eres un trader. Eres un Piloto. Este es el juramento que separa a quienes navegan de quienes apuestan.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/es/chronicle/the-prophet/index.html
+++ b/es/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="El Profeta: Volume Oracle">
   <meta property="og:description" content="Volume Oracle escucha lo que el retail no puede—los pasos de las instituciones moviéndose en la oscuridad.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Profeta: Volume Oracle">
+  <meta name="twitter:description" content="Volume Oracle escucha lo que el retail no puede—los pasos de las instituciones moviéndose en la oscuridad.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/es/chronicle/the-scales/index.html
+++ b/es/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="La Balanza: Plutus Flow">
   <meta property="og:description" content="Peso lo invisible. La presión no miente.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Balanza: Plutus Flow">
+  <meta name="twitter:description" content="Peso lo invisible. La presión no miente.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/es/chronicle/the-watchman/index.html
+++ b/es/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="El Vigilante: Augury Grid">
   <meta property="og:description" content="Mientras tú observas un gráfico, yo los observo todos.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="El Vigilante: Augury Grid">
+  <meta name="twitter:description" content="Mientras tú observas un gráfico, yo los observo todos.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/es/chronicle/why-non-repainting-matters/index.html
+++ b/es/chronicle/why-non-repainting-matters/index.html
@@ -15,9 +15,12 @@
   <meta property="og:title" content="Por Qué Importa el No-Repintado">
   <meta property="og:description" content="La mayoría de los indicadores te mienten cambiando sus señales históricas. Aquí está por qué el no-repintado es innegociable.">
   <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Por Qué Importa el No-Repintado">
+  <meta name="twitter:description" content="La mayoría de los indicadores te mienten cambiando sus señales históricas. Aquí está por qué el no-repintado es innegociable.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/fr/chronicle/birth-of-the-elite-seven/index.html
+++ b/fr/chronicle/birth-of-the-elite-seven/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="La Naissance des Sept d'Élite">
   <meta property="og:description" content="Avant que les marchés n'aient des noms, avant que les bougies ne racontent des histoires, il n'y avait que du bruit.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Naissance des Sept d'Élite">
+  <meta name="twitter:description" content="Avant que les marchés n'aient des noms, avant que les bougies ne racontent des histoires, il n'y avait que du bruit.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/meet-the-sovereign/index.html
+++ b/fr/chronicle/meet-the-sovereign/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Rencontre Le Souverain : Pentarch Expliqué">
   <meta property="og:description" content="Une plongée profonde dans Pentarch, l'indicateur phare qui cartographie les cinq phases des cycles de marché.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Rencontre Le Souverain : Pentarch Expliqué">
+  <meta name="twitter:description" content="Une plongée profonde dans Pentarch, l'indicateur phare qui cartographie les cinq phases des cycles de marché.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-arbiter/index.html
+++ b/fr/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="L'Arbitre : Harmonic Oscillator">
   <meta property="og:description" content="Quatre voix. Un verdict. Je décide quand la gâchette est tirée.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="L'Arbitre : Harmonic Oscillator">
+  <meta name="twitter:description" content="Quatre voix. Un verdict. Je décide quand la gâchette est tirée.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-cartographer/index.html
+++ b/fr/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Le Cartographe : Janus Atlas">
   <meta property="og:description" content="Chaque champ de bataille a son terrain. Janus Atlas cartographie où les guerres seront livrées.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Le Cartographe : Janus Atlas">
+  <meta name="twitter:description" content="Chaque champ de bataille a son terrain. Janus Atlas cartographie où les guerres seront livrées.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-commander/index.html
+++ b/fr/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Le Commandant : OmniDeck">
   <meta property="og:description" content="Dix systèmes. Une vision. Clarté totale.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Le Commandant : OmniDeck">
+  <meta name="twitter:description" content="Dix systèmes. Une vision. Clarté totale.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-council-assembles/index.html
+++ b/fr/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Le Conseil S'Assemble">
   <meta property="og:description" content="Vous avez rencontré chaque membre. Maintenant regardez-les travailler comme un seul.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Le Conseil S'Assemble">
+  <meta name="twitter:description" content="Vous avez rencontré chaque membre. Maintenant regardez-les travailler comme un seul.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-hierarchy-of-signals/index.html
+++ b/fr/chronicle/the-hierarchy-of-signals/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="La Hiérarchie des Signaux">
   <meta property="og:description" content="Les Sept n'existent pas isolément. Ils forment une constellation—une hiérarchie de but.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Hiérarchie des Signaux">
+  <meta name="twitter:description" content="Les Sept n'existent pas isolément. Ils forment une constellation—une hiérarchie de but.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-pilots-oath/index.html
+++ b/fr/chronicle/the-pilots-oath/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Le Serment du Pilote">
   <meta property="og:description" content="Toi qui manies Les Sept d'Élite n'es pas un trader. Tu es un Pilote.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Le Serment du Pilote">
+  <meta name="twitter:description" content="Toi qui manies Les Sept d'Élite n'es pas un trader. Tu es un Pilote.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-prophet/index.html
+++ b/fr/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Le Prophète : Volume Oracle">
   <meta property="og:description" content="Volume Oracle entend ce que les particuliers ne peuvent pas—les pas des institutions se déplaçant dans l'obscurité.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Le Prophète : Volume Oracle">
+  <meta name="twitter:description" content="Volume Oracle entend ce que les particuliers ne peuvent pas—les pas des institutions se déplaçant dans l'obscurité.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-scales/index.html
+++ b/fr/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="La Balance : Plutus Flow">
   <meta property="og:description" content="Je pèse l'invisible. La pression ne ment pas.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Balance : Plutus Flow">
+  <meta name="twitter:description" content="Je pèse l'invisible. La pression ne ment pas.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/the-watchman/index.html
+++ b/fr/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Le Vigilant : Augury Grid">
   <meta property="og:description" content="Pendant que vous regardez un graphique, je les regarde tous.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Le Vigilant : Augury Grid">
+  <meta name="twitter:description" content="Pendant que vous regardez un graphique, je les regarde tous.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/fr/chronicle/why-non-repainting-matters/index.html
+++ b/fr/chronicle/why-non-repainting-matters/index.html
@@ -13,9 +13,12 @@
   <meta property="og:title" content="Pourquoi Le Non-Repaint Est Important">
   <meta property="og:description" content="La plupart des indicateurs vous mentent en modifiant leurs signaux historiques. Voici pourquoi le non-repaint est non négociable.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Pourquoi Le Non-Repaint Est Important">
+  <meta name="twitter:description" content="La plupart des indicateurs vous mentent en modifiant leurs signaux historiques. Voici pourquoi le non-repaint est non négociable.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/birth-of-the-elite-seven/index.html
+++ b/hu/chronicle/birth-of-the-elite-seven/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Az Elit Hetek Születése">
   <meta property="og:description" content="Mielőtt a piacoknak nevük lett volna, mielőtt a gyertyák történeteket meséltek volna, csak zaj volt.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Az Elit Hetek Születése">
+  <meta name="twitter:description" content="Mielőtt a piacoknak nevük lett volna, mielőtt a gyertyák történeteket meséltek volna, csak zaj volt.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/meet-the-sovereign/index.html
+++ b/hu/chronicle/meet-the-sovereign/index.html
@@ -15,9 +15,12 @@
   <meta property="og:title" content="Ismerd Meg a Szuverént: A Pentarch Bemutatása">
   <meta property="og:description" content="Mély betekintés a Pentarchba, a zászlóshajó indikátorba, amely feltérképezi a piaci ciklusok öt fázisát.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Ismerd Meg a Szuverént: A Pentarch Bemutatása">
+  <meta name="twitter:description" content="Mély betekintés a Pentarchba, a zászlóshajó indikátorba, amely feltérképezi a piaci ciklusok öt fázisát.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/hu/chronicle/the-arbiter/index.html
+++ b/hu/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="A Döntőbíró: Harmonic Oscillator">
   <meta property="og:description" content="Négy hang. Egy ítélet. Én döntöm el, mikor húzzuk meg a ravaszt.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Döntőbíró: Harmonic Oscillator">
+  <meta name="twitter:description" content="Négy hang. Egy ítélet. Én döntöm el, mikor húzzuk meg a ravaszt.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/the-cartographer/index.html
+++ b/hu/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="A Kartográfus: Janus Atlas">
   <meta property="og:description" content="Minden csatatérnek megvan a terepje. A Janus Atlas térképezi, hol zajlanak a háborúk.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Kartográfus: Janus Atlas">
+  <meta name="twitter:description" content="Minden csatatérnek megvan a terepje. A Janus Atlas térképezi, hol zajlanak a háborúk.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/the-commander/index.html
+++ b/hu/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="A Parancsnok: OmniDeck">
   <meta property="og:description" content="Tíz rendszer. Egy vízió. Teljes tisztánlátás.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Parancsnok: OmniDeck">
+  <meta name="twitter:description" content="Tíz rendszer. Egy vízió. Teljes tisztánlátás.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/the-council-assembles/index.html
+++ b/hu/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="A Konsey Toplanyor">
   <meta property="og:description" content="Megismerted minden tagot. Most nézd, hogyan dolgoznak egyként.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Konsey Toplanyor">
+  <meta name="twitter:description" content="Megismerted minden tagot. Most nézd, hogyan dolgoznak egyként.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/the-hierarchy-of-signals/index.html
+++ b/hu/chronicle/the-hierarchy-of-signals/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="A Jelek Hierarchiája">
   <meta property="og:description" content="A Hetek nem elszigetelten léteznek. Csillagképet alkotnak—célok hierarchiáját.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Jelek Hierarchiája">
+  <meta name="twitter:description" content="A Hetek nem elszigetelten léteznek. Csillagképet alkotnak—célok hierarchiáját.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/hu/chronicle/the-pilots-oath/index.html
+++ b/hu/chronicle/the-pilots-oath/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="A Pilóta Esküje">
   <meta property="og:description" content="Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy. Ez az eskü választja el azokat, akik navigálnak, azoktól, akik szerencsejátékot űznek.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Pilóta Esküje">
+  <meta name="twitter:description" content="Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy. Ez az eskü választja el azokat, akik navigálnak, azoktól, akik szerencsejátékot űznek.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/hu/chronicle/the-prophet/index.html
+++ b/hu/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="A Próféta: Volume Oracle">
   <meta property="og:description" content="A Volume Oracle hallja, amit a kisbefektetők nem—az intézmények lépteit, amint a sötétségben mozognak.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Próféta: Volume Oracle">
+  <meta name="twitter:description" content="A Volume Oracle hallja, amit a kisbefektetők nem—az intézmények lépteit, amint a sötétségben mozognak.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/the-scales/index.html
+++ b/hu/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="A Mérleg: Plutus Flow">
   <meta property="og:description" content="Mérem a láthatatlant. A nyomás nem hazudik.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Mérleg: Plutus Flow">
+  <meta name="twitter:description" content="Mérem a láthatatlant. A nyomás nem hazudik.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/the-watchman/index.html
+++ b/hu/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Az Őrszem: Augury Grid">
   <meta property="og:description" content="Míg te egy chartot figyelsz, én mindegyiket figyelem.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Az Őrszem: Augury Grid">
+  <meta name="twitter:description" content="Míg te egy chartot figyelsz, én mindegyiket figyelem.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/hu/chronicle/why-non-repainting-matters/index.html
+++ b/hu/chronicle/why-non-repainting-matters/index.html
@@ -15,9 +15,12 @@
   <meta property="og:title" content="Miért Fontos a Nem-Újrafestés">
   <meta property="og:description" content="A legtöbb indikátor hazudik, mert megváltoztatja a történelmi jelzéseit.">
   <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Miért Fontos a Nem-Újrafestés">
+  <meta name="twitter:description" content="A legtöbb indikátor hazudik, mert megváltoztatja a történelmi jelzéseit.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/it/chronicle/birth-of-the-elite-seven/index.html
+++ b/it/chronicle/birth-of-the-elite-seven/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="La Nascita dei Sette d'Élite">
   <meta property="og:description" content="In un'epoca di caos, sette indicatori si sono forgiati dal rumore.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Nascita dei Sette d'Élite">
+  <meta name="twitter:description" content="In un'epoca di caos, sette indicatori si sono forgiati dal rumore.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/meet-the-sovereign/index.html
+++ b/it/chronicle/meet-the-sovereign/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Incontra Il Sovrano: Pentarch Spiegato">
   <meta property="og:description" content="L'indicatore ammiraglia che mappa le cinque fasi dei cicli di mercato.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Incontra Il Sovrano: Pentarch Spiegato">
+  <meta name="twitter:description" content="L'indicatore ammiraglia che mappa le cinque fasi dei cicli di mercato.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-arbiter/index.html
+++ b/it/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="L'Arbitro: Harmonic Oscillator">
   <meta property="og:description" content="Quattro voci. Un verdetto. Io decido quando premere il grilletto.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="L'Arbitro: Harmonic Oscillator">
+  <meta name="twitter:description" content="Quattro voci. Un verdetto. Io decido quando premere il grilletto.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-cartographer/index.html
+++ b/it/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Il Cartografo: Janus Atlas">
   <meta property="og:description" content="Ogni campo di battaglia ha il suo terreno. Janus Atlas mappa dove verranno combattute le guerre.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Il Cartografo: Janus Atlas">
+  <meta name="twitter:description" content="Ogni campo di battaglia ha il suo terreno. Janus Atlas mappa dove verranno combattute le guerre.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-commander/index.html
+++ b/it/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Il Comandante: OmniDeck">
   <meta property="og:description" content="Dieci sistemi. Una visione. Chiarezza totale.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Il Comandante: OmniDeck">
+  <meta name="twitter:description" content="Dieci sistemi. Una visione. Chiarezza totale.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-council-assembles/index.html
+++ b/it/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Il Consiglio Si Riunisce">
   <meta property="og:description" content="Hai incontrato ogni membro. Ora guardali lavorare come uno.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Il Consiglio Si Riunisce">
+  <meta name="twitter:description" content="Hai incontrato ogni membro. Ora guardali lavorare come uno.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-hierarchy-of-signals/index.html
+++ b/it/chronicle/the-hierarchy-of-signals/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="La Gerarchia dei Segnali">
   <meta property="og:description" content="Non tutti i segnali sono uguali. Impara come I Sette formano una costellazione di scopo.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Gerarchia dei Segnali">
+  <meta name="twitter:description" content="Non tutti i segnali sono uguali. Impara come I Sette formano una costellazione di scopo.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-pilots-oath/index.html
+++ b/it/chronicle/the-pilots-oath/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Il Giuramento del Pilota">
   <meta property="og:description" content="Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Il Giuramento del Pilota">
+  <meta name="twitter:description" content="Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-prophet/index.html
+++ b/it/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Il Profeta: Volume Oracle">
   <meta property="og:description" content="Volume Oracle sente quello che i retail non possono—i passi delle istituzioni che si muovono nell'oscurità.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Il Profeta: Volume Oracle">
+  <meta name="twitter:description" content="Volume Oracle sente quello che i retail non possono—i passi delle istituzioni che si muovono nell'oscurità.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-scales/index.html
+++ b/it/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="La Bilancia: Plutus Flow">
   <meta property="og:description" content="Peso l'invisibile. La pressione non mente.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Bilancia: Plutus Flow">
+  <meta name="twitter:description" content="Peso l'invisibile. La pressione non mente.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/the-watchman/index.html
+++ b/it/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="La Sentinella: Augury Grid">
   <meta property="og:description" content="Mentre tu guardi un grafico, io li guardo tutti.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="La Sentinella: Augury Grid">
+  <meta name="twitter:description" content="Mentre tu guardi un grafico, io li guardo tutti.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/it/chronicle/why-non-repainting-matters/index.html
+++ b/it/chronicle/why-non-repainting-matters/index.html
@@ -13,9 +13,12 @@
   <meta property="og:title" content="Perché il Non-Repainting È Importante">
   <meta property="og:description" content="La maggior parte degli indicatori ti mente cambiando i loro segnali storici. Ecco perché il non-repainting non è negoziabile.">
   <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Perché il Non-Repainting È Importante">
+  <meta name="twitter:description" content="La maggior parte degli indicatori ti mente cambiando i loro segnali storici. Ecco perché il non-repainting non è negoziabile.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ja/chronicle/birth-of-the-elite-seven/index.html
+++ b/ja/chronicle/birth-of-the-elite-seven/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="エリートセブンの誕生">
   <meta property="og:description" content="すべてはシグナルの混乱から始まった。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="エリートセブンの誕生">
+  <meta name="twitter:description" content="すべてはシグナルの混乱から始まった。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/meet-the-sovereign/index.html
+++ b/ja/chronicle/meet-the-sovereign/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="ソブリンに会う：Pentarch">
   <meta property="og:description" content="サイクルのマスター、シグナルの王。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ソブリンに会う：Pentarch">
+  <meta name="twitter:description" content="サイクルのマスター、シグナルの王。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-arbiter/index.html
+++ b/ja/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="アービター：Harmonic Oscillator">
   <meta property="og:description" content="4つの声。一つの判定。私がトリガーを引くときを決める。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="アービター：Harmonic Oscillator">
+  <meta name="twitter:description" content="4つの声。一つの判定。私がトリガーを引くときを決める。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-cartographer/index.html
+++ b/ja/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="カートグラファー：Janus Atlas">
   <meta property="og:description" content="すべての戦場には地形がある。私は戦いが行われる場所をマッピングする。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="カートグラファー：Janus Atlas">
+  <meta name="twitter:description" content="すべての戦場には地形がある。私は戦いが行われる場所をマッピングする。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-commander/index.html
+++ b/ja/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="コマンダー：OmniDeck">
   <meta property="og:description" content="10のシステム。一つのビジョン。完全な明晰さ。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="コマンダー：OmniDeck">
+  <meta name="twitter:description" content="10のシステム。一つのビジョン。完全な明晰さ。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-council-assembles/index.html
+++ b/ja/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="評議会は集う">
   <meta property="og:description" content="各メンバーと会いました。今、彼らが一つとして働くのを見てください。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="評議会は集う">
+  <meta name="twitter:description" content="各メンバーと会いました。今、彼らが一つとして働くのを見てください。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-hierarchy-of-signals/index.html
+++ b/ja/chronicle/the-hierarchy-of-signals/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="シグナルの階層">
   <meta property="og:description" content="エリートセブンがどのように統一されたシステムとして機能するか。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="シグナルの階層">
+  <meta name="twitter:description" content="エリートセブンがどのように統一されたシステムとして機能するか。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-pilots-oath/index.html
+++ b/ja/chronicle/the-pilots-oath/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="パイロットの誓い">
   <meta property="og:description" content="すべてのパイロットが従う規律の核心にあるもの。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="パイロットの誓い">
+  <meta name="twitter:description" content="すべてのパイロットが従う規律の核心にあるもの。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-prophet/index.html
+++ b/ja/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="プロフェット：Volume Oracle">
   <meta property="og:description" content="私は小売が聞けないものを聞く。私は巨人が闇の中で動くのを見る。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="プロフェット：Volume Oracle">
+  <meta name="twitter:description" content="私は小売が聞けないものを聞く。私は巨人が闇の中で動くのを見る。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-scales/index.html
+++ b/ja/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="スケール：Plutus Flow">
   <meta property="og:description" content="見えないものを量る。圧力は嘘をつかない。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="スケール：Plutus Flow">
+  <meta name="twitter:description" content="見えないものを量る。圧力は嘘をつかない。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/the-watchman/index.html
+++ b/ja/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="ウォッチマン：Augury Grid">
   <meta property="og:description" content="あなたが一つのチャートを見ている間、私はすべてを見ている。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ウォッチマン：Augury Grid">
+  <meta name="twitter:description" content="あなたが一つのチャートを見ている間、私はすべてを見ている。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ja/chronicle/why-non-repainting-matters/index.html
+++ b/ja/chronicle/why-non-repainting-matters/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="なぜノンリペイントが重要か">
   <meta property="og:description" content="あなたのインジケーターがリペイントするとき、あなたは嘘の上でトレードしている。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="なぜノンリペイントが重要か">
+  <meta name="twitter:description" content="あなたのインジケーターがリペイントするとき、あなたは嘘の上でトレードしている。">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/nl/chronicle/birth-of-the-elite-seven/index.html
+++ b/nl/chronicle/birth-of-the-elite-seven/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Geboorte van de Elite Zeven">
   <meta property="og:description" content="Waar het allemaal begon. Het oorsprongsverhaal.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Geboorte van de Elite Zeven">
+  <meta name="twitter:description" content="Waar het allemaal begon. Het oorsprongsverhaal.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/meet-the-sovereign/index.html
+++ b/nl/chronicle/meet-the-sovereign/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Ontmoet de Soeverein: Pentarch">
   <meta property="og:description" content="De eerste en machtigste. De lezer van cycli.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Ontmoet de Soeverein: Pentarch">
+  <meta name="twitter:description" content="De eerste en machtigste. De lezer van cycli.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-arbiter/index.html
+++ b/nl/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Arbiter: Harmonic Oscillator">
   <meta property="og:description" content="Vier stemmen. Eén oordeel. Ik beslis wanneer de trekker wordt overgehaald.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Arbiter: Harmonic Oscillator">
+  <meta name="twitter:description" content="Vier stemmen. Eén oordeel. Ik beslis wanneer de trekker wordt overgehaald.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-cartographer/index.html
+++ b/nl/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Cartograaf: Janus Atlas">
   <meta property="og:description" content="Elk slagveld heeft zijn terrein. Ik kaart waar oorlogen worden uitgevochten.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Cartograaf: Janus Atlas">
+  <meta name="twitter:description" content="Elk slagveld heeft zijn terrein. Ik kaart waar oorlogen worden uitgevochten.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-commander/index.html
+++ b/nl/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Commandant: OmniDeck">
   <meta property="og:description" content="Tien systemen. Eén visie. Totale helderheid.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Commandant: OmniDeck">
+  <meta name="twitter:description" content="Tien systemen. Eén visie. Totale helderheid.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-council-assembles/index.html
+++ b/nl/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Raad Komt Bijeen">
   <meta property="og:description" content="Je hebt elk lid ontmoet. Nu zie je hoe ze als één werken.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Raad Komt Bijeen">
+  <meta name="twitter:description" content="Je hebt elk lid ontmoet. Nu zie je hoe ze als één werken.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-hierarchy-of-signals/index.html
+++ b/nl/chronicle/the-hierarchy-of-signals/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Hiërarchie van Signalen">
   <meta property="og:description" content="Hoe de Zeven een constellatie van doel vormen.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Hiërarchie van Signalen">
+  <meta name="twitter:description" content="Hoe de Zeven een constellatie van doel vormen.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-pilots-oath/index.html
+++ b/nl/chronicle/the-pilots-oath/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Eed van de Piloot">
   <meta property="og:description" content="Een code van discipline die traders van gokkers onderscheidt.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Eed van de Piloot">
+  <meta name="twitter:description" content="Een code van discipline die traders van gokkers onderscheidt.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-prophet/index.html
+++ b/nl/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Profeet: Volume Oracle">
   <meta property="og:description" content="Ik hoor wat retail niet kan. Ik zie de giganten bewegen in duisternis.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Profeet: Volume Oracle">
+  <meta name="twitter:description" content="Ik hoor wat retail niet kan. Ik zie de giganten bewegen in duisternis.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-scales/index.html
+++ b/nl/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Weegschaal: Plutus Flow">
   <meta property="og:description" content="Ik weeg het onzichtbare. Druk liegt niet.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Weegschaal: Plutus Flow">
+  <meta name="twitter:description" content="Ik weeg het onzichtbare. Druk liegt niet.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/the-watchman/index.html
+++ b/nl/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="De Wachter: Augury Grid">
   <meta property="og:description" content="Terwijl jij één grafiek bekijkt, bekijk ik ze allemaal.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="De Wachter: Augury Grid">
+  <meta name="twitter:description" content="Terwijl jij één grafiek bekijkt, bekijk ik ze allemaal.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/nl/chronicle/why-non-repainting-matters/index.html
+++ b/nl/chronicle/why-non-repainting-matters/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Waarom Niet-Herpainting Belangrijk Is">
   <meta property="og:description" content="De fundamentele garantie die eerlijke analyse mogelijk maakt.">
   <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Waarom Niet-Herpainting Belangrijk Is">
+  <meta name="twitter:description" content="De fundamentele garantie die eerlijke analyse mogelijk maakt.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/pt/chronicle/birth-of-the-elite-seven/index.html
+++ b/pt/chronicle/birth-of-the-elite-seven/index.html
@@ -15,10 +15,13 @@
   <meta property="og:title" content="O Nascimento dos Sete de Elite">
   <meta property="og:description" content="Antes que os mercados tivessem nomes, antes que as velas contassem histórias, havia apenas ruído. Esta é a história de origem dos Sete de Elite.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="O Nascimento dos Sete de Elite">
+  <meta name="twitter:description" content="Antes que os mercados tivessem nomes, antes que as velas contassem histórias, havia apenas ruído. Esta é a história de origem dos Sete de Elite.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:title" content="O Nascimento dos Sete de Elite">
   <meta name="twitter:description" content="A história de origem de sete sinais celestiais que emergiram para navegar o vazio.">
 

--- a/pt/chronicle/meet-the-sovereign/index.html
+++ b/pt/chronicle/meet-the-sovereign/index.html
@@ -14,9 +14,12 @@
   <meta property="og:title" content="Conheça O Soberano: Pentarch Explicado">
   <meta property="og:description" content="Um mergulho profundo no Pentarch, o indicador principal que mapeia as cinco fases dos ciclos de mercado.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Conheça O Soberano: Pentarch Explicado">
+  <meta name="twitter:description" content="Um mergulho profundo no Pentarch, o indicador principal que mapeia as cinco fases dos ciclos de mercado.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/pt/chronicle/the-arbiter/index.html
+++ b/pt/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="O Árbitro: Harmonic Oscillator">
   <meta property="og:description" content="Quatro vozes. Um veredito. Eu decido quando o gatilho é puxado.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="O Árbitro: Harmonic Oscillator">
+  <meta name="twitter:description" content="Quatro vozes. Um veredito. Eu decido quando o gatilho é puxado.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/pt/chronicle/the-cartographer/index.html
+++ b/pt/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="O Cartógrafo: Janus Atlas">
   <meta property="og:description" content="Todo campo de batalha tem seu terreno. Eu mapeio onde as guerras serão travadas.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="O Cartógrafo: Janus Atlas">
+  <meta name="twitter:description" content="Todo campo de batalha tem seu terreno. Eu mapeio onde as guerras serão travadas.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/pt/chronicle/the-commander/index.html
+++ b/pt/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="O Comandante: OmniDeck">
   <meta property="og:description" content="Dez sistemas. Uma visão. Clareza total.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="O Comandante: OmniDeck">
+  <meta name="twitter:description" content="Dez sistemas. Uma visão. Clareza total.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/pt/chronicle/the-council-assembles/index.html
+++ b/pt/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="O Conselho Se Reúne">
   <meta property="og:description" content="Você conheceu cada membro. Agora veja-os trabalhar como um só.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="O Conselho Se Reúne">
+  <meta name="twitter:description" content="Você conheceu cada membro. Agora veja-os trabalhar como um só.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/pt/chronicle/the-hierarchy-of-signals/index.html
+++ b/pt/chronicle/the-hierarchy-of-signals/index.html
@@ -14,10 +14,13 @@
   <meta property="og:title" content="A Hierarquia dos Sinais">
   <meta property="og:description" content="Os Sete não existem isoladamente. Eles formam uma constelação—uma hierarquia de propósito.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Hierarquia dos Sinais">
+  <meta name="twitter:description" content="Os Sete não existem isoladamente. Eles formam uma constelação—uma hierarquia de propósito.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/pt/chronicle/the-pilots-oath/index.html
+++ b/pt/chronicle/the-pilots-oath/index.html
@@ -14,10 +14,13 @@
   <meta property="og:title" content="O Juramento do Piloto">
   <meta property="og:description" content="Você que empunha Os Sete de Elite não é um trader. Você é um Piloto. Este é o juramento que separa aqueles que navegam daqueles que apostam.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="O Juramento do Piloto">
+  <meta name="twitter:description" content="Você que empunha Os Sete de Elite não é um trader. Você é um Piloto. Este é o juramento que separa aqueles que navegam daqueles que apostam.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/pt/chronicle/the-prophet/index.html
+++ b/pt/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="O Profeta: Volume Oracle">
   <meta property="og:description" content="Volume Oracle ouve o que o varejo não consegue—os passos das instituições movendo-se na escuridão.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="O Profeta: Volume Oracle">
+  <meta name="twitter:description" content="Volume Oracle ouve o que o varejo não consegue—os passos das instituições movendo-se na escuridão.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/pt/chronicle/the-scales/index.html
+++ b/pt/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="A Balança: Plutus Flow">
   <meta property="og:description" content="Eu peso o invisível. A pressão não mente.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Balança: Plutus Flow">
+  <meta name="twitter:description" content="Eu peso o invisível. A pressão não mente.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/pt/chronicle/the-watchman/index.html
+++ b/pt/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="A Sentinela: Augury Grid">
   <meta property="og:description" content="Enquanto você observa um gráfico, eu observo todos.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="A Sentinela: Augury Grid">
+  <meta name="twitter:description" content="Enquanto você observa um gráfico, eu observo todos.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/pt/chronicle/why-non-repainting-matters/index.html
+++ b/pt/chronicle/why-non-repainting-matters/index.html
@@ -14,9 +14,12 @@
   <meta property="og:title" content="Por Que Não Repintar Importa">
   <meta property="og:description" content="A maioria dos indicadores mente para você mudando seus sinais históricos. Aqui está por que não repintar não é negociável.">
   <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Por Que Não Repintar Importa">
+  <meta name="twitter:description" content="A maioria dos indicadores mente para você mudando seus sinais históricos. Aqui está por que não repintar não é negociável.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/ru/chronicle/birth-of-the-elite-seven/index.html
+++ b/ru/chronicle/birth-of-the-elite-seven/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Рождение Элитной Семёрки">
   <meta property="og:description" content="До того как рынки получили названия, до того как свечи рассказывали истории, был только шум.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Рождение Элитной Семёрки">
+  <meta name="twitter:description" content="До того как рынки получили названия, до того как свечи рассказывали истории, был только шум.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/meet-the-sovereign/index.html
+++ b/ru/chronicle/meet-the-sovereign/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Познакомьтесь с Сувереном: Pentarch">
   <meta property="og:description" content="Глубокое погружение в Pentarch, флагманский индикатор, который картирует пять фаз рыночных циклов.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Познакомьтесь с Сувереном: Pentarch">
+  <meta name="twitter:description" content="Глубокое погружение в Pentarch, флагманский индикатор, который картирует пять фаз рыночных циклов.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-arbiter/index.html
+++ b/ru/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Арбитр: Harmonic Oscillator">
   <meta property="og:description" content="Четыре голоса. Один вердикт. Я решаю, когда нажать на курок.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Арбитр: Harmonic Oscillator">
+  <meta name="twitter:description" content="Четыре голоса. Один вердикт. Я решаю, когда нажать на курок.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-cartographer/index.html
+++ b/ru/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Картограф: Janus Atlas">
   <meta property="og:description" content="На каждом поле боя есть своя местность. Я картографирую места будущих сражений.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Картограф: Janus Atlas">
+  <meta name="twitter:description" content="На каждом поле боя есть своя местность. Я картографирую места будущих сражений.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-commander/index.html
+++ b/ru/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Командир: OmniDeck">
   <meta property="og:description" content="Десять систем. Одно видение. Полная ясность.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Командир: OmniDeck">
+  <meta name="twitter:description" content="Десять систем. Одно видение. Полная ясность.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-council-assembles/index.html
+++ b/ru/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Совет Собирается">
   <meta property="og:description" content="Вы познакомились с каждым участником. Теперь смотрите, как они работают как единое целое.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Совет Собирается">
+  <meta name="twitter:description" content="Вы познакомились с каждым участником. Теперь смотрите, как они работают как единое целое.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-hierarchy-of-signals/index.html
+++ b/ru/chronicle/the-hierarchy-of-signals/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Иерархия Сигналов">
   <meta property="og:description" content="Семёрка не существует в изоляции. Они образуют созвездие — иерархию целей.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Иерархия Сигналов">
+  <meta name="twitter:description" content="Семёрка не существует в изоляции. Они образуют созвездие — иерархию целей.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-pilots-oath/index.html
+++ b/ru/chronicle/the-pilots-oath/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Клятва Пилота">
   <meta property="og:description" content="Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Клятва Пилота">
+  <meta name="twitter:description" content="Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-prophet/index.html
+++ b/ru/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Пророк: Volume Oracle">
   <meta property="og:description" content="Volume Oracle слышит то, что недоступно розничным — шаги институций, движущихся во тьме.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Пророк: Volume Oracle">
+  <meta name="twitter:description" content="Volume Oracle слышит то, что недоступно розничным — шаги институций, движущихся во тьме.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-scales/index.html
+++ b/ru/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Весы: Plutus Flow">
   <meta property="og:description" content="Я взвешиваю невидимое. Давление не лжёт.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Весы: Plutus Flow">
+  <meta name="twitter:description" content="Я взвешиваю невидимое. Давление не лжёт.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/the-watchman/index.html
+++ b/ru/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Страж: Augury Grid">
   <meta property="og:description" content="Пока вы смотрите на один график, я слежу за всеми.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Страж: Augury Grid">
+  <meta name="twitter:description" content="Пока вы смотрите на один график, я слежу за всеми.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/ru/chronicle/why-non-repainting-matters/index.html
+++ b/ru/chronicle/why-non-repainting-matters/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Почему Отсутствие Перерисовки Важно">
   <meta property="og:description" content="Большинство индикаторов лгут вам, изменяя свои исторические сигналы.">
   <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Почему Отсутствие Перерисовки Важно">
+  <meta name="twitter:description" content="Большинство индикаторов лгут вам, изменяя свои исторические сигналы.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/birth-of-the-elite-seven/index.html
+++ b/tr/chronicle/birth-of-the-elite-seven/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Elit Yedilinin Doğuşu">
   <meta property="og:description" content="Her efsanenin bir başlangıcı vardır. Bu bizim hikayemiz.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Elit Yedilinin Doğuşu">
+  <meta name="twitter:description" content="Her efsanenin bir başlangıcı vardır. Bu bizim hikayemiz.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/meet-the-sovereign/index.html
+++ b/tr/chronicle/meet-the-sovereign/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Hükümdar ile Tanışın: Pentarch">
   <meta property="og:description" content="Hiçbir şey döngüsüz var olmaz. Ben onları okurum.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Hükümdar ile Tanışın: Pentarch">
+  <meta name="twitter:description" content="Hiçbir şey döngüsüz var olmaz. Ben onları okurum.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-arbiter/index.html
+++ b/tr/chronicle/the-arbiter/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Hakem: Harmonic Oscillator">
   <meta property="og:description" content="Dört ses. Tek karar. Tetiğin ne zaman çekileceğine ben karar veririm.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-arbiter">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Hakem: Harmonic Oscillator">
+  <meta name="twitter:description" content="Dört ses. Tek karar. Tetiğin ne zaman çekileceğine ben karar veririm.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-cartographer/index.html
+++ b/tr/chronicle/the-cartographer/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Kartograf: Janus Atlas">
   <meta property="og:description" content="Her savaş alanının bir arazisi var. Savaşların nerede yapılacağını haritalandırıyorum.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-cartographer">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Kartograf: Janus Atlas">
+  <meta name="twitter:description" content="Her savaş alanının bir arazisi var. Savaşların nerede yapılacağını haritalandırıyorum.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-commander/index.html
+++ b/tr/chronicle/the-commander/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Komutan: OmniDeck">
   <meta property="og:description" content="On sistem. Tek vizyon. Tam netlik.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-commander">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Komutan: OmniDeck">
+  <meta name="twitter:description" content="On sistem. Tek vizyon. Tam netlik.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-council-assembles/index.html
+++ b/tr/chronicle/the-council-assembles/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Konsey Toplanıyor">
   <meta property="og:description" content="Her üyeyle tanıştınız. Şimdi birlikte çalışmalarını izleyin.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-council-assembles">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Konsey Toplanıyor">
+  <meta name="twitter:description" content="Her üyeyle tanıştınız. Şimdi birlikte çalışmalarını izleyin.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-hierarchy-of-signals/index.html
+++ b/tr/chronicle/the-hierarchy-of-signals/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Sinyallerin Hiyerarşisi">
   <meta property="og:description" content="Göstergeler savaşır. Sistem uyum sağlar.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Sinyallerin Hiyerarşisi">
+  <meta name="twitter:description" content="Göstergeler savaşır. Sistem uyum sağlar.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-pilots-oath/index.html
+++ b/tr/chronicle/the-pilots-oath/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Pilotun Yemini">
   <meta property="og:description" content="Sabır ile giriş yapacağım. Disiplinle çıkış yapacağım.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-pilots-oath">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Pilotun Yemini">
+  <meta name="twitter:description" content="Sabır ile giriş yapacağım. Disiplinle çıkış yapacağım.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-prophet/index.html
+++ b/tr/chronicle/the-prophet/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Peygamber: Volume Oracle">
   <meta property="og:description" content="Perakendecilerin duyamadığını duyarım. Devlerin karanlıkta hareket ettiğini görürüm.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-prophet">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Peygamber: Volume Oracle">
+  <meta name="twitter:description" content="Perakendecilerin duyamadığını duyarım. Devlerin karanlıkta hareket ettiğini görürüm.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-scales/index.html
+++ b/tr/chronicle/the-scales/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Terazi: Plutus Flow">
   <meta property="og:description" content="Görünmezi tartıyorum. Baskı yalan söylemez.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-scales">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Terazi: Plutus Flow">
+  <meta name="twitter:description" content="Görünmezi tartıyorum. Baskı yalan söylemez.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/the-watchman/index.html
+++ b/tr/chronicle/the-watchman/index.html
@@ -13,8 +13,11 @@
   <meta property="og:title" content="Nöbetçi: Augury Grid">
   <meta property="og:description" content="Siz bir grafiği izlerken, ben hepsini izliyorum.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-watchman">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Nöbetçi: Augury Grid">
+  <meta name="twitter:description" content="Siz bir grafiği izlerken, ben hepsini izliyorum.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">

--- a/tr/chronicle/why-non-repainting-matters/index.html
+++ b/tr/chronicle/why-non-repainting-matters/index.html
@@ -10,11 +10,14 @@
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">
   <meta property="og:type" content="article">
-  <meta property:og:title" content="Neden Non-Repainting Önemlidir">
+  <meta property="og:title" content="Neden Non-Repainting Önemlidir">
   <meta property="og:description" content="500$'lık meydan okumamız. Dokunulmadan duruyor.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
+  <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Neden Non-Repainting Önemlidir">
+  <meta name="twitter:description" content="500$'lık meydan okumamız. Dokunulmadan duruyor.">
+  <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Gugi&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">


### PR DESCRIPTION
… articles

- Updated og:image from generic /preview.png to article-specific preview images across all 11 non-English language versions (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr)
- Added missing twitter:title, twitter:description, and twitter:image meta tags
- Fixed typo in Turkish why-non-repainting-matters article (property:og:title -> property="og:title")

This ensures social media link previews display the correct article-specific images when sharing URLs in any language.