### PR TITLE
Fix mobile text sizes and UI issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -2512,7 +2512,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}
@@ -4591,7 +4591,7 @@
 
           <h2 class="headline lg" style="text-align:center;margin-bottom:1rem"><span class="shimmer-text">Why Traders Switch</span></h2>
 
-          <p style="text-align:center;color:var(--muted);font-size:1.05rem;margin-bottom:3rem">
+          <p style="text-align:center;color:var(--muted);font-size:clamp(1rem, 4vw, 1.15rem);margin-bottom:3rem">
             Two approaches. One puts you in control.
           </p>
 
@@ -4982,22 +4982,36 @@
         .trustpilot-widget-inner {
           flex-wrap: wrap;
           justify-content: center;
-          gap: 0.75rem;
+          gap: 1rem;
           padding: 1rem 1.25rem;
           text-align: center;
         }
 
+        .trustpilot-logo {
+          width: 100%;
+          justify-content: center;
+        }
+
         .trustpilot-logo svg {
-          width: 80px;
+          width: 22px;
+          height: 22px;
+        }
+
+        .trustpilot-text {
+          font-size: 1rem;
         }
 
         .trustpilot-rating {
           align-items: center;
         }
 
+        .trustpilot-score {
+          font-size: 1.3rem;
+        }
+
         .trustpilot-cta {
           width: 100%;
-          padding-top: 0.5rem;
+          padding-top: 0.75rem;
           border-top: 1px solid rgba(255,255,255,0.06);
         }
       }
@@ -5006,11 +5020,20 @@
         .trustpilot-widget-inner {
           flex-direction: column;
           gap: 0.75rem;
+          padding: 0.85rem 1rem;
         }
 
         .trustpilot-stars svg {
-          width: 18px;
-          height: 18px;
+          width: 16px;
+          height: 16px;
+        }
+
+        .trustpilot-score {
+          font-size: 1.2rem;
+        }
+
+        .trustpilot-count {
+          font-size: 0.75rem;
         }
       }
     </style>
@@ -5031,7 +5054,7 @@
           <span class="badge" style="margin-bottom:1rem">INTERACTIVE DEMO</span>
           <h2 class="headline lg"><span class="shimmer-text">The Difference</span></h2>
           <p style="color:var(--muted);font-size:1.1rem;line-height:1.6;margin-top:1rem">
-            <strong style="color:var(--brand)">👆 Drag the slider</strong> to compare trading with and without <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>. Same chart. Same timeframe. Completely different clarity.
+            <strong style="color:var(--brand)">👇 Drag the slider</strong> to compare trading with and without <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-weight:400">Signal Pilot</span>. Same chart. Same timeframe. Completely different clarity.
           </p>
         </div>
 
@@ -5485,7 +5508,7 @@
         <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
           <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">The SignalPilot Chronicle</p>
           <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">The Stories Behind The Seven</span></h2>
-          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:1.15rem;color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">
+          <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:clamp(1.1rem, 4vw, 1.25rem);color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">
             "Before the markets had names, before the candles told stories, there was only noise. Then came The Seven."
           </p>
         </div>


### PR DESCRIPTION
- Increase .headline.lg size on mobile (1.6rem -> 1.9rem)
- Fix slider emoji direction (👆 -> 👇) since slider is below text
- Fix TrustPilot widget mobile layout (proper sizing, centered logo)
- Add responsive font sizes for subtitle text and chronicle quote