### PR TITLE
Fix broken navigation HTML structure

### DIFF
--- a/chronicle/the-scales/index.html
+++ b/chronicle/the-scales/index.html
@@ -38,6 +38,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
 
     /* Resources Dropdown */
     .nav-dropdown{position:relative;z-index:65}

--- a/chronicle/the-watchman/index.html
+++ b/chronicle/the-watchman/index.html
@@ -38,6 +38,9 @@
     .header-nav{display:flex;align-items:center;gap:1.5rem}
     .header-nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
     .header-nav a:hover{color:var(--text)}
+    nav ul{list-style:none;display:flex;align-items:center;gap:2rem}
+    nav a{font-family:'Space Grotesk',system-ui,sans-serif;color:var(--muted);text-decoration:none;font-size:0.95rem;font-weight:500;transition:color 0.2s}
+    nav a:hover{color:var(--text)}
 
     /* Resources Dropdown */
     .nav-dropdown{position:relative;z-index:65}


### PR DESCRIPTION
Add missing nav ul, nav a, and nav a:hover CSS rules to the-scales and the-watchman chronicle pages. Without these rules, the navigation displayed with default list bullet points instead of proper horizontal styling.