### PR TITLE
Add grouped mobile nav with translations for all 11 languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -3055,6 +3055,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7318,15 +7340,26 @@ html[lang="ar"] [style*="text-align:center"] {
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">جربها مجاناً لمدة 7 أيام ←</a>
-        <a href="#inside">ما بالداخل</a>
-        <a href="/ar/chronicle/">السجل</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">الوثائق</a>
-        <a href="https://blog.signalpilot.io/ar/" target="_blank" rel="noopener">مدونة</a>
-        <a href="/tools/">أدوات</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">مركز التعليم</a>
-        <a href="/ar/faq.html">مركز الأسئلة الشائعة</a>
-        <a href="#pricing">الأسعار</a>
-        <a href="/ar/affiliates.html">الشركاء</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">المنتج</div>
+          <a href="#inside">ما بالداخل</a>
+          <a href="#pricing">الأسعار</a>
+          <a href="/ar/chronicle/">السجل</a>
+          <a href="/tools/">أدوات</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">تعلّم</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">الوثائق</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">مركز التعليم</a>
+          <a href="https://blog.signalpilot.io/ar/" target="_blank" rel="noopener">مدونة</a>
+          <a href="/ar/faq.html">مركز الأسئلة الشائعة</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/ar/affiliates.html">الشركاء</a>
+        </div>
       `;
 
       // Assemble menu

--- a/de/index.html
+++ b/de/index.html
@@ -2998,6 +2998,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7239,15 +7261,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">7 Tage kostenlos testen →</a>
-        <a href="#inside">Was ist enthalten</a>
-        <a href="/de/chronicle/">Chronik</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a>
-        <a href="https://blog.signalpilot.io/de/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Werkzeuge</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Bildungszentrum</a>
-        <a href="/faq.html">FAQ-Center</a>
-        <a href="#pricing">Preise</a>
-        <a href="/affiliates.html">Partner</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Produkt</div>
+          <a href="#inside">Was ist enthalten</a>
+          <a href="#pricing">Preise</a>
+          <a href="/de/chronicle/">Chronik</a>
+          <a href="/tools/">Werkzeuge</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Lernen</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Bildungszentrum</a>
+          <a href="https://blog.signalpilot.io/de/" target="_blank" rel="noopener">Blog</a>
+          <a href="/faq.html">FAQ-Center</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/affiliates.html">Partner</a>
+        </div>
       `;
 
       // Assemble menu

--- a/es/index.html
+++ b/es/index.html
@@ -3243,6 +3243,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7544,15 +7566,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Prueba Gratis 7 Días →</a>
-        <a href="#inside">Qué incluye</a>
-        <a href="/es/chronicle/">Crónica</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a>
-        <a href="https://blog.signalpilot.io/es/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Herramientas</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro Educativo</a>
-        <a href="/es/faq.html">Centro de Preguntas</a>
-        <a href="#pricing">Precios</a>
-        <a href="/es/affiliates.html">Afiliados</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Producto</div>
+          <a href="#inside">Qué incluye</a>
+          <a href="#pricing">Precios</a>
+          <a href="/es/chronicle/">Crónica</a>
+          <a href="/tools/">Herramientas</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Aprende</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro Educativo</a>
+          <a href="https://blog.signalpilot.io/es/" target="_blank" rel="noopener">Blog</a>
+          <a href="/es/faq.html">Centro de Preguntas</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/es/affiliates.html">Afiliados</a>
+        </div>
       `;
 
       // Assemble menu

--- a/fr/index.html
+++ b/fr/index.html
@@ -3097,6 +3097,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7418,15 +7440,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Essai Gratuit 7 Jours →</a>
-        <a href="#inside">Contenu inclus</a>
-        <a href="/fr/chronicle/">Chronique</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
-        <a href="https://blog.signalpilot.io/fr/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Outils</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centre de Formation</a>
-        <a href="/fr/faq.html">Centre FAQ</a>
-        <a href="#pricing">Tarifs</a>
-        <a href="/fr/affiliates.html">Affiliés</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Produit</div>
+          <a href="#inside">Contenu inclus</a>
+          <a href="#pricing">Tarifs</a>
+          <a href="/fr/chronicle/">Chronique</a>
+          <a href="/tools/">Outils</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Apprendre</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centre de Formation</a>
+          <a href="https://blog.signalpilot.io/fr/" target="_blank" rel="noopener">Blog</a>
+          <a href="/fr/faq.html">Centre FAQ</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/fr/affiliates.html">Affiliés</a>
+        </div>
       `;
 
       // Assemble menu

--- a/hu/index.html
+++ b/hu/index.html
@@ -3066,6 +3066,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7243,15 +7265,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Próbáld 7 Napig Ingyen →</a>
-        <a href="#inside">Mi van benne</a>
-        <a href="/hu/chronicle/">Krónika</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a>
-        <a href="https://blog.signalpilot.io/hu/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Eszközök</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Oktatási Központ</a>
-        <a href="/hu/faq.html">GYIK Központ</a>
-        <a href="#pricing">Árazás</a>
-        <a href="/hu/affiliates.html">Ajánlói Program</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Termék</div>
+          <a href="#inside">Mi van benne</a>
+          <a href="#pricing">Árazás</a>
+          <a href="/hu/chronicle/">Krónika</a>
+          <a href="/tools/">Eszközök</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Tanulás</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Oktatási Központ</a>
+          <a href="https://blog.signalpilot.io/hu/" target="_blank" rel="noopener">Blog</a>
+          <a href="/hu/faq.html">GYIK Központ</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/hu/affiliates.html">Ajánlói Program</a>
+        </div>
       `;
 
       // Assemble menu

--- a/it/index.html
+++ b/it/index.html
@@ -2985,6 +2985,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7079,15 +7101,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Prova Gratis 7 Giorni →</a>
-        <a href="#inside">Cosa c'è dentro</a>
-        <a href="/it/chronicle/">Cronaca</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
-        <a href="https://blog.signalpilot.io/it/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Strumenti</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Hub Educativo</a>
-        <a href="/it/faq.html">Centro FAQ</a>
-        <a href="#pricing">Prezzi</a>
-        <a href="/it/affiliates.html">Affiliati</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Prodotto</div>
+          <a href="#inside">Cosa c'è dentro</a>
+          <a href="#pricing">Prezzi</a>
+          <a href="/it/chronicle/">Cronaca</a>
+          <a href="/tools/">Strumenti</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Impara</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Hub Educativo</a>
+          <a href="https://blog.signalpilot.io/it/" target="_blank" rel="noopener">Blog</a>
+          <a href="/it/faq.html">Centro FAQ</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/it/affiliates.html">Affiliati</a>
+        </div>
       `;
 
       // Assemble menu

--- a/ja/index.html
+++ b/ja/index.html
@@ -3328,6 +3328,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7424,15 +7446,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">7日間無料トライアル →</a>
-        <a href="#inside">アドベントカレンダー</a>
-        <a href="/ja/chronicle/">クロニクル</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a>
-        <a href="https://blog.signalpilot.io/ja/" target="_blank" rel="noopener">ブログ</a>
-        <a href="/tools/">ツール</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">トレーニングセンター</a>
-        <a href="/ja/faq.html">FAQセンター</a>
-        <a href="#pricing">料金プラン</a>
-        <a href="/ja/affiliates.html">アフィリエイト</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">製品</div>
+          <a href="#inside">アドベントカレンダー</a>
+          <a href="#pricing">料金プラン</a>
+          <a href="/ja/chronicle/">クロニクル</a>
+          <a href="/tools/">ツール</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">学習</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">トレーニングセンター</a>
+          <a href="https://blog.signalpilot.io/ja/" target="_blank" rel="noopener">ブログ</a>
+          <a href="/ja/faq.html">FAQセンター</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/ja/affiliates.html">アフィリエイト</a>
+        </div>
       `;
 
       // Assemble menu

--- a/nl/index.html
+++ b/nl/index.html
@@ -3041,6 +3041,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7133,15 +7155,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Probeer 7 Dagen Gratis →</a>
-        <a href="#inside">Wat zit erin</a>
-        <a href="/nl/chronicle/">Kroniek</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a>
-        <a href="https://blog.signalpilot.io/nl/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Tools</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Educatie Hub</a>
-        <a href="/nl/faq.html">FAQ Centrum</a>
-        <a href="#pricing">Prijzen</a>
-        <a href="/nl/affiliates.html">Partners</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Product</div>
+          <a href="#inside">Wat zit erin</a>
+          <a href="#pricing">Prijzen</a>
+          <a href="/nl/chronicle/">Kroniek</a>
+          <a href="/tools/">Tools</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Leer</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Educatie Hub</a>
+          <a href="https://blog.signalpilot.io/nl/" target="_blank" rel="noopener">Blog</a>
+          <a href="/nl/faq.html">FAQ Centrum</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/nl/affiliates.html">Partners</a>
+        </div>
       `;
 
       // Assemble menu

--- a/pt/index.html
+++ b/pt/index.html
@@ -3170,6 +3170,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7416,15 +7438,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">Teste Grátis 7 Dias →</a>
-        <a href="#inside">O que está incluído</a>
-        <a href="/pt/chronicle/">Crônica</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a>
-        <a href="https://blog.signalpilot.io/pt/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Ferramentas</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro de Educação</a>
-        <a href="/pt/faq.html">Central de FAQ</a>
-        <a href="#pricing">Preços</a>
-        <a href="/pt/affiliates.html">Afiliados</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Produto</div>
+          <a href="#inside">O que está incluído</a>
+          <a href="#pricing">Preços</a>
+          <a href="/pt/chronicle/">Crônica</a>
+          <a href="/tools/">Ferramentas</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Aprender</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro de Educação</a>
+          <a href="https://blog.signalpilot.io/pt/" target="_blank" rel="noopener">Blog</a>
+          <a href="/pt/faq.html">Central de FAQ</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/pt/affiliates.html">Afiliados</a>
+        </div>
       `;
 
       // Assemble menu

--- a/ru/index.html
+++ b/ru/index.html
@@ -2971,6 +2971,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7087,15 +7109,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">7 Дней Бесплатно →</a>
-        <a href="#inside">Что внутри</a>
-        <a href="/ru/chronicle/">Хроника</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a>
-        <a href="https://blog.signalpilot.io/ru/" target="_blank" rel="noopener">Блог</a>
-        <a href="/tools/">Инструменты</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Образовательный центр</a>
-        <a href="/faq.html">Центр FAQ</a>
-        <a href="#pricing">Цены</a>
-        <a href="/affiliates.html">Партнёрская программа</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Продукт</div>
+          <a href="#inside">Что внутри</a>
+          <a href="#pricing">Цены</a>
+          <a href="/ru/chronicle/">Хроника</a>
+          <a href="/tools/">Инструменты</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Обучение</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Образовательный центр</a>
+          <a href="https://blog.signalpilot.io/ru/" target="_blank" rel="noopener">Блог</a>
+          <a href="/faq.html">Центр FAQ</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/affiliates.html">Партнёрская программа</a>
+        </div>
       `;
 
       // Assemble menu

--- a/tr/index.html
+++ b/tr/index.html
@@ -3064,6 +3064,28 @@
         color: #fff;
       }
 
