### PR TITLE
Fix broken links returning 404 errors

### DIFF
--- a/tools/index.html
+++ b/tools/index.html
@@ -987,7 +987,7 @@
           <div id="rr-verdict"></div>
           <button class="share-result" id="rr-share" onclick="shareCalc('rr')">📋 Copy shareable link</button>
         </div>
-        <a href="https://blog.signalpilot.io/the-1-rule" target="_blank" rel="noopener" class="learn-link">Why R:R matters →</a>
+        <a href="/chronicle/the-pilots-oath" class="learn-link">Why R:R matters →</a>
       </div>
 
       <!-- Profit/Loss Calculator -->
@@ -1073,7 +1073,7 @@
           </div>
           <div class="insight" id="dd-insight"></div>
         </div>
-        <a href="https://blog.signalpilot.io/accumulation-vs-distribution" target="_blank" rel="noopener" class="learn-link">Avoid drawdowns →</a>
+        <a href="/chronicle/the-prophet" class="learn-link">Avoid drawdowns →</a>
       </div>
 
       <!-- Kelly Criterion -->
@@ -1155,7 +1155,7 @@
           </div>
           <div class="insight" id="exp-insight"></div>
         </div>
-        <a href="https://blog.signalpilot.io/building-your-first-system" target="_blank" rel="noopener" class="learn-link">Build a trading system →</a>
+        <a href="/chronicle/the-hierarchy-of-signals" class="learn-link">Build a trading system →</a>
       </div>
 
       <!-- Portfolio Heat -->
@@ -1281,7 +1281,7 @@
             <span class="result-value bad" id="be-costs">—</span>
           </div>
         </div>
-        <a href="https://blog.signalpilot.io/free-indicators-vs-professional-tools" target="_blank" rel="noopener" class="learn-link">Choose the right tools →</a>
+        <a href="/chronicle/why-non-repainting-matters" class="learn-link">Choose the right tools →</a>
       </div>
 
       <!-- R-Multiple -->
@@ -1310,7 +1310,7 @@
           <div id="rm-verdict"></div>
           <div class="insight">A +2R win means you made twice what you risked. Track all trades in R to normalize performance across different position sizes.</div>
         </div>
-        <a href="https://blog.signalpilot.io/your-first-trade" target="_blank" rel="noopener" class="learn-link">Track your first trade →</a>
+        <a href="/chronicle/birth-of-the-elite-seven" class="learn-link">Track your first trade →</a>
       </div>
     </div>
 
@@ -1318,28 +1318,28 @@
     <div class="blog-section">
       <h2>📚 From the Blog</h2>
       <div class="blog-grid">
-        <a href="https://blog.signalpilot.io/the-1-rule" target="_blank" rel="noopener" class="blog-card">
+        <a href="/chronicle/the-pilots-oath" class="blog-card">
           <span class="blog-icon">💰</span>
           <div>
             <h3>The 1% Rule</h3>
             <p>Why risking 1% per trade changed everything</p>
           </div>
         </a>
-        <a href="https://blog.signalpilot.io/building-your-first-system" target="_blank" rel="noopener" class="blog-card">
+        <a href="/chronicle/the-hierarchy-of-signals" class="blog-card">
           <span class="blog-icon">🔧</span>
           <div>
             <h3>Building Your First System</h3>
             <p>From random trades to consistent profits</p>
           </div>
         </a>
-        <a href="https://blog.signalpilot.io/how-smart-money-moves" target="_blank" rel="noopener" class="blog-card">
+        <a href="/chronicle/the-prophet" class="blog-card">
           <span class="blog-icon">🏛️</span>
           <div>
             <h3>How Smart Money Moves</h3>
             <p>Follow institutional footprints in the market</p>
           </div>
         </a>
-        <a href="https://blog.signalpilot.io/why-your-indicators-keep-failing" target="_blank" rel="noopener" class="blog-card">
+        <a href="/chronicle/why-non-repainting-matters" class="blog-card">
           <span class="blog-icon">📉</span>
           <div>
             <h3>Why Your Indicators Keep Failing</h3>


### PR DESCRIPTION
Replace 9 non-existent blog.signalpilot.io links with working /chronicle/ article links:
- the-1-rule → /chronicle/the-pilots-oath
- accumulation-vs-distribution → /chronicle/the-prophet
- building-your-first-system → /chronicle/the-hierarchy-of-signals
- free-indicators-vs-professional-tools → /chronicle/why-non-repainting-matters
- your-first-trade → /chronicle/birth-of-the-elite-seven
- how-smart-money-moves → /chronicle/the-prophet
- why-your-indicators-keep-failing → /chronicle/why-non-repainting-matters