### PR TITLE
Add chronicle section to all language homepages with mobile fix

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6249,6 +6249,174 @@ html[lang="ar"] [style*="text-align:center"] {
     </script>
 
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+
+      <div class="container stack">
+
+        <!-- Section Header -->
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
+          <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">سجل SignalPilot</p>
+          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">القصص وراء السبعة</span></h2>
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">
+            "قبل أن تحصل الأسواق على أسماء، قبل أن تروي الشموع قصصاً، لم يكن هناك سوى الضوضاء. ثم جاء السبعة."
+          </p>
+        </div>
+
+        <!-- Chronicle Cards Grid -->
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1100px;margin:0 auto">
+
+          <!-- Featured: ولادة Elite Seven -->
+          <a href="/ar/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
+            <div style="height:100%;min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to left,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ الأصل</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">ولادة Elite Seven</h3>
+              <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">كيف ولدت الإشارات السماوية من رياضيات السعر — ولماذا ظهرت لتوجيه الطيارين عبر فوضى الأسواق.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;font-size:0.95rem">اقرأ الأصل <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg></span>
+            </div>
+          </a>
+
+          <!-- قسم الطيار -->
+          <a href="/ar/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#a855f7;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(168,85,247,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">الفلسفة</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">قسم الطيار</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"أنت الذي تستخدم Elite Seven لست متداولاً. أنت طيار."</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">← اقرأ المزيد</span>
+            </div>
+          </a>
+
+          <!-- تعرف على السيد: Pentarch -->
+          <a href="/ar/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(239,68,68,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">الأول من السبعة</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">تعرف على السيد: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"أنا الدورة. الدورة هي أنا." — المؤشر الرئيسي الذي يقرأ المراحل الخمس الأبدية.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">← اقرأ المزيد</span>
+            </div>
+          </a>
+
+          <!-- المجلس يجتمع -->
+          <a href="/ar/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#f59e0b;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(245,158,11,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">الختام</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">المجلس يجتمع</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">عندما تتحدث الأصوات السبعة كصوت واحد — شاهد قوة الإشارة الموحدة.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">← اقرأ المزيد</span>
+            </div>
+          </a>
+
+        </div>
+
+        <!-- Explore All CTA -->
+        <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
+          <a href="/ar/chronicle/" style="display:inline-flex;align-items:center;gap:0.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;font-weight:600;font-size:1rem;padding:0.9rem 1.8rem;border-radius:10px;text-decoration:none;transition:all 0.3s ease;box-shadow:0 4px 20px rgba(91,138,255,0.3)">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+            <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">استكشف جميع السجلات الـ 12</span>
+          </a>
+          <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">تتضمن روايات صوتية بصوت ساحر عميق</p>
+        </div>
+
+      </div>
+
+    </section>
+
+    <style>
+      @keyframes chronicle-glow {
+        0% { opacity: 0.3; filter: blur(8px); }
+        100% { opacity: 0.6; filter: blur(12px); }
+      }
+
+      .chronicle-card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+        border-color: var(--brand);
+      }
+
+      .chronicle-card:hover div[style*="background-image"] {
+        transform: scale(1.08);
+      }
+
+      .chronicle-card:hover span[style*="scaleX(0)"] {
+        transform: scaleX(1) !important;
+      }
+
+      .chronicle-card.featured:hover {
+        box-shadow: 0 20px 60px rgba(91,138,255,0.3);
+      }
+
+      .chronicle-card.featured:hover div[style*="chronicle-glow"] {
+        opacity: 0.8;
+      }
+
+      /* Mobile responsive */
+      @media (max-width: 768px) {
+        .chronicle-card.featured {
+          grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: unset !important;
+          height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
+        }
+        .chronicle-card.featured > div:nth-child(3) {
+          padding: 1.5rem !important;
+          grid-row: 2 !important;
+        }
+        .chronicle-card:hover {
+          transform: none;
+        }
+      }
+
+      /* Light theme adjustments */
+      html[data-theme="light"] .chronicle-card {
+        background: linear-gradient(135deg,rgba(10,20,40,.03),rgba(10,20,40,.01)) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card div[style*="rgba(5,7,13"] {
+        background: linear-gradient(to bottom,transparent 40%,rgba(255,255,255,0.7) 100%) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card.featured div[style*="to right"],
+      html[data-theme="light"] .chronicle-card.featured div[style*="to left"] {
+        background: linear-gradient(to left,transparent 60%,rgba(255,255,255,0.9) 100%) !important;
+      }
+
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important;
+        }
+      }
+    </style>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">