+      .mobile-nav-section {
+        padding: 0.5rem 1.25rem 0.25rem;
+        margin-top: 0.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+      }
+      .mobile-nav-section:first-of-type {
+        border-top: none;
+        margin-top: 0;
+      }
+      .mobile-nav-section-label {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(183, 194, 217, 0.5);
+        padding: 0.5rem 0;
+      }
+      .mobile-nav-section a {
+        padding: 0.85rem 0.5rem;
+        border-left: none;
+      }
+
       /* Hide desktop CTA on mobile */
       .cta-header{display:none}
 
@@ -7182,15 +7204,26 @@
       links.className = 'mobile-nav-links';
       links.innerHTML = `
         <a href="#trial" style="display:block;background:linear-gradient(135deg,#5b8aff,#764ba2);color:#fff !important;padding:1rem 1.5rem;border-radius:10px;font-weight:700;text-align:center;margin:1rem 1.25rem;box-shadow:0 4px 16px rgba(91,138,255,.35)">7 Gün Ücretsiz Dene →</a>
-        <a href="#inside">İçerik</a>
-        <a href="/tr/chronicle/">Kronik</a>
-        <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokümantasyon</a>
-        <a href="https://blog.signalpilot.io/tr/" target="_blank" rel="noopener">Blog</a>
-        <a href="/tools/">Araçlar</a>
-        <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Eğitim Merkezi</a>
-        <a href="/tr/faq.html">SSS Merkezi</a>
-        <a href="#pricing">Fiyatlandırma</a>
-        <a href="/tr/affiliates.html">Ortaklar</a>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Ürün</div>
+          <a href="#inside">İçerik</a>
+          <a href="#pricing">Fiyatlandırma</a>
+          <a href="/tr/chronicle/">Kronik</a>
+          <a href="/tools/">Araçlar</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <div class="mobile-nav-section-label">Öğren</div>
+          <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokümantasyon</a>
+          <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Eğitim Merkezi</a>
+          <a href="https://blog.signalpilot.io/tr/" target="_blank" rel="noopener">Blog</a>
+          <a href="/tr/faq.html">SSS Merkezi</a>
+        </div>
+
+        <div class="mobile-nav-section">
+          <a href="/tr/affiliates.html">Ortaklar</a>
+        </div>
       `;
 
       // Assemble menu


### PR DESCRIPTION
Apply the same mobile nav reorganization to all language versions:
- ar, de, es, fr, hu, it, ja, nl, pt, ru, tr

Each language now has:
- Product section (with localized label)
- Learn section (with localized label)
- Affiliates standalone at bottom

CSS for section headers added to all files.