### PR TITLE
Audit all pages and links

### DIFF
--- a/404.html
+++ b/404.html
@@ -41,7 +41,7 @@
         <a class="btn" href="/">Homepage</a>
         <a class="ghost" href="/#product">Product</a>
         <a class="ghost" href="/#docs">Docs</a>
-        <a class="ghost" href="/resources/">Resources</a>
+        <a class="ghost" href="/tools/">Tools</a>
       </div>
     </div>
   </main>

--- a/ru/chronicle/birth-of-the-elite-seven/index.html
+++ b/ru/chronicle/birth-of-the-elite-seven/index.html
@@ -131,11 +131,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -162,11 +162,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/index.html
+++ b/ru/chronicle/index.html
@@ -799,11 +799,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -829,11 +829,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </nav>
 

--- a/ru/chronicle/meet-the-sovereign/index.html
+++ b/ru/chronicle/meet-the-sovereign/index.html
@@ -152,11 +152,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -183,11 +183,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-arbiter/index.html
+++ b/ru/chronicle/the-arbiter/index.html
@@ -144,11 +144,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -175,11 +175,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-cartographer/index.html
+++ b/ru/chronicle/the-cartographer/index.html
@@ -128,11 +128,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -159,11 +159,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-commander/index.html
+++ b/ru/chronicle/the-commander/index.html
@@ -128,11 +128,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -159,11 +159,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-council-assembles/index.html
+++ b/ru/chronicle/the-council-assembles/index.html
@@ -141,11 +141,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -172,11 +172,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-hierarchy-of-signals/index.html
+++ b/ru/chronicle/the-hierarchy-of-signals/index.html
@@ -141,11 +141,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -172,11 +172,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-pilots-oath/index.html
+++ b/ru/chronicle/the-pilots-oath/index.html
@@ -131,11 +131,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -162,11 +162,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-prophet/index.html
+++ b/ru/chronicle/the-prophet/index.html
@@ -135,11 +135,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -166,11 +166,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-scales/index.html
+++ b/ru/chronicle/the-scales/index.html
@@ -136,11 +136,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -167,11 +167,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/the-watchman/index.html
+++ b/ru/chronicle/the-watchman/index.html
@@ -143,11 +143,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -174,11 +174,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/ru/chronicle/why-non-repainting-matters/index.html
+++ b/ru/chronicle/why-non-repainting-matters/index.html
@@ -144,11 +144,11 @@
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
-              <li><a href="/ru/faq.html">Центр FAQ</a></li>
+              <li><a href="/faq.html">Центр FAQ</a></li>
             </ul>
           </li>
           <li><a href="/ru/#pricing">Цены</a></li>
-          <li><a href="/ru/affiliates.html">Партнёры</a></li>
+          <li><a href="/affiliates.html">Партнёры</a></li>
         </ul>
       </nav>
       <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -175,11 +175,11 @@
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
-          <li><a href="/ru/faq.html">Центр FAQ</a></li>
+          <li><a href="/faq.html">Центр FAQ</a></li>
         </ul>
       </li>
       <li><a href="/ru/#pricing">Цены</a></li>
-      <li><a href="/ru/affiliates.html">Партнёры</a></li>
+      <li><a href="/affiliates.html">Партнёры</a></li>
     </ul>
   </div>
 

--- a/tools/index.html
+++ b/tools/index.html
@@ -21,7 +21,7 @@
   <meta name="twitter:description" content="Position size, risk/reward, drawdown recovery, Kelly criterion & more. Free, no signup.">
   <meta name="twitter:image" content="https://signalpilot.io/assets/og-tools.png">
 
-  <link rel="icon" href="/assets/favicon.ico">
+  <link rel="icon" href="/favicon.ico">
 
   <!-- Space Grotesk Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/tools/quiz/index.html
+++ b/tools/quiz/index.html
@@ -21,7 +21,7 @@
   <meta name="twitter:description" content="Discover your ideal trading style in 2 minutes. Personalized recommendations included.">
   <meta name="twitter:image" content="https://signalpilot.io/assets/og-quiz.png">
 
-  <link rel="icon" href="/assets/favicon.ico">
+  <link rel="icon" href="/favicon.ico">
 
   <!-- Space Grotesk Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
- Update 404.html: Change broken /resources/ link to /tools/
- Fix all 13 Russian chronicle pages: Change /ru/faq.html and /ru/affiliates.html to /faq.html and /affiliates.html (since Russian versions don't exist)
- Fix tools/index.html and tools/quiz/index.html: Correct favicon path from /assets/favicon.ico to /favicon.ico