### PR TITLE
Add missing nav-dropdown CSS to DE, HU, and JA article pages

### DIFF
--- a/de/chronicle/the-hierarchy-of-signals/index.html
+++ b/de/chronicle/the-hierarchy-of-signals/index.html
@@ -180,6 +180,103 @@
 
     nav a:hover { color: var(--text); }
 
+    .nav-dropdown { position: relative; z-index: 65; }
+
+    .nav-dropdown-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      padding: 0.5rem 0.9rem;
+      border-radius: 999px;
+      color: var(--muted);
+      font-weight: 600;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      font-size: 0.95rem;
+      white-space: nowrap;
+    }
+
+    .nav-dropdown-toggle:hover,
+    .nav-dropdown-toggle:focus-visible {
+      color: var(--text);
+      background: rgba(91, 138, 255, 0.15);
+      transform: translateY(-1px);
+    }
+
+    .dropdown-arrow {
+      font-size: 0.7em;
+      transition: transform 0.2s ease;
+    }
+
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow {
+      transform: rotate(180deg);
+    }
+
+    .nav-dropdown-menu {
+      position: absolute;
+      top: calc(100% - 4px);
+      left: 0;
+      padding-top: 8px;
+      background: rgba(10, 12, 20, 0.98);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 12px;
+      padding: 0.5rem;
+      padding-top: calc(0.5rem + 8px);
+      margin-top: 4px;
+      min-width: 200px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      display: none;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.25rem;
+      z-index: 66;
+      backdrop-filter: blur(4px);
+    }
+
+    html[data-theme="light"] .nav-dropdown-menu {
+      background: rgba(255, 255, 255, 0.98);
+      border-color: rgba(30, 41, 59, 0.2);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    }
+
+    .nav-dropdown-menu::before {
+      content: '';
+      position: absolute;
+      top: -12px;
+      left: 0;
+      right: 0;
+      height: 16px;
+    }
+
+    .nav-dropdown-menu.show { display: flex; }
+
+    @media (min-width: 769px) {
+      .nav-dropdown:hover .nav-dropdown-menu { display: flex; }
+      .nav-dropdown:hover .nav-dropdown-toggle { color: var(--text); background: rgba(91, 138, 255, 0.15); }
+      .nav-dropdown:hover .dropdown-arrow { transform: rotate(180deg); }
+    }
+
+    .nav-dropdown-menu li { display: block; }
+
+    .nav-dropdown-menu a {
+      position: relative;
+      padding: 0.6rem 0.9rem;
+      display: flex !important;
+      align-items: center;
+      justify-content: flex-start !important;
+      gap: 0.5rem;
+      border-radius: 8px;
+      width: 100%;
+      text-align: left !important;
+    }
+
+    .nav-dropdown-menu a:hover {
+      background: rgba(91, 138, 255, 0.15);
+    }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/de/chronicle/the-pilots-oath/index.html
+++ b/de/chronicle/the-pilots-oath/index.html
@@ -181,6 +181,103 @@
 
     nav a:hover { color: var(--text); }
 
