### PR TITLE
Add 3 more translated blog articles to carousel fallback

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -7143,6 +7143,21 @@ html[lang="ar"] [style*="text-align:center"] {
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">كيف تتحرك الأموال الذكية فعلياً</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">فك شفرة أنماط حركة المؤسسات.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/ar/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">إدارة المخاطر</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">إدارة التراجع: كيف تتعافى من الخسارة</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">الرياضيات والنفسية للبقاء في اللعبة.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/ar/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">الأساسيات</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">ما هي الميزة في التداول؟</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">وكيف تعرف إذا كانت لديك واحدة.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/ar/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">إدارة المخاطر</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">حجم المركز 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">الرياضيات التي تبقيك في اللعبة.</p>
+            </a>
           `;
         });
     })();

--- a/de/index.html
+++ b/de/index.html
@@ -7062,6 +7062,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Wie sich Smart Money wirklich bewegt</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Entschlüsseln Sie institutionelle Bewegungsmuster.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/de/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">RISIKOMANAGEMENT</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Drawdown-Management: Wie man Verlustserien überlebt</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Die Mathematik und Psychologie des Überlebens im Trading.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/de/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GRUNDLAGEN</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Was Ist Ein Trading-Vorteil?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Und wie Sie erkennen, ob Sie einen haben.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/de/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">RISIKOMANAGEMENT</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Positionsgrößenbestimmung 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Die Mathematik, die Sie im Spiel hält.</p>
+            </a>
           `;
         });
     })();

--- a/es/index.html
+++ b/es/index.html
@@ -7367,6 +7367,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Cómo se Mueve Realmente el Dinero Inteligente</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodifica los patrones de movimiento institucional.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/es/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GESTIÓN DE RIESGO</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Gestión de Drawdown: Cómo Sobrevivir a las Rachas Perdedoras</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">La matemática y psicología para mantenerte en el juego.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/es/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FUNDAMENTOS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">¿Qué Es Una Ventaja de Trading?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Y cómo saber si tienes una.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/es/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GESTIÓN DE RIESGO</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Tamaño de Posición 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Las matemáticas que te mantienen en el juego.</p>
+            </a>
           `;
         });
     })();

--- a/fr/index.html
+++ b/fr/index.html
@@ -7243,6 +7243,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Comment le Smart Money se Déplace Réellement</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Décodez les patterns de mouvement institutionnel.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/fr/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GESTION DU RISQUE</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Gestion du Drawdown : Comment Survivre aux Séries de Pertes</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Les maths et la psychologie pour rester dans le jeu.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/fr/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FONDAMENTAUX</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Qu'est-ce Qu'un Avantage en Trading ?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Et comment savoir si vous en avez un.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/fr/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GESTION DU RISQUE</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Taille de Position 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Les maths qui vous gardent en jeu.</p>
+            </a>
           `;
         });
     })();

--- a/hu/index.html
+++ b/hu/index.html
@@ -7064,6 +7064,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Hogyan Mozog Valójában az Okos Pénz</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Fejtsd meg az intézményi mozgási mintákat.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/hu/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">KOCKÁZATKEZELÉS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Lehívás Kezelése: Hogyan Éljük Túl a Veszteségsorozatokat</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">A matematika és pszichológia a játékban maradáshoz.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/hu/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ALAPOK</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Mi Az a Trading Előny?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">És hogyan tudod meg, van-e neked.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/hu/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">KOCKÁZATKEZELÉS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Pozícióméretezés 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">A matematika, ami a játékban tart.</p>
+            </a>
           `;
         });
     })();

--- a/it/index.html
+++ b/it/index.html
@@ -6901,6 +6901,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Come si Muove Davvero lo Smart Money</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodifica i pattern di movimento istituzionale.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/it/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GESTIONE DEL RISCHIO</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Gestione del Drawdown: Come Sopravvivere alle Serie di Perdite</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">La matematica e la psicologia per restare nel gioco.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/it/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FONDAMENTALI</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Cos'è un Vantaggio nel Trading?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">E come sapere se ne hai uno.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/it/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GESTIONE DEL RISCHIO</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Dimensionamento Posizione 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">La matematica che ti tiene in gioco.</p>
+            </a>
           `;
         });
     })();

