### PR TITLE
Fix hamburger menu links for mobile navigation

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -7321,6 +7321,8 @@ html[lang="ar"] [style*="text-align:center"] {
         <a href="#inside">ما بالداخل</a>
         <a href="/ar/chronicle/">السجل</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">الوثائق</a>
+        <a href="https://blog.signalpilot.io/ar/" target="_blank" rel="noopener">مدونة</a>
+        <a href="/tools/">أدوات</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">مركز التعليم</a>
         <a href="/ar/faq.html">مركز الأسئلة الشائعة</a>
         <a href="#pricing">الأسعار</a>

--- a/de/index.html
+++ b/de/index.html
@@ -7242,6 +7242,8 @@
         <a href="#inside">Was ist enthalten</a>
         <a href="/de/chronicle/">Chronik</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a>
+        <a href="https://blog.signalpilot.io/de/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Werkzeuge</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Bildungszentrum</a>
         <a href="/faq.html">FAQ-Center</a>
         <a href="#pricing">Preise</a>

--- a/es/index.html
+++ b/es/index.html
@@ -7547,6 +7547,8 @@
         <a href="#inside">Qué incluye</a>
         <a href="/es/chronicle/">Crónica</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a>
+        <a href="https://blog.signalpilot.io/es/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Herramientas</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro Educativo</a>
         <a href="/es/faq.html">Centro de Preguntas</a>
         <a href="#pricing">Precios</a>

--- a/fr/index.html
+++ b/fr/index.html
@@ -7421,6 +7421,8 @@
         <a href="#inside">Contenu inclus</a>
         <a href="/fr/chronicle/">Chronique</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
+        <a href="https://blog.signalpilot.io/fr/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Outils</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centre de Formation</a>
         <a href="/fr/faq.html">Centre FAQ</a>
         <a href="#pricing">Tarifs</a>

--- a/hu/index.html
+++ b/hu/index.html
@@ -7246,6 +7246,8 @@
         <a href="#inside">Mi van benne</a>
         <a href="/hu/chronicle/">Krónika</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a>
+        <a href="https://blog.signalpilot.io/hu/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Eszközök</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Oktatási Központ</a>
         <a href="/hu/faq.html">GYIK Központ</a>
         <a href="#pricing">Árazás</a>

--- a/index.html
+++ b/index.html
@@ -6361,6 +6361,8 @@
         <a href="#inside">What's inside</a>
         <a href="/chronicle/">Chronicle</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
+        <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Tools</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a>
         <a href="/faq.html">FAQ Center</a>
         <a href="#pricing">Pricing</a>

--- a/it/index.html
+++ b/it/index.html
@@ -7082,6 +7082,8 @@
         <a href="#inside">Cosa c'è dentro</a>
         <a href="/it/chronicle/">Cronaca</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
+        <a href="https://blog.signalpilot.io/it/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Strumenti</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Hub Educativo</a>
         <a href="/it/faq.html">Centro FAQ</a>
         <a href="#pricing">Prezzi</a>

--- a/ja/index.html
+++ b/ja/index.html
@@ -7427,6 +7427,8 @@
         <a href="#inside">アドベントカレンダー</a>
         <a href="/ja/chronicle/">クロニクル</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a>
+        <a href="https://blog.signalpilot.io/ja/" target="_blank" rel="noopener">ブログ</a>
+        <a href="/tools/">ツール</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">トレーニングセンター</a>
         <a href="/ja/faq.html">FAQセンター</a>
         <a href="#pricing">料金プラン</a>

--- a/nl/index.html
+++ b/nl/index.html
@@ -7136,6 +7136,8 @@
         <a href="#inside">Wat zit erin</a>
         <a href="/nl/chronicle/">Kroniek</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a>
+        <a href="https://blog.signalpilot.io/nl/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Tools</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Educatie Hub</a>
         <a href="/nl/faq.html">FAQ Centrum</a>
         <a href="#pricing">Prijzen</a>

--- a/pt/index.html
+++ b/pt/index.html
@@ -7419,6 +7419,8 @@
         <a href="#inside">O que está incluído</a>
         <a href="/pt/chronicle/">Crônica</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a>
+        <a href="https://blog.signalpilot.io/pt/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Ferramentas</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro de Educação</a>
         <a href="/pt/faq.html">Central de FAQ</a>
         <a href="#pricing">Preços</a>

--- a/ru/index.html
+++ b/ru/index.html
@@ -7090,6 +7090,8 @@
         <a href="#inside">Что внутри</a>
         <a href="/ru/chronicle/">Хроника</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a>
+        <a href="https://blog.signalpilot.io/ru/" target="_blank" rel="noopener">Блог</a>
+        <a href="/tools/">Инструменты</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Образовательный центр</a>
         <a href="/faq.html">Центр FAQ</a>
         <a href="#pricing">Цены</a>

--- a/tr/index.html
+++ b/tr/index.html
@@ -7185,6 +7185,8 @@
         <a href="#inside">İçerik</a>
         <a href="/tr/chronicle/">Kronik</a>
         <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokümantasyon</a>
+        <a href="https://blog.signalpilot.io/tr/" target="_blank" rel="noopener">Blog</a>
+        <a href="/tools/">Araçlar</a>
         <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Eğitim Merkezi</a>
         <a href="/tr/faq.html">SSS Merkezi</a>
         <a href="#pricing">Fiyatlandırma</a>


### PR DESCRIPTION
Added missing Blog and Tools navigation links to the mobile hamburger menu across all 12 language versions. Each language links to the correct localized blog URL (e.g., blog.signalpilot.io/de/ for German) and uses the properly translated label for Tools.