### PR TITLE
Replace chronicle background-image divs with img tags on all sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6269,7 +6269,7 @@ html[lang="ar"] [style*="text-align:center"] {
           <a href="/ar/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to left,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6283,7 +6283,7 @@ html[lang="ar"] [style*="text-align:center"] {
           <!-- قسم الطيار -->
           <a href="/ar/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6298,7 +6298,7 @@ html[lang="ar"] [style*="text-align:center"] {
           <!-- تعرف على السيد: Pentarch -->
           <a href="/ar/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6313,7 +6313,7 @@ html[lang="ar"] [style*="text-align:center"] {
           <!-- المجلس يجتمع -->
           <a href="/ar/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6352,7 +6352,7 @@ html[lang="ar"] [style*="text-align:center"] {
         border-color: var(--brand);
       }
 
-      .chronicle-card:hover div[style*="background-image"] {
+      .chronicle-card:hover .chronicle-img {
         transform: scale(1.08);
       }
 
@@ -6403,16 +6403,15 @@ html[lang="ar"] [style*="text-align:center"] {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
@@ -6435,22 +6434,19 @@ html[lang="ar"] [style*="text-align:center"] {
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
 
         .chronicle-card:hover {

--- a/de/index.html
+++ b/de/index.html
@@ -6190,7 +6190,7 @@
           <a href="/de/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6204,7 +6204,7 @@
           <!-- Der Eid des Piloten -->
           <a href="/de/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6219,7 +6219,7 @@
           <!-- Der Souverän: Pentarch -->
           <a href="/de/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6234,7 +6234,7 @@
           <!-- Der Rat versammelt sich -->
           <a href="/de/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6273,7 +6273,7 @@
         border-color: var(--brand);
       }
 
-      .chronicle-card:hover div[style*="background-image"] {
+      .chronicle-card:hover .chronicle-img {
         transform: scale(1.08);
       }
 
@@ -6324,16 +6324,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
@@ -6356,22 +6355,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
 
         .chronicle-card:hover {

--- a/es/index.html
+++ b/es/index.html
@@ -6496,7 +6496,7 @@
           <a href="/es/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6510,7 +6510,7 @@
           <!-- El Juramento del Piloto -->
           <a href="/es/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6525,7 +6525,7 @@
           <!-- El Soberano: Pentarch -->
           <a href="/es/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6540,7 +6540,7 @@
           <!-- El Consejo se Reúne -->
           <a href="/es/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6579,7 +6579,7 @@
         border-color: var(--brand);
       }
 
-      .chronicle-card:hover div[style*="background-image"] {
+      .chronicle-card:hover .chronicle-img {
         transform: scale(1.08);
       }
 
@@ -6630,16 +6630,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
@@ -6662,22 +6661,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
 
         .chronicle-card:hover {

--- a/fr/index.html
+++ b/fr/index.html
@@ -6347,7 +6347,7 @@
           <a href="/fr/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6361,7 +6361,7 @@
           <!-- Le Serment du Pilote -->
           <a href="/fr/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6376,7 +6376,7 @@
           <!-- Le Souverain : Pentarch -->
           <a href="/fr/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6391,7 +6391,7 @@
           <!-- Le Conseil se Rassemble -->
           <a href="/fr/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6437,7 +6437,7 @@
         border-color: var(--brand);
       }
 
-      .chronicle-card:hover div[style*="background-image"] {
+      .chronicle-card:hover .chronicle-img {
         transform: scale(1.08);
       }
 
@@ -6488,16 +6488,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
@@ -6520,22 +6519,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
 
         .chronicle-card:hover {

--- a/hu/index.html
+++ b/hu/index.html
@@ -6195,7 +6195,7 @@
           <a href="/hu/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6209,7 +6209,7 @@
           <!-- A Pilóta esküje -->
           <a href="/hu/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6224,7 +6224,7 @@
           <!-- Ismerd meg az Uralkodót: Pentarch -->
           <a href="/hu/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6239,7 +6239,7 @@
           <!-- A Tanács összeül -->
           <a href="/hu/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6278,7 +6278,7 @@
         border-color: var(--brand);
       }
 
-      .chronicle-card:hover div[style*="background-image"] {
+      .chronicle-card:hover .chronicle-img {
         transform: scale(1.08);
       }
 
@@ -6329,16 +6329,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
@@ -6361,22 +6360,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
 
         .chronicle-card:hover {

--- a/index.html
+++ b/index.html
@@ -5195,7 +5195,7 @@
           <a href="/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -5209,7 +5209,7 @@
           <!-- The Pilot's Oath -->
           <a href="/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -5224,7 +5224,7 @@
           <!-- Meet The Sovereign: Pentarch -->
           <a href="/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -5239,7 +5239,7 @@
           <!-- The Council Assembles -->
           <a href="/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -5285,7 +5285,7 @@
         border-color: var(--brand);
       }
 
-      .chronicle-card:hover div[style*="background-image"] {
+      .chronicle-card:hover .chronicle-img {
         transform: scale(1.08);
       }
 
@@ -5368,22 +5368,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         .chronicle-card:hover {
           transform: none;

--- a/it/index.html
+++ b/it/index.html
@@ -6105,7 +6105,7 @@
           <a href="/it/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6117,7 +6117,7 @@
           </a>
           <a href="/it/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6130,7 +6130,7 @@
           </a>
           <a href="/it/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6143,7 +6143,7 @@
           </a>
           <a href="/it/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6168,7 +6168,7 @@
     <style>
       @keyframes chronicle-glow { 0% { opacity: 0.3; filter: blur(8px); } 100% { opacity: 0.6; filter: blur(12px); } }
       .chronicle-card:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.3); border-color: var(--brand); }
-      .chronicle-card:hover div[style*="background-image"] { transform: scale(1.08); }
+      .chronicle-card:hover .chronicle-img { transform: scale(1.08); }
       .chronicle-card:hover span[style*="scaleX(0)"] { transform: scaleX(1) !important; }
       .chronicle-card.featured:hover { box-shadow: 0 20px 60px rgba(91,138,255,0.3); }
       .chronicle-card.featured:hover div[style*="chronicle-glow"] { opacity: 0.8; }
@@ -6191,16 +6191,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important; z-index: 2 !important; }
@@ -6215,22 +6214,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
 
         .chronicle-card:hover { transform: none; }

--- a/ja/index.html
+++ b/ja/index.html
@@ -6450,7 +6450,7 @@
           <a href="/ja/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6462,7 +6462,7 @@
           </a>
           <a href="/ja/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6475,7 +6475,7 @@
           </a>
           <a href="/ja/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6488,7 +6488,7 @@
           </a>
           <a href="/ja/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6513,7 +6513,7 @@
     <style>
       @keyframes chronicle-glow { 0% { opacity: 0.3; filter: blur(8px); } 100% { opacity: 0.6; filter: blur(12px); } }
       .chronicle-card:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.3); border-color: var(--brand); }
-      .chronicle-card:hover div[style*="background-image"] { transform: scale(1.08); }
+      .chronicle-card:hover .chronicle-img { transform: scale(1.08); }
       .chronicle-card:hover span[style*="scaleX(0)"] { transform: scaleX(1) !important; }
       .chronicle-card.featured:hover { box-shadow: 0 20px 60px rgba(91,138,255,0.3); }
       .chronicle-card.featured:hover div[style*="chronicle-glow"] { opacity: 0.8; }
@@ -6536,16 +6536,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important; z-index: 2 !important; }
@@ -6560,22 +6559,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
 
         .chronicle-card:hover { transform: none; }

--- a/nl/index.html
+++ b/nl/index.html
@@ -6160,7 +6160,7 @@
           <a href="/nl/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured" data-reveal="fade-up" data-reveal-delay="100" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;gap:0;background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.05));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative;transition:all 0.3s ease">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,var(--brand),var(--accent),var(--brand-2));border-radius:18px;z-index:-1;opacity:0.4;animation:chronicle-glow 4s ease-in-out infinite alternate;pointer-events:none"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6172,7 +6172,7 @@
           </a>
           <a href="/nl/chronicle/the-pilots-oath/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="200" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#a855f7;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6185,7 +6185,7 @@
           </a>
           <a href="/nl/chronicle/meet-the-sovereign/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="300" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:#ef4444;transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6198,7 +6198,7 @@
           </a>
           <a href="/nl/chronicle/the-council-assembles/" class="chronicle-card" data-reveal="fade-up" data-reveal-delay="400" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(245,158,11,.02));border:1px solid var(--border);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;transition:all 0.3s ease;display:flex;flex-direction:column">
             <div style="height:180px;position:relative;overflow:hidden;border-bottom:1px solid var(--border)">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;transition:transform 0.5s ease"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to bottom,transparent 40%,rgba(5,7,13,0.7) 100%)"></div>
               <span style="position:absolute;bottom:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#f59e0b,#fbbf24);transform:scaleX(0);transition:transform 0.3s ease"></span>
             </div>
