### PR TITLE
Add missing .article-hero CSS to 33 non-English chronicle articles

### DIFF
--- a/ar/chronicle/birth-of-the-elite-seven/index.html
+++ b/ar/chronicle/birth-of-the-elite-seven/index.html
@@ -775,6 +775,7 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
+    .article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
     .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
     .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>

--- a/ar/chronicle/meet-the-sovereign/index.html
+++ b/ar/chronicle/meet-the-sovereign/index.html
@@ -133,7 +133,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-arbiter/index.html
+++ b/ar/chronicle/the-arbiter/index.html
@@ -787,7 +787,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-cartographer/index.html
+++ b/ar/chronicle/the-cartographer/index.html
@@ -699,7 +699,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-commander/index.html
+++ b/ar/chronicle/the-commander/index.html
@@ -698,7 +698,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-council-assembles/index.html
+++ b/ar/chronicle/the-council-assembles/index.html
@@ -770,7 +770,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-hierarchy-of-signals/index.html
+++ b/ar/chronicle/the-hierarchy-of-signals/index.html
@@ -805,7 +805,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-pilots-oath/index.html
+++ b/ar/chronicle/the-pilots-oath/index.html
@@ -750,7 +750,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-prophet/index.html
+++ b/ar/chronicle/the-prophet/index.html
@@ -283,7 +283,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-scales/index.html
+++ b/ar/chronicle/the-scales/index.html
@@ -746,7 +746,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/the-watchman/index.html
+++ b/ar/chronicle/the-watchman/index.html
@@ -766,7 +766,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/ar/chronicle/why-non-repainting-matters/index.html
+++ b/ar/chronicle/why-non-repainting-matters/index.html
@@ -784,7 +784,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:left}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/hu/chronicle/birth-of-the-elite-seven/index.html
+++ b/hu/chronicle/birth-of-the-elite-seven/index.html
@@ -123,7 +123,8 @@
 .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
 .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
 .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/hu/chronicle/meet-the-sovereign/index.html
+++ b/hu/chronicle/meet-the-sovereign/index.html
@@ -445,6 +445,7 @@
       padding: 0 1.5rem;
     }
 
+    .article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
     .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
     .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
 

--- a/hu/chronicle/the-hierarchy-of-signals/index.html
+++ b/hu/chronicle/the-hierarchy-of-signals/index.html
@@ -619,7 +619,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/hu/chronicle/the-pilots-oath/index.html
+++ b/hu/chronicle/the-pilots-oath/index.html
@@ -565,7 +565,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/hu/chronicle/why-non-repainting-matters/index.html
+++ b/hu/chronicle/why-non-repainting-matters/index.html
@@ -593,7 +593,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/it/chronicle/birth-of-the-elite-seven/index.html
+++ b/it/chronicle/birth-of-the-elite-seven/index.html
@@ -118,7 +118,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/it/chronicle/meet-the-sovereign/index.html
+++ b/it/chronicle/meet-the-sovereign/index.html
@@ -127,7 +127,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/it/chronicle/the-hierarchy-of-signals/index.html
+++ b/it/chronicle/the-hierarchy-of-signals/index.html
@@ -126,7 +126,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/it/chronicle/the-pilots-oath/index.html
+++ b/it/chronicle/the-pilots-oath/index.html
@@ -122,7 +122,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/it/chronicle/why-non-repainting-matters/index.html
+++ b/it/chronicle/why-non-repainting-matters/index.html
@@ -144,7 +144,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/pt/chronicle/birth-of-the-elite-seven/index.html
+++ b/pt/chronicle/birth-of-the-elite-seven/index.html
@@ -595,7 +595,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/pt/chronicle/meet-the-sovereign/index.html
+++ b/pt/chronicle/meet-the-sovereign/index.html
@@ -46,7 +46,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/pt/chronicle/the-hierarchy-of-signals/index.html
+++ b/pt/chronicle/the-hierarchy-of-signals/index.html
@@ -67,7 +67,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/pt/chronicle/the-pilots-oath/index.html
+++ b/pt/chronicle/the-pilots-oath/index.html
@@ -70,7 +70,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/pt/chronicle/the-prophet/index.html
+++ b/pt/chronicle/the-prophet/index.html
@@ -96,7 +96,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>

--- a/pt/chronicle/why-non-repainting-matters/index.html
+++ b/pt/chronicle/why-non-repainting-matters/index.html
@@ -46,7 +46,8 @@
     .audio-bar{flex:1;height:4px;background:var(--bg-elev);border-radius:2px;cursor:pointer;overflow:hidden}
     .audio-bar-fill{height:100%;background:linear-gradient(90deg,var(--brand),var(--accent));width:0%;transition:width 0.1s}
     .audio-time{font-family:'Space Grotesk',monospace;font-size:0.8rem;color:var(--muted);min-width:80px;text-align:right}
-.article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
+.article-hero{max-width:900px;margin:0 auto 3rem;padding:0 1.5rem}
+    .article-hero-image{width:100%;max-height:500px;border-radius:var(--radius);overflow:hidden}
 .article-hero-image img{width:100%;height:100%;max-height:500px;object-fit:cover;object-position:center top}
   </style>
 </head>


### PR DESCRIPTION
Fixed hero image container sizing issue where images were displaying full-width instead of constrained to max-width: 900px.

Affected languages: ar (12), es (1), hu (5), it (5), pt (6), ru (4)