### PR TITLE
Fix chronicle card images on mobile with correct CSS selectors

### DIFF
--- a/assets/device-optimizations.css
+++ b/assets/device-optimizations.css
@@ -392,14 +392,40 @@
     overflow: hidden !important;
   }
 
-  /* Force chronicle card images to display */
-  .chronicle-card > div:first-child,
+  /* Force chronicle card images to display - REGULAR cards */
+  .chronicle-card:not(.featured) > div:first-child {
+    position: relative !important;
+    overflow: hidden !important;
+    height: 180px !important;
+    min-height: 180px !important;
+  }
+
+  .chronicle-card:not(.featured) > div:first-child > div:first-child {
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    background-size: cover !important;
+    background-position: center !important;
+  }
+
+  /* Force chronicle card images to display - FEATURED card */
+  .chronicle-card.featured {
+    grid-template-columns: 1fr !important;
+    grid-template-rows: 200px auto !important;
+  }
+
   .chronicle-card.featured > div:nth-child(2) {
     position: relative !important;
     overflow: hidden !important;
+    height: 200px !important;
+    min-height: 200px !important;
+    grid-row: 1 !important;
   }
 
-  .chronicle-card > div:first-child > div:first-child,
   .chronicle-card.featured > div:nth-child(2) > div:first-child {
     position: absolute !important;
     top: 0 !important;
@@ -410,6 +436,12 @@
     height: 100% !important;
     background-size: cover !important;
     background-position: center !important;
+  }
+
+  /* Featured card content area */
+  .chronicle-card.featured > div:nth-child(3) {
+    grid-row: 2 !important;
+    padding: 1.5rem !important;
   }
 
   /* Signal legend - stack items */


### PR DESCRIPTION
- Changed .chronicle-card > div:first-child to .chronicle-card:not(.featured) to avoid incorrectly targeting the glow overlay div on featured cards
- Added explicit height (180px/200px) to image containers
- Ensured background-image divs fill their containers with absolute positioning
- Added grid layout rules for featured card mobile layout