### PR TITLE
Add missing CSS files to all language pages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -3688,6 +3688,30 @@ html[lang="ar"] [style*="text-align:center"] {
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -4053,11 +4077,6 @@ html[lang="ar"] [style*="text-align:center"] {
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/de/index.html
+++ b/de/index.html
@@ -3553,6 +3553,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -3974,11 +3998,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/es/index.html
+++ b/es/index.html
@@ -3791,6 +3791,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -4212,11 +4236,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/fr/index.html
+++ b/fr/index.html
@@ -3706,6 +3706,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -4141,11 +4165,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/hu/index.html
+++ b/hu/index.html
@@ -3614,6 +3614,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -3979,11 +4003,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/it/index.html
+++ b/it/index.html
@@ -3533,6 +3533,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -3898,11 +3922,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/ja/index.html
+++ b/ja/index.html
@@ -3876,6 +3876,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -4241,11 +4265,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/nl/index.html
+++ b/nl/index.html
@@ -3589,6 +3589,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -3953,11 +3977,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/ru/index.html
+++ b/ru/index.html
@@ -3519,6 +3519,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -3884,11 +3908,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>

--- a/tr/index.html
+++ b/tr/index.html
@@ -3612,6 +3612,30 @@
   <link rel="stylesheet" href="/assets/device-optimizations.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="/assets/device-optimizations.css"></noscript>
 
+  <!-- Micro-Interactions (async) -->
+  <link rel="stylesheet" href="/assets/micro-interactions.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/micro-interactions.css"></noscript>
+
+  <!-- Horizontal Scroll (async) -->
+  <link rel="stylesheet" href="/assets/horizontal-scroll.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/horizontal-scroll.css"></noscript>
+
+  <!-- Text Stagger Animation (async) -->
+  <link rel="stylesheet" href="/assets/text-stagger.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/text-stagger.css"></noscript>
+
+  <!-- Character Shuffle Effect (async) -->
+  <link rel="stylesheet" href="/assets/character-shuffle.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/character-shuffle.css"></noscript>
+
+  <!-- Scroll Reveal Animations (async) -->
+  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
+
+  <!-- Premium Effects - Parallax, Glow, 3D (async) -->
+  <link rel="stylesheet" href="/assets/premium-effects.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="/assets/premium-effects.css"></noscript>
+
   <!-- Structured Data (Schema.org) for SEO -->
   <script type="application/ld+json">
   {
@@ -3977,11 +4001,6 @@
     }
 
   </style>
-
-<!-- Scroll Reveal Animations (async) -->
-  <link rel="stylesheet" href="/assets/scroll-reveal.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/scroll-reveal.css"></noscript>
-
 </head>
 
 <body>


### PR DESCRIPTION
Added missing CSS includes to ar, de, es, fr, hu, it, ja, nl, ru, tr:
- micro-interactions.css
- horizontal-scroll.css
- text-stagger.css
- character-shuffle.css
- scroll-reveal.css
- premium-effects.css

Also removed duplicate scroll-reveal.css entries from all pages.