+    .nav-dropdown { position: relative; z-index: 65; }
+
+    .nav-dropdown-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      padding: 0.5rem 0.9rem;
+      border-radius: 999px;
+      color: var(--muted);
+      font-weight: 600;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      font-size: 0.95rem;
+      white-space: nowrap;
+    }
+
+    .nav-dropdown-toggle:hover,
+    .nav-dropdown-toggle:focus-visible {
+      color: var(--text);
+      background: rgba(91, 138, 255, 0.15);
+      transform: translateY(-1px);
+    }
+
+    .dropdown-arrow {
+      font-size: 0.7em;
+      transition: transform 0.2s ease;
+    }
+
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow {
+      transform: rotate(180deg);
+    }
+
+    .nav-dropdown-menu {
+      position: absolute;
+      top: calc(100% - 4px);
+      left: 0;
+      padding-top: 8px;
+      background: rgba(10, 12, 20, 0.98);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 12px;
+      padding: 0.5rem;
+      padding-top: calc(0.5rem + 8px);
+      margin-top: 4px;
+      min-width: 200px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      display: none;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.25rem;
+      z-index: 66;
+      backdrop-filter: blur(4px);
+    }
+
+    html[data-theme="light"] .nav-dropdown-menu {
+      background: rgba(255, 255, 255, 0.98);
+      border-color: rgba(30, 41, 59, 0.2);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    }
+
+    .nav-dropdown-menu::before {
+      content: '';
+      position: absolute;
+      top: -12px;
+      left: 0;
+      right: 0;
+      height: 16px;
+    }
+
+    .nav-dropdown-menu.show { display: flex; }
+
+    @media (min-width: 769px) {
+      .nav-dropdown:hover .nav-dropdown-menu { display: flex; }
+      .nav-dropdown:hover .nav-dropdown-toggle { color: var(--text); background: rgba(91, 138, 255, 0.15); }
+      .nav-dropdown:hover .dropdown-arrow { transform: rotate(180deg); }
+    }
+
+    .nav-dropdown-menu li { display: block; }
+
+    .nav-dropdown-menu a {
+      position: relative;
+      padding: 0.6rem 0.9rem;
+      display: flex !important;
+      align-items: center;
+      justify-content: flex-start !important;
+      gap: 0.5rem;
+      border-radius: 8px;
+      width: 100%;
+      text-align: left !important;
+    }
+
+    .nav-dropdown-menu a:hover {
+      background: rgba(91, 138, 255, 0.15);
+    }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/de/chronicle/why-non-repainting-matters/index.html
+++ b/de/chronicle/why-non-repainting-matters/index.html
@@ -185,6 +185,103 @@
 
     nav a:hover { color: var(--text); }
 
+    .nav-dropdown { position: relative; z-index: 65; }
+
+    .nav-dropdown-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      padding: 0.5rem 0.9rem;
+      border-radius: 999px;
+      color: var(--muted);
+      font-weight: 600;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      font-size: 0.95rem;
+      white-space: nowrap;
+    }
+
+    .nav-dropdown-toggle:hover,
+    .nav-dropdown-toggle:focus-visible {
+      color: var(--text);
+      background: rgba(91, 138, 255, 0.15);
+      transform: translateY(-1px);
+    }
+
+    .dropdown-arrow {
+      font-size: 0.7em;
+      transition: transform 0.2s ease;
+    }
+
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow {
+      transform: rotate(180deg);
+    }
+
+    .nav-dropdown-menu {
+      position: absolute;
+      top: calc(100% - 4px);
+      left: 0;
+      padding-top: 8px;
+      background: rgba(10, 12, 20, 0.98);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 12px;
+      padding: 0.5rem;
+      padding-top: calc(0.5rem + 8px);
+      margin-top: 4px;
+      min-width: 200px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      display: none;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.25rem;
+      z-index: 66;
+      backdrop-filter: blur(4px);
+    }
+
+    html[data-theme="light"] .nav-dropdown-menu {
+      background: rgba(255, 255, 255, 0.98);
+      border-color: rgba(30, 41, 59, 0.2);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    }
+
+    .nav-dropdown-menu::before {
+      content: '';
+      position: absolute;
+      top: -12px;
+      left: 0;
+      right: 0;
+      height: 16px;
+    }
+
+    .nav-dropdown-menu.show { display: flex; }
+
+    @media (min-width: 769px) {
+      .nav-dropdown:hover .nav-dropdown-menu { display: flex; }
+      .nav-dropdown:hover .nav-dropdown-toggle { color: var(--text); background: rgba(91, 138, 255, 0.15); }
+      .nav-dropdown:hover .dropdown-arrow { transform: rotate(180deg); }
+    }
+
+    .nav-dropdown-menu li { display: block; }
+
+    .nav-dropdown-menu a {
+      position: relative;
+      padding: 0.6rem 0.9rem;
+      display: flex !important;
+      align-items: center;
+      justify-content: flex-start !important;
+      gap: 0.5rem;
+      border-radius: 8px;
+      width: 100%;
+      text-align: left !important;
+    }
+
+    .nav-dropdown-menu a:hover {
+      background: rgba(91, 138, 255, 0.15);
+    }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/hu/chronicle/the-cartographer/index.html
+++ b/hu/chronicle/the-cartographer/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--warn),var(--gold));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-commander/index.html
+++ b/hu/chronicle/the-commander/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--brand),var(--accent));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-council-assembles/index.html
+++ b/hu/chronicle/the-council-assembles/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--gold),var(--warn));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-hierarchy-of-signals/index.html
+++ b/hu/chronicle/the-hierarchy-of-signals/index.html
@@ -212,6 +212,20 @@
 
     nav a:hover { color: var(--text); }
 
