### PR TITLE
Improve mobile layout for transformation grid

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4709,15 +4709,36 @@ html[lang="ar"] [style*="text-align:center"] {
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/de/index.html
+++ b/de/index.html
@@ -4632,15 +4632,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/es/index.html
+++ b/es/index.html
@@ -4868,15 +4868,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/fr/index.html
+++ b/fr/index.html
@@ -4800,15 +4800,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/hu/index.html
+++ b/hu/index.html
@@ -4637,15 +4637,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/index.html
+++ b/index.html
@@ -3525,15 +3525,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/it/index.html
+++ b/it/index.html
@@ -4554,15 +4554,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/ja/index.html
+++ b/ja/index.html
@@ -4899,15 +4899,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/nl/index.html
+++ b/nl/index.html
@@ -4609,15 +4609,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/pt/index.html
+++ b/pt/index.html
@@ -4921,15 +4921,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/ru/index.html
+++ b/ru/index.html
@@ -4544,15 +4544,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }

--- a/tr/index.html
+++ b/tr/index.html
@@ -4635,15 +4635,36 @@
     <!-- Mobile-friendly transformation grid -->
     <style>
       @media (max-width: 600px) {
+        /* Stack rows vertically with spacing */
         .transformation-grid > div {
           grid-template-columns: 1fr !important;
-          gap: 0.5rem !important;
+          gap: 0.25rem !important;
           text-align: center !important;
+          margin-bottom: 1.5rem !important;
         }
-        .transformation-grid > div > span {
+        /* Hide the header row */
+        .transformation-grid > div:first-child {
+          display: none !important;
+        }
+        /* Hide the horizontal arrow */
+        .transformation-grid > div > span:nth-child(2) {
+          display: none !important;
+        }
+        /* Style before text */
+        .transformation-grid > div > span:first-child {
           text-align: center !important;
+          font-size: 0.9rem !important;
         }
-        .transformation-grid > div > div {
+        /* Add down arrow after before text */
+        .transformation-grid > div > span:first-child::after {
+          content: '↓';
+          display: block;
+          color: var(--brand);
+          font-size: 1rem;
+          margin: 0.25rem 0;
+        }
+        /* Style after text */
+        .transformation-grid > div > span:last-child {
           text-align: center !important;
         }
       }


### PR DESCRIPTION
- Hide horizontal arrows on mobile
- Add vertical down arrows (↓) via CSS pseudo-element
- Hide Before/After header on mobile for cleaner look
- Add spacing between transformation rows