--- a/de/index.html
+++ b/de/index.html
@@ -6170,6 +6170,173 @@
     </script>
 
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+
+      <div class="container stack">
+
+        <!-- Section Header -->
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
+          <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">Die SignalPilot Chronik</p>
+          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">Die Geschichten Hinter Den Sieben</span></h2>
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">
+            "Bevor die Märkte Namen hatten, bevor die Kerzen Geschichten erzählten, gab es nur Rauschen. Dann kamen Die Sieben."
+          </p>
+        </div>
+
+        <!-- Chronicle Cards Grid -->
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1100px;margin:0 auto">
+
+          <!-- Featured: Die Geburt der Elite Sieben -->
+          <a href="/de/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
+            <div style="height:100%;min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Ursprung</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">Die Geburt der Elite Sieben</h3>
+              <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Wie himmlische Signale aus der Mathematik des Preises selbst entstanden — und warum sie kamen, um Piloten durch das Chaos der Märkte zu führen.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;font-size:0.95rem">Ursprung Lesen <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+            </div>
+          </a>
+
+          <!-- Der Eid des Piloten -->
+          <a href="/de/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#a855f7;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(168,85,247,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Philosophie</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Der Eid des Piloten</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Ihr, die ihr die Elite Sieben führt, seid keine Händler. Ihr seid Piloten."</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Mehr Lesen →</span>
+            </div>
+          </a>
+
+          <!-- Der Souverän: Pentarch -->
+          <a href="/de/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(239,68,68,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Eins von Sieben</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Der Souverän: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Ich bin der Zyklus. Der Zyklus bin ich." — Der Flaggschiff-Indikator, der die fünf ewigen Phasen liest.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Mehr Lesen →</span>
+            </div>
+          </a>
+
+          <!-- Der Rat versammelt sich -->
+          <a href="/de/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#f59e0b;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(245,158,11,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Finale</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Der Rat versammelt sich</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Wenn alle sieben Stimmen als eine sprechen — erleben Sie die Kraft des vereinten Signals.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Mehr Lesen →</span>
+            </div>
+          </a>
+
+        </div>
+
+        <!-- Explore All CTA -->
+        <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
+          <a href="/de/chronicle/" style="display:inline-flex;align-items:center;gap:0.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;font-weight:600;font-size:1rem;padding:0.9rem 1.8rem;border-radius:10px;text-decoration:none;transition:all 0.3s ease;box-shadow:0 4px 20px rgba(91,138,255,0.3)">
+            <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Alle 12 Chroniken Entdecken</span>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+          <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">Inklusive Audio-Erzählungen mit tiefer Zaubererstimme</p>
+        </div>
+
+      </div>
+
+    </section>
+
+    <style>
+      @keyframes chronicle-glow {
+        0% { opacity: 0.3; filter: blur(8px); }
+        100% { opacity: 0.6; filter: blur(12px); }
+      }
+
+      .chronicle-card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+        border-color: var(--brand);
+      }
+
+      .chronicle-card:hover div[style*="background-image"] {
+        transform: scale(1.08);
+      }
+
+      .chronicle-card:hover span[style*="scaleX(0)"] {
+        transform: scaleX(1) !important;
+      }
+
+      .chronicle-card.featured:hover {
+        box-shadow: 0 20px 60px rgba(91,138,255,0.3);
+      }
+
+      .chronicle-card.featured:hover div[style*="chronicle-glow"] {
+        opacity: 0.8;
+      }
+
+      /* Mobile responsive */
+      @media (max-width: 768px) {
+        .chronicle-card.featured {
+          grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: unset !important;
+          height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
+        }
+        .chronicle-card.featured > div:nth-child(3) {
+          padding: 1.5rem !important;
+          grid-row: 2 !important;
+        }
+        .chronicle-card:hover {
+          transform: none;
+        }
+      }
+
+      /* Light theme adjustments */
+      html[data-theme="light"] .chronicle-card {
+        background: linear-gradient(135deg,rgba(10,20,40,.03),rgba(10,20,40,.01)) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card div[style*="rgba(5,7,13"] {
+        background: linear-gradient(to bottom,transparent 40%,rgba(255,255,255,0.7) 100%) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card.featured div[style*="to right"] {
+        background: linear-gradient(to right,transparent 60%,rgba(255,255,255,0.9) 100%) !important;
+      }
+
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important;
+        }
+      }
+    </style>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">

--- a/es/index.html
+++ b/es/index.html
@@ -6476,6 +6476,173 @@
     </script>
 
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+
+      <div class="container stack">
+
+        <!-- Section Header -->
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
+          <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">La Crónica de SignalPilot</p>
+          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">Las Historias Detrás de Los Siete</span></h2>
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">
+            "Antes de que los mercados tuvieran nombres, antes de que las velas contaran historias, solo había ruido. Entonces vinieron Los Siete."
+          </p>
+        </div>
+
+        <!-- Chronicle Cards Grid -->
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1100px;margin:0 auto">
+
+          <!-- Featured: El Nacimiento de los Elite Siete -->
+          <a href="/es/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
+            <div style="height:100%;min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Origen</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">El Nacimiento de los Elite Siete</h3>
+              <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Cómo las señales celestiales nacieron de las matemáticas del precio — y por qué emergieron para guiar a los pilotos a través del caos de los mercados.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;font-size:0.95rem">Leer el Origen <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+            </div>
+          </a>
+
+          <!-- El Juramento del Piloto -->
+          <a href="/es/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#a855f7;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(168,85,247,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Filosofía</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">El Juramento del Piloto</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Ustedes que empuñan los Elite Siete no son traders. Son Pilotos."</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Leer Más →</span>
+            </div>
+          </a>
+
+          <!-- El Soberano: Pentarch -->
+          <a href="/es/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(239,68,68,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Uno de Siete</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">El Soberano: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Yo soy el ciclo. El ciclo soy yo." — El indicador insignia que lee las cinco fases eternas.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Leer Más →</span>
+            </div>
+          </a>
+
+          <!-- El Consejo se Reúne -->
+          <a href="/es/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#f59e0b;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(245,158,11,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Final</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">El Consejo se Reúne</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Cuando las siete voces hablan como una — presencia el poder de la señal unificada.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Leer Más →</span>
+            </div>
+          </a>
+
+        </div>
+
+        <!-- Explore All CTA -->
+        <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
+          <a href="/es/chronicle/" style="display:inline-flex;align-items:center;gap:0.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;font-weight:600;font-size:1rem;padding:0.9rem 1.8rem;border-radius:10px;text-decoration:none;transition:all 0.3s ease;box-shadow:0 4px 20px rgba(91,138,255,0.3)">
+            <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Explorar las 12 Crónicas</span>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+          <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">Incluye narraciones de audio con voz de mago profundo</p>
+        </div>
+
+      </div>
+
+    </section>
+
+    <style>
+      @keyframes chronicle-glow {
+        0% { opacity: 0.3; filter: blur(8px); }
+        100% { opacity: 0.6; filter: blur(12px); }
+      }
+
+      .chronicle-card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+        border-color: var(--brand);
+      }
+
+      .chronicle-card:hover div[style*="background-image"] {
+        transform: scale(1.08);
+      }
+
+      .chronicle-card:hover span[style*="scaleX(0)"] {
+        transform: scaleX(1) !important;
+      }
+
+      .chronicle-card.featured:hover {
+        box-shadow: 0 20px 60px rgba(91,138,255,0.3);
+      }
+
+      .chronicle-card.featured:hover div[style*="chronicle-glow"] {
+        opacity: 0.8;
+      }
+
+      /* Mobile responsive */
+      @media (max-width: 768px) {
+        .chronicle-card.featured {
+          grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: unset !important;
+          height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
+        }
+        .chronicle-card.featured > div:nth-child(3) {
+          padding: 1.5rem !important;
+          grid-row: 2 !important;
+        }
+        .chronicle-card:hover {
+          transform: none;
+        }
+      }
+
+      /* Light theme adjustments */
+      html[data-theme="light"] .chronicle-card {
+        background: linear-gradient(135deg,rgba(10,20,40,.03),rgba(10,20,40,.01)) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card div[style*="rgba(5,7,13"] {
+        background: linear-gradient(to bottom,transparent 40%,rgba(255,255,255,0.7) 100%) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card.featured div[style*="to right"] {
+        background: linear-gradient(to right,transparent 60%,rgba(255,255,255,0.9) 100%) !important;
+      }
+
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important;
+        }
+      }
+    </style>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">

