### PR TITLE
Replace nav-spacer with margin-left:auto for better layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1686,7 +1686,7 @@
 
 
 
-    .nav-spacer{flex:1;max-width:3rem}
+    /* nav-spacer removed - using margin-left:auto on lang-dropdown instead */
 
 
 
@@ -3091,9 +3091,7 @@
 
       </nav>
 
-      <div class="nav-spacer"></div>
-
-      <div class="lang-dropdown">
+      <div class="lang-dropdown" style="margin-left:auto">
         <button id="langToggle" class="btn btn-ghost btn-sm" type="button" aria-label="Language selection" style="font-size:.85rem;padding:.5rem .7rem;color:var(--text)">
           <img src="https://flagcdn.com/w20/us.png" width="20" height="15" alt="English" style="vertical-align:middle;border-radius:2px">
         </button>


### PR DESCRIPTION
Using margin-left:auto on the language dropdown pushes buttons to the right edge without creating awkward gaps in the middle of the nav.