### PR TITLE
Fix Windows display gap by replacing 100vw with 100% for container wi…

### DIFF
--- a/assets/deferred.css
+++ b/assets/deferred.css
@@ -213,12 +213,12 @@
       /* Mobile overflow fixes */
       .container{
         overflow-x:hidden;
-        max-width:100vw;
+        max-width:100%;
       }
 
       /* Ensure all sections respect mobile width */
       section{
-        max-width:100vw;
+        max-width:100%;
         overflow-x:hidden;
       }
 

--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@
         left: 50% !important;
         top: -80px !important;
         transform: translateX(-50%) scaleX(-1) !important;
-        width: 100vw !important;
+        width: 100% !important;
         height: calc(100% + 80px) !important;
         object-fit: cover !important;
         object-position: center 50% !important;
@@ -583,13 +583,13 @@
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
         border-bottom: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
       header .container.nav {
-        max-width: 100vw !important;
+        max-width: 100% !important;
         overflow-x: hidden !important;
         box-sizing: border-box !important;
       }
@@ -944,7 +944,7 @@
 
     @media (max-width:768px){
       /* Prevent horizontal overflow on mobile */
-      body,html{overflow-x:hidden !important;max-width:100vw}
+      body,html{overflow-x:hidden !important;max-width:100%}
 
       /* Product cards - optimize button layout for tablets */
       .card.product .btn-sm {
@@ -1086,13 +1086,13 @@
       /* Prevent any horizontal overflow at root level */
       html, body {
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
         width: 100% !important;
       }
 
       /* Ensure all major containers respect viewport */
       body, .section, .container, .stack {
-        max-width: 100vw !important;
+        max-width: 100% !important;
         width: 100% !important;
         overflow-x: hidden !important;
         box-sizing: border-box !important;
@@ -1890,12 +1890,12 @@
       .lang-dropdown-menu {
         right: 10px;
         min-width: 160px;
-        max-width: calc(100vw - 20px);
+        max-width: calc(100% - 20px);
       }
 
       /* Ensure header doesn't exceed viewport width and allows natural height */
       header {
-        max-width: 100vw;
+        max-width: 100%;
         height: auto !important;
         max-height: none !important;
         min-height: auto !important;


### PR DESCRIPTION
…dths

On Windows browsers, 100vw includes the scrollbar width (~15-17px), causing elements to extend beyond the visible viewport and create horizontal gaps.

Changed to 100% for:
- Header max-width constraints
- Body/html overflow constraints
- Section and container max-widths
- Language dropdown menu max-width