### PR TITLE
Fix mobile menu animation order using nth-of-type selectors

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -3098,20 +3098,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/de/index.html
+++ b/de/index.html
@@ -3041,20 +3041,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/es/index.html
+++ b/es/index.html
@@ -3286,20 +3286,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/fr/index.html
+++ b/fr/index.html
@@ -3140,20 +3140,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/hu/index.html
+++ b/hu/index.html
@@ -3109,20 +3109,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/index.html
+++ b/index.html
@@ -2204,20 +2204,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/it/index.html
+++ b/it/index.html
@@ -3028,20 +3028,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/ja/index.html
+++ b/ja/index.html
@@ -3371,20 +3371,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/nl/index.html
+++ b/nl/index.html
@@ -3084,20 +3084,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/pt/index.html
+++ b/pt/index.html
@@ -3213,20 +3213,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/ru/index.html
+++ b/ru/index.html
@@ -3014,20 +3014,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}

--- a/tr/index.html
+++ b/tr/index.html
@@ -3107,20 +3107,16 @@
       .mobile-nav.active .mobile-nav-links a {
         animation: mobileSlideUp 0.7s ease-out forwards;
       }
-      .mobile-nav.active .mobile-nav-links a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-links a:nth-child(5){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(1){animation-delay:0.12s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(2){animation-delay:0.24s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(3){animation-delay:0.36s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-child(4){animation-delay:0.48s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(1){animation-delay:0.6s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(2){animation-delay:0.72s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(3){animation-delay:0.84s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-child(4){animation-delay:0.96s}
-      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-links > a:nth-of-type(1){animation-delay:0.12s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(1){animation-delay:0.24s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(2){animation-delay:0.36s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(3){animation-delay:0.48s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(1) a:nth-of-type(4){animation-delay:0.6s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(1){animation-delay:0.72s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(2){animation-delay:0.84s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(3){animation-delay:0.96s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(2) a:nth-of-type(4){animation-delay:1.08s}
+      .mobile-nav.active .mobile-nav-section:nth-of-type(3) a{animation-delay:1.2s}
       @keyframes mobileSlideUp{
         from{opacity:0;transform:translateY(15px)}
         to{opacity:1;transform:translateY(0)}


### PR DESCRIPTION
Changed CSS selectors from a:nth-child(n) to a:nth-of-type(n) to properly target anchor elements inside mobile-nav-section divs. The previous selectors failed because the first child of each section is a label div, not an anchor element, causing animations to play in the wrong order.