### PR TITLE
Add fallback blog cards when API fetch fails

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -7126,7 +7126,25 @@ html[lang="ar"] [style*="text-align:center"] {
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/ar/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/ar/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/ar/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
     // Capture ref/UTM

--- a/de/index.html
+++ b/de/index.html
@@ -7045,7 +7045,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/de/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/de/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/de/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
     // Capture ref/UTM

--- a/es/index.html
+++ b/es/index.html
@@ -7350,7 +7350,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/es/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/es/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/es/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -7226,7 +7226,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/fr/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/fr/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/fr/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
     // Capture ref/UTM

--- a/hu/index.html
+++ b/hu/index.html
@@ -7047,7 +7047,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/hu/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/hu/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/hu/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
 

--- a/it/index.html
+++ b/it/index.html
@@ -6884,7 +6884,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/it/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/it/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/it/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -7231,7 +7231,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/ja/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/ja/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/ja/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -6939,7 +6939,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/nl/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/nl/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/nl/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -7216,7 +7216,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/pt/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/pt/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/pt/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -6893,7 +6893,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/ru/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/ru/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/ru/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
     // Capture ref/UTM

--- a/tr/index.html
+++ b/tr/index.html
@@ -6988,7 +6988,25 @@
             carousel.appendChild(createArticleCard(article));
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          carousel.innerHTML = `
+            <a href="https://blog.signalpilot.io/tr/articles/why-your-indicators-keep-failing/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Why Your Indicators Keep Failing</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Explores why traders with multiple indicators still struggle.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/tr/articles/the-repainting-problem/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(91,138,255,.15);color:var(--brand);border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">INDICATORS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">The Repainting Problem</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">How most indicators cheat with lookahead bias.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/tr/articles/how-smart-money-moves/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(52,211,153,.15);color:#34d399;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">MARKET CYCLES</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">How Smart Money Actually Moves</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decode institutional movement patterns.</p>
+            </a>
+          `;
+        });
     })();
 
 


### PR DESCRIPTION
Each language now shows actual blog article cards (not empty skeletons) if the blog API fetch fails. Links point to language-specific blog URLs.