### PR TITLE
Add missing clickable elements CSS to French site

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -773,15 +773,16 @@
       font-size: inherit !important;
     }
 
-    header .brand {
-      flex-shrink: 0 !important;
-      min-width: auto !important;
-      white-space:nowrap !important;
-    }
+    *{box-sizing:border-box}
 
-    header nav[aria-label="Main"] {
-      flex-shrink: 1 !important;
-      min-width: 0 !important;
+    /* Ensure clickable elements always work */
+    nav[aria-label="Main"] a,
+    nav[aria-label="Main"] button,
+    .menu-toggle,
+    #menuToggle,
+    .mobile-nav-close {
+      pointer-events: auto !important;
+      cursor: pointer !important;
     }
 
     /* Prevent all header buttons and text from wrapping */
@@ -1476,15 +1477,16 @@
       font-size: inherit !important;
     }
 
-    header .brand {
-      flex-shrink: 0 !important;
-      min-width: auto !important;
-      white-space:nowrap !important;
-    }
+    *{box-sizing:border-box}
 
-    header nav[aria-label="Main"] {
-      flex-shrink: 1 !important;
-      min-width: 0 !important;
+    /* Ensure clickable elements always work */
+    nav[aria-label="Main"] a,
+    nav[aria-label="Main"] button,
+    .menu-toggle,
+    #menuToggle,
+    .mobile-nav-close {
+      pointer-events: auto !important;
+      cursor: pointer !important;
     }
 
     /* Prevent all header buttons and text from wrapping */


### PR DESCRIPTION
French was missing the critical CSS block that all other languages have:
- pointer-events: auto for menu-toggle, #menuToggle, nav buttons
- cursor: pointer for clickable elements
- box-sizing: border-box rule

Also removed French-only header .brand and header nav rules that other languages don't have.