### PR TITLE
Fix French site flickering and mobile header issues

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -6473,6 +6473,13 @@
         100% { opacity: 0.6; filter: blur(12px); }
       }
 
+      /* Fix flickering on the featured card glow animation - disable animation */
+      .chronicle-card.featured > div[style*="chronicle-glow"] {
+        animation: none !important;
+        opacity: 0.4 !important;
+        filter: blur(10px) !important;
+      }
+
       .chronicle-card:hover {
         transform: translateY(-6px);
         box-shadow: 0 20px 40px rgba(0,0,0,0.3);

--- a/index.html
+++ b/index.html
@@ -703,7 +703,7 @@
 
       /* Force all sections transparent on mobile so starfield shows through */
       html, body, main, header, section, .section, .container, .stack, #main-content, .nav-backdrop,
-      .hero, article, footer, aside, div:not(.card):not(.card *):not(.btn):not(.modal-card):not(.mobile-nav):not(.mobile-nav *) {
+      .hero, article, footer, aside, div:not(.card):not(.card *):not(.btn):not(.modal-card):not(.mobile-nav):not(.mobile-nav *):not(.lang-dropdown-menu):not(.lang-dropdown-menu *) {
         background: transparent !important;
         background-color: transparent !important;
       }
@@ -1806,7 +1806,8 @@
       position: fixed !important;
       top: 70px;
       right: 20px;
-      background: rgba(10, 12, 20, 0.98);
+      background: rgba(10, 12, 20, 0.98) !important;
+      background-color: rgba(10, 12, 20, 0.98) !important;
       border: 2px solid rgba(255, 255, 255, 0.4);
       border-radius: 12px;
       padding: 0.5rem;
@@ -1814,7 +1815,7 @@
       max-height: 500px;
       overflow-y: auto;
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-      z-index: 76 !important;
+      z-index: 9999 !important;
       opacity: 0 !important;
       visibility: hidden !important;
       transform: translateY(-10px);


### PR DESCRIPTION
- Main site: Add .lang-dropdown-menu to CSS exception list so it's not made transparent by the mobile starfield-through rule
- Main site: Add !important to background and increase z-index to 9999
- French site: Disable the chronicle-glow animation on the featured card to stop the blue box from flickering