### PR TITLE
Replace static chronicle cards with loading skeletons

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6904,27 +6904,24 @@ html[lang="ar"] [style*="text-align:center"] {
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <!-- Static Arabic chronicle articles -->
-        <a href="/ar/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">الأصل</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">ولادة Elite Seven</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">كيف ظهرت سبع إشارات سماوية من رياضيات السعر.</p>
-        </a>
-        <a href="/ar/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">الفلسفة</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">قسم الطيار</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">القسم الذي يفصل بين الملاحين والمقامرين.</p>
-        </a>
-        <a href="/ar/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">النظام</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">تسلسل الإشارات</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">السبعة يشكلون كوكبة الهدف.</p>
-        </a>
-        <a href="/ar/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">الأول من السبعة</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">تعرف على السيد: Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch يقرأ المراحل الخمس التي تحكم كل سعر.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/de/index.html
+++ b/de/index.html
@@ -6825,26 +6825,22 @@
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
 
-        <a href="/de/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">URSPRUNG</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Die Geburt der Elite Sieben</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Wie sieben himmlische Signale aus der Mathematik des Preises entstanden.</p>
-        </a>
-        <a href="/de/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PHILOSOPHIE</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Der Eid des Piloten</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Der Eid, der Navigatoren von Spielern unterscheidet.</p>
-        </a>
-        <a href="/de/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">SYSTEM</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Die Hierarchie der Signale</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Die Sieben bilden eine Konstellation des Zwecks.</p>
-        </a>
-        <a href="/de/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">EINS VON SIEBEN</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Der Souverän: Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch liest die fünf Marktphasen aller Preisbewegungen.</p>
-        </a>
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
 
       </div>
 

--- a/es/index.html
+++ b/es/index.html
@@ -7130,26 +7130,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <a href="/es/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ORIGEN</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">El Nacimiento de los Elite Siete</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Cómo siete señales celestiales emergieron de las matemáticas del precio.</p>
-        </a>
-        <a href="/es/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FILOSOFÍA</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">El Juramento del Piloto</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">El juramento que separa navegantes de jugadores.</p>
-        </a>
-        <a href="/es/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">SISTEMA</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">La Jerarquía de las Señales</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Los Siete forman una constelación del propósito.</p>
-        </a>
-        <a href="/es/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">UNO DE SIETE</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">El Soberano: Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch lee las cinco fases que gobiernan todo precio.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/fr/index.html
+++ b/fr/index.html
@@ -7002,27 +7002,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <!-- French Chronicle Articles -->
-        <a href="/fr/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ORIGINE</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">La Naissance des Elite Sept</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Comment sept signaux célestes ont émergé des mathématiques du prix.</p>
-        </a>
-        <a href="/fr/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">PHILOSOPHIE</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Le Serment du Pilote</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Le serment qui sépare ceux qui naviguent de ceux qui jouent.</p>
-        </a>
-        <a href="/fr/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">SYSTÈME</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">La Hiérarchie des Signaux</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Les Sept forment une constellation du but.</p>
-        </a>
-        <a href="/fr/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">UN SUR SEPT</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Le Souverain : Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch lit les cinq phases qui gouvernent tout prix.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/hu/index.html
+++ b/hu/index.html
@@ -6829,27 +6829,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <!-- Static Hungarian chronicle articles -->
-        <a href="/hu/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">EREDET</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Az Elite Seven születése</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Hogyan született meg hét égi jelzés az ár matematikájából.</p>
-        </a>
-        <a href="/hu/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FILOZÓFIA</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">A Pilóta esküje</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Az eskü, amely elválasztja a navigálókat a szerencsejátékosoktól.</p>
-        </a>
-        <a href="/hu/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">RENDSZER</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">A jelek hierarchiája</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">A Hetek a cél konstellációját alkotják.</p>
-        </a>
-        <a href="/hu/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ELSŐ A HÉTBŐL</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Ismerd meg az Uralkodót: Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch olvassa az öt fázist, amely minden árat irányít.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/it/index.html
+++ b/it/index.html
@@ -6666,26 +6666,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <a href="/it/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ORIGINE</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">La Nascita degli Elite Sette</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Come sette segnali celesti sono emersi dalla matematica del prezzo.</p>
-        </a>
-        <a href="/it/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FILOSOFIA</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Il Giuramento del Pilota</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Il giuramento che separa chi naviga da chi gioca d'azzardo.</p>
-        </a>
-        <a href="/it/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">SISTEMA</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">La Gerarchia dei Segnali</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">I Sette formano una costellazione dello scopo.</p>
-        </a>
-        <a href="/it/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">UNO DI SETTE</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Il Sovrano: Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch legge le cinque fasi che governano ogni prezzo.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/ja/index.html
+++ b/ja/index.html
@@ -7011,26 +7011,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <a href="/ja/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">起源</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Elite Sevenの誕生</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">7つの天空のシグナルが価格の数学から生まれた物語。</p>
-        </a>
-        <a href="/ja/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">哲学</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">パイロットの誓い</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">ナビゲートする者とギャンブルする者を分ける誓い。</p>
-        </a>
-        <a href="/ja/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">システム</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">シグナルの階層</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">7つは目的の星座を形成する。</p>
-        </a>
-        <a href="/ja/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">7つの1番目</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">支配者に会う：Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarchはすべての価格を支配する5つのフェーズを読み取る。</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/nl/index.html
+++ b/nl/index.html
@@ -6721,27 +6721,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <!-- Dutch Chronicle Articles -->
-        <a href="/nl/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">OORSPRONG</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">De Geboorte van de Elite Zeven</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Hoe zeven hemelse signalen ontstonden uit de wiskunde van de prijs.</p>
-        </a>
-        <a href="/nl/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FILOSOFIE</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">De Eed van de Piloot</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">De eed die navigators van gokkers scheidt.</p>
-        </a>
-        <a href="/nl/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">SYSTEEM</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">De Hiërarchie van Signalen</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">De Zeven vormen een constellatie van doel.</p>
-        </a>
-        <a href="/nl/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">EEN VAN ZEVEN</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">De Soeverein: Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch leest de vijf fases die alle prijzen beheersen.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/pt/index.html
+++ b/pt/index.html
@@ -6998,26 +6998,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <a href="/pt/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ORIGEM</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">O Nascimento dos Elite Sete</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Como sete sinais celestiais emergiram da matemática do preço.</p>
-        </a>
-        <a href="/pt/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FILOSOFIA</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">O Juramento do Piloto</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">O juramento que separa navegantes de jogadores.</p>
-        </a>
-        <a href="/pt/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">SISTEMA</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">A Hierarquia dos Sinais</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Os Sete formam uma constelação de propósito.</p>
-        </a>
-        <a href="/pt/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">UM DOS SETE</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">O Soberano: Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch lê as cinco fases que governam todo preço.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/ru/index.html
+++ b/ru/index.html
@@ -6675,26 +6675,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <a href="/ru/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ПРОИСХОЖДЕНИЕ</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Рождение Elite Seven</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Как семь небесных сигналов возникли из математики цены.</p>
-        </a>
-        <a href="/ru/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ФИЛОСОФИЯ</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Клятва Пилота</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Клятва, отделяющая навигаторов от игроков.</p>
-        </a>
-        <a href="/ru/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">СИСТЕМА</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Иерархия Сигналов</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Семеро образуют созвездие предназначения.</p>
-        </a>
-        <a href="/ru/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ПЕРВЫЙ ИЗ СЕМИ</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Знакомьтесь: Правитель — Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch читает пять фаз, управляющих всеми ценами.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">

--- a/tr/index.html
+++ b/tr/index.html
@@ -6768,26 +6768,24 @@
       </div>
 
       <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
-        <a href="/tr/chronicle/birth-of-the-elite-seven/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(245,158,11,.15);color:#f59e0b;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">KÖKEN</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Elite Seven'ın Doğuşu</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Yedi göksel sinyal fiyatın matematiğinden nasıl doğdu.</p>
-        </a>
-        <a href="/tr/chronicle/the-pilots-oath/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FELSEFİ</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Pilotun Yemini</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Navigatörleri kumarbazlardan ayıran yemin.</p>
-        </a>
-        <a href="/tr/chronicle/the-hierarchy-of-signals/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(59,130,246,.15);color:#3b82f6;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">SİSTEM</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Sinyallerin Hiyerarşisi</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Yediler amaç takımyıldızını oluşturur.</p>
-        </a>
-        <a href="/tr/chronicle/meet-the-sovereign/" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
-          <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">YEDİDEN BİRİ</span>
-          <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Hükümdarla Tanışın: Pentarch</h3>
-          <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Pentarch tüm fiyatları yöneten beş fazı okur.</p>
-        </a>
+
+        <!-- Loading skeleton -->
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+        <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+          <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:100%;height:24px;background:var(--border);border-radius:4px;margin-bottom:.5rem;animation:pulse 1.5s infinite"></div>
+          <div style="width:90%;height:16px;background:var(--border);border-radius:4px;animation:pulse 1.5s infinite"></div>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:1.5rem">


### PR DESCRIPTION
The static chronicle article cards were showing instead of dynamic blog content. Now showing loading skeletons that get replaced when the blog API fetch completes successfully.