### PR TITLE
Add shimmer-text CSS animation to all language pages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1968,6 +1968,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/de/index.html
+++ b/de/index.html
@@ -1915,6 +1915,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/es/index.html
+++ b/es/index.html
@@ -2119,6 +2119,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(min(100%, 300px),1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/fr/index.html
+++ b/fr/index.html
@@ -1988,6 +1988,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/hu/index.html
+++ b/hu/index.html
@@ -1983,6 +1983,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/it/index.html
+++ b/it/index.html
@@ -1909,6 +1909,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/ja/index.html
+++ b/ja/index.html
@@ -2175,6 +2175,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/nl/index.html
+++ b/nl/index.html
@@ -1966,6 +1966,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/pt/index.html
+++ b/pt/index.html
@@ -1996,6 +1996,28 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/ru/index.html
+++ b/ru/index.html
@@ -1896,6 +1896,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}

--- a/tr/index.html
+++ b/tr/index.html
@@ -1988,6 +1988,25 @@
 
     .grid{display:grid;gap:1rem}
 
+    /* ==================== SHIMMERING GRADIENT ANIMATION ==================== */
+    @keyframes shimmerGradient {
+      0% { background-position: 200% 50%; }
+      100% { background-position: -200% 50%; }
+    }
+    .shimmer-text {
+      position: relative;
+      display: inline-block;
+      background: linear-gradient(90deg, #9cc0ff 0%, #86a8ff 20%, #7ccaff 40%, #ffffff 50%, #7ccaff 60%, #86a8ff 80%, #9cc0ff 100%);
+      background-size: 200% auto;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      animation: shimmerGradient 8s linear infinite;
+    }
+    h1.shimmer-text, h2.shimmer-text, h3.shimmer-text { display: block; }
+
     .grid.auto-300{grid-template-columns:repeat(auto-fit,minmax(300px,1fr))}
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}


### PR DESCRIPTION
Added the missing @keyframes shimmerGradient animation and .shimmer-text CSS class to all 11 language pages. This CSS was only present in the English version, causing the shimmering gradient effect on hero headlines to not work on translated pages.