### PR TITLE
Add min-width to Details button for "Hide Details" text

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2473,6 +2473,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/de/index.html
+++ b/de/index.html
@@ -2420,6 +2420,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/es/index.html
+++ b/es/index.html
@@ -2655,6 +2655,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -2508,6 +2508,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -2488,6 +2488,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/index.html
+++ b/index.html
@@ -1491,6 +1491,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/it/index.html
+++ b/it/index.html
@@ -2414,6 +2414,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -2688,6 +2688,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -2471,6 +2471,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -2539,6 +2539,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -2401,6 +2401,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -2493,6 +2493,11 @@
       overflow: visible;
     }
 
+    /* Ensure toggle-details button fits "Hide Details" text in all languages */
+    .card.product .toggle-details {
+      min-width: 165px;
+    }
+
     /* Form validation checkmarks */
     .input-wrapper{position:relative}
 


### PR DESCRIPTION
The expanded button text "Hide Details ▲" (and translations like "Masquer les Détails ▲") is longer than "Details ▼" and was getting cut off. Added min-width: 165px to accommodate all languages.