### PR TITLE
Fix chronicle images on mobile - exclude from general img rule

### DIFF
--- a/assets/device-optimizations.css
+++ b/assets/device-optimizations.css
@@ -219,7 +219,7 @@
   }
 
   /* RESPONSIVE IMAGES & MEDIA - CONSOLIDATED */
-  img {
+  img:not(.chronicle-img) {
     max-width: 100%;
     height: auto;
     display: block;
@@ -392,17 +392,18 @@
     overflow: hidden !important;
   }
 
-  /* Chronicle card images - simple class-based targeting */
+  /* Chronicle card images - now using img tags with object-fit */
   .chronicle-img {
     position: absolute !important;
     top: 0 !important;
     left: 0 !important;
-    right: 0 !important;
-    bottom: 0 !important;
     width: 100% !important;
     height: 100% !important;
-    background-size: cover !important;
-    background-position: center !important;
+    object-fit: cover !important;
+    object-position: center !important;
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
   }
 
   /* Force chronicle card images to display - REGULAR cards */


### PR DESCRIPTION
The real culprit: device-optimizations.css had a global rule
img { height: auto; } that was overriding the chronicle images.

Fixes:
- Exclude .chronicle-img from the general img rule using :not()
- Update .chronicle-img CSS to use object-fit (for img tags) instead of background-size (which was for div tags)