### PR TITLE
Sync all FAQ pages with full English structure

### DIFF
--- a/ar/faq.html
+++ b/ar/faq.html
@@ -473,6 +473,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -689,8 +713,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -885,7 +915,12 @@
         <input type="text" id="faqSearch" placeholder="ابحث في الأسئلة الشائعة..." aria-label="البحث في الأسئلة الشائعة">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">الكل</button>
         <button class="category-btn" data-category="getting-started">البدء</button>
@@ -897,19 +932,19 @@
         <button class="category-btn" data-category="support">الدعم</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon">🚀</span>
           البدء
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -965,12 +1000,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon">📊</span>
           المؤشرات السبعة النخبوية
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1064,12 +1099,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           المنصة والتقنية
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1145,12 +1180,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           التداول والاستراتيجية
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1206,12 +1241,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon">🎓</span>
           التعليم والتعلم
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1257,12 +1292,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           التسعير والخطط
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1328,12 +1363,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           الدعم والحساب
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/de/faq.html
+++ b/de/faq.html
@@ -477,6 +477,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -693,8 +717,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -891,7 +921,12 @@
         <input type="text" id="faqSearch" placeholder="FAQs durchsuchen..." aria-label="FAQs durchsuchen">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Alle</button>
         <button class="category-btn" data-category="getting-started">Erste Schritte</button>
@@ -903,19 +938,19 @@
         <button class="category-btn" data-category="support">Unterstützung</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Erste Schritte
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -971,12 +1006,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Die Elite Seven Indikatoren
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1070,12 +1105,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           Plattform & Technisch
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1151,12 +1186,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           Handel & Strategie
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1212,12 +1247,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Bildung & Lernen
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1263,12 +1298,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           Preise & Pläne
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1334,12 +1369,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           Support & Konto
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/es/faq.html
+++ b/es/faq.html
@@ -471,6 +471,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -687,8 +711,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -883,7 +913,12 @@
         <input type="text" id="faqSearch" placeholder="Buscar preguntas frecuentes..." aria-label="Buscar preguntas frecuentes">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Todas</button>
         <button class="category-btn" data-category="getting-started">Primeros pasos</button>
@@ -895,19 +930,19 @@
         <button class="category-btn" data-category="support">Soporte</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Primeros pasos
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -963,12 +998,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Los Siete Indicadores Élite
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1062,12 +1097,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           Plataforma y aspectos técnicos
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1143,12 +1178,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           Trading y estrategia
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1204,12 +1239,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Educación y aprendizaje
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1255,12 +1290,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           Precios y planes
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1326,12 +1361,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           Soporte y cuenta
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/faq.html
+++ b/faq.html
@@ -824,40 +824,6 @@
       margin-bottom: 0;
     }
 
