### PR TITLE
Force menu-toggle styling on mobile for French site

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -3926,6 +3926,17 @@
         background-image: none !important;
       }
 
+      /* OVERRIDE: Restore menu-toggle styling on mobile */
+      header .menu-toggle,
+      header button.menu-toggle,
+      .menu-toggle#menuToggle {
+        background: linear-gradient(135deg, rgba(91,138,255,.2), rgba(91,138,255,.1)) !important;
+        border: 1px solid rgba(255,255,255,.25) !important;
+        border-radius: 12px !important;
+        color: #fff !important;
+        box-shadow: 0 4px 12px rgba(0,0,0,.3) !important;
+      }
+
       header {
         position: relative;
         z-index: 100;


### PR DESCRIPTION
Add explicit override CSS after the background-stripping rule to restore the menu-toggle button styling on mobile (max-width: 768px). Uses multiple high-specificity selectors with !important to ensure the gradient background, border, and colors are applied.