### PR TITLE
Fix blog API to fetch from language-specific endpoints

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -7116,7 +7116,7 @@ html[lang="ar"] [style*="text-align:center"] {
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/ar/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/de/index.html
+++ b/de/index.html
@@ -7035,7 +7035,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/de/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/es/index.html
+++ b/es/index.html
@@ -7340,7 +7340,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/es/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/fr/index.html
+++ b/fr/index.html
@@ -7216,7 +7216,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/fr/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/hu/index.html
+++ b/hu/index.html
@@ -7037,7 +7037,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/hu/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/it/index.html
+++ b/it/index.html
@@ -6874,7 +6874,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/it/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/ja/index.html
+++ b/ja/index.html
@@ -7221,7 +7221,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/ja/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/nl/index.html
+++ b/nl/index.html
@@ -6929,7 +6929,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/nl/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/pt/index.html
+++ b/pt/index.html
@@ -7206,7 +7206,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/pt/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/ru/index.html
+++ b/ru/index.html
@@ -6883,7 +6883,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/ru/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);

--- a/tr/index.html
+++ b/tr/index.html
@@ -6978,7 +6978,7 @@
         return a;
       }
 
-      fetch('https://blog.signalpilot.io/api/articles.json')
+      fetch('https://blog.signalpilot.io/tr/api/articles.json')
         .then(r => r.json())
         .then(data => {
           const articles = Array.isArray(data) ? data : (data.articles || []);


### PR DESCRIPTION
Changed fetch URL from /api/articles.json to /{lang}/api/articles.json for all 11 language sites so they load translated blog content dynamically instead of English.