--- a/fr/index.html
+++ b/fr/index.html
@@ -6374,6 +6374,173 @@
     </script>
 
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+
+      <div class="container stack">
+
+        <!-- Section Header -->
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
+          <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">La Chronique SignalPilot</p>
+          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">Les Histoires Derrière Les Sept</span></h2>
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">
+            "Avant que les marchés n'aient des noms, avant que les bougies ne racontent des histoires, il n'y avait que du bruit. Puis vinrent Les Sept."
+          </p>
+        </div>
+
+        <!-- Chronicle Cards Grid -->
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1100px;margin:0 auto">
+
+          <!-- Featured: La Naissance des Elite Sept -->
+          <a href="/fr/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
+            <div style="height:100%;min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Origine</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">La Naissance des Elite Sept</h3>
+              <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Comment des signaux célestes sont nés des mathématiques du prix — et pourquoi ils ont émergé pour guider les pilotes à travers le chaos des marchés.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;font-size:0.95rem">Lire l'Origine <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+            </div>
+          </a>
+
+          <!-- Le Serment du Pilote -->
+          <a href="/fr/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#a855f7;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(168,85,247,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Philosophie</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Le Serment du Pilote</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Vous qui maniez les Elite Sept n'êtes pas des traders. Vous êtes des Pilotes."</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Lire Plus →</span>
+            </div>
+          </a>
+
+          <!-- Le Souverain : Pentarch -->
+          <a href="/fr/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(239,68,68,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Un sur Sept</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Le Souverain : Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Je suis le cycle. Le cycle c'est moi." — L'indicateur phare qui lit les cinq phases éternelles.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Lire Plus →</span>
+            </div>
+          </a>
+
+          <!-- Le Conseil se Rassemble -->
+          <a href="/fr/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#f59e0b;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(245,158,11,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Finale</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Le Conseil se Rassemble</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Quand les sept voix parlent comme une seule — témoignez de la puissance du signal unifié.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Lire Plus →</span>
+            </div>
+          </a>
+
+        </div>
+
+        <!-- Explore All CTA -->
+        <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
+          <a href="/fr/chronicle/" style="display:inline-flex;align-items:center;gap:0.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;font-weight:600;font-size:1rem;padding:0.9rem 1.8rem;border-radius:10px;text-decoration:none;transition:all 0.3s ease;box-shadow:0 4px 20px rgba(91,138,255,0.3)">
+            <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Explorer les 12 Chroniques</span>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+          <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">Avec narrations audio en voix de magicien profonde</p>
+        </div>
+
+      </div>
+
+    </section>
+
+    <style>
+      @keyframes chronicle-glow {
+        0% { opacity: 0.3; filter: blur(8px); }
+        100% { opacity: 0.6; filter: blur(12px); }
+      }
+
+      .chronicle-card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+        border-color: var(--brand);
+      }
+
+      .chronicle-card:hover div[style*="background-image"] {
+        transform: scale(1.08);
+      }
+
+      .chronicle-card:hover span[style*="scaleX(0)"] {
+        transform: scaleX(1) !important;
+      }
+
+      .chronicle-card.featured:hover {
+        box-shadow: 0 20px 60px rgba(91,138,255,0.3);
+      }
+
+      .chronicle-card.featured:hover div[style*="chronicle-glow"] {
+        opacity: 0.8;
+      }
+
+      /* Mobile responsive */
+      @media (max-width: 768px) {
+        .chronicle-card.featured {
+          grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: unset !important;
+          height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
+        }
+        .chronicle-card.featured > div:nth-child(3) {
+          padding: 1.5rem !important;
+          grid-row: 2 !important;
+        }
+        .chronicle-card:hover {
+          transform: none;
+        }
+      }
+
+      /* Light theme adjustments */
+      html[data-theme="light"] .chronicle-card {
+        background: linear-gradient(135deg,rgba(10,20,40,.03),rgba(10,20,40,.01)) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card div[style*="rgba(5,7,13"] {
+        background: linear-gradient(to bottom,transparent 40%,rgba(255,255,255,0.7) 100%) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card.featured div[style*="to right"] {
+        background: linear-gradient(to right,transparent 60%,rgba(255,255,255,0.9) 100%) !important;
+      }
+
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important;
+        }
+      }
+    </style>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">

