### PR TITLE
Fix broken CSS in French site header button styling

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -868,12 +868,13 @@
 
       /* Ensure header buttons adapt to smaller text when necessary */
       header .btn,
-      header 
-
-      /* Language button - allow slight shrinking if needed */
-        max-width: 30px !important;
+      header #themeToggle {
+        font-size: .8rem !important;
+        padding: .4rem .6rem !important;
+        white-space: nowrap !important;
         overflow: hidden !important;
-        text-overflow: clip !important;
+        text-overflow: ellipsis !important;
+        flex-shrink: 1 !important;
       }
 
       /* CTA button - ensure it doesn't overflow */
@@ -1587,12 +1588,13 @@
 
       /* Ensure header buttons adapt to smaller text when necessary */
       header .btn,
-      header 
-
-      /* Language button - allow slight shrinking if needed */
-        max-width: 30px !important;
+      header #themeToggle {
+        font-size: .8rem !important;
+        padding: .4rem .6rem !important;
+        white-space: nowrap !important;
         overflow: hidden !important;
-        text-overflow: clip !important;
+        text-overflow: ellipsis !important;
+        flex-shrink: 1 !important;
       }
 
       /* CTA button - ensure it doesn't overflow */


### PR DESCRIPTION
The French site had corrupted CSS with incomplete selectors for header buttons, missing the #themeToggle target and several essential properties (font-size, padding, white-space, flex-shrink). This caused visual inconsistencies with the hamburger menu compared to other language versions.