### PR TITLE
Add horizontal scroll carousel to all 11 language files

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5559,7 +5559,23 @@ html[lang="ar"] [style*="text-align:center"] {
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="التمرير يسارًا">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="التمرير يمينًا">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -5813,7 +5829,8 @@ html[lang="ar"] [style*="text-align:center"] {
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/de/index.html
+++ b/de/index.html
@@ -5482,7 +5482,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Nach links scrollen">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Nach rechts scrollen">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -5736,7 +5752,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/es/index.html
+++ b/es/index.html
@@ -5763,7 +5763,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Desplazar izquierda">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Desplazar derecha">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -6028,7 +6044,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -5650,7 +5650,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Défiler à gauche">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Défiler à droite">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -5904,7 +5920,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -5487,7 +5487,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Görgetés balra">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Görgetés jobbra">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -5741,7 +5757,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/it/index.html
+++ b/it/index.html
@@ -5404,7 +5404,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Scorri a sinistra">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Scorri a destra">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -5658,7 +5674,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -5749,7 +5749,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="左にスクロール">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="右にスクロール">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -6003,7 +6019,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -5459,7 +5459,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Scroll naar links">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Scroll naar rechts">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -5713,7 +5729,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -5771,7 +5771,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Rolar para a esquerda">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Rolar para a direita">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -6025,7 +6041,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -5394,7 +5394,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Прокрутить влево">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Прокрутить вправо">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -5648,7 +5664,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -5485,7 +5485,23 @@
 
         </div>
 
-        <div class="grid auto-300">
+        <!-- Horizontal Scroll Navigation -->
+        <div class="horizontal-scroll-nav">
+          <button class="scroll-arrow scroll-arrow-left" aria-label="Sola kaydır">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+          <div class="scroll-dots"></div>
+          <button class="scroll-arrow scroll-arrow-right" aria-label="Sağa kaydır">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
+
+        <div class="horizontal-scroll-container">
+          <div class="horizontal-scroll-track" id="elite-seven-track">
 
           <!-- INDICATOR 1: PENTARCH (FLAGSHIP) -->
           <article class="card product" style="position:relative;border:2px solid var(--brand);box-shadow:0 0 40px rgba(91,138,255,.15)">
@@ -5739,7 +5755,8 @@
             </div>
           </article>
 
-        </div>
+          </div><!-- .horizontal-scroll-track -->
+        </div><!-- .horizontal-scroll-container -->
 
       </div>
 


### PR DESCRIPTION
Replace grid layout with horizontal-scroll-container + horizontal-scroll-track structure for the Elite Seven products section, matching the English site. Includes localized aria-labels for scroll navigation buttons.