### PR TITLE
Remove language flag button completely from FAQ pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -187,10 +187,6 @@
       max-height: 64px;
     }
 
-    header .container > .lang-dropdown {
-      flex-shrink: 0;
-    }
-
     .brand {
       display: flex;
       align-items: center;
@@ -380,55 +376,6 @@
     html[data-theme="light"] .nav-dropdown-menu {
       background: rgba(255, 255, 255, 0.98);
       border-color: rgba(0, 0, 0, 0.1);
-    }
-
-    .lang-dropdown {
-      position: relative;
-      flex-shrink: 0;
-    }
-
-    .lang-dropdown-menu {
-      position: fixed;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.75rem;
-      min-width: 160px;
-      max-height: 400px;
-      overflow-y: auto;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-10px);
-      transition: all 0.2s;
-      z-index: 9999;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
-
-    .lang-dropdown-menu.show {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
-
-    .lang-dropdown-menu button {
-      display: block;
-      width: 100%;
-      padding: 0.6rem 0.8rem;
-      border: none;
-      background: transparent;
-      border-radius: 6px;
-      color: var(--muted);
-      text-align: left;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-size: 0.9rem;
-      font-family: 'Space Grotesk', system-ui, sans-serif;
-      font-weight: 500;
-    }
-
-    .lang-dropdown-menu button:hover {
-      background: rgba(91, 138, 255, 0.15);
-      color: var(--text);
     }
 
     .btn {
@@ -996,8 +943,7 @@
     nav ul li:nth-child(3) { animation: fadeInUp 0.4s ease 0.3s forwards; opacity: 0; }
     nav ul li:nth-child(4) { animation: fadeInUp 0.4s ease 0.4s forwards; opacity: 0; }
     nav ul li:nth-child(5) { animation: fadeInUp 0.4s ease 0.45s forwards; opacity: 0; }
-    .lang-dropdown { animation: fadeInUp 0.4s ease 0.5s forwards; opacity: 0; }
-    #themeToggle { animation: fadeInUp 0.4s ease 0.55s forwards; opacity: 0; }
+    #themeToggle { animation: fadeInUp 0.4s ease 0.5s forwards; opacity: 0; }
 
     /* Theme toggle spin animation */
     @keyframes spinToggle {
@@ -1149,12 +1095,6 @@
       <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Open menu" aria-expanded="false">
         <span>&#9776;</span>
       </button>
-
-      <div class="lang-dropdown">
-        <button id="langToggle" class="btn" type="button" aria-label="Language selection" aria-expanded="false" aria-haspopup="true">
-          <img src="https://flagcdn.com/w20/us.png" width="20" height="15" alt="English" style="vertical-align:middle;border-radius:2px">
-        </button>
-      </div>
     </div>
   </header>
 
@@ -1782,62 +1722,6 @@
           if (menu) menu.classList.remove('show');
           if (toggle) toggle.setAttribute('aria-expanded', 'false');
           dropdownOpen = false;
-        }
-      });
-    })();
-
-    // Language Dropdown with flags - navigates to translated FAQ pages
-    (function() {
-      const langBtn = document.getElementById('langToggle');
-      if (!langBtn) return;
-
-      const langMenu = document.createElement('div');
-      langMenu.className = 'lang-dropdown-menu';
-
-      // Languages with actual translated FAQ pages
-      const languages = [
-        { code: 'en', name: 'English', flag: 'us', url: '/faq.html' },
-        { code: 'ar', name: 'العربية', flag: 'sa', url: '/ar/faq.html' },
-        { code: 'de', name: 'Deutsch', flag: 'de', url: '/de/faq.html' },
-        { code: 'es', name: 'Español', flag: 'es', url: '/es/faq.html' },
-        { code: 'fr', name: 'Français', flag: 'fr', url: '/fr/faq.html' },
-        { code: 'hu', name: 'Magyar', flag: 'hu', url: '/hu/faq.html' },
-        { code: 'it', name: 'Italiano', flag: 'it', url: '/it/faq.html' },
-        { code: 'ja', name: '日本語', flag: 'jp', url: '/ja/faq.html' },
-        { code: 'nl', name: 'Nederlands', flag: 'nl', url: '/nl/faq.html' },
-        { code: 'pt', name: 'Português', flag: 'br', url: '/pt/faq.html' },
-        { code: 'tr', name: 'Türkçe', flag: 'tr', url: '/tr/faq.html' }
-      ];
-
-      languages.forEach(lang => {
-        const btn = document.createElement('button');
-        btn.innerHTML = '<img src="https://flagcdn.com/w20/' + lang.flag + '.png" width="20" height="15" alt="" style="vertical-align:middle;border-radius:2px;margin-right:8px">' + lang.name;
-        btn.onclick = () => { window.location.href = lang.url; };
-        langMenu.appendChild(btn);
-      });
-
-      document.body.appendChild(langMenu);
-
-      let menuOpen = false;
-
-      langBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        menuOpen = !menuOpen;
-        langMenu.classList.toggle('show', menuOpen);
-        langBtn.setAttribute('aria-expanded', menuOpen);
-
-        if (menuOpen) {
-          const rect = langBtn.getBoundingClientRect();
-          langMenu.style.top = (rect.bottom + 8) + 'px';
-          langMenu.style.left = (rect.left - langMenu.offsetWidth + rect.width) + 'px';
-        }
-      });
-
-      document.addEventListener('click', function(e) {
-        if (menuOpen && !langBtn.contains(e.target) && !langMenu.contains(e.target)) {
-          menuOpen = false;
-          langMenu.classList.remove('show');
-          langBtn.setAttribute('aria-expanded', 'false');
         }
       });
     })();


### PR DESCRIPTION
Removed all lang-dropdown HTML, CSS, and JavaScript since each language has its own dedicated translated FAQ page.