### PR TITLE
Remove dark theme toggle from non-English sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4181,13 +4181,6 @@ html[lang="ar"] [style*="text-align:center"] {
 
       <div class="nav-spacer"></div>
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Theme selection" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/ar/privacy.html
+++ b/ar/privacy.html
@@ -197,7 +197,6 @@
   <header>
     <div class="container">
       <a href="/ar/" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">الوضع</button>
     </div>
   </header>
 

--- a/ar/refund.html
+++ b/ar/refund.html
@@ -19,7 +19,6 @@
   <header>
     <div class="container">
       <a href="/ar/" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">الوضع</button>
     </div>
   </header>
   <main>

--- a/ar/terms.html
+++ b/ar/terms.html
@@ -19,7 +19,6 @@
   <header>
     <div class="container">
       <a href="/ar/" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">الوضع</button>
     </div>
   </header>
   <main>

--- a/de/index.html
+++ b/de/index.html
@@ -4102,13 +4102,6 @@
 
       <div class="nav-spacer"></div>
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Themenauswahl" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/de/privacy.html
+++ b/de/privacy.html
@@ -196,7 +196,6 @@
   <header>
     <div class="container">
       <a href="../index.html" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Thema</button>
     </div>
   </header>
 

--- a/de/refund.html
+++ b/de/refund.html
@@ -272,7 +272,6 @@
   <header>
     <div class="container">
       <a href="index.html" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Design</button>
     </div>
   </header>
 

--- a/de/terms.html
+++ b/de/terms.html
@@ -209,7 +209,6 @@
   <header>
     <div class="container">
       <a href="index.html" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Design</button>
     </div>
   </header>
 

--- a/es/index.html
+++ b/es/index.html
@@ -4340,13 +4340,6 @@
 
       <div class="nav-spacer"></div>
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Selección de tema" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/es/privacy.html
+++ b/es/privacy.html
@@ -196,7 +196,6 @@
   <header>
     <div class="container">
       <a href="/es/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/es/refund.html
+++ b/es/refund.html
@@ -272,7 +272,6 @@
   <header>
     <div class="container">
       <a href="/es/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/es/terms.html
+++ b/es/terms.html
@@ -209,7 +209,6 @@
   <header>
     <div class="container">
       <a href="/es/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -4305,13 +4305,6 @@
 
 
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Sélection de thème" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/fr/privacy.html
+++ b/fr/privacy.html
@@ -216,7 +216,6 @@
   <header>
     <div class="container">
       <a href="/fr/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Thème</button>
     </div>
   </header>
 

--- a/fr/refund.html
+++ b/fr/refund.html
@@ -293,7 +293,6 @@
   <header>
     <div class="container">
       <a href="/fr/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Thème</button>
     </div>
   </header>
 

--- a/fr/terms.html
+++ b/fr/terms.html
@@ -233,7 +233,6 @@
   <header>
     <div class="container">
       <a href="/fr/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Thème</button>
     </div>
   </header>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -4107,13 +4107,6 @@
 
       <div class="nav-spacer"></div>
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Témaválasztás" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/hu/privacy.html
+++ b/hu/privacy.html
@@ -196,7 +196,6 @@
   <header>
     <div class="container">
       <a href="/hu/" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">Téma</button>
     </div>
   </header>
 

--- a/hu/refund.html
+++ b/hu/refund.html
@@ -272,7 +272,6 @@
   <header>
     <div class="container">
       <a href="/hu/" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">Téma</button>
     </div>
   </header>
 

--- a/hu/terms.html
+++ b/hu/terms.html
@@ -209,7 +209,6 @@
   <header>
     <div class="container">
       <a href="/hu/" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">Téma</button>
     </div>
   </header>
 

--- a/it/index.html
+++ b/it/index.html
@@ -4026,13 +4026,6 @@
 
       <div class="nav-spacer"></div>
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Selezione tema" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/it/privacy.html
+++ b/it/privacy.html
@@ -196,7 +196,6 @@
   <header>
     <div class="container">
       <a href="/it/index.html" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/it/refund.html
+++ b/it/refund.html
@@ -272,7 +272,6 @@
   <header>
     <div class="container">
       <a href="/it/index.html" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/it/terms.html
+++ b/it/terms.html
@@ -209,7 +209,6 @@
   <header>
     <div class="container">
       <a href="/it/index.html" class="logo"><span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span></a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -4371,13 +4371,6 @@
 
 
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Theme selection" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/ja/privacy.html
+++ b/ja/privacy.html
@@ -213,7 +213,6 @@
   <header>
     <div class="container">
       <a href="/ja/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">テーマ</button>
     </div>
   </header>
 

--- a/ja/refund.html
+++ b/ja/refund.html
@@ -290,7 +290,6 @@
   <header>
     <div class="container">
       <a href="/ja/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">テーマ</button>
     </div>
   </header>
 

--- a/ja/terms.html
+++ b/ja/terms.html
@@ -232,7 +232,6 @@
   <header>
     <div class="container">
       <a href="/ja/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">テーマ</button>
     </div>
   </header>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -4081,13 +4081,6 @@
 
       <div class="nav-spacer"></div>
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Thema selectie" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/nl/privacy.html
+++ b/nl/privacy.html
@@ -196,7 +196,6 @@
   <header>
     <div class="container">
       <a href="/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Thema</button>
     </div>
   </header>
 

--- a/nl/refund.html
+++ b/nl/refund.html
@@ -272,7 +272,6 @@
   <header>
     <div class="container">
       <a href="/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Thema</button>
     </div>
   </header>
 

--- a/nl/terms.html
+++ b/nl/terms.html
@@ -209,7 +209,6 @@
   <header>
     <div class="container">
       <a href="/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Thema</button>
     </div>
   </header>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -4420,13 +4420,6 @@
 
 
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Seleção de tema" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/pt/privacy.html
+++ b/pt/privacy.html
@@ -196,7 +196,6 @@
   <header>
     <div class="container">
       <a href="/pt/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/pt/refund.html
+++ b/pt/refund.html
@@ -272,7 +272,6 @@
   <header>
     <div class="container">
       <a href="/pt/index.html" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/pt/terms.html
+++ b/pt/terms.html
@@ -209,7 +209,6 @@
   <header>
     <div class="container">
       <a href="index.html" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -4014,13 +4014,6 @@
 
 
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Выбор темы" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/ru/privacy.html
+++ b/ru/privacy.html
@@ -197,7 +197,6 @@
   <header>
     <div class="container">
       <a href="/ru/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Режим</button>
     </div>
   </header>
 

--- a/ru/refund.html
+++ b/ru/refund.html
@@ -19,7 +19,6 @@
   <header>
     <div class="container">
       <a href="/ru/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Режим</button>
     </div>
   </header>
   <main>

--- a/ru/terms.html
+++ b/ru/terms.html
@@ -19,7 +19,6 @@
   <header>
     <div class="container">
       <a href="/ru/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Режим</button>
     </div>
   </header>
   <main>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4107,13 +4107,6 @@
 
 
 
-      <button id="themeToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Tema seçimi" style="padding:.5rem .7rem;color:var(--text)">
-        <span id="theme-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;vertical-align:middle;opacity:0.7">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-        </span>
-      </button>
 
 
 

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -207,7 +207,6 @@
   <header>
     <div class="container">
       <a href="/tr/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/tr/refund.html
+++ b/tr/refund.html
@@ -283,7 +283,6 @@
   <header>
     <div class="container">
       <a href="/tr/" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 

--- a/tr/terms.html
+++ b/tr/terms.html
@@ -219,7 +219,6 @@
   <header>
     <div class="container">
       <a href="/tr/index.html" class="logo">Signal Pilot</a>
-      <button id="themeToggle" class="theme-toggle">Tema</button>
     </div>
   </header>
 


### PR DESCRIPTION
Removed theme toggle button from index.html, terms.html, privacy.html, and refund.html for all 11 non-English language versions (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr) to match the English main site which no longer has the theme toggle feature.