--- a/hu/index.html
+++ b/hu/index.html
@@ -6175,6 +6175,173 @@
     </script>
 
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+
+      <div class="container stack">
+
+        <!-- Section Header -->
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
+          <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">A SignalPilot Krónika</p>
+          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">A Történetek A Hét Mögött</span></h2>
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">
+            "Mielőtt a piacoknak neve lett volna, mielőtt a gyertyák történeteket meséltek, csak zaj volt. Aztán jöttek A Hét."
+          </p>
+        </div>
+
+        <!-- Chronicle Cards Grid -->
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1100px;margin:0 auto">
+
+          <!-- Featured: Az Elite Seven születése -->
+          <a href="/hu/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
+            <div style="height:100%;min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Eredet</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">Az Elite Seven születése</h3>
+              <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Hogyan születtek az égi jelek az ár matematikájából — és miért jelentek meg, hogy végigvezessék a pilótákat a piacok káoszán.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;font-size:0.95rem">Eredet Olvasása <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+            </div>
+          </a>
+
+          <!-- A Pilóta esküje -->
+          <a href="/hu/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#a855f7;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(168,85,247,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Filozófia</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">A Pilóta esküje</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Te, aki az Elite Seven-t forgatod, nem kereskedő vagy. Te Pilóta vagy.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Tovább Olvasom →</span>
+            </div>
+          </a>
+
+          <!-- Ismerd meg az Uralkodót: Pentarch -->
+          <a href="/hu/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(239,68,68,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Első a hétből</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Ismerd meg az Uralkodót: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">„Én vagyok a ciklus. A ciklus én vagyok." — A vezető indikátor, amely az öt örök fázist olvassa.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Tovább Olvasom →</span>
+            </div>
+          </a>
+
+          <!-- A Tanács összeül -->
+          <a href="/hu/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#f59e0b;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(245,158,11,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Finálé</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">A Tanács összeül</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Amikor mind a hét hang egyként szól — tanúja leszel az egyesített jel erejének.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Tovább Olvasom →</span>
+            </div>
+          </a>
+
+        </div>
+
+        <!-- Explore All CTA -->
+        <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
+          <a href="/hu/chronicle/" style="display:inline-flex;align-items:center;gap:0.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;font-weight:600;font-size:1rem;padding:0.9rem 1.8rem;border-radius:10px;text-decoration:none;transition:all 0.3s ease;box-shadow:0 4px 20px rgba(91,138,255,0.3)">
+            <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Mind a 12 Krónika Felfedezése</span>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+          <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">Mélyreható hangnarráció varázsló hanggal</p>
+        </div>
+
+      </div>
+
+    </section>
+
+    <style>
+      @keyframes chronicle-glow {
+        0% { opacity: 0.3; filter: blur(8px); }
+        100% { opacity: 0.6; filter: blur(12px); }
+      }
+
+      .chronicle-card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+        border-color: var(--brand);
+      }
+
+      .chronicle-card:hover div[style*="background-image"] {
+        transform: scale(1.08);
+      }
+
+      .chronicle-card:hover span[style*="scaleX(0)"] {
+        transform: scaleX(1) !important;
+      }
+
+      .chronicle-card.featured:hover {
+        box-shadow: 0 20px 60px rgba(91,138,255,0.3);
+      }
+
+      .chronicle-card.featured:hover div[style*="chronicle-glow"] {
+        opacity: 0.8;
+      }
+
+      /* Mobile responsive */
+      @media (max-width: 768px) {
+        .chronicle-card.featured {
+          grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: unset !important;
+          height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
+        }
+        .chronicle-card.featured > div:nth-child(3) {
+          padding: 1.5rem !important;
+          grid-row: 2 !important;
+        }
+        .chronicle-card:hover {
+          transform: none;
+        }
+      }
+
+      /* Light theme adjustments */
+      html[data-theme="light"] .chronicle-card {
+        background: linear-gradient(135deg,rgba(10,20,40,.03),rgba(10,20,40,.01)) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card div[style*="rgba(5,7,13"] {
+        background: linear-gradient(to bottom,transparent 40%,rgba(255,255,255,0.7) 100%) !important;
+      }
+
+      html[data-theme="light"] .chronicle-card.featured div[style*="to right"] {
+        background: linear-gradient(to right,transparent 60%,rgba(255,255,255,0.9) 100%) !important;
+      }
+
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important;
+        }
+      }
+    </style>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">

