### PR TITLE
Fix Portuguese page layout and overflow issues

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -6887,12 +6887,14 @@
 
     <!-- FAQ -->
 
-    <section id="faq" class="section" role="region" aria-labelledpor="faq-heading" style="padding-top:1.5rem">
+    <section id="faq" class="section" role="region" aria-labelledby="faq-heading" style="padding-top:1.5rem">
   <div class="container stack">
-    <h2 id="faq-heading" class="headline lg" style="text-align:center">Perguntas Frequentes</h2>
-    <p style="text-align:center;color:var(--muted);margin:-0.5rem 0 1.5rem 0;font-size:.9rem">Perguntas pré-compra respondidas. Para guias de configuração: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a> ou <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro de Educação</a>.</p>
+    <div data-reveal="fade-up">
+      <h2 id="faq-heading" class="headline lg" style="text-align:center"><span class="shimmer-text">Perguntas Frequentes</span></h2>
+      <p style="text-align:center;color:var(--muted);margin:-0.5rem 0 1.5rem 0;font-size:.9rem">Perguntas pré-compra respondidas. Para guias de configuração: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a> ou <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro de Educação</a>.</p>
+    </div>
 
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;max-width:960px;margin:0 auto">
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;max-width:1100px;margin:0 auto">
 
       <!-- EDUCATION HUB -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-0">


### PR DESCRIPTION
- Changed FAQ grid max-width from 960px to 1100px for proper card sizing
- Fixed typo: aria-labelledpor → aria-labelledby
- Added missing data-reveal="fade-up" wrapper for animation consistency
- Added shimmer-text class on FAQ heading to match English styling