@@ -6223,7 +6223,7 @@
     <style>
       @keyframes chronicle-glow { 0% { opacity: 0.3; filter: blur(8px); } 100% { opacity: 0.6; filter: blur(12px); } }
       .chronicle-card:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.3); border-color: var(--brand); }
-      .chronicle-card:hover div[style*="background-image"] { transform: scale(1.08); }
+      .chronicle-card:hover .chronicle-img { transform: scale(1.08); }
       .chronicle-card:hover span[style*="scaleX(0)"] { transform: scaleX(1) !important; }
       .chronicle-card.featured:hover { box-shadow: 0 20px 60px rgba(91,138,255,0.3); }
       .chronicle-card.featured:hover div[style*="chronicle-glow"] { opacity: 0.8; }
@@ -6246,16 +6246,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child { background: linear-gradient(to bottom, transparent 40%, rgba(5,7,13,0.9) 100%) !important; z-index: 2 !important; }
@@ -6270,22 +6269,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
 
         .chronicle-card:hover { transform: none; }

--- a/pt/index.html
+++ b/pt/index.html
@@ -6418,7 +6418,7 @@
           <a href="/pt/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured cat-origin" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;background:linear-gradient(135deg,rgba(245,158,11,.08),rgba(245,158,11,.02));border:1px solid rgba(245,158,11,.3);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,#f59e0b,#fbbf24);border-radius:18px;z-index:-1;opacity:0.4;filter:blur(8px)"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;opacity:0.8"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.8">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6432,7 +6432,7 @@
           <!-- Article 2 -->
           <a href="/pt/chronicle/the-pilots-oath/" class="chronicle-card cat-philosophy" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid rgba(168,85,247,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6445,7 +6445,7 @@
           <!-- Article 3 -->
           <a href="/pt/chronicle/meet-the-sovereign/" class="chronicle-card cat-one" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid rgba(239,68,68,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6458,7 +6458,7 @@
           <!-- Article 4 -->
           <a href="/pt/chronicle/the-council-assembles/" class="chronicle-card cat-finale" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(251,191,36,.02));border:1px solid rgba(245,158,11,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6514,16 +6514,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
@@ -6546,22 +6545,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
       }
       html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {

--- a/ru/index.html
+++ b/ru/index.html
@@ -6095,7 +6095,7 @@
           <a href="/ru/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured cat-origin" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;background:linear-gradient(135deg,rgba(245,158,11,.08),rgba(245,158,11,.02));border:1px solid rgba(245,158,11,.3);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,#f59e0b,#fbbf24);border-radius:18px;z-index:-1;opacity:0.4;filter:blur(8px)"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;opacity:0.8"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.8">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6109,7 +6109,7 @@
           <!-- Article 2 -->
           <a href="/ru/chronicle/the-pilots-oath/" class="chronicle-card cat-philosophy" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid rgba(168,85,247,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6122,7 +6122,7 @@
           <!-- Article 3 -->
           <a href="/ru/chronicle/meet-the-sovereign/" class="chronicle-card cat-one" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid rgba(239,68,68,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6135,7 +6135,7 @@
           <!-- Article 4 -->
           <a href="/ru/chronicle/the-council-assembles/" class="chronicle-card cat-finale" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(251,191,36,.02));border:1px solid rgba(245,158,11,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6191,16 +6191,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
@@ -6223,22 +6222,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
       }
       html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {

--- a/tr/index.html
+++ b/tr/index.html
@@ -6188,7 +6188,7 @@
           <a href="/tr/chronicle/birth-of-the-elite-seven/" class="chronicle-card featured cat-origin" style="grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr;background:linear-gradient(135deg,rgba(245,158,11,.08),rgba(245,158,11,.02));border:1px solid rgba(245,158,11,.3);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;position:relative">
             <div style="position:absolute;inset:-2px;background:linear-gradient(135deg,#f59e0b,#fbbf24);border-radius:18px;z-index:-1;opacity:0.4;filter:blur(8px)"></div>
             <div style="background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));min-height:280px;position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/elite-seven-council-preview.jpg');background-size:cover;background-position:center;opacity:0.8"></div>
+              <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.8">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
             </div>
             <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
@@ -6202,7 +6202,7 @@
           <!-- Article 2 -->
           <a href="/tr/chronicle/the-pilots-oath/" class="chronicle-card cat-philosophy" style="background:linear-gradient(135deg,rgba(168,85,247,.06),rgba(168,85,247,.02));border:1px solid rgba(168,85,247,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/pilots-oath-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/pilots-oath-preview.jpg" alt="The Pilot's Oath" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6215,7 +6215,7 @@
           <!-- Article 3 -->
           <a href="/tr/chronicle/meet-the-sovereign/" class="chronicle-card cat-one" style="background:linear-gradient(135deg,rgba(239,68,68,.06),rgba(239,68,68,.02));border:1px solid rgba(239,68,68,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/sovereign-pentarch-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/sovereign-pentarch-preview.jpg" alt="Meet The Sovereign: Pentarch" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6228,7 +6228,7 @@
           <!-- Article 4 -->
           <a href="/tr/chronicle/the-council-assembles/" class="chronicle-card cat-finale" style="background:linear-gradient(135deg,rgba(245,158,11,.06),rgba(251,191,36,.02));border:1px solid rgba(245,158,11,.2);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column">
             <div style="height:160px;background:linear-gradient(135deg,var(--bg-elev),var(--bg-soft));position:relative;overflow:hidden">
-              <div class="chronicle-img" style="position:absolute;top:0;right:0;bottom:0;left:0;background-image:url('/chronicle/council-assembles-preview.jpg');background-size:cover;background-position:center;opacity:0.7"></div>
+              <img class="chronicle-img" src="/chronicle/council-assembles-preview.jpg" alt="The Council Assembles" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.7">
               <div style="position:absolute;bottom:0;left:0;right:0;height:60%;background:linear-gradient(to top,var(--bg-soft),transparent)"></div>
             </div>
             <div style="padding:1.5rem;flex:1;display:flex;flex-direction:column">
@@ -6284,16 +6284,15 @@
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
         /* Change gradient from horizontal to vertical on mobile */
         .chronicle-card.featured > div:nth-child(2) > div:last-child {
@@ -6316,22 +6315,19 @@
           position: relative !important;
           overflow: hidden !important;
         }
-        .chronicle-card:not(.featured) > div:first-child > div[style*="background-image"],
         .chronicle-img {
           position: absolute !important;
           top: 0 !important;
           left: 0 !important;
-          right: 0 !important;
-          bottom: 0 !important;
           width: 100% !important;
           height: 100% !important;
           display: block !important;
           visibility: visible !important;
           opacity: 1 !important;
           z-index: 1 !important;
-          background-size: cover !important;
-          background-position: center !important;
-          -webkit-background-size: cover !important;
+          object-fit: cover !important;
+          object-position: center !important;
+          -webkit-object-fit: cover !important;
         }
       }
       html[data-theme="light"] .chronicle-card.featured > div:nth-child(2) > div:last-child {


### PR DESCRIPTION
- Background-image CSS approach doesn't work reliably on mobile Safari
- Changed to actual <img> tags with object-fit:cover for reliable display
- Updated CSS selectors to target .chronicle-img class
- Updated mobile CSS to use object-fit instead of background-size
- Applied to English site + all 11 language sites