+    .nav-dropdown { position: relative; z-index: 65; }
+    .nav-dropdown-toggle { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.5rem 0.9rem; border-radius: 999px; color: var(--muted); font-weight: 600; font-family: 'Space Grotesk', system-ui, sans-serif; background: transparent; border: none; cursor: pointer; transition: all 0.2s ease; font-size: 0.95rem; white-space: nowrap; }
+    .nav-dropdown-toggle:hover, .nav-dropdown-toggle:focus-visible { color: var(--text); background: rgba(91, 138, 255, 0.15); transform: translateY(-1px); }
+    .dropdown-arrow { font-size: 0.7em; transition: transform 0.2s ease; }
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow { transform: rotate(180deg); }
+    .nav-dropdown-menu { position: absolute; top: calc(100% - 4px); left: 0; padding-top: 8px; background: rgba(10, 12, 20, 0.98); border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 12px; padding: 0.5rem; padding-top: calc(0.5rem + 8px); margin-top: 4px; min-width: 200px; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); display: none; flex-direction: column; align-items: stretch; gap: 0.25rem; z-index: 66; backdrop-filter: blur(4px); }
+    html[data-theme="light"] .nav-dropdown-menu { background: rgba(255, 255, 255, 0.98); border-color: rgba(30, 41, 59, 0.2); box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15); }
+    .nav-dropdown-menu::before { content: ''; position: absolute; top: -12px; left: 0; right: 0; height: 16px; }
+    .nav-dropdown-menu.show { display: flex; }
+    @media (min-width: 769px) { .nav-dropdown:hover .nav-dropdown-menu { display: flex; } .nav-dropdown:hover .nav-dropdown-toggle { color: var(--text); background: rgba(91, 138, 255, 0.15); } .nav-dropdown:hover .dropdown-arrow { transform: rotate(180deg); } }
+    .nav-dropdown-menu li { display: block; }
+    .nav-dropdown-menu a { position: relative; padding: 0.6rem 0.9rem; display: flex !important; align-items: center; justify-content: flex-start !important; gap: 0.5rem; border-radius: 8px; width: 100%; text-align: left !important; }
+    .nav-dropdown-menu a:hover { background: rgba(91, 138, 255, 0.15); }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/hu/chronicle/the-pilots-oath/index.html
+++ b/hu/chronicle/the-pilots-oath/index.html
@@ -215,6 +215,103 @@
 
     nav a:hover { color: var(--text); }
 
