### PR TITLE
Restore dynamic blog fetch with language-specific endpoints

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6928,7 +6928,7 @@ html[lang="ar"] [style*="text-align:center"] {
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/ar/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/ar/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           عرض جميع المقالات <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -7083,7 +7083,54 @@ html[lang="ar"] [style*="text-align:center"] {
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/ar/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/ar/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
     // Capture ref/UTM
 

--- a/de/index.html
+++ b/de/index.html
@@ -6849,7 +6849,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/de/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/de/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Alle Artikel anzeigen <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -7003,7 +7003,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/de/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/de/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
     // Capture ref/UTM
 

--- a/es/index.html
+++ b/es/index.html
@@ -7153,7 +7153,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/es/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/es/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Ver Todos los Artículos <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -7306,7 +7306,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/es/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/es/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
 
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -7026,7 +7026,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/fr/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/fr/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Voir Tous les Articles <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -7183,9 +7183,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
 
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
 
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/fr/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/fr/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
     // Capture ref/UTM
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -6853,7 +6853,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/hu/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/hu/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Összes Cikk Megtekintése <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -7004,7 +7004,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/hu/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/hu/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
 
 

--- a/it/index.html
+++ b/it/index.html
@@ -6689,7 +6689,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/it/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/it/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Vedi Tutti gli Articoli <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -6840,7 +6840,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/it/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/it/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
 
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -7034,7 +7034,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/ja/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/ja/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           すべての記事を見る <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -7187,7 +7187,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/ja/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/ja/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
 
     // Capture ref/UTM

--- a/nl/index.html
+++ b/nl/index.html
@@ -6745,7 +6745,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/nl/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/nl/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Bekijk Alle Artikelen <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -6896,7 +6896,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/nl/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/nl/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
 
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -7021,7 +7021,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/pt/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/pt/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Ver Todos os Artigos <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -7172,7 +7172,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/pt/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/pt/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
 
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -6698,7 +6698,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/ru/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/ru/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Смотреть Все Статьи <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -6849,7 +6849,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/ru/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/ru/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
     // Capture ref/UTM
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -6791,7 +6791,7 @@
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">
-        <a href="/tr/chronicle/" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
+        <a href="https://blog.signalpilot.io/tr/" target="_blank" rel="noopener" class="btn btn-primary" style="display:inline-flex;align-items:center;gap:.5rem">
           Tüm Makaleleri Görüntüle <span style="font-size:1.1rem">→</span>
         </a>
       </div>
@@ -6944,7 +6944,54 @@
 
     function live(msg){ const el=document.getElementById('live'); if(!el) return; el.textContent=''; setTimeout(()=>el.textContent=msg,10); }
 
-    /* ======================== Blog Carousel (Static for localized content) ======================== */
+    /* ======================== Dynamic Blog Carousel ======================== */
+    (function(){
+      const carousel = document.getElementById('blog-carousel');
+      if (!carousel) return;
+
+      const tagColors = {
+        'indicators': { bg: 'rgba(91,138,255,.15)', color: 'var(--brand)' },
+        'psychology': { bg: 'rgba(118,75,162,.15)', color: '#a78bfa' },
+        'market-cycles': { bg: 'rgba(52,211,153,.15)', color: '#34d399' },
+        'practical': { bg: 'rgba(251,191,36,.15)', color: '#fbbf24' },
+        'strategy': { bg: 'rgba(236,72,153,.15)', color: '#ec4899' },
+        'beginner': { bg: 'rgba(59,130,246,.15)', color: '#3b82f6' },
+        'intermediate': { bg: 'rgba(168,85,247,.15)', color: '#a855f7' },
+        'advanced': { bg: 'rgba(239,68,68,.15)', color: '#ef4444' },
+        'backtesting': { bg: 'rgba(20,184,166,.15)', color: '#14b8a6' },
+        'risk-management': { bg: 'rgba(249,115,22,.15)', color: '#f97316' }
+      };
+
+      function createArticleCard(article) {
+        const tag = (article.tags && article.tags[0]) || 'indicators';
+        const displayTag = tag.replace(/-/g, ' ').toUpperCase();
+        const colors = tagColors[tag] || tagColors['indicators'];
+        const a = document.createElement('a');
+        a.href = article.url || `https://blog.signalpilot.io/tr/articles/${article.slug}/`;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'article-card';
+        a.style.cssText = 'flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s';
+        a.innerHTML = `
+          <span style="display:inline-block;padding:.25rem .5rem;background:${colors.bg};color:${colors.color};border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">${displayTag}</span>
+          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">${article.title}</h3>
+          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">${article.description || ''}</p>
+        `;
+        return a;
+      }
+
+      fetch('https://blog.signalpilot.io/tr/api/articles.json')
+        .then(r => r.json())
+        .then(data => {
+          const articles = Array.isArray(data) ? data : (data.articles || []);
+          if (articles.length === 0) return;
+          carousel.innerHTML = '';
+          articles.slice(0, 8).forEach(article => {
+            carousel.appendChild(createArticleCard(article));
+          });
+        })
+        .catch(() => {});
+    })();
 
 
 


### PR DESCRIPTION
Update all localized sites to fetch from blog.signalpilot.io/[lang]/api/articles.json instead of using static content. Each language now fetches from its own blog endpoint:
- de, es, fr, pt, ja, it, nl, ar, hu, ru, tr

"View All Articles" buttons now link to blog.signalpilot.io/[lang]/