### PR TITLE
Add shimmer-text effect to hero headlines in all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4295,7 +4295,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">مؤشرات TradingView احترافية</span>
-            الميزة ليست في رؤية المزيد. بل في رؤية ما يهم.
+            <span class="shimmer-text">الميزة ليست في رؤية المزيد. بل في رؤية ما يهم.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;min-height:3.5rem">

--- a/de/index.html
+++ b/de/index.html
@@ -4216,7 +4216,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professionelle TradingView-Indikatoren</span>
-            Der Vorteil liegt nicht darin, mehr zu sehen. Sondern darin, das Wesentliche zu sehen.
+            <span class="shimmer-text">Der Vorteil liegt nicht darin, mehr zu sehen. Sondern darin, das Wesentliche zu sehen.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">

--- a/es/index.html
+++ b/es/index.html
@@ -4454,7 +4454,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Indicadores Profesionales de TradingView</span>
-            La ventaja no es ver más. Es ver lo que importa.
+            <span class="shimmer-text">La ventaja no es ver más. Es ver lo que importa.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0">

--- a/fr/index.html
+++ b/fr/index.html
@@ -4386,7 +4386,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Indicateurs Professionnels TradingView</span>
-            L'avantage n'est pas de voir plus. C'est de voir ce qui compte.
+            <span class="shimmer-text">L'avantage n'est pas de voir plus. C'est de voir ce qui compte.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">

--- a/hu/index.html
+++ b/hu/index.html
@@ -4221,7 +4221,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professzionális TradingView indikátorok</span>
-            A siker nem abban rejlik, hogy többet láss, hanem abban, hogy azt lásd, ami számít.
+            <span class="shimmer-text">A siker nem abban rejlik, hogy többet láss, hanem abban, hogy azt lásd, ami számít.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">

--- a/it/index.html
+++ b/it/index.html
@@ -4140,7 +4140,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Indicatori Professionali TradingView</span>
-            Il vantaggio non è vedere di più. È vedere ciò che conta.
+            <span class="shimmer-text">Il vantaggio non è vedere di più. È vedere ciò che conta.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">

--- a/ja/index.html
+++ b/ja/index.html
@@ -4485,7 +4485,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">TradingView プロフェッショナル・インジケーター</span>
-            優位性は多くを見ることではない。重要なものを見ることだ。
+            <span class="shimmer-text">優位性は多くを見ることではない。重要なものを見ることだ。</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">

--- a/nl/index.html
+++ b/nl/index.html
@@ -4195,7 +4195,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Professionele TradingView Indicatoren</span>
-            Het voordeel zit niet in meer zien. Maar in zien wat ertoe doet.
+            <span class="shimmer-text">Het voordeel zit niet in meer zien. Maar in zien wat ertoe doet.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">

--- a/pt/index.html
+++ b/pt/index.html
@@ -4535,7 +4535,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Indicadores Profissionais para TradingView</span>
-            A vantagem não é ver mais. É ver o que importa.
+            <span class="shimmer-text">A vantagem não é ver mais. É ver o que importa.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0">

--- a/ru/index.html
+++ b/ru/index.html
@@ -4128,7 +4128,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Профессиональные индикаторы TradingView</span>
-            Преимущество не в том, чтобы видеть больше. А в том, чтобы видеть то, что важно.
+            <span class="shimmer-text">Преимущество не в том, чтобы видеть больше. А в том, чтобы видеть то, что важно.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">

--- a/tr/index.html
+++ b/tr/index.html
@@ -4221,7 +4221,7 @@
 
           <h1 class="headline xl">
             <span style="font-size:0.5em;display:block;margin-bottom:0.5rem;color:#9ca3af !important;-webkit-text-fill-color:#9ca3af !important;font-weight:600;text-transform:uppercase;letter-spacing:0.05em">Profesyonel TradingView Göstergeleri</span>
-            Avantaj daha fazla görmek değil. Önemli olanı görmektir.
+            <span class="shimmer-text">Avantaj daha fazla görmek değil. Önemli olanı görmektir.</span>
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">


### PR DESCRIPTION
Added the shimmer-text class wrapper to the main hero headline in all 11 language pages (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr) to match the English version's shimmering gradient animation effect.