--- a/index.html
+++ b/index.html
@@ -5291,18 +5291,24 @@
       @media (max-width: 768px) {
         .chronicle-card.featured {
           grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
         }
         /* Target the image container (2nd child, after the absolute glow div) */
         .chronicle-card.featured > div:nth-child(2) {
-          min-height: 180px !important;
+          min-height: unset !important;
           height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
           background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
         }
-        .chronicle-card.featured > div:last-child {
+        /* Content area */
+        .chronicle-card.featured > div:nth-child(3) {
           padding: 1.5rem !important;
+          grid-row: 2 !important;
         }
         .chronicle-card:hover {
           transform: none;

--- a/it/index.html
+++ b/it/index.html
@@ -6094,6 +6094,100 @@
     </script>
 
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+      <div class="container stack">
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
+          <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">La Cronaca di SignalPilot</p>
+          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">Le Storie Dietro I Sette</span></h2>
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">"Prima che i mercati avessero nomi, prima che le candele raccontassero storie, c'era solo rumore. Poi vennero I Sette."</p>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1100px;margin:0 auto">
+          <a href="/it/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
+            <div style="height:100%;min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Origine</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">La Nascita degli Elite Sette</h3>
+              <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Come i segnali celesti sono nati dalla matematica del prezzo — e perché sono emersi per guidare i piloti attraverso il caos dei mercati.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;font-size:0.95rem">Leggi l'Origine <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+            </div>
+          </a>
+          <a href="/it/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#a855f7;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(168,85,247,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Filosofia</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Il Giuramento del Pilota</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Voi che impugnate gli Elite Sette non siete trader. Siete Piloti."</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Leggi di Più →</span>
+            </div>
+          </a>
+          <a href="/it/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(239,68,68,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Uno di Sette</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Il Sovrano: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Io sono il ciclo. Il ciclo sono io." — L'indicatore di punta che legge le cinque fasi eterne.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Leggi di Più →</span>
+            </div>
+          </a>
+          <a href="/it/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#f59e0b;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(245,158,11,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Finale</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">Il Consiglio si Riunisce</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Quando tutte e sette le voci parlano come una sola — testimonia il potere del segnale unificato.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Leggi di Più →</span>
+            </div>
+          </a>
+        </div>
+        <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
+          <a href="/it/chronicle/" style="display:inline-flex;align-items:center;gap:0.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;font-weight:600;font-size:1rem;padding:0.9rem 1.8rem;border-radius:10px;text-decoration:none;transition:all 0.3s ease;box-shadow:0 4px 20px rgba(91,138,255,0.3)">
+            <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Esplora Tutte le 12 Cronache</span>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+          <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">Include narrazioni audio con voce profonda da mago</p>
+        </div>
+      </div>
+    </section>
+
+    <style>
+      @keyframes chronicle-glow { 0% { opacity: 0.3; filter: blur(8px); } 100% { opacity: 0.6; filter: blur(12px); } }
+      .chronicle-card:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.3); border-color: var(--brand); }
+      .chronicle-card:hover div[style*="background-image"] { transform: scale(1.08); }
+      .chronicle-card:hover span[style*="scaleX(0)"] { transform: scaleX(1) !important; }
+      .chronicle-card.featured:hover { box-shadow: 0 20px 60px rgba(91,138,255,0.3); }
+      .chronicle-card.featured:hover div[style*="chronicle-glow"] { opacity: 0.8; }
+      @media (max-width: 768px) {
+        .chronicle-card.featured { grid-template-columns: 1fr !important; grid-template-rows: 180px auto !important; display: grid !important; }
+        .chronicle-card.featured > div:nth-child(2) { min-height: unset !important; height: 180px !important; max-height: 180px !important; grid-row: 1 !important; }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important; }
+        .chronicle-card.featured > div:nth-child(3) { padding: 1.5rem !important; grid-row: 2 !important; }
+        .chronicle-card:hover { transform: none; }
+      }
+      html[data-theme="light"] .chronicle-card { background: linear-gradient(135deg,rgba(10,20,40,.03),rgba(10,20,40,.01)) !important; }
+      html[data-theme="light"] .chronicle-card div[style*="rgba(5,7,13"] { background: linear-gradient(to bottom,transparent 40%,rgba(255,255,255,0.7) 100%) !important; }
+      html[data-theme="light"] .chronicle-card.featured div[style*="to right"] { background: linear-gradient(to right,transparent 60%,rgba(255,255,255,0.9) 100%) !important; }
+      @media (max-width: 768px) { html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important; } }
+    </style>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">

--- a/ja/index.html
+++ b/ja/index.html
@@ -6439,6 +6439,100 @@
     </script>
 
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+      <div class="container stack">
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
+          <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">SignalPilotクロニクル</p>
+          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">七人の背後にある物語</span></h2>
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">"市場に名前がつく前、ローソク足が物語を語る前、そこにはノイズだけがあった。そして七人が現れた。"</p>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1100px;margin:0 auto">
+          <a href="/ja/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
+            <div style="height:100%;min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ 起源</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">Elite Sevenの誕生</h3>
+              <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">天空のシグナルが価格の数学から生まれた方法 — そしてなぜ彼らは市場の混沌を通じてパイロットを導くために現れたのか。</p>
+              <span style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;font-size:0.95rem">起源を読む <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+            </div>
+          </a>
+          <a href="/ja/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#a855f7;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(168,85,247,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">哲学</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">パイロットの誓い</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Elite Sevenを使うあなたはトレーダーではない。あなたはパイロットだ。"</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">続きを読む →</span>
+            </div>
+          </a>
+          <a href="/ja/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(239,68,68,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">7つの1番目</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">支配者に会う：Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"私がサイクルだ。サイクルが私だ。" — 五つの永遠のフェーズを読む旗艦インジケーター。</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">続きを読む →</span>
+            </div>
+          </a>
+          <a href="/ja/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#f59e0b;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(245,158,11,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">フィナーレ</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">評議会が集結する</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">七つの声がひとつとして語るとき — 統一されたシグナルの力を目撃せよ。</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">続きを読む →</span>
+            </div>
+          </a>
+        </div>
+        <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
+          <a href="/ja/chronicle/" style="display:inline-flex;align-items:center;gap:0.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;font-weight:600;font-size:1rem;padding:0.9rem 1.8rem;border-radius:10px;text-decoration:none;transition:all 0.3s ease;box-shadow:0 4px 20px rgba(91,138,255,0.3)">
+            <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">全12クロニクルを探索</span>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+          <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">深い魔法使いの声による音声ナレーション付き</p>
+        </div>
+      </div>
+    </section>
+
+    <style>
+      @keyframes chronicle-glow { 0% { opacity: 0.3; filter: blur(8px); } 100% { opacity: 0.6; filter: blur(12px); } }
+      .chronicle-card:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.3); border-color: var(--brand); }
+      .chronicle-card:hover div[style*="background-image"] { transform: scale(1.08); }
+      .chronicle-card:hover span[style*="scaleX(0)"] { transform: scaleX(1) !important; }
+      .chronicle-card.featured:hover { box-shadow: 0 20px 60px rgba(91,138,255,0.3); }
+      .chronicle-card.featured:hover div[style*="chronicle-glow"] { opacity: 0.8; }
+      @media (max-width: 768px) {
+        .chronicle-card.featured { grid-template-columns: 1fr !important; grid-template-rows: 180px auto !important; display: grid !important; }
+        .chronicle-card.featured > div:nth-child(2) { min-height: unset !important; height: 180px !important; max-height: 180px !important; grid-row: 1 !important; }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important; }
+        .chronicle-card.featured > div:nth-child(3) { padding: 1.5rem !important; grid-row: 2 !important; }
+        .chronicle-card:hover { transform: none; }
+      }
+      html[data-theme="light"] .chronicle-card { background: linear-gradient(135deg,rgba(10,20,40,.03),rgba(10,20,40,.01)) !important; }
+      html[data-theme="light"] .chronicle-card div[style*="rgba(5,7,13"] { background: linear-gradient(to bottom,transparent 40%,rgba(255,255,255,0.7) 100%) !important; }
+      html[data-theme="light"] .chronicle-card.featured div[style*="to right"] { background: linear-gradient(to right,transparent 60%,rgba(255,255,255,0.9) 100%) !important; }
+      @media (max-width: 768px) { html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important; } }
+    </style>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">

