### PR TITLE
Remove redundant Quick Jump Links from language FAQ pages

### DIFF
--- a/ar/faq.html
+++ b/ar/faq.html
@@ -658,40 +658,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -730,15 +696,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -926,17 +883,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="ابحث في الأسئلة الشائعة..." aria-label="البحث في الأسئلة الشائعة">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> البدء</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> المؤشرات</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> تقني</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> التداول</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> التعليم</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> التسعير</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> الدعم</a>
       </div>
 
       <!-- Category Navigation -->

--- a/de/faq.html
+++ b/de/faq.html
@@ -662,40 +662,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -734,15 +700,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -932,17 +889,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="FAQs durchsuchen..." aria-label="FAQs durchsuchen">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Erste Schritte</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Indikatoren</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Technisch</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Handel</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Bildung</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> Preise</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Support</a>
       </div>
 
       <!-- Category Navigation -->

--- a/es/faq.html
+++ b/es/faq.html
@@ -656,40 +656,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -728,15 +694,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -924,17 +881,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="Buscar preguntas frecuentes..." aria-label="Buscar preguntas frecuentes">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Primeros pasos</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Indicadores</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Técnico</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Trading</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Educación</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> Precios</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Soporte</a>
       </div>
 
       <!-- Category Navigation -->

--- a/fr/faq.html
+++ b/fr/faq.html
@@ -670,40 +670,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -742,15 +708,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -943,17 +900,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="Rechercher dans les questions..." aria-label="Rechercher dans les questions">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Premiers Pas</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Indicateurs</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Technique</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Trading</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Formation</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> Tarifs</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Support</a>
       </div>
 
       <!-- Category Navigation -->

--- a/hu/faq.html
+++ b/hu/faq.html
@@ -656,40 +656,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -728,15 +694,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -924,17 +881,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="Keresés a GYIK-ben..." aria-label="Keresés a GYIK-ben">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Kezdés</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Indikátorok</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Technikai</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Kereskedés</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Oktatás</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> Árazás</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Támogatás</a>
       </div>
 
       <!-- Category Navigation -->

--- a/it/faq.html
+++ b/it/faq.html
@@ -656,40 +656,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -728,15 +694,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -924,17 +881,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="Cerca nelle FAQ..." aria-label="Cerca nelle FAQ">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Iniziare</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Indicatori</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Tecnico</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Trading</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Formazione</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> Prezzi</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Supporto</a>
       </div>
 
       <!-- Category Navigation -->

--- a/ja/faq.html
+++ b/ja/faq.html
@@ -679,40 +679,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -751,15 +717,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -947,17 +904,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="FAQを検索..." aria-label="FAQを検索">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> はじめに</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> インジケーター</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> 技術</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> トレーディング</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> 教育</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> 価格設定</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> サポート</a>
       </div>
 
       <!-- Category Navigation -->

--- a/nl/faq.html
+++ b/nl/faq.html
@@ -662,40 +662,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -734,15 +700,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -932,17 +889,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="Zoek in FAQ's..." aria-label="Zoek in FAQ's">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Aan de slag</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Indicatoren</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Technisch</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Handelen</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Onderwijs</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> Prijzen</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Ondersteuning</a>
       </div>
 
       <!-- Category Navigation -->

--- a/pt/faq.html
+++ b/pt/faq.html
@@ -656,40 +656,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -728,15 +694,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -924,17 +881,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="Buscar perguntas..." aria-label="Buscar perguntas">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Primeiros Passos</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Indicadores</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Técnico</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Trading</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Educação</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> Preços</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Suporte</a>
       </div>
 
       <!-- Category Navigation -->

--- a/tr/faq.html
+++ b/tr/faq.html
@@ -667,40 +667,6 @@
       text-decoration: underline;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       nav ul {
@@ -739,15 +705,6 @@
       .category-nav button {
         padding: 0.5rem 1rem;
         font-size: 0.85rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -829,17 +786,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="SSS'lerde ara..." aria-label="SSS'lerde ara">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Başlarken</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Göstergeler</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Teknik</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Trading</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Eğitim</a>
-        <a href="#pricing"><span class="section-jump-icon">💎</span> Fiyatlandırma</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Destek</a>
       </div>
 
       <!-- Category Navigation -->


### PR DESCRIPTION
The section-jump links duplicated the category-nav buttons and didn't work properly without id attributes on the target sections. Removed both the HTML and CSS for section-jump from all 10 language FAQ files.