--- a/ja/index.html
+++ b/ja/index.html
@@ -7248,6 +7248,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">スマートマネーの本当の動き方</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">機関投資家の動きパターンを解読します。</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/ja/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">リスク管理</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">ドローダウン管理：連敗を乗り越える方法</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">ゲームに残り続けるための数学と心理学。</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/ja/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">基礎</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">トレーディングエッジとは？</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">そしてあなたが持っているかの見分け方。</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/ja/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">リスク管理</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">ポジションサイジング101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">ゲームに残り続ける数学。</p>
+            </a>
           `;
         });
     })();

--- a/nl/index.html
+++ b/nl/index.html
@@ -6956,6 +6956,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Hoe Smart Money Echt Beweegt</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Ontcijfer institutionele bewegingspatronen.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/nl/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">RISICOBEHEER</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Drawdown Management: Hoe Je Verliesreeksen Overleeft</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">De wiskunde en psychologie om in het spel te blijven.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/nl/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">BASISKENNIS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Wat Is Een Trading Edge?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">En hoe weet je of je er een hebt.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/nl/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">RISICOBEHEER</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Positiegrootte 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">De wiskunde die je in het spel houdt.</p>
+            </a>
           `;
         });
     })();

--- a/pt/index.html
+++ b/pt/index.html
@@ -7233,6 +7233,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Como o Smart Money Realmente se Move</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Decodifique os padrões de movimento institucional.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/pt/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GESTÃO DE RISCO</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Gestão de Drawdown: Como Sobreviver a Sequências de Perdas</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">A matemática e psicologia para se manter no jogo.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/pt/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">FUNDAMENTOS</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">O Que É Uma Vantagem no Trading?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">E como saber se você tem uma.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/pt/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">GESTÃO DE RISCO</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Dimensionamento de Posição 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">A matemática que te mantém no jogo.</p>
+            </a>
           `;
         });
     })();

--- a/ru/index.html
+++ b/ru/index.html
@@ -6910,6 +6910,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Как на Самом Деле Движутся Умные Деньги</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Расшифруйте паттерны движения институциональных игроков.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/ru/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">УПРАВЛЕНИЕ РИСКАМИ</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Управление просадками: Как пережить серию убытков</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Математика и психология для того, чтобы остаться в игре.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/ru/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">ОСНОВЫ</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Что Такое Торговое Преимущество?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">И как узнать, есть ли оно у вас.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/ru/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">УПРАВЛЕНИЕ РИСКАМИ</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Размер Позиции 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Математика, которая держит вас в игре.</p>
+            </a>
           `;
         });
     })();

--- a/tr/index.html
+++ b/tr/index.html
@@ -7005,6 +7005,21 @@
               <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Akıllı Para Gerçekte Nasıl Hareket Eder</h3>
               <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Kurumsal hareket kalıplarını çözün.</p>
             </a>
+            <a href="https://blog.signalpilot.io/articles/drawdown-management/tr/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">RİSK YÖNETİMİ</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Düşüş Yönetimi: Kayıptan Nasıl Kurtulursunuz</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Oyunda kalmanız için matematik ve psikoloji.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/what-is-a-trading-edge/tr/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(168,85,247,.15);color:#a855f7;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">TEMEL BİLGİLER</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Trading Avantajı Nedir?</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Ve nasıl anlarsınız sizde var mı.</p>
+            </a>
+            <a href="https://blog.signalpilot.io/articles/position-sizing-101/tr/" target="_blank" rel="noopener" class="article-card" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;text-decoration:none;transition:transform .2s,box-shadow .2s">
+              <span style="display:inline-block;padding:.25rem .5rem;background:rgba(239,68,68,.15);color:#ef4444;border-radius:4px;font-size:.75rem;font-weight:600;margin-bottom:.75rem">RİSK YÖNETİMİ</span>
+              <h3 style="font-size:1.1rem;font-weight:600;color:var(--text);margin:0 0 .5rem 0;line-height:1.3">Pozisyon Boyutlandırma 101</h3>
+              <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.5">Sizi oyunda tutan matematik.</p>
+            </a>
           `;
         });
     })();


### PR DESCRIPTION
Increased fallback blog articles from 3 to 6 per language to match the English site carousel. Added translated versions of:
- drawdown-management
- what-is-a-trading-edge
- position-sizing-101

All titles, descriptions, and category labels properly translated for all 11 languages (de, es, fr, pt, ja, it, nl, ar, hu, ru, tr).