### PR TITLE
Remove CSS overrides that forced FAQ to 100% width

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -3289,37 +3289,6 @@
       }
     }
 
-    /* Mobile optimizations */
-    
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        border: none !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        border: none !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        border: none !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
-
     @media (max-width:768px){
       body, main{
         overflow-x:hidden !important;


### PR DESCRIPTION
Removed CSS rules that were outside media query and applying max-width: 100% !important to FAQ elements on all screen sizes, which was overriding the inline max-width constraints.