### PR TITLE
Reorganize navigation button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2141,6 +2141,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -6358,15 +6380,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Try Free 7 Days →</a>
-        <a href="#inside">What's inside</a>
-        <a href="/chronicle/">Chronicle</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
-        <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Tools</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a>
-        <a href="/faq.html">FAQ Center</a>
-        <a href="#pricing">Pricing</a>
-        <a href="/affiliates.html">Affiliates</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Product</div>
+          <a href="#inside">What's inside</a>
+          <a href="#pricing">Pricing</a>
+          <a href="/chronicle/">Chronicle</a>
+          <a href="/tools/">Tools</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Learn</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a>
+          <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
+          <a href="/faq.html">FAQ Center</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/affiliates.html">Affiliates</a>
+        </div>
       `;
 
       // Assemble menu


### PR DESCRIPTION
Group navigation items into logical categories:
- Product: What's inside, Pricing, Chronicle, Tools
- Learn: Documentation, Education Hub, Blog, FAQ Center
- Affiliates standalone at bottom

Added subtle section headers with dividers for cleaner UX.