### PR TITLE
Further reduce FAQ width to 800px with 2-column max layout

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -6936,7 +6936,7 @@
       <p style="text-align:center;color:var(--muted);margin:-0.5rem 0 1.5rem 0;font-size:.9rem">Perguntas pré-compra respondidas. Para guias de configuração: <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a> ou <a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Centro de Educação</a>.</p>
     </div>
 
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(min(280px,100%),1fr));gap:1rem;max-width:900px;margin:0 auto;overflow:hidden">
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(min(340px,100%),1fr));gap:1rem;max-width:800px;margin:0 auto;overflow:hidden">
 
       <!-- EDUCATION HUB -->
       <div class="card" role="button" aria-expanded="true" tabindex="0" aria-controls="faq-answer-0">


### PR DESCRIPTION
- Reduced max-width from 900px to 800px
- Increased min card width from 280px to 340px (forces max 2 columns)
- This matches the narrower width of other content sections