-    /* Section Jump Links */
-    .section-jump {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-top: 1.5rem;
-    }
-
-    .section-jump a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.4rem 0.8rem;
-      background: var(--bg-soft);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.8rem;
-      font-weight: 500;
-      transition: all 0.2s;
-    }
-
-    .section-jump a:hover {
-      background: var(--bg-elev);
-      color: var(--text);
-      border-color: var(--brand);
-    }
-
-    .section-jump-icon {
-      font-size: 0.9rem;
-    }
-
     /* Responsive */
     @media (max-width: 768px) {
       .mobile-menu-toggle {
@@ -911,15 +877,6 @@
       .category-nav button {
         padding: 0.5rem 0.8rem;
         font-size: 0.8rem;
-      }
-
-      .section-jump {
-        gap: 0.4rem;
-      }
-
-      .section-jump a {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.75rem;
       }
 
       .faq-item {
@@ -1148,17 +1105,6 @@
       <div class="search-box">
         <span class="search-icon">🔍</span>
         <input type="text" id="faqSearch" placeholder="Search FAQs..." aria-label="Search FAQs">
-      </div>
-
-      <!-- Quick Jump Links -->
-      <div class="section-jump">
-        <a href="#getting-started"><span class="section-jump-icon">🚀</span> Getting Started</a>
-        <a href="#indicators"><span class="section-jump-icon">📊</span> Indicators</a>
-        <a href="#technical"><span class="section-jump-icon">💻</span> Technical</a>
-        <a href="#trading"><span class="section-jump-icon">📈</span> Trading</a>
-        <a href="#education"><span class="section-jump-icon">📚</span> Education</a>
-        <a href="#pricing-section"><span class="section-jump-icon">💎</span> Pricing</a>
-        <a href="#support"><span class="section-jump-icon">🛟</span> Support</a>
       </div>
     </div>
   </section>

--- a/fr/faq.html
+++ b/fr/faq.html
@@ -485,6 +485,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -701,8 +725,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -902,7 +932,12 @@
         <input type="text" id="faqSearch" placeholder="Rechercher dans les questions..." aria-label="Rechercher dans les questions">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Toutes</button>
         <button class="category-btn" data-category="getting-started">Premiers Pas</button>
@@ -914,19 +949,19 @@
         <button class="category-btn" data-category="support">Support</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon">🚀</span>
           Premiers Pas
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -982,12 +1017,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon">⭐</span>
           Les Sept d'Élite
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1081,12 +1116,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           Plateforme et Technique
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1162,12 +1197,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           Trading et Stratégie
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1223,12 +1258,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon">🎓</span>
           Formation et Apprentissage
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1274,12 +1309,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           Tarifs et Formules
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1345,12 +1380,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           Support et Compte
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/hu/faq.html
+++ b/hu/faq.html
@@ -471,6 +471,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -687,8 +711,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -883,7 +913,12 @@
         <input type="text" id="faqSearch" placeholder="Keresés a GYIK-ben..." aria-label="Keresés a GYIK-ben">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Összes</button>
         <button class="category-btn" data-category="getting-started">Kezdés</button>
@@ -895,19 +930,19 @@
         <button class="category-btn" data-category="support">Támogatás</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Kezdés
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -963,12 +998,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Az Elit Seven Indikátorok
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1062,12 +1097,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           Platform & Technikai
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1143,12 +1178,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           Kereskedés & Stratégia
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1204,12 +1239,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Oktatás & Tanulás
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1255,12 +1290,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           Árazás & Csomagok
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1326,12 +1361,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           Támogatás & Fiók
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/it/faq.html
+++ b/it/faq.html
@@ -471,6 +471,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -687,8 +711,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -883,7 +913,12 @@
         <input type="text" id="faqSearch" placeholder="Cerca nelle FAQ..." aria-label="Cerca nelle FAQ">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Tutti</button>
         <button class="category-btn" data-category="getting-started">Iniziare</button>
@@ -895,19 +930,19 @@
         <button class="category-btn" data-category="support">Supporto</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Iniziare
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -963,12 +998,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon"></span>
           I Sette d'Élite Indicatori
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1062,12 +1097,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           Piattaforma e Tecnico
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1143,12 +1178,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           Trading e Strategia
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1204,12 +1239,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Formazione e Apprendimento
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1255,12 +1290,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           Prezzi e Piani
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1326,12 +1361,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           Supporto e Account
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/ja/faq.html
+++ b/ja/faq.html
@@ -494,6 +494,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -710,8 +734,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -906,7 +936,12 @@
         <input type="text" id="faqSearch" placeholder="FAQを検索..." aria-label="FAQを検索">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">すべて</button>
         <button class="category-btn" data-category="getting-started">はじめに</button>
@@ -918,19 +953,19 @@
         <button class="category-btn" data-category="support">サポート</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon">🚀</span>
           はじめに
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -986,12 +1021,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon">⭐</span>
           エリートセブン
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1085,12 +1120,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           プラットフォームと技術
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1166,12 +1201,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           トレーディングと戦略
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1227,12 +1262,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon">🎓</span>
           教育と学習
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1278,12 +1313,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           価格設定とプラン
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1349,12 +1384,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           サポートとアカウント
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/nl/faq.html
+++ b/nl/faq.html
@@ -477,6 +477,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -693,8 +717,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -891,7 +921,12 @@
         <input type="text" id="faqSearch" placeholder="Zoek in FAQ's..." aria-label="Zoek in FAQ's">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Alle</button>
         <button class="category-btn" data-category="getting-started">Aan de slag</button>
@@ -903,19 +938,19 @@
         <button class="category-btn" data-category="support">Ondersteuning</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Aan de slag
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -971,12 +1006,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon"></span>
           De Elite Seven Indicatoren
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1070,12 +1105,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           Platform & Technisch
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1151,12 +1186,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           Handelen & Strategie
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1212,12 +1247,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Onderwijs & Leren
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1263,12 +1298,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           Prijzen & Plannen
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1334,12 +1369,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           Ondersteuning & Account
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/pt/faq.html
+++ b/pt/faq.html
@@ -471,6 +471,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -687,8 +711,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -883,7 +913,12 @@
         <input type="text" id="faqSearch" placeholder="Buscar perguntas..." aria-label="Buscar perguntas">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Todas</button>
         <button class="category-btn" data-category="getting-started">Primeiros Passos</button>
@@ -895,19 +930,19 @@
         <button class="category-btn" data-category="support">Suporte</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Primeiros Passos
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -963,12 +998,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Os Sete de Elite
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -1062,12 +1097,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           Plataforma e Técnico
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1143,12 +1178,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           Trading e Estratégia
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1204,12 +1239,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon"></span>
           Educação e Aprendizado
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1255,12 +1290,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           Preços e Planos
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1326,12 +1361,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           Suporte e Conta
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">

--- a/tr/faq.html
+++ b/tr/faq.html
@@ -482,6 +482,30 @@
       font-size: 1.2rem;
     }
 
+    /* Sticky Category Nav */
+    .category-nav-wrapper {
+      position: sticky;
+      top: 64px;
+      z-index: 50;
+      background: var(--bg);
+      padding: 1rem 0;
+      margin: -1rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(14px);
+    }
+
+    html[data-theme="light"] .category-nav-wrapper {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    html[data-theme="dark"] .category-nav-wrapper {
+      background: rgba(5, 7, 13, 0.95);
+    }
+
+    .category-nav-wrapper .category-nav {
+      margin-bottom: 0;
+    }
+
     /* Category Navigation */
     .category-nav {
       display: flex;
@@ -698,8 +722,14 @@
         font-size: 1rem;
       }
 
+      .category-nav-wrapper {
+        top: 64px;
+        padding: 0.75rem 0;
+      }
+
       .category-nav {
         gap: 0.5rem;
+        padding: 0 0.5rem;
       }
 
       .category-nav button {
@@ -788,7 +818,12 @@
         <input type="text" id="faqSearch" placeholder="SSS'lerde ara..." aria-label="SSS'lerde ara">
       </div>
 
-      <!-- Category Navigation -->
+    </div>
+  </section>
+
+  <!-- Sticky Category Navigation -->
+  <div class="category-nav-wrapper">
+    <div class="container">
       <div class="category-nav">
         <button class="category-btn active" data-category="all">Tümü</button>
         <button class="category-btn" data-category="getting-started">Başlarken</button>
@@ -800,19 +835,19 @@
         <button class="category-btn" data-category="support">Destek</button>
       </div>
     </div>
-  </section>
+  </div>
 
   <!-- FAQ Content -->
   <section class="faq-content">
     <div class="container">
 
       <!-- Getting Started -->
-      <div class="faq-category" data-category="getting-started">
+      <div class="faq-category" id="getting-started" data-category="getting-started">
         <h2 class="category-title">
           <span class="category-icon">🚀</span>
           Başlarken
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="getting-started">
             <div class="faq-question">
@@ -868,12 +903,12 @@
       </div>
 
       <!-- The Elite Seven Indicators -->
-      <div class="faq-category" data-category="indicators">
+      <div class="faq-category" id="indicators" data-category="indicators">
         <h2 class="category-title">
           <span class="category-icon">📊</span>
           Elit Yedi Gösterge
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="indicators">
             <div class="faq-question">
@@ -967,12 +1002,12 @@
       </div>
 
       <!-- Platform & Technical -->
-      <div class="faq-category" data-category="technical">
+      <div class="faq-category" id="technical" data-category="technical">
         <h2 class="category-title">
           <span class="category-icon">💻</span>
           Platform & Teknik
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="technical">
             <div class="faq-question">
@@ -1048,12 +1083,12 @@
       </div>
 
       <!-- Trading & Strategy -->
-      <div class="faq-category" data-category="trading">
+      <div class="faq-category" id="trading" data-category="trading">
         <h2 class="category-title">
           <span class="category-icon">📈</span>
           Trading & Strateji
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="trading">
             <div class="faq-question">
@@ -1109,12 +1144,12 @@
       </div>
 
       <!-- Education & Learning -->
-      <div class="faq-category" data-category="education">
+      <div class="faq-category" id="education" data-category="education">
         <h2 class="category-title">
           <span class="category-icon">🎓</span>
           Eğitim & Öğrenme
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="education">
             <div class="faq-question">
@@ -1160,12 +1195,12 @@
       </div>
 
       <!-- Pricing & Plans -->
-      <div class="faq-category" data-category="pricing">
+      <div class="faq-category" id="pricing-section" data-category="pricing">
         <h2 class="category-title">
           <span class="category-icon">💎</span>
           Fiyatlandırma & Planlar
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="pricing">
             <div class="faq-question">
@@ -1231,12 +1266,12 @@
       </div>
 
       <!-- Support & Account -->
-      <div class="faq-category" data-category="support">
+      <div class="faq-category" id="support" data-category="support">
         <h2 class="category-title">
           <span class="category-icon">🛟</span>
           Destek & Hesap
         </h2>
-        <div class="faq-grid">
+        <div class="faq-grid" data-reveal-stagger>
 
           <div class="faq-item" data-category="support">
             <div class="faq-question">


### PR DESCRIPTION
- Remove duplicate section-jump links from English faq.html
- Add sticky category-nav-wrapper to all 10 language FAQs
- Add id attributes to faq-category divs for anchor links
- Add data-reveal-stagger to faq-grid for scroll animations
- Add category-nav-wrapper CSS (sticky, backdrop-filter, responsive)

All language FAQ pages now match English structure exactly.