### PR TITLE
Remove all duplicate FAQ CSS overrides forcing 100% width

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -845,35 +845,6 @@
       background:transparent !important;
     }
     
-    /* Prevent any overflow issues on mobile */
-    
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
-
-
     @media (max-width:768px){
       body, main{
         overflow-x:hidden !important;
@@ -1078,33 +1049,6 @@
       /* Reduce parallax intensity on tablets */
       #parallax-orb-1,#parallax-orb-2{opacity:0.7}
     }
-
-    
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
 
     @media (max-width:768px){
       /* Prevent horizontal overflow on mobile */
@@ -1563,34 +1507,6 @@
       background:transparent !important;
     }
     
-    /* Prevent any overflow issues on mobile */
-    
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
-
     @media (max-width:768px){
       body, main{
         overflow-x:hidden !important;
@@ -1795,33 +1711,6 @@
       /* Reduce parallax intensity on tablets */
       #parallax-orb-1,#parallax-orb-2{opacity:0.7}
     }
-
-    
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
 
     @media (max-width:768px){
       /* Prevent horizontal overflow on mobile */
@@ -2226,34 +2115,6 @@
 
     /* Additional mobile fixes for guarantee and other elements */
     
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        border: none !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        border: none !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        border: none !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
 
     @media (max-width:768px){
       /* Fix 7-day money back guarantee - be very specific */
@@ -2629,34 +2490,6 @@
 
     /* Mobile lightbox optimizations */
     
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        border: none !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        border: none !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        border: none !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
 
     @media (max-width:768px){
       .lightbox-overlay{padding:1rem;backdrop-filter:blur(10px)}
@@ -2886,34 +2719,6 @@
 
     /* Make theme and language buttons smaller on mobile */
     
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        border: none !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        border: none !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        border: none !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
 
     @media (max-width:768px){
       #themeToggle{
@@ -3663,34 +3468,6 @@
 
     /* Carousel caption mobile styles */
     
-      /* FIX: FAQ section - prevent overflow */
-      #faq,
-      #faq * {
-        overflow-x: hidden !important;
-        max-width: 100% !important;
-        border: none !important;
-        box-sizing: border-box !important;
-      }
-
-      #faq > div,
-      #faq > div > div {
-        overflow-x: hidden !important;
-        max-width: 100vw !important;
-      }
-
-      /* Ensure FAQ cards don't overflow */
-      #faq .card {
-        max-width: 100% !important;
-        border: none !important;
-        overflow: visible !important;
-      }
-
-      #faq .card > * {
-        max-width: 100% !important;
-        border: none !important;
-        word-wrap: break-word !important;
-        overflow-wrap: break-word !important;
-      }
 
     @media (max-width:768px){
       /* Reduce caption text size on tablets and mobile */


### PR DESCRIPTION
Removed multiple duplicate CSS blocks that were outside media queries and forcing max-width: 100% !important on FAQ elements on all screen sizes. These were overriding the inline max-width constraints on desktop.