### PR TITLE
Fix blog links to point to language-specific blog pages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4164,7 +4164,7 @@ html[lang="ar"] [style*="text-align:center"] {
             <ul class="nav-dropdown-menu">
               <li><a href="/ar/chronicle/">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">الوثائق</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
+              <li><a href="https://blog.signalpilot.io/ar/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">الآلات الحاسبة</a></li>
               <li><a href="/ar/faq.html">مركز الأسئلة الشائعة</a></li>
@@ -6973,7 +6973,7 @@ html[lang="ar"] [style*="text-align:center"] {
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">الأسعار</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">التوثيق</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">المركز التعليمي</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">المدونة</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/ar/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">المدونة</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">الأسئلة الشائعة</a></li>
           </ul>
         </div>

--- a/de/index.html
+++ b/de/index.html
@@ -4085,7 +4085,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/de/chronicle/">Chronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
+              <li><a href="https://blog.signalpilot.io/de/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Werkzeuge</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Rechner</a></li>
               <li><a href="/faq.html">FAQ-Center</a></li>
@@ -6892,7 +6892,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Preise</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Dokumentation</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Bildungszentrum</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/de/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">FAQ</a></li>
           </ul>
         </div>

--- a/es/index.html
+++ b/es/index.html
@@ -4323,7 +4323,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/es/chronicle/">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
+              <li><a href="https://blog.signalpilot.io/es/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calculadoras</a></li>
               <li><a href="/es/faq.html">Centro de Preguntas</a></li>
@@ -7198,7 +7198,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Precios</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Documentación</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Centro Educativo</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/es/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Preguntas Frecuentes</a></li>
           </ul>
         </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -4252,7 +4252,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/fr/chronicle/">Chronique</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
+              <li><a href="https://blog.signalpilot.io/fr/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Outils</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calculateurs</a></li>
               <li><a href="/fr/faq.html">Centre FAQ</a></li>
@@ -7070,7 +7070,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Tarifs</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Documentation</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Centre de Formation</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/fr/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">FAQ</a></li>
           </ul>
         </div>

--- a/hu/index.html
+++ b/hu/index.html
@@ -4090,7 +4090,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/hu/chronicle/">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
+              <li><a href="https://blog.signalpilot.io/hu/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Számológépek</a></li>
               <li><a href="/hu/faq.html">GYIK központ</a></li>
@@ -6897,7 +6897,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Árazás</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Dokumentáció</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Oktatási Központ</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/hu/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">GYIK</a></li>
           </ul>
         </div>

--- a/it/index.html
+++ b/it/index.html
@@ -4009,7 +4009,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/it/chronicle/">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
+              <li><a href="https://blog.signalpilot.io/it/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calcolatori</a></li>
               <li><a href="/it/faq.html">Centro FAQ</a></li>
@@ -6734,7 +6734,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Prezzi</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Documentazione</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Hub Educativo</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/it/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">FAQ</a></li>
           </ul>
         </div>

--- a/ja/index.html
+++ b/ja/index.html
@@ -4352,7 +4352,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/ja/chronicle/">クロニクル</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
+              <li><a href="https://blog.signalpilot.io/ja/" target="_blank" rel="noopener">ブログ</a></li>
               <li><a href="/tools/">ツール</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">計算機</a></li>
               <li><a href="/ja/faq.html">FAQセンター</a></li>
@@ -7079,7 +7079,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">料金プラン</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">ドキュメント</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">トレーニングセンター</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">ブログ</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/ja/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">ブログ</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">FAQ</a></li>
           </ul>
         </div>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4064,7 +4064,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/nl/chronicle/">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
+              <li><a href="https://blog.signalpilot.io/nl/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Rekenmachines</a></li>
               <li><a href="/nl/faq.html">FAQ Centrum</a></li>
@@ -6789,7 +6789,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Prijzen</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Documentatie</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Educatie Hub</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/nl/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">FAQ</a></li>
           </ul>
         </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -4401,7 +4401,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/pt/chronicle/">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
+              <li><a href="https://blog.signalpilot.io/pt/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calculadoras</a></li>
               <li><a href="/pt/faq.html">Central de FAQ</a></li>
@@ -7066,7 +7066,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Preços</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Documentação</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Centro de Educação</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/pt/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Perguntas Frequentes</a></li>
           </ul>
         </div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -3995,7 +3995,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/ru/chronicle/">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
+              <li><a href="https://blog.signalpilot.io/ru/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Калькуляторы</a></li>
               <li><a href="/faq.html">Центр FAQ</a></li>
@@ -6743,7 +6743,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Цены</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Документация</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Образовательный центр</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Блог</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/ru/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Блог</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Центр FAQ</a></li>
           </ul>
         </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4088,7 +4088,7 @@
             <ul class="nav-dropdown-menu">
               <li><a href="/tr/chronicle/">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokümantasyon</a></li>
-              <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
+              <li><a href="https://blog.signalpilot.io/tr/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Hesap Makineleri</a></li>
               <li><a href="/tr/faq.html">SSS Merkezi</a></li>
@@ -6836,7 +6836,7 @@
             <li style="margin-bottom:.4rem"><a href="#pricing" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Fiyatlandırma</a></li>
             <li style="margin-bottom:.4rem"><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Dokümantasyon</a></li>
             <li style="margin-bottom:.4rem"><a href="https://education.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Eğitim Merkezi</a></li>
-            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
+            <li style="margin-bottom:.4rem"><a href="https://blog.signalpilot.io/tr/" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">Blog</a></li>
             <li style="margin-bottom:.4rem"><a href="#faq" style="color:var(--muted);text-decoration:none;font-size:.85rem;transition:color .2s">SSS</a></li>
           </ul>
         </div>


### PR DESCRIPTION
All language pages were linking to the English blog (blog.signalpilot.io/) instead of their respective language versions. Updated nav and footer blog links for all 11 languages to use correct URLs:
- /de/, /fr/, /es/, /it/, /tr/, /nl/, /pt/, /ja/, /hu/, /ru/, /ar/