### PR TITLE
Add 1950px nav breakpoint to all language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2907,6 +2907,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/de/index.html
+++ b/de/index.html
@@ -2846,6 +2846,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors - German text is longer */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/es/index.html
+++ b/es/index.html
@@ -3099,6 +3099,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/fr/index.html
+++ b/fr/index.html
@@ -2944,6 +2944,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/hu/index.html
+++ b/hu/index.html
@@ -2914,6 +2914,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/it/index.html
+++ b/it/index.html
@@ -2840,6 +2840,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/ja/index.html
+++ b/ja/index.html
@@ -3177,6 +3177,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/nl/index.html
+++ b/nl/index.html
@@ -2897,6 +2897,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/pt/index.html
+++ b/pt/index.html
@@ -3025,6 +3025,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/ru/index.html
+++ b/ru/index.html
@@ -2827,6 +2827,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Compact nav items on medium screens */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}

--- a/tr/index.html
+++ b/tr/index.html
@@ -2919,6 +2919,17 @@
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
 
+    /* Adjust for 1920px monitors */
+    @media (max-width:1950px){
+      nav a{padding:.5rem .75rem;font-size:.92rem}
+      .nav-dropdown-toggle{padding:.5rem .75rem;font-size:.92rem}
+      nav ul{gap:.6rem}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.85rem !important;
+      }
+    }
+
     /* Adjust for longer translations - start compacting nav items earlier */
     @media (max-width:1600px){
       nav a{padding:.5rem .75rem;font-size:.92rem}


### PR DESCRIPTION
Apply the same fix from English site to all 11 language sites to ensure nav fits properly on 1920x1080 monitors. Also compact the CTA button earlier since translated text is longer.