### PR TITLE
Sync French hamburger menu CSS with German version

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2895,26 +2895,12 @@
       transition:all 0.2s ease;
       position:relative;
       z-index:45;
-      cursor:pointer;
     }
 
     .menu-toggle:hover{
       background:linear-gradient(135deg, rgba(91,138,255,.3), rgba(91,138,255,.15));
       transform:translateY(-1px);
       box-shadow:0 6px 16px rgba(0,0,0,.4);
-    }
-
-    /* Light mode menu toggle button styling */
-    html[data-theme="light"] .menu-toggle {
-      border-color:rgba(30,41,59,.2);
-      background:linear-gradient(135deg, rgba(91,138,255,.15), rgba(91,138,255,.08));
-      color:#0f172a;
-      box-shadow:0 2px 8px rgba(0,0,0,.1);
-    }
-
-    html[data-theme="light"] .menu-toggle:hover {
-      background:linear-gradient(135deg, rgba(91,138,255,.25), rgba(91,138,255,.12));
-      box-shadow:0 4px 12px rgba(0,0,0,.15);
     }
 
 
@@ -2958,7 +2944,7 @@
     }
 
     /* Even more compact before hamburger menu appears */
-    @media (max-width:1024px){
+    @media (max-width:1400px){
       nav a{padding:.5rem .6rem;font-size:.86rem}
       .nav-dropdown-toggle{padding:.5rem .6rem;font-size:.86rem}
       nav ul{gap:.35rem}
@@ -3020,18 +3006,12 @@
       /* Better mobile header button sizing */
       #themeToggle {
         flex-shrink: 0;
-      }
-
-      #themeToggle {
         min-width: 44px; /* iOS minimum tap target */
         min-height: 44px;
       }
 
       .menu-toggle{
         display:inline-flex;
-        align-items:center;
-        justify-content:center;
-        gap:0.4rem;
         position:relative;
         z-index:68 !important;
       }


### PR DESCRIPTION
Remove French-only styling differences:
- Remove cursor:pointer from base .menu-toggle
- Remove light mode .menu-toggle styling block
- Remove extra align-items, justify-content, gap from media query
- Fix breakpoint from 1024px to 1400px for compact nav
- Consolidate duplicate #themeToggle rules