### PR TITLE
Fix nested scroll conflict in chronicles section

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6381,6 +6381,17 @@ html[lang="ar"] [style*="text-align:center"] {
 
       /* Mobile responsive */
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }

--- a/de/index.html
+++ b/de/index.html
@@ -6302,6 +6302,17 @@
 
       /* Mobile responsive */
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }

--- a/es/index.html
+++ b/es/index.html
@@ -6608,6 +6608,17 @@
 
       /* Mobile responsive */
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }

--- a/fr/index.html
+++ b/fr/index.html
@@ -6480,6 +6480,17 @@
 
       /* Mobile responsive */
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }

--- a/hu/index.html
+++ b/hu/index.html
@@ -6307,6 +6307,17 @@
 
       /* Mobile responsive */
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }

--- a/index.html
+++ b/index.html
@@ -5314,6 +5314,17 @@
 
       /* Mobile responsive */
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }

--- a/it/index.html
+++ b/it/index.html
@@ -6183,6 +6183,17 @@
         backface-visibility: hidden;
       }
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-card.featured { grid-template-columns: 1fr !important; grid-template-rows: 180px auto !important; display: grid !important; }
         /* Target the image container (2nd child, after the absolute glow div) */
         .chronicle-card.featured > div:nth-child(2) { min-height: unset !important; height: 180px !important; max-height: 180px !important; grid-row: 1 !important; position: relative !important; overflow: hidden !important; }

--- a/ja/index.html
+++ b/ja/index.html
@@ -6528,6 +6528,17 @@
         backface-visibility: hidden;
       }
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-card.featured { grid-template-columns: 1fr !important; grid-template-rows: 180px auto !important; display: grid !important; }
         /* Target the image container (2nd child, after the absolute glow div) */
         .chronicle-card.featured > div:nth-child(2) { min-height: unset !important; height: 180px !important; max-height: 180px !important; grid-row: 1 !important; position: relative !important; overflow: hidden !important; }

--- a/nl/index.html
+++ b/nl/index.html
@@ -6238,6 +6238,17 @@
         backface-visibility: hidden;
       }
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-card.featured { grid-template-columns: 1fr !important; grid-template-rows: 180px auto !important; display: grid !important; }
         /* Target the image container (2nd child, after the absolute glow div) */
         .chronicle-card.featured > div:nth-child(2) { min-height: unset !important; height: 180px !important; max-height: 180px !important; grid-row: 1 !important; position: relative !important; overflow: hidden !important; }

--- a/pt/index.html
+++ b/pt/index.html
@@ -6492,6 +6492,17 @@
       }
 
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }

--- a/ru/index.html
+++ b/ru/index.html
@@ -6169,6 +6169,17 @@
       }
 
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }

--- a/tr/index.html
+++ b/tr/index.html
@@ -6262,6 +6262,17 @@
       }
 
       @media (max-width: 768px) {
+        /* Fix nested scrollbar issue - override overflow-x:hidden from .stack */
+        #chronicle,
+        #chronicle .container,
+        #chronicle .container.stack,
+        .chronicle-grid {
+          overflow: visible !important;
+          overflow-x: visible !important;
+          overflow-y: visible !important;
+          -webkit-overflow-scrolling: auto !important;
+          touch-action: pan-y !important;
+        }
         .chronicle-grid {
           grid-template-columns: 1fr !important;
         }


### PR DESCRIPTION
The Chronicles section was creating a nested scroll context on mobile due to overflow-x:hidden being set on .stack containers without explicit overflow-y settings. This caused:
- A visible gray scrollbar inside the Chronicles section
- Touch events being captured preventing page scroll
- Scrollbar disappearing after scrolling past the section

Fix applies to all language versions:
- Set overflow: visible on #chronicle and its containers
- Set -webkit-overflow-scrolling: auto to reset scroll context
- Set touch-action: pan-y to allow vertical scroll pass-through