+    .nav-dropdown { position: relative; z-index: 65; }
+
+    .nav-dropdown-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      padding: 0.5rem 0.9rem;
+      border-radius: 999px;
+      color: var(--muted);
+      font-weight: 600;
+      font-family: 'Space Grotesk', system-ui, sans-serif;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      font-size: 0.95rem;
+      white-space: nowrap;
+    }
+
+    .nav-dropdown-toggle:hover,
+    .nav-dropdown-toggle:focus-visible {
+      color: var(--text);
+      background: rgba(91, 138, 255, 0.15);
+      transform: translateY(-1px);
+    }
+
+    .dropdown-arrow {
+      font-size: 0.7em;
+      transition: transform 0.2s ease;
+    }
+
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow {
+      transform: rotate(180deg);
+    }
+
+    .nav-dropdown-menu {
+      position: absolute;
+      top: calc(100% - 4px);
+      left: 0;
+      padding-top: 8px;
+      background: rgba(10, 12, 20, 0.98);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 12px;
+      padding: 0.5rem;
+      padding-top: calc(0.5rem + 8px);
+      margin-top: 4px;
+      min-width: 200px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      display: none;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.25rem;
+      z-index: 66;
+      backdrop-filter: blur(4px);
+    }
+
+    html[data-theme="light"] .nav-dropdown-menu {
+      background: rgba(255, 255, 255, 0.98);
+      border-color: rgba(30, 41, 59, 0.2);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    }
+
+    .nav-dropdown-menu::before {
+      content: '';
+      position: absolute;
+      top: -12px;
+      left: 0;
+      right: 0;
+      height: 16px;
+    }
+
+    .nav-dropdown-menu.show { display: flex; }
+
+    @media (min-width: 769px) {
+      .nav-dropdown:hover .nav-dropdown-menu { display: flex; }
+      .nav-dropdown:hover .nav-dropdown-toggle { color: var(--text); background: rgba(91, 138, 255, 0.15); }
+      .nav-dropdown:hover .dropdown-arrow { transform: rotate(180deg); }
+    }
+
+    .nav-dropdown-menu li { display: block; }
+
+    .nav-dropdown-menu a {
+      position: relative;
+      padding: 0.6rem 0.9rem;
+      display: flex !important;
+      align-items: center;
+      justify-content: flex-start !important;
+      gap: 0.5rem;
+      border-radius: 8px;
+      width: 100%;
+      text-align: left !important;
+    }
+
+    .nav-dropdown-menu a:hover {
+      background: rgba(91, 138, 255, 0.15);
+    }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/hu/chronicle/the-prophet/index.html
+++ b/hu/chronicle/the-prophet/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-scales/index.html
+++ b/hu/chronicle/the-scales/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--good),var(--bad));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/the-watchman/index.html
+++ b/hu/chronicle/the-watchman/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/hu/chronicle/why-non-repainting-matters/index.html
+++ b/hu/chronicle/why-non-repainting-matters/index.html
@@ -185,6 +185,20 @@
 
     nav a:hover { color: var(--text); }
 
+    .nav-dropdown { position: relative; z-index: 65; }
+    .nav-dropdown-toggle { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.5rem 0.9rem; border-radius: 999px; color: var(--muted); font-weight: 600; font-family: 'Space Grotesk', system-ui, sans-serif; background: transparent; border: none; cursor: pointer; transition: all 0.2s ease; font-size: 0.95rem; white-space: nowrap; }
+    .nav-dropdown-toggle:hover, .nav-dropdown-toggle:focus-visible { color: var(--text); background: rgba(91, 138, 255, 0.15); transform: translateY(-1px); }
+    .dropdown-arrow { font-size: 0.7em; transition: transform 0.2s ease; }
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow { transform: rotate(180deg); }
+    .nav-dropdown-menu { position: absolute; top: calc(100% - 4px); left: 0; padding-top: 8px; background: rgba(10, 12, 20, 0.98); border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 12px; padding: 0.5rem; padding-top: calc(0.5rem + 8px); margin-top: 4px; min-width: 200px; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); display: none; flex-direction: column; align-items: stretch; gap: 0.25rem; z-index: 66; backdrop-filter: blur(4px); }
+    html[data-theme="light"] .nav-dropdown-menu { background: rgba(255, 255, 255, 0.98); border-color: rgba(30, 41, 59, 0.2); box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15); }
+    .nav-dropdown-menu::before { content: ''; position: absolute; top: -12px; left: 0; right: 0; height: 16px; }
+    .nav-dropdown-menu.show { display: flex; }
+    @media (min-width: 769px) { .nav-dropdown:hover .nav-dropdown-menu { display: flex; } .nav-dropdown:hover .nav-dropdown-toggle { color: var(--text); background: rgba(91, 138, 255, 0.15); } .nav-dropdown:hover .dropdown-arrow { transform: rotate(180deg); } }
+    .nav-dropdown-menu li { display: block; }
+    .nav-dropdown-menu a { position: relative; padding: 0.6rem 0.9rem; display: flex !important; align-items: center; justify-content: flex-start !important; gap: 0.5rem; border-radius: 8px; width: 100%; text-align: left !important; }
+    .nav-dropdown-menu a:hover { background: rgba(91, 138, 255, 0.15); }
+
     .btn {
       background: var(--bg-soft);
       border: 1px solid var(--border);

--- a/ja/chronicle/the-commander/index.html
+++ b/ja/chronicle/the-commander/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--brand),var(--accent));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-council-assembles/index.html
+++ b/ja/chronicle/the-council-assembles/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--gold),var(--warn));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-hierarchy-of-signals/index.html
+++ b/ja/chronicle/the-hierarchy-of-signals/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-pilots-oath/index.html
+++ b/ja/chronicle/the-pilots-oath/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--gold),var(--warn));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-prophet/index.html
+++ b/ja/chronicle/the-prophet/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-scales/index.html
+++ b/ja/chronicle/the-scales/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--good),var(--bad));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/the-watchman/index.html
+++ b/ja/chronicle/the-watchman/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--accent),var(--brand));z-index:99;transition:width 0.1s}

