### PR TITLE
Add portrait desktop fix for conduit video centering

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4164,6 +4164,15 @@ html[lang="ar"] [style*="text-align:center"] {
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/de/index.html
+++ b/de/index.html
@@ -4087,6 +4087,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/es/index.html
+++ b/es/index.html
@@ -4323,6 +4323,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/fr/index.html
+++ b/fr/index.html
@@ -4252,6 +4252,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/hu/index.html
+++ b/hu/index.html
@@ -4092,6 +4092,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/index.html
+++ b/index.html
@@ -722,7 +722,16 @@
       }
 
     }
-    
+
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* Removed reveal animations - not needed */
 
 

--- a/it/index.html
+++ b/it/index.html
@@ -4009,6 +4009,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/ja/index.html
+++ b/ja/index.html
@@ -4352,6 +4352,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/nl/index.html
+++ b/nl/index.html
@@ -4064,6 +4064,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/pt/index.html
+++ b/pt/index.html
@@ -4373,6 +4373,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/ru/index.html
+++ b/ru/index.html
@@ -3997,6 +3997,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;

--- a/tr/index.html
+++ b/tr/index.html
@@ -4088,6 +4088,15 @@
     }
 
 
+    /* Portrait desktop screens - center conduit video */
+    @media (min-width: 769px) and (max-aspect-ratio: 1/1) {
+      #energy-beam-video {
+        left: 50% !important;
+        transform: translateX(-50%) scaleX(-1) !important;
+        object-position: center 30% !important;
+      }
+    }
+
     /* FINAL OVERRIDE: Force energy-beam-video to blend correctly with starfield */
     #energy-beam-video {
       mix-blend-mode: screen !important;


### PR DESCRIPTION
- Targets screens wider than 768px with portrait aspect ratio
- Centers the conduit video so it's visible on vertical monitors
- Applied to all 12 language versions