### PR TITLE
Fix broken CSS selectors in nl and de FAQ pages

### DIFF
--- a/de/faq.html
+++ b/de/faq.html
@@ -187,10 +187,6 @@
       max-height: 64px;
     }
 
-    header .container > 
-
-    header .container > 
-
     .brand {
       display: flex;
       align-items: center;

--- a/nl/faq.html
+++ b/nl/faq.html
@@ -187,10 +187,6 @@
       max-height: 64px;
     }
 
-    header .container > 
-
-    header .container > 
-
     .brand {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Remove incomplete 'header .container >' selectors that were causing CSS parsing errors.