### PR TITLE
Fix nav link clipping by preventing flex shrink

### DIFF
--- a/index.html
+++ b/index.html
@@ -1694,7 +1694,7 @@
 
     .mobile-nav-header{display:none}
 
-    nav a{display:inline-flex;padding:.5rem .9rem;border-radius:999px;color:#b7c2d9;font-weight:600;font-family:'Space Grotesk',system-ui,sans-serif;text-decoration:none;font-size:1.05rem;white-space:nowrap;min-width:0;flex-shrink:1}
+    nav a{display:inline-flex;padding:.5rem .9rem;border-radius:999px;color:#b7c2d9;font-weight:600;font-family:'Space Grotesk',system-ui,sans-serif;text-decoration:none;font-size:1.05rem;white-space:nowrap;flex-shrink:0}
 
     nav a{position:relative;overflow:hidden}
     nav a::after{
@@ -1733,6 +1733,7 @@
       transition:all .2s ease;
       font-size:1.05rem;
       white-space:nowrap;
+      flex-shrink:0;
     }
 
     .nav-dropdown-toggle:hover,


### PR DESCRIPTION
Changed nav links and dropdown toggle to flex-shrink:0 so they maintain full width and don't get clipped on Windows/larger screens.