### PR TITLE
Fix mobile text sizes across all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -3401,7 +3401,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/de/index.html
+++ b/de/index.html
@@ -3346,7 +3346,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/es/index.html
+++ b/es/index.html
@@ -3589,7 +3589,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/fr/index.html
+++ b/fr/index.html
@@ -3490,7 +3490,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/hu/index.html
+++ b/hu/index.html
@@ -3414,7 +3414,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/index.html
+++ b/index.html
@@ -5507,7 +5507,7 @@
         <!-- Section Header -->
         <div data-reveal="fade-up" style="text-align:center;margin-bottom:3rem">
           <p style="font-size:0.85rem;font-weight:600;text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);margin-bottom:1rem;display:inline-block;padding:0.4rem 1rem;border:1px solid rgba(118,221,255,0.3);border-radius:999px;background:rgba(118,221,255,0.1)">The SignalPilot Chronicle</p>
-          <h2 class="headline lg" style="max-width:20ch;margin-left:auto;margin-right:auto"><span class="shimmer-text">The Stories Behind The Seven</span></h2>
+          <h2 class="headline lg" style="margin-left:auto;margin-right:auto"><span class="shimmer-text">The Stories Behind The Seven</span></h2>
           <p class="note" style="max-width:600px;margin:1rem auto 0;font-size:clamp(1.1rem, 4vw, 1.25rem);color:var(--muted);line-height:1.6;font-family:'EB Garamond',Georgia,serif;font-style:italic">
             "Before the markets had names, before the candles told stories, there was only noise. Then came The Seven."
           </p>

--- a/it/index.html
+++ b/it/index.html
@@ -3331,7 +3331,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/ja/index.html
+++ b/ja/index.html
@@ -3674,7 +3674,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/nl/index.html
+++ b/nl/index.html
@@ -3387,7 +3387,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/pt/index.html
+++ b/pt/index.html
@@ -3665,7 +3665,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/ru/index.html
+++ b/ru/index.html
@@ -3319,7 +3319,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}

--- a/tr/index.html
+++ b/tr/index.html
@@ -3410,7 +3410,7 @@
       .btn{padding:.7rem 1rem;font-size:.95rem;min-height:44px}
       .btn-sm{padding:.5rem .75rem;font-size:.88rem;min-height:40px}
       .headline.xl{font-size:1.95rem}
-      .headline.lg{font-size:1.6rem}
+      .headline.lg{font-size:1.9rem}
       .badge{font-size:.72rem;padding:.3rem .7rem}
       .mini-pill{font-size:.75rem;padding:.25rem .5rem}
       .price{font-size:1.8rem}


### PR DESCRIPTION
- Increase .headline.lg size from 1.6rem to 1.9rem on mobile (480px breakpoint)
- Remove max-width:20ch constraint on Chronicle section headline to prevent text cutoff
- Applied fixes to all 12 language versions (en, ar, de, es, fr, hu, it, ja, nl, pt, ru, tr)