### PR TITLE
Add lightbox click-to-expand and mobile optimization for indicator sc…

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2550,9 +2550,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2575,6 +2575,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9350,10 +9359,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/de/index.html
+++ b/de/index.html
@@ -2497,9 +2497,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2522,6 +2522,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9275,10 +9284,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/es/index.html
+++ b/es/index.html
@@ -2732,9 +2732,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2757,6 +2757,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9568,10 +9577,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/fr/index.html
+++ b/fr/index.html
@@ -2585,9 +2585,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2610,6 +2610,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9449,10 +9458,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/hu/index.html
+++ b/hu/index.html
@@ -2565,9 +2565,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2590,6 +2590,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9272,10 +9281,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/index.html
+++ b/index.html
@@ -1560,9 +1560,9 @@
     .card img, .card video, #comparison-slider {overflow:hidden}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -1584,6 +1584,14 @@
       .lightbox-content{max-width:95vw;max-height:85vh}
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
+
+      /* Larger screenshot boxes on mobile */
+      .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
     }
 
     @keyframes lightboxZoomIn{
@@ -8223,11 +8231,12 @@ if ('serviceWorker' in navigator) {
     const lightboxImg = lightbox.querySelector('img');
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
-    // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    // Make all indicator screenshots clickable
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
-      // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      // Only if image has actual src and is visible
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/it/index.html
+++ b/it/index.html
@@ -2491,9 +2491,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2516,6 +2516,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9106,10 +9115,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/ja/index.html
+++ b/ja/index.html
@@ -2765,9 +2765,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2790,6 +2790,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9456,10 +9465,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/nl/index.html
+++ b/nl/index.html
@@ -2548,9 +2548,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2573,6 +2573,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9165,10 +9174,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/pt/index.html
+++ b/pt/index.html
@@ -2616,9 +2616,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2671,6 +2671,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9449,10 +9458,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/ru/index.html
+++ b/ru/index.html
@@ -2478,9 +2478,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2503,6 +2503,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9117,10 +9126,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';

--- a/tr/index.html
+++ b/tr/index.html
@@ -2570,9 +2570,9 @@
     html[data-theme="light"] .card:hover{border-color:rgba(91,138,255,0.3);box-shadow:0 20px 60px rgba(91,138,255,0.15);background:linear-gradient(180deg,rgba(10,20,40,.05),rgba(10,20,40,.02))}
 
     /* Indicator card clickable cursor */
-    .card.product img{cursor:pointer;transition:opacity 0.3s ease}
+    .card.product img.indicator-screenshot{cursor:pointer;transition:transform 0.3s ease, box-shadow 0.3s ease}
 
-    .card.product img:hover{opacity:0.8}
+    .card.product img.indicator-screenshot:hover{transform:scale(1.02);box-shadow:0 8px 32px rgba(91,138,255,0.4)}
 
     /* Lightbox modal */
     .lightbox-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);z-index:9999;display:flex;align-items:center;justify-content:center;padding:2rem;opacity:0;pointer-events:none;transition:opacity 0.3s ease}
@@ -2595,6 +2595,15 @@
 
       .lightbox-close{top:-15px;right:-15px;width:44px;height:44px;font-size:1.8rem}
     }
+
+    /* Larger screenshot boxes on mobile */
+    .card.product > div:first-child{max-width:100%!important;margin-bottom:1rem!important}
+    }
+
+    /* Tablet screenshot sizing */
+    @media (max-width:1024px) and (min-width:769px){
+      .card.product > div:first-child{max-width:320px!important}
+    
 
     @keyframes lightboxZoomIn{
       from{transform:scale(0.8);opacity:0}
@@ -9213,10 +9222,11 @@ if ('serviceWorker' in navigator) {
     const closeBtn = lightbox.querySelector('.lightbox-close');
 
     // Make all indicator images clickable
-    const indicatorImages = document.querySelectorAll('.card.product img');
+    const indicatorImages = document.querySelectorAll('.indicator-screenshot');
     indicatorImages.forEach(img => {
       // Only if image has actual src (not placeholder)
-      if (img.src && !img.src.includes('data:image')) {
+      if (img.src && !img.src.includes('data:image') && img.offsetParent !== null) {
+        img.style.cursor = 'pointer';
         img.addEventListener('click', () => {
           lightboxImg.src = img.src;
           lightboxImg.alt = img.alt || 'Indicator preview';


### PR DESCRIPTION
…reenshots

- Screenshots now clickable with hover effect (scale + glow)
- Lightbox opens full-size image on click
- Mobile: screenshots expand to full card width
- Tablet: screenshots use 320px max-width
- Updated selector to specifically target .indicator-screenshot class