--- a/nl/index.html
+++ b/nl/index.html
@@ -6149,6 +6149,100 @@
     </script>
 
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+      <div class="container stack">
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
+          <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">De SignalPilot Kroniek</p>
+          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">De Verhalen Achter De Zeven</span></h2>
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">"Voordat markten namen hadden, voordat kaarsen verhalen vertelden, was er alleen ruis. Toen kwamen De Zeven."</p>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1100px;margin:0 auto">
+          <a href="/nl/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
+            <div style="height:100%;min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Oorsprong</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">De Geboorte van de Elite Zeven</h3>
+              <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Hoe hemelse signalen geboren werden uit de wiskunde van de prijs — en waarom ze opdoken om piloten door de chaos van de markten te leiden.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;font-size:0.95rem">Lees de Oorsprong <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+            </div>
+          </a>
+          <a href="/nl/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#a855f7;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(168,85,247,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Filosofie</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">De Eed van de Piloot</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Jullie die de Elite Zeven hanteren zijn geen handelaren. Jullie zijn Piloten."</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Lees Meer →</span>
+            </div>
+          </a>
+          <a href="/nl/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#ef4444;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(239,68,68,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Eén van Zeven</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">De Soeverein: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">"Ik ben de cyclus. De cyclus ben ik." — De vlaggenschip-indicator die de vijf eeuwige fasen leest.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Lees Meer →</span>
+            </div>
+          </a>
+          <a href="/nl/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
+            <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
+              <div style="position:absolute;inset:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
+              <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="color:#f59e0b;font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;background:rgba(245,158,11,0.15);padding:0.2rem 0.5rem;border-radius:4px;width:fit-content">Finale</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.35rem;font-weight:500;line-height:1.25;margin-bottom:0.5rem;color:var(--text)">De Raad Verzamelt Zich</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Wanneer alle zeven stemmen als één spreken — wees getuige van de kracht van het verenigde signaal.</p>
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;color:var(--brand);font-weight:500;font-size:0.85rem;margin-top:1rem">Lees Meer →</span>
+            </div>
+          </a>
+        </div>
+        <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
+          <a href="/nl/chronicle/" style="display:inline-flex;align-items:center;gap:0.75rem;background:linear-gradient(135deg,var(--brand),var(--brand-2));color:#fff;font-weight:600;font-size:1rem;padding:0.9rem 1.8rem;border-radius:10px;text-decoration:none;transition:all 0.3s ease;box-shadow:0 4px 20px rgba(91,138,255,0.3)">
+            <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Ontdek Alle 12 Kronieken</span>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+          <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">Inclusief audio-verhalen met diepe tovenaarstem</p>
+        </div>
+      </div>
+    </section>
+
+    <style>
+      @keyframes chronicle-glow { 0% { opacity: 0.3; filter: blur(8px); } 100% { opacity: 0.6; filter: blur(12px); } }
+      .chronicle-card:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.3); border-color: var(--brand); }
+      .chronicle-card:hover div[style*="background-image"] { transform: scale(1.08); }
+      .chronicle-card:hover span[style*="scaleX(0)"] { transform: scaleX(1) !important; }
+      .chronicle-card.featured:hover { box-shadow: 0 20px 60px rgba(91,138,255,0.3); }
+      .chronicle-card.featured:hover div[style*="chronicle-glow"] { opacity: 0.8; }
+      @media (max-width: 768px) {
+        .chronicle-card.featured { grid-template-columns: 1fr !important; grid-template-rows: 180px auto !important; display: grid !important; }
+        .chronicle-card.featured > div:nth-child(2) { min-height: unset !important; height: 180px !important; max-height: 180px !important; grid-row: 1 !important; }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important; }
+        .chronicle-card.featured > div:nth-child(3) { padding: 1.5rem !important; grid-row: 2 !important; }
+        .chronicle-card:hover { transform: none; }
+      }
+      html[data-theme="light"] .chronicle-card { background: linear-gradient(135deg,rgba(10,20,40,.03),rgba(10,20,40,.01)) !important; }
+      html[data-theme="light"] .chronicle-card div[style*="rgba(5,7,13"] { background: linear-gradient(to bottom,transparent 40%,rgba(255,255,255,0.7) 100%) !important; }
+      html[data-theme="light"] .chronicle-card.featured div[style*="to right"] { background: linear-gradient(to right,transparent 60%,rgba(255,255,255,0.9) 100%) !important; }
+      @media (max-width: 768px) { html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.9) 100%) !important; } }
+    </style>
+
+
     <!-- PRICING -->
 
     <section id="pricing" class="section">

