### PR TITLE
Fix menu-toggle display rule in French site

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -2948,15 +2948,8 @@
     /* Hide mobile nav on desktop - it should only appear on mobile */
     @media (min-width: 1401px) {
       .mobile-nav,
-      .mobile-nav-backdrop,
-      .menu-toggle {
+      .mobile-nav-backdrop {
         display: none !important;
-      }
-
-      /* Better spacing for desktop */
-      .container {
-        padding-left: calc(clamp(24px, 5vw, 48px) + env(safe-area-inset-left));
-        padding-right: calc(clamp(24px, 5vw, 48px) + env(safe-area-inset-right));
       }
     }
 


### PR DESCRIPTION
French was incorrectly hiding .menu-toggle in the desktop media query (@media min-width: 1401px) along with .mobile-nav and .mobile-nav-backdrop. Other languages only hide .mobile-nav and .mobile-nav-backdrop on desktop. Also removed extra .container padding rules that other languages don't have.