### PR TITLE
Fix Details button text being cut off on product cards

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2463,13 +2463,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3431,10 +3432,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/de/index.html
+++ b/de/index.html
@@ -2410,13 +2410,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3376,10 +3377,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/es/index.html
+++ b/es/index.html
@@ -2645,13 +2645,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3619,10 +3620,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/fr/index.html
+++ b/fr/index.html
@@ -2498,13 +2498,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3520,10 +3521,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* FIX: Slider control buttons - wrap and shrink on very small screens */

--- a/hu/index.html
+++ b/hu/index.html
@@ -2478,13 +2478,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3444,10 +3445,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/index.html
+++ b/index.html
@@ -1481,13 +1481,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -2518,10 +2519,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/it/index.html
+++ b/it/index.html
@@ -2404,13 +2404,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3361,10 +3362,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/ja/index.html
+++ b/ja/index.html
@@ -2678,13 +2678,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3705,10 +3706,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/nl/index.html
+++ b/nl/index.html
@@ -2461,13 +2461,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3417,10 +3418,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/pt/index.html
+++ b/pt/index.html
@@ -2529,13 +2529,14 @@
     /* Produto card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3695,10 +3696,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/ru/index.html
+++ b/ru/index.html
@@ -2391,13 +2391,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3349,10 +3350,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */

--- a/tr/index.html
+++ b/tr/index.html
@@ -2483,13 +2483,14 @@
     /* Product card button container - ensure equal height alignment */
     .card.product .toggle-details,
     .card.product .toggle-details + a.btn {
-      flex: 1;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       white-space: nowrap;
       min-height: 38px;
+      overflow: visible;
     }
 
     /* Form validation checkmarks */
@@ -3440,10 +3441,12 @@
         flex-wrap: wrap;
       }
 
-      /* Ensure toggle-details buttons are full width on very small screens for easier tapping */
+      /* Ensure toggle-details buttons are touch-friendly on very small screens */
       .toggle-details {
-        flex: 1;
-        min-width: 120px;
+        flex: 1 0 auto;
+        min-width: fit-content;
+        padding-left: 1rem;
+        padding-right: 1rem;
       }
 
       /* Adjust punch line min-height for mobile to accommodate text wrapping */


### PR DESCRIPTION
- Changed flex property from `flex: 1` to `flex: 0 0 auto` to prevent button shrinking
- Added `overflow: visible` to ensure text is never clipped
- Updated media query to use `flex: 1 0 auto` and `min-width: fit-content` for proper sizing on small screens
- Applied fix to all 12 language versions (en, ar, de, es, fr, hu, it, ja, nl, pt, ru, tr)