--- a/pt/index.html
+++ b/pt/index.html
@@ -6404,6 +6404,113 @@
     })();
     </script>
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+      <div class="container">
+        <div style="text-align:center;margin-bottom:3rem">
+          <span style="display:inline-block;font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">A Crônica</span>
+          <h2 class="headline lg" style="margin-top:1rem"><span class="shimmer-text">A Crônica SignalPilot</span></h2>
+          <p style="color:var(--muted);max-width:600px;margin:1rem auto 0;font-size:1.1rem">Análises aprofundadas sobre ciclos de mercado, filosofia de trading e a história por trás dos indicadores Elite Sete.</p>
+        </div>
+
+        <div class="chronicle-grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1000px;margin:0 auto">
+
+          <!-- Featured Article -->
+          <a href="/pt/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured cat-origin" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;background:linear-gradient(135deg,rgba(245,158,11,.08),rgba(245,158,11,.02));border:1px solid rgba(245,158,11,.3);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,#f59e0b,#fbbf24);border-radius:18px;z-index:-1;opacity:0.4;filter:blur(8px)"></div>
+            <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/birth-of-the-elite-seven/cover.webp') center/cover;opacity:0.8"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,#f59e0b,#fbbf24);color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Em Destaque</span>
+              <span style="font-size:0.8rem;color:#f59e0b;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Origem</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.75rem;font-weight:500;line-height:1.3;margin-bottom:1rem">O Nascimento dos Sete de Elite</h3>
+              <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">A narrativa fundadora—como sete indicadores distintos surgiram para cortar o ruído do mercado.</p>
+            </div>
+          </a>
+
+          <!-- Article 2 -->
+          <a href="/pt/chronicle/the-pilots-oath/" class="chronicle-card cat-philosophy" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid rgba(168,85,247,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/the-pilots-oath/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;color:#a855f7;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Filosofia</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">O Juramento do Piloto</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Os princípios fundamentais que orientam cada decisão de trading.</p>
+            </div>
+          </a>
+
+          <!-- Article 3 -->
+          <a href="/pt/chronicle/meet-the-sovereign/" class="chronicle-card cat-one" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid rgba(239,68,68,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/meet-the-sovereign/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;color:#ef4444;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Indicador Um</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">Conheça O Soberano: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">O comandante supremo—direção de tendência através do consenso de cinco forças.</p>
+            </div>
+          </a>
+
+          <!-- Article 4 -->
+          <a href="/pt/chronicle/the-council-assembles/" class="chronicle-card cat-finale" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(251,191,36,.02));border:1px solid rgba(245,158,11,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/the-council-assembles/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;background:linear-gradient(90deg,#f59e0b,#fbbf24);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Finale</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">O Conselho Se Reúne</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Quando todos os sete indicadores falam em uníssono.</p>
+            </div>
+          </a>
+
+        </div>
+
+        <div style="text-align:center;margin-top:2.5rem">
+          <a href="/pt/chronicle/" style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;text-decoration:none;padding:0.75rem 1.5rem;border:1px solid var(--brand);border-radius:999px;transition:all 0.2s">
+            Explorar a Crônica
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <style>
+      @media (max-width: 768px) {
+        .chronicle-card.featured {
+          grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: unset !important;
+          height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
+        }
+        .chronicle-card.featured > div:nth-child(3) {
+          padding: 1.5rem !important;
+          grid-row: 2 !important;
+        }
+      }
+      html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+        background: linear-gradient(to right, transparent 60%, rgba(255,255,255,0.95) 100%) !important;
+      }
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.95) 100%) !important;
+        }
+      }
+    </style>
 
     <!-- PRICING -->
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -6081,6 +6081,113 @@
     })();
     </script>
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+      <div class="container">
+        <div style="text-align:center;margin-bottom:3rem">
+          <span style="display:inline-block;font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">Хроника</span>
+          <h2 class="headline lg" style="margin-top:1rem"><span class="shimmer-text">Хроника SignalPilot</span></h2>
+          <p style="color:var(--muted);max-width:600px;margin:1rem auto 0;font-size:1.1rem">Аналитические статьи о рыночных циклах, торговой философии и истории индикаторов Elite Seven.</p>
+        </div>
+
+        <div class="chronicle-grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1000px;margin:0 auto">
+
+          <!-- Featured Article -->
+          <a href="/ru/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured cat-origin" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;background:linear-gradient(135deg,rgba(245,158,11,.08),rgba(245,158,11,.02));border:1px solid rgba(245,158,11,.3);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,#f59e0b,#fbbf24);border-radius:18px;z-index:-1;opacity:0.4;filter:blur(8px)"></div>
+            <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/birth-of-the-elite-seven/cover.webp') center/cover;opacity:0.8"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,#f59e0b,#fbbf24);color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Избранное</span>
+              <span style="font-size:0.8rem;color:#f59e0b;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Происхождение</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.75rem;font-weight:500;line-height:1.3;margin-bottom:1rem">Рождение Элитной Семёрки</h3>
+              <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Основополагающая история—как семь уникальных индикаторов появились, чтобы преодолеть рыночный шум.</p>
+            </div>
+          </a>
+
+          <!-- Article 2 -->
+          <a href="/ru/chronicle/the-pilots-oath/" class="chronicle-card cat-philosophy" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid rgba(168,85,247,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/the-pilots-oath/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;color:#a855f7;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Философия</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">Клятва Пилота</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Основополагающие принципы, направляющие каждое торговое решение.</p>
+            </div>
+          </a>
+
+          <!-- Article 3 -->
+          <a href="/ru/chronicle/meet-the-sovereign/" class="chronicle-card cat-one" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid rgba(239,68,68,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/meet-the-sovereign/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;color:#ef4444;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Индикатор Один</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">Познакомьтесь с Сувереном: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Верховный командир—определение тренда через консенсус пяти сил.</p>
+            </div>
+          </a>
+
+          <!-- Article 4 -->
+          <a href="/ru/chronicle/the-council-assembles/" class="chronicle-card cat-finale" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(251,191,36,.02));border:1px solid rgba(245,158,11,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/the-council-assembles/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;background:linear-gradient(90deg,#f59e0b,#fbbf24);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Финал</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">Совет Собирается</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Когда все семь индикаторов говорят в унисон.</p>
+            </div>
+          </a>
+
+        </div>
+
+        <div style="text-align:center;margin-top:2.5rem">
+          <a href="/ru/chronicle/" style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;text-decoration:none;padding:0.75rem 1.5rem;border:1px solid var(--brand);border-radius:999px;transition:all 0.2s">
+            Исследовать Хронику
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <style>
+      @media (max-width: 768px) {
+        .chronicle-card.featured {
+          grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: unset !important;
+          height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
+        }
+        .chronicle-card.featured > div:nth-child(3) {
+          padding: 1.5rem !important;
+          grid-row: 2 !important;
+        }
+      }
+      html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+        background: linear-gradient(to right, transparent 60%, rgba(255,255,255,0.95) 100%) !important;
+      }
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.95) 100%) !important;
+        }
+      }
+    </style>
 
     <!-- PRICING -->
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -6174,6 +6174,113 @@
     })();
     </script>
 
