### PR TITLE
Fix lore section mobile display issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -5292,8 +5292,14 @@
         .chronicle-card.featured {
           grid-template-columns: 1fr !important;
         }
-        .chronicle-card.featured > div:first-child {
-          min-height: 200px !important;
+        /* Target the image container (2nd child, after the absolute glow div) */
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: 180px !important;
+          height: 180px !important;
+        }
+        /* Change gradient from horizontal to vertical on mobile */
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
         }
         .chronicle-card.featured > div:last-child {
           padding: 1.5rem !important;
@@ -5314,6 +5320,13 @@
 
       html[data-theme="light"] .chronicle-card.featured div[style*="to right"] {
         background: linear-gradient(to right,transparent 60%,rgba(255,255,255,0.9) 100%) !important;
+      }
+
+      /* Light theme mobile adjustments */
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important;
+        }
       }
     </style>
 


### PR DESCRIPTION
- Fix incorrect CSS selector targeting glow div instead of image container
- Reduce image container height on mobile from 200px to 180px with fixed height
- Change gradient direction from horizontal (to right) to vertical (to bottom) on mobile
- Add light theme mobile gradient adjustment

Fixes the large empty space appearing in the featured chronicle card on mobile devices.