--- a/ja/chronicle/why-non-repainting-matters/index.html
+++ b/ja/chronicle/why-non-repainting-matters/index.html
@@ -36,6 +36,19 @@
     nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
     nav a{font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     nav a:hover{color:var(--text)}
+    .nav-dropdown{position:relative;z-index:65}
+    .nav-dropdown-toggle{display:inline-flex;align-items:center;gap:0.3rem;padding:0.5rem 0.9rem;border-radius:999px;color:var(--muted);font-weight:600;font-family:'Noto Sans JP','Space Grotesk',system-ui,sans-serif;background:transparent;border:none;cursor:pointer;transition:all 0.2s ease;font-size:0.95rem;white-space:nowrap}
+    .nav-dropdown-toggle:hover,.nav-dropdown-toggle:focus-visible{color:var(--text);background:rgba(91,138,255,0.15);transform:translateY(-1px)}
+    .dropdown-arrow{font-size:0.7em;transition:transform 0.2s ease}
+    .nav-dropdown-toggle[aria-expanded="true"] .dropdown-arrow{transform:rotate(180deg)}
+    .nav-dropdown-menu{position:absolute;top:calc(100% - 4px);left:0;padding-top:8px;background:rgba(10,12,20,0.98);border:1px solid rgba(255,255,255,0.2);border-radius:12px;padding:0.5rem;padding-top:calc(0.5rem + 8px);margin-top:4px;min-width:200px;box-shadow:0 8px 24px rgba(0,0,0,0.4);display:none;flex-direction:column;align-items:stretch;gap:0.25rem;z-index:66;backdrop-filter:blur(4px)}
+    html[data-theme="light"] .nav-dropdown-menu{background:rgba(255,255,255,0.98);border-color:rgba(30,41,59,0.2);box-shadow:0 8px 24px rgba(0,0,0,0.15)}
+    .nav-dropdown-menu::before{content:'';position:absolute;top:-12px;left:0;right:0;height:16px}
+    .nav-dropdown-menu.show{display:flex}
+    @media(min-width:769px){.nav-dropdown:hover .nav-dropdown-menu{display:flex}.nav-dropdown:hover .nav-dropdown-toggle{color:var(--text);background:rgba(91,138,255,0.15)}.nav-dropdown:hover .dropdown-arrow{transform:rotate(180deg)}}
+    .nav-dropdown-menu li{display:block}
+    .nav-dropdown-menu a{position:relative;padding:0.6rem 0.9rem;display:flex !important;align-items:center;justify-content:flex-start !important;gap:0.5rem;border-radius:8px;width:100%;text-align:left !important}
+    .nav-dropdown-menu a:hover{background:rgba(91,138,255,0.15)}
     .btn{background:var(--bg-soft);border:1px solid var(--border);color:var(--text);padding:0.4rem 0.7rem;border-radius:6px;cursor:pointer;font-size:1rem;transition:all 0.2s}
     .btn:hover{background:var(--bg-elev)}
     .progress-bar{position:fixed;top:64px;left:0;width:0%;height:3px;background:linear-gradient(90deg,var(--good),var(--accent));z-index:99;transition:width 0.1s}


### PR DESCRIPTION
Fix navigation dropdown display issue where menu items were showing inline instead of hidden. Added nav-dropdown, nav-dropdown-toggle, and nav-dropdown-menu CSS rules with display:none default state across 20 affected article pages in German, Hungarian, and Japanese.