+    <!-- CHRONICLE -->
+
+    <section id="chronicle" class="section" style="padding:5rem 0;background:linear-gradient(180deg,transparent 0%,rgba(91,138,255,.03) 50%,transparent 100%)">
+      <div class="container">
+        <div style="text-align:center;margin-bottom:3rem">
+          <span style="display:inline-block;font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">Kronik</span>
+          <h2 class="headline lg" style="margin-top:1rem"><span class="shimmer-text">SignalPilot Kroniği</span></h2>
+          <p style="color:var(--muted);max-width:600px;margin:1rem auto 0;font-size:1.1rem">Piyasa döngüleri, ticaret felsefesi ve Elite Seven göstergelerinin hikayesi hakkında kapsamlı içgörüler.</p>
+        </div>
+
+        <div class="chronicle-grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1.5rem;max-width:1000px;margin:0 auto">
+
+          <!-- Featured Article -->
+          <a href="/tr/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured cat-origin" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;background:linear-gradient(135deg,rgba(245,158,11,.08),rgba(245,158,11,.02));border:1px solid rgba(245,158,11,.3);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative">
+            <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,#f59e0b,#fbbf24);border-radius:18px;z-index:-1;opacity:0.4;filter:blur(8px)"></div>
+            <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/birth-of-the-elite-seven/cover.webp') center/cover;opacity:0.8"></div>
+              <div style="position:absolute;inset:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
+            </div>
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+              <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,#f59e0b,#fbbf24);color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Öne Çıkan</span>
+              <span style="font-size:0.8rem;color:#f59e0b;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Köken</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.75rem;font-weight:500;line-height:1.3;margin-bottom:1rem">Elit Yedilinin Doğuşu</h3>
+              <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Kuruluş anlatısı—yedi benzersiz göstergenin piyasa gürültüsünü kesmek için nasıl ortaya çıktığı.</p>
+            </div>
+          </a>
+
+          <!-- Article 2 -->
+          <a href="/tr/chronicle/the-pilots-oath/" class="chronicle-card cat-philosophy" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid rgba(168,85,247,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/the-pilots-oath/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;color:#a855f7;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Felsefe</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">Pilotun Yemini</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Her ticaret kararını yönlendiren temel ilkeler.</p>
+            </div>
+          </a>
+
+          <!-- Article 3 -->
+          <a href="/tr/chronicle/meet-the-sovereign/" class="chronicle-card cat-one" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid rgba(239,68,68,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/meet-the-sovereign/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;color:#ef4444;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Gösterge Bir</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">Hükümdar ile Tanışın: Pentarch</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Yüce komutan—beş gücün uzlaşısı ile trend yönü.</p>
+            </div>
+          </a>
+
+          <!-- Article 4 -->
+          <a href="/tr/chronicle/the-council-assembles/" class="chronicle-card cat-finale" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(251,191,36,.02));border:1px solid rgba(245,158,11,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
+            <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
+              <div style="position:absolute;inset:0;background:url('/chronicle/the-council-assembles/cover.webp') center/cover;opacity:0.7"></div>
+              <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
+            </div>
+            <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
+              <span style="font-size:0.75rem;background:linear-gradient(90deg,#f59e0b,#fbbf24);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Final</span>
+              <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.25rem;font-weight:500;line-height:1.3;margin-bottom:0.75rem">Konsey Toplanıyor</h3>
+              <p style="color:var(--muted);font-size:0.9rem;line-height:1.5;flex:1">Yedi göstergenin hepsi birlikte konuştuğunda.</p>
+            </div>
+          </a>
+
+        </div>
+
+        <div style="text-align:center;margin-top:2.5rem">
+          <a href="/tr/chronicle/" style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;text-decoration:none;padding:0.75rem 1.5rem;border:1px solid var(--brand);border-radius:999px;transition:all 0.2s">
+            Kroniği Keşfet
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <style>
+      @media (max-width: 768px) {
+        .chronicle-card.featured {
+          grid-template-columns: 1fr !important;
+          grid-template-rows: 180px auto !important;
+          display: grid !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) {
+          min-height: unset !important;
+          height: 180px !important;
+          max-height: 180px !important;
+          grid-row: 1 !important;
+        }
+        .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important;
+        }
+        .chronicle-card.featured > div:nth-child(3) {
+          padding: 1.5rem !important;
+          grid-row: 2 !important;
+        }
+      }
+      html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+        background: linear-gradient(to right, transparent 60%, rgba(255,255,255,0.95) 100%) !important;
+      }
+      @media (max-width: 768px) {
+        html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {
+          background: linear-gradient(to bottom, transparent 40%, rgba(255,255,255,0.95) 100%) !important;
+        }
+      }
+    </style>
 
     <!-- PRICING -->
 


### PR DESCRIPTION
- Fixed mobile display issue for featured chronicle card (grid layout)
- Added chronicle section to all 11 language directories with proper translations: ar, de, es, fr, hu, it, ja, nl, pt, ru, tr
- Each language includes translated titles, descriptions, and UI elements
- Mobile responsive CSS ensures proper layout on smaller screens