### PR TITLE
Adjust headline sizing for long-text languages (RU, DE, HU)

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -3056,12 +3056,14 @@
     .headline{font-family:'Gugi',system-ui,-apple-system,sans-serif;font-weight:900;letter-spacing:.02em;line-height:1.12;background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
 
     /* Hero and section headers use EB Garamond for sophistication */
+    /* German: Reduced font-size due to longer text */
     .headline.xl{
-      font-size:clamp(2.2rem,7vw,4rem);
+      font-size:clamp(1.9rem,5.5vw,3.2rem);
       font-family:'EB Garamond',serif;
       font-weight:600;
       letter-spacing:-.02em;
       line-height:1.2;
+      text-wrap:balance;
     }
 
     .headline.lg{

--- a/hu/index.html
+++ b/hu/index.html
@@ -3124,12 +3124,14 @@
     .headline{font-family:'Gugi',system-ui,-apple-system,sans-serif;font-weight:900;letter-spacing:.02em;line-height:1.12;background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
 
     /* Hero and section headers use EB Garamond for sophistication */
+    /* Hungarian: Reduced font-size due to longer text */
     .headline.xl{
-      font-size:clamp(2.2rem,7vw,4rem);
+      font-size:clamp(1.9rem,5.5vw,3.2rem);
       font-family:'EB Garamond',serif;
       font-weight:600;
       letter-spacing:-.02em;
       line-height:1.2;
+      text-wrap:balance;
     }
 
     .headline.lg{

--- a/ru/index.html
+++ b/ru/index.html
@@ -3029,12 +3029,14 @@
     .headline{font-family:'Gugi',system-ui,-apple-system,sans-serif;font-weight:900;letter-spacing:.02em;line-height:1.12;background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
 
     /* Hero and section headers use EB Garamond for sophistication */
+    /* Russian: Reduced font-size due to longer text */
     .headline.xl{
-      font-size:clamp(2.2rem,7vw,4rem);
+      font-size:clamp(1.9rem,5.5vw,3.2rem);
       font-family:'EB Garamond',serif;
       font-weight:600;
       letter-spacing:-.02em;
       line-height:1.2;
+      text-wrap:balance;
     }
 
     .headline.lg{


### PR DESCRIPTION
- Reduced .headline.xl font-size from clamp(2.2rem,7vw,4rem) to clamp(1.9rem,5.5vw,3.2rem) for Russian, German, and Hungarian
- Added text-wrap:balance for better line breaking
- These languages have significantly longer translations that were causing awkward line breaks in the hero section