### PR TITLE
Fix Harmonic Oscillator voting components count

### DIFF
--- a/COMPLETE_30_DAY_GUIDE.md
+++ b/COMPLETE_30_DAY_GUIDE.md
@@ -521,22 +521,24 @@ Seven of Seven.
 
 HARMONIC OSCILLATOR — The Arbiter.
 
-"Five voices. One verdict. I decide when the trigger is pulled."
+"Seven voices. One verdict. I decide when the trigger is pulled."
 
 The council is complete.
 
-Five oscillators convene:
-• MACD — trend direction
-• RSI Triple Envelope — trend-following momentum
-• Stochastic RSI — extreme zone reversals
-• Volume Delta — buying vs selling pressure
-• Divergence Detection — price/oscillator misalignments
+Seven components convene:
+• RSI
+• Stochastic RSI
+• MACD
+• EMA Trend
+• Momentum
+• Volume
+• Divergence Zone
 
-Each votes: Bull. Bear. Neutral. Results show as X/5.
+Each votes: Bull. Bear. Neutral. Results show as X/7.
 
-5/5 or 4/5 = STRONG signal. Maximum conviction. Strike.
-3/5 = Bull/Bear signal. Solid consensus.
-2/5 or less = NEUT. Stand aside. Let others guess.
+7/7 or 6/7 = STRONG signal. Maximum conviction. Strike.
+5/7 or 4/7 = Bull/Bear signal. Solid consensus.
+3/7 or less = NEUT. Stand aside. Let others guess.
 
 Signals without consensus are noise.
 False entries drain accounts through a thousand cuts.
@@ -560,11 +562,11 @@ Full lore: signalpilot.io/chronicle/the-arbiter
 ```
 SEVEN OF SEVEN: HARMONIC OSCILLATOR — The Arbiter
 
-"Five voices. One verdict."
+"Seven voices. One verdict."
 
 This is the final piece.
 
-MACD + RSI Triple Envelope + Stochastic RSI + Volume Delta + Divergence Detection convene as a council.
+Seven components convene as a council.
 
 Each votes: Bull | Bear | Neutral
 
@@ -575,9 +577,9 @@ The verdict determines when you pull the trigger. 🧵
 ```
 The voting system:
 
-5/5 or 4/5 = STRONG signal. Maximum conviction. STRIKE.
-3/5 = Bull/Bear signal. Solid consensus.
-2/5 or less = NEUT signal. STAND ASIDE. Let others guess.
+7/7 or 6/7 = STRONG signal. Maximum conviction. STRIKE.
+5/7 or 4/7 = Bull/Bear signal. Solid consensus.
+3/7 or less = NEUT signal. STAND ASIDE. Let others guess.
 
 This is how you stop taking bad entries.
 ```
@@ -623,12 +625,12 @@ Seven of Seven.
 
 HARMONIC OSCILLATOR — The Arbiter.
 
-Five oscillators. One verdict.
+Seven components. One verdict.
 
-MACD. RSI Triple Envelope. Stochastic RSI. Volume Delta. Divergence Detection.
+RSI. Stochastic RSI. MACD. EMA Trend. Momentum. Volume. Divergence Zone.
 
-5/5 agreement? STRONG signal. STRIKE.
-2/5 or less? NEUT. Stand aside.
+7/7 agreement? STRONG signal. STRIKE.
+3/7 or less? NEUT. Stand aside.
 
 "The patient pilot survives. The impulsive pilot donates."
 
@@ -2724,26 +2726,28 @@ More scans in bio.
 ```
 HARMONIC OSCILLATOR — The Arbiter
 
-Deep Dive: 5-Voice Consensus
+Deep Dive: 7-Component Consensus
 
-Five oscillators convene:
-• MACD — trend direction
-• RSI Triple Envelope — trend-following momentum (7/14/28 periods)
-• Stochastic RSI — extreme zone reversals
-• Volume Delta — buying vs selling pressure
-• Divergence Detection — price/oscillator misalignments
+Seven components convene:
+• RSI
+• Stochastic RSI
+• MACD
+• EMA Trend
+• Momentum
+• Volume
+• Divergence Zone
 
-Each votes: Bull | Bear | Neutral. Results show as X/5.
+Each votes: Bull | Bear | Neutral. Results show as X/7.
 
 THE VOTING SYSTEM:
 
-5/5 or 4/5 = STRONG signal
+7/7 or 6/7 = STRONG signal
 MAXIMUM CONVICTION. Strike.
 
-3/5 = Bull/Bear signal
+5/7 or 4/7 = Bull/Bear signal
 SOLID CONSENSUS. Worth attention.
 
-2/5 or less = NEUT signal
+3/7 or less = NEUT signal
 UNCLEAR. Stand aside. Let others guess.
 
 The Arbiter is not your first signal.
@@ -2767,7 +2771,7 @@ docs.signalpilot.io/harmonic-oscillator-v10
 ```
 HARMONIC OSCILLATOR DEEP DIVE — The Arbiter
 
-"Five voices. One verdict."
+"Seven voices. One verdict."
 
 You've seen the setup.
 Cycle looks good.
@@ -2783,30 +2787,26 @@ The Arbiter decides.
 
 **Post 2:**
 ```
-THE FIVE VOICES:
+THE SEVEN COMPONENTS:
 
-1. MACD — trend direction via crossovers
-2. RSI Triple Envelope — trend momentum (7/14/28 periods)
-3. Stochastic RSI — extreme zone reversals
-4. Volume Delta — buying vs selling pressure
-5. Divergence Detection — price/oscillator misalignments
+RSI | Stochastic RSI | MACD | EMA Trend | Momentum | Volume | Divergence Zone
 
 Each votes: Bull | Bear | Neutral
 
-The Arbiter tallies the council. Shows X/5.
+The Arbiter tallies the council. Shows X/7.
 ```
 
 **Post 3:**
 ```
 THE VOTING SYSTEM:
 
-5/5 or 4/5 = STRONG signal
+7/7 or 6/7 = STRONG signal
 MAXIMUM CONVICTION. Strike.
 
-3/5 = Bull/Bear signal
+5/7 or 4/7 = Bull/Bear signal
 SOLID CONSENSUS. Worth attention.
 
-2/5 or less = NEUT signal
+3/7 or less = NEUT signal
 UNCLEAR. Stand aside. Let others guess.
 ```
 
@@ -2822,7 +2822,7 @@ Most traders:
 
 Pilots:
 → Wait for consensus
-→ 5 systems voting
+→ 7 components voting
 → Enter with conviction on STRONG
 → Higher probability
 ```
@@ -2838,7 +2838,7 @@ It's your LAST checkpoint.
 2. Volume Oracle confirms ✓
 3. Janus Atlas shows level ✓
 4. Plutus Flow confirms pressure ✓
-5. Arbiter says... 5/5 STRONG
+5. Arbiter says... 7/7 STRONG
 
 NOW you strike.
 ```
@@ -2866,29 +2866,33 @@ Should you take this trade?
 
 Let's ask the council.
 
-MACD says... bullish.
-RSI Triple Envelope says... bullish.
+RSI says... bullish.
 Stochastic RSI says... bullish.
-Volume Delta says... bullish.
-Divergence says... bullish.
+MACD says... bullish.
+EMA Trend says... bullish.
+Momentum says... bullish.
+Volume says... bullish.
+Divergence Zone says... bullish.
 
-5/5. STRONG signal. Maximum conviction.
+7/7. STRONG signal. Maximum conviction.
 
 STRIKE.
 
 But what if:
 
-MACD says bullish.
-RSI says bearish.
-StochRSI says neutral.
-Volume Delta says bullish.
-Divergence says neutral.
+RSI says bullish.
+Stochastic RSI says bearish.
+MACD says neutral.
+EMA Trend says bullish.
+Momentum says neutral.
+Volume says neutral.
+Divergence Zone says neutral.
 
-2/5. NEUT signal.
+3/7. NEUT signal.
 
 STAND ASIDE. Let others guess.
 
-The Arbiter tallies the five voices.
+The Arbiter tallies the seven voices.
 It's not your first signal.
 It's your FINAL confirmation.
 

--- a/ELITE_SEVEN_LORE.md
+++ b/ELITE_SEVEN_LORE.md
@@ -171,25 +171,25 @@ Stop flipping through charts. Let The Watchman bring the opportunities to you.
 
 **HARMONIC OSCILLATOR — Seven of Seven**
 
-*"Five voices. One verdict. I decide when the trigger is pulled."*
+*"Seven voices. One verdict. I decide when the trigger is pulled."*
 
 Every indicator can generate a signal. But signals without consensus are noise — false entries that drain accounts through a thousand cuts.
 
 The Arbiter was created to end the tyranny of false signals.
 
-Within Harmonic Oscillator, five ancient oscillators convene in constant deliberation. Each casts a vote:
+Within Harmonic Oscillator, seven components convene in constant deliberation. Each casts a vote:
 
 - **Bull** — Momentum favors the longs.
 - **Bear** — Momentum favors the shorts.
 - **Neutral** — Abstention. Unclear conditions.
 
-When all five align, The Arbiter speaks with maximum conviction:
+When all seven align, The Arbiter speaks with maximum conviction:
 
-*5/5 STRONG. Strike now.*
+*7/7 STRONG. Strike now.*
 
 When the vote splits, The Arbiter counsels patience:
 
-*2/5. NEUT. Stand aside. Let others guess.*
+*3/7. NEUT. Stand aside. Let others guess.*
 
 The Arbiter is not the first signal. It is the *final confirmation* — the last checkpoint before capital is deployed.
 

--- a/LORE_SOCIAL_CONTENT.md
+++ b/LORE_SOCIAL_CONTENT.md
@@ -163,10 +163,10 @@ Seven of Seven.
 
 HARMONIC OSCILLATOR — The Arbiter.
 
-"Five voices. One verdict. I decide when the trigger is pulled."
+"Seven voices. One verdict. I decide when the trigger is pulled."
 
-Five oscillators deliberate.
-When all five align: 5/5 STRONG. Strike now.
+Seven components deliberate.
+When all seven align: 7/7 STRONG. Strike now.
 When they split: NEUT. Stand aside.
 
 The seventh lesson: The patient pilot survives.

--- a/SOCIAL_MEDIA_KIT.md
+++ b/SOCIAL_MEDIA_KIT.md
@@ -627,22 +627,24 @@ Seven of Seven.
 
 HARMONIC OSCILLATOR — The Arbiter.
 
-"Five voices. One verdict. I decide when the trigger is pulled."
+"Seven voices. One verdict. I decide when the trigger is pulled."
 
 The council is complete.
 
-Five oscillators convene:
-• MACD — trend direction
-• RSI Triple Envelope — trend-following momentum
-• Stochastic RSI — extreme zone reversals
-• Volume Delta — buying vs selling pressure
-• Divergence Detection — price/oscillator misalignments
+Seven components convene:
+• RSI
+• Stochastic RSI
+• MACD
+• EMA Trend
+• Momentum
+• Volume
+• Divergence Zone
 
-Each votes: Bull. Bear. Neutral. Results show as X/5.
+Each votes: Bull. Bear. Neutral. Results show as X/7.
 
-5/5 or 4/5 = STRONG signal. Maximum conviction. Strike.
-3/5 = Bull/Bear signal. Solid consensus.
-2/5 or less = NEUT. Stand aside. Let others guess.
+7/7 or 6/7 = STRONG signal. Maximum conviction. Strike.
+5/7 or 4/7 = Bull/Bear signal. Solid consensus.
+3/7 or less = NEUT. Stand aside. Let others guess.
 
 Signals without consensus are noise.
 False entries drain accounts through a thousand cuts.
@@ -666,11 +668,11 @@ Full lore: signalpilot.io/chronicle/the-arbiter
 ```
 SEVEN OF SEVEN: HARMONIC OSCILLATOR — The Arbiter
 
-"Five voices. One verdict."
+"Seven voices. One verdict."
 
 This is the final piece.
 
-MACD + RSI Triple Envelope + Stochastic RSI + Volume Delta + Divergence Detection convene as a council.
+Seven components convene as a council.
 
 Each votes: Bull | Bear | Neutral
 
@@ -681,9 +683,9 @@ The verdict determines when you pull the trigger. 🧵
 ```
 The voting system:
 
-5/5 or 4/5 = STRONG signal. Maximum conviction. STRIKE.
-3/5 = Bull/Bear signal. Solid consensus.
-2/5 or less = NEUT signal. STAND ASIDE. Let others guess.
+7/7 or 6/7 = STRONG signal. Maximum conviction. STRIKE.
+5/7 or 4/7 = Bull/Bear signal. Solid consensus.
+3/7 or less = NEUT signal. STAND ASIDE. Let others guess.
 
 This is how you stop taking bad entries.
 ```
@@ -729,12 +731,12 @@ Seven of Seven.
 
 HARMONIC OSCILLATOR — The Arbiter.
 
-Five oscillators. One verdict.
+Seven components. One verdict.
 
-MACD. RSI Triple Envelope. Stochastic RSI. Volume Delta. Divergence Detection.
+RSI. Stochastic RSI. MACD. EMA Trend. Momentum. Volume. Divergence Zone.
 
-5/5 agreement? STRONG signal. STRIKE.
-2/5 or less? NEUT. Stand aside.
+7/7 agreement? STRONG signal. STRIKE.
+3/7 or less? NEUT. Stand aside.
 
 "The patient pilot survives. The impulsive pilot donates."
 
@@ -3029,26 +3031,28 @@ Harmonic Oscillator Deep Dive — The Consensus System
 ```
 HARMONIC OSCILLATOR — The Arbiter
 
-Deep Dive: 5-Voice Consensus
+Deep Dive: 7-Component Consensus
 
-Five oscillators convene:
-• MACD — trend direction
-• RSI Triple Envelope — trend-following momentum (7/14/28 periods)
-• Stochastic RSI — extreme zone reversals
-• Volume Delta — buying vs selling pressure
-• Divergence Detection — price/oscillator misalignments
+Seven components convene:
+• RSI
+• Stochastic RSI
+• MACD
+• EMA Trend
+• Momentum
+• Volume
+• Divergence Zone
 
-Each votes: Bull | Bear | Neutral. Results show as X/5.
+Each votes: Bull | Bear | Neutral. Results show as X/7.
 
 THE VOTING SYSTEM:
 
-5/5 or 4/5 = STRONG signal
+7/7 or 6/7 = STRONG signal
 MAXIMUM CONVICTION. Strike.
 
-3/5 = Bull/Bear signal
+5/7 or 4/7 = Bull/Bear signal
 SOLID CONSENSUS. Worth attention.
 
-2/5 or less = NEUT signal
+3/7 or less = NEUT signal
 UNCLEAR. Stand aside. Let others guess.
 
 The Arbiter is not your first signal.
@@ -3072,7 +3076,7 @@ docs.signalpilot.io/harmonic-oscillator-v10
 ```
 HARMONIC OSCILLATOR DEEP DIVE — The Arbiter
 
-"Five voices. One verdict."
+"Seven voices. One verdict."
 
 You've seen the setup.
 Cycle looks good.
@@ -3088,30 +3092,26 @@ The Arbiter decides.
 
 **Post 2:**
 ```
-THE FIVE VOICES:
+THE SEVEN COMPONENTS:
 
-1. MACD — trend direction via crossovers
-2. RSI Triple Envelope — trend momentum (7/14/28 periods)
-3. Stochastic RSI — extreme zone reversals
-4. Volume Delta — buying vs selling pressure
-5. Divergence Detection — price/oscillator misalignments
+RSI | Stochastic RSI | MACD | EMA Trend | Momentum | Volume | Divergence Zone
 
 Each votes: Bull | Bear | Neutral
 
-The Arbiter tallies the council. Shows X/5.
+The Arbiter tallies the council. Shows X/7.
 ```
 
 **Post 3:**
 ```
 THE VOTING SYSTEM:
 
-5/5 or 4/5 = STRONG signal
+7/7 or 6/7 = STRONG signal
 MAXIMUM CONVICTION. Strike.
 
-3/5 = Bull/Bear signal
+5/7 or 4/7 = Bull/Bear signal
 SOLID CONSENSUS. Worth attention.
 
-2/5 or less = NEUT signal
+3/7 or less = NEUT signal
 UNCLEAR. Stand aside. Let others guess.
 ```
 
@@ -3127,7 +3127,7 @@ Most traders:
 
 Pilots:
 → Wait for consensus
-→ 5 systems voting
+→ 7 components voting
 → Enter with conviction on STRONG
 → Higher probability
 ```
@@ -3143,7 +3143,7 @@ It's your LAST checkpoint.
 2. Volume Oracle confirms ✓
 3. Janus Atlas shows level ✓
 4. Plutus Flow confirms pressure ✓
-5. Arbiter says... 5/5 STRONG
+5. Arbiter says... 7/7 STRONG
 
 NOW you strike.
 ```
@@ -3171,29 +3171,33 @@ Should you take this trade?
 
 Let's ask the council.
 
-MACD says... bullish.
-RSI Triple Envelope says... bullish.
+RSI says... bullish.
 Stochastic RSI says... bullish.
-Volume Delta says... bullish.
-Divergence says... bullish.
+MACD says... bullish.
+EMA Trend says... bullish.
+Momentum says... bullish.
+Volume says... bullish.
+Divergence Zone says... bullish.
 
-5/5. STRONG signal. Maximum conviction.
+7/7. STRONG signal. Maximum conviction.
 
 STRIKE.
 
 But what if:
 
-MACD says bullish.
-RSI says bearish.
-StochRSI says neutral.
-Volume Delta says bullish.
-Divergence says neutral.
+RSI says bullish.
+Stochastic RSI says bearish.
+MACD says neutral.
+EMA Trend says bullish.
+Momentum says neutral.
+Volume says neutral.
+Divergence Zone says neutral.
 
-2/5. NEUT signal.
+3/7. NEUT signal.
 
 STAND ASIDE. Let others guess.
 
-The Arbiter tallies the five voices.
+The Arbiter tallies the seven voices.
 It's not your first signal.
 It's your FINAL confirmation.
 

--- a/SOCIAL_MEDIA_LORE_CAMPAIGN.md
+++ b/SOCIAL_MEDIA_LORE_CAMPAIGN.md
@@ -627,11 +627,11 @@ Stop flipping through charts. Let the opportunities come to you.
 ```
 THE ARBITER — Seven of Seven
 
-"Five voices. One verdict."
+"Seven voices. One verdict."
 
 Signals without consensus are noise.
 
-When all five align: "5/5 STRONG. Strike now."
+When all seven align: "7/7 STRONG. Strike now."
 When the vote splits: "NEUT. Stand aside."
 
 The patient pilot survives. The impulsive pilot donates.
@@ -647,7 +647,7 @@ The patient pilot survives. The impulsive pilot donates.
 ```
 THE ARBITER — Seven of Seven
 
-"Five voices. One verdict. I decide when the trigger is pulled."
+"Seven voices. One verdict. I decide when the trigger is pulled."
 
 Every indicator can generate a signal.
 
@@ -655,19 +655,19 @@ But signals without consensus are noise — false entries that drain accounts th
 
 The Arbiter was created to end the tyranny of false signals.
 
-Within Harmonic Oscillator, five ancient oscillators convene in constant deliberation. Each casts a vote:
+Within Harmonic Oscillator, seven components convene in constant deliberation. Each casts a vote:
 
 • Bull — Momentum favors the longs
 • Bear — Momentum favors the shorts
 • Neutral — Abstention. Unclear conditions.
 
-When all five align, The Arbiter speaks with maximum conviction:
+When all seven align, The Arbiter speaks with maximum conviction:
 
-"5/5 STRONG. Strike now."
+"7/7 STRONG. Strike now."
 
 When the vote splits, The Arbiter counsels patience:
 
-"2/5. NEUT. Stand aside. Let others guess."
+"3/7. NEUT. Stand aside. Let others guess."
 
 The Arbiter is not the first signal. It is the final confirmation — the last checkpoint before capital is deployed.
 
@@ -687,11 +687,11 @@ All Seven revealed. The hierarchy awaits.
 ```
 THE ARBITER — Seven of Seven
 
-"Five voices. One verdict."
+"Seven voices. One verdict."
 
 Every indicator generates signals. But signals without consensus are noise.
 
-When all five align: "5/5 STRONG. Strike now."
+When all seven align: "7/7 STRONG. Strike now."
 When the vote splits: "NEUT. Stand aside."
 
 The patient pilot survives. The impulsive pilot donates.
@@ -699,7 +699,7 @@ The patient pilot survives. The impulsive pilot donates.
 #trading #forex #crypto #oscillators #fyp #tradingview #technicalanalysis #patience
 ```
 
-**Video Idea:** Silver/balanced aesthetic. Show five voting elements. X/5 score appearing for consensus. Judicial/decisive music.
+**Video Idea:** Silver/balanced aesthetic. Show seven voting components. X/7 score appearing for consensus. Judicial/decisive music.
 
 ---
 

--- a/ar/index.html
+++ b/ar/index.html
@@ -5835,13 +5835,13 @@ html[lang="ar"] [style*="text-align:center"] {
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/ar/" target="_blank" rel="noopener" style="color:var(--brand)">شاهده في العمل ←</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> مذبذبات تصوت.</strong> تظهر الإشارات فقط عندما تتفق مؤشرات الزخم المتعددة:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> مكونات تصوت.</strong> تظهر الإشارات فقط عندما تتفق مؤشرات الزخم المتعددة:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• عد الأصوات المباشر يعرض التحليل في الوقت الفعلي (مثلاً، "3 صاعد، 2 محايد")</li>
-                <li>• نظام تقييم X/5 — درجة أعلى = توافق أكبر</li>
-                <li>• الخط المركب يجمع كل المذبذبات الخمسة لسهولة العرض</li>
+                <li>• عد الأصوات المباشر يعرض التحليل في الوقت الفعلي (مثلاً، "5 صاعد، 2 محايد")</li>
+                <li>• نظام تقييم X/7 — درجة أعلى = توافق أكبر</li>
+                <li>• الخط المركب يجمع كل المكونات السبعة لسهولة العرض</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = جميع الـ 5 متفقون (ثقة عالية). تصويت مقسم = ظروف غير واضحة.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = جميع الـ 7 متفقون (ثقة عالية). تصويت مقسم = ظروف غير واضحة.</p>
             </div>
           </article>
 

--- a/chronicle/birth-of-the-elite-seven/index.html
+++ b/chronicle/birth-of-the-elite-seven/index.html
@@ -971,9 +971,9 @@
     <div class="signal-card">
       <h4>Seven of Seven</h4>
       <h3>Harmonic Oscillator — The Arbiter</h3>
-      <p class="tagline">"Five voices. One verdict. I decide when the trigger is pulled."</p>
+      <p class="tagline">"Seven voices. One verdict. I decide when the trigger is pulled."</p>
       <p>Every indicator can generate a signal. But signals without consensus are noise—false entries that drain accounts through a thousand cuts. The Arbiter was created to end the tyranny of false signals.</p>
-      <p>When all five voices align, The Arbiter speaks with maximum conviction: <em>5/5 STRONG. Strike now.</em> When the vote splits, The Arbiter counsels patience: <em>Stand aside. Let others guess.</em></p>
+      <p>When all seven voices align, The Arbiter speaks with maximum conviction: <em>7/7 STRONG. Strike now.</em> When the vote splits, The Arbiter counsels patience: <em>Stand aside. Let others guess.</em></p>
     </div>
 
     <div class="divider">✧ ✧ ✧</div>

--- a/chronicle/index.html
+++ b/chronicle/index.html
@@ -1210,7 +1210,7 @@
               <span>December 24, 2025</span>
             </div>
             <h2 class="article-title">The Arbiter: Harmonic Oscillator</h2>
-            <p class="article-excerpt">"Five voices. One verdict. I decide when the trigger is pulled." The final confirmation before capital is deployed.</p>
+            <p class="article-excerpt">"Seven voices. One verdict. I decide when the trigger is pulled." The final confirmation before capital is deployed.</p>
             <div class="article-footer">
               <span class="article-author">Signal Pilot Labs</span>
               <span class="read-time">8 min read</span>

--- a/chronicle/the-arbiter/index.html
+++ b/chronicle/the-arbiter/index.html
@@ -4,21 +4,21 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Arbiter: Harmonic Oscillator — Signal Pilot</title>
-  <meta name="description" content="Harmonic Oscillator unifies five oscillators into a single verdict, confirming when to strike. The seventh and final of The Elite Seven.">
+  <meta name="description" content="Harmonic Oscillator unifies seven components into a single verdict, confirming when to strike. The seventh and final of The Elite Seven.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-arbiter">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Arbiter: Harmonic Oscillator">
-  <meta property="og:description" content="Five voices. One verdict. I decide when the trigger is pulled.">
+  <meta property="og:description" content="Seven voices. One verdict. I decide when the trigger is pulled.">
   <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-arbiter">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="The Arbiter: Harmonic Oscillator">
-  <meta name="twitter:description" content="Five voices. One verdict. I decide when the trigger is pulled.">
+  <meta name="twitter:description" content="Seven voices. One verdict. I decide when the trigger is pulled.">
   <meta name="twitter:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -201,7 +201,7 @@
     <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Seven of Seven</span>
     <h1>The Arbiter: Harmonic Oscillator</h1>
-    <p class="article-subtitle">"Five voices. One verdict. I decide when the trigger is pulled."</p>
+    <p class="article-subtitle">"Seven voices. One verdict. I decide when the trigger is pulled."</p>
     <div class="article-meta">
       <span>Signal Pilot Labs</span>
       <span>·</span>
@@ -245,9 +245,9 @@
 
     <div class="divider">✧ ✧ ✧</div>
 
-    <h2>Five Voices, One Council</h2>
+    <h2>Seven Voices, One Council</h2>
 
-    <p>Within Harmonic Oscillator, five ancient oscillators convene in constant deliberation. Each measures momentum through a different lens. Each casts a vote:</p>
+    <p>Within Harmonic Oscillator, seven components convene in constant deliberation. Each measures momentum through a different lens. Each casts a vote:</p>
 
     <div class="concept-card">
       <h4>Bull Vote</h4>
@@ -264,7 +264,7 @@
       <p>Abstention. Conditions are unclear—the oscillator neither confirms bullish nor bearish bias. When in doubt, The Arbiter counsels patience.</p>
     </div>
 
-    <p>The power comes from combination. Any single oscillator can give false signals. But when five independent momentum calculations agree? That's consensus. That's conviction. That's when The Arbiter speaks.</p>
+    <p>The power comes from combination. Any single oscillator can give false signals. But when seven independent voters agree? That's consensus. That's conviction. That's when The Arbiter speaks.</p>
 
     <div class="verdict-demo">
       <h4>Reading The Verdict</h4>
@@ -274,30 +274,34 @@
         <div class="star bull">★</div>
         <div class="star bull">★</div>
         <div class="star bull">★</div>
+        <div class="star bull">★</div>
+        <div class="star bull">★</div>
       </div>
-      <div class="verdict-label strong">5/5 STRONG BULL — Maximum Conviction</div>
+      <div class="verdict-label strong">7/7 STRONG BULL — Maximum Conviction</div>
 
       <div class="stars-row" style="margin-top:2rem">
         <div class="star bull">★</div>
         <div class="star bull">★</div>
+        <div class="star bull">★</div>
+        <div class="star neutral">★</div>
         <div class="star neutral">★</div>
         <div class="star neutral">★</div>
         <div class="star neutral">★</div>
       </div>
-      <div class="verdict-label wait">2/5 NEUT — Stand Aside</div>
+      <div class="verdict-label wait">3/7 NEUT — Stand Aside</div>
     </div>
 
     <h2>The Voting System</h2>
 
-    <p>The Arbiter communicates through a voting system—showing X/5 agreement that cuts through complexity:</p>
+    <p>The Arbiter communicates through a voting system—showing X/7 agreement that cuts through complexity:</p>
 
-    <p><strong>5/5 or 4/5 (STRONG):</strong> Maximum conviction. All or nearly all oscillators agree. This is the cleanest signal The Arbiter can give. Strike now.</p>
+    <p><strong>7/7 or 6/7 (STRONG):</strong> Maximum conviction. All or nearly all components agree. This is the cleanest signal The Arbiter can give. Strike now.</p>
 
-    <p><strong>3/5 (Bull/Bear):</strong> Solid conviction. Three oscillators agree, others abstain or dissent. Still a valid signal with good consensus.</p>
+    <p><strong>5/7 or 4/7 (Bull/Bear):</strong> Solid conviction. A majority of components agree, others abstain or dissent. Still a valid signal with good consensus.</p>
 
-    <p><strong>2/5 or less (NEUT):</strong> Weak or conflicting. The council is divided. Stand aside. Let others guess. The Arbiter counsels restraint.</p>
+    <p><strong>3/7 or less (NEUT):</strong> Weak or conflicting. The council is divided. Stand aside. Let others guess. The Arbiter counsels restraint.</p>
 
-    <p>This simplicity is intentional. In the heat of market action, you don't have time to analyze five separate oscillators. The Arbiter does the analysis and delivers a verdict you can act on instantly.</p>
+    <p>This simplicity is intentional. In the heat of market action, you don't have time to analyze seven separate components. The Arbiter does the analysis and delivers a verdict you can act on instantly.</p>
 
     <div class="pull-quote">
       <p>"The patient pilot survives. The impulsive pilot donates."</p>
@@ -323,7 +327,7 @@
 
     <p>A setup can be perfect on every other level and still fail if momentum isn't aligned. The Arbiter protects you from this fate—the frustration of being right about everything except timing.</p>
 
-    <h2>Why Five Oscillators?</h2>
+    <h2>Why Seven Components?</h2>
 
     <p>One oscillator is unreliable. It can spend extended periods in overbought or oversold territory while price continues trending. It can whipsaw during consolidation. It can give false reversal signals.</p>
 
@@ -331,9 +335,9 @@
 
     <p>Three oscillators create majority, but 2-1 splits are common and difficult to interpret.</p>
 
-    <p>Five oscillators create the perfect council. Full agreement (5/5) is rare and powerful. Strong consensus (4/5) is actionable. Solid consensus (3/5) is still valid. Anything less is a clear signal to wait.</p>
+    <p>Seven components create the perfect council. Full agreement (7/7) is rare and powerful. Strong consensus (6/7) is actionable. Solid consensus (5/7) is still valid. Anything less is a clear signal to wait.</p>
 
-    <p>The specific oscillators are chosen for their complementary characteristics. Each measures momentum differently. When all five see the same thing, it's not coincidence—it's truth.</p>
+    <p>The specific components are chosen for their complementary characteristics. Each measures momentum differently. When all seven see the same thing, it's not coincidence—it's truth.</p>
 
     <h2>The Art of Restraint</h2>
 
@@ -357,11 +361,11 @@
 
     <p>The Arbiter enforces this discipline. It doesn't just confirm good trades—it blocks bad ones. It turns your impulse to act into a system that filters for quality.</p>
 
-    <p>When The Arbiter shows 5/5 STRONG, trade with confidence. When the verdict splits, find something else to do. Read. Walk. Wait. The next high-conviction setup will come.</p>
+    <p>When The Arbiter shows 7/7 STRONG, trade with confidence. When the verdict splits, find something else to do. Read. Walk. Wait. The next high-conviction setup will come.</p>
 
     <p>And when it does, you'll have the capital to take it—because The Arbiter kept you out of the traps.</p>
 
-    <p><em>Five voices. One verdict. Final confirmation.</em></p>
+    <p><em>Seven voices. One verdict. Final confirmation.</em></p>
   </article>
 
   <div class="share-section">

--- a/chronicle/the-council-assembles/index.html
+++ b/chronicle/the-council-assembles/index.html
@@ -276,7 +276,7 @@
 
     <p><strong>Systems unify.</strong> OmniDeck synthesizes everything into a single visual layer. Augury Grid scans the universe, surfacing opportunities you would have missed.</p>
 
-    <p><strong>Finally, The Arbiter decides.</strong> Harmonic Oscillator delivers the verdict. Five oscillators vote. Do they agree? Is momentum aligned? Is this the moment to strike?</p>
+    <p><strong>Finally, The Arbiter decides.</strong> Harmonic Oscillator delivers the verdict. Seven components vote. Do they agree? Is momentum aligned? Is this the moment to strike?</p>
 
     <div class="pull-quote">
       <p>"Seven voices. One truth. Total clarity."</p>

--- a/chronicle/the-hierarchy-of-signals/index.html
+++ b/chronicle/the-hierarchy-of-signals/index.html
@@ -1067,7 +1067,7 @@
       <div class="role-content">
         <h4>Harmonic Oscillator</h4>
         <span class="role-title">The Arbiter — Level 6</span>
-        <p><strong>The Arbiter speaks last.</strong> Five oscillators vote. When all agree, the verdict is clear: <em>Strike now.</em> When they conflict, the verdict is equally clear: <em>Stand aside.</em> The Arbiter is not the first signal—it's the final confirmation before capital is deployed.</p>
+        <p><strong>The Arbiter speaks last.</strong> Seven components vote. When all agree, the verdict is clear: <em>Strike now.</em> When they conflict, the verdict is equally clear: <em>Stand aside.</em> The Arbiter is not the first signal—it's the final confirmation before capital is deployed.</p>
       </div>
     </div>
 

--- a/chronicle/the-watchman/index.html
+++ b/chronicle/the-watchman/index.html
@@ -388,7 +388,7 @@
         </a>
         <a href="/chronicle/the-arbiter" class="related-card">
           <h4>The Arbiter: Harmonic Oscillator</h4>
-          <p>Five voices. One verdict. I decide when the trigger is pulled.</p>
+          <p>Seven voices. One verdict. I decide when the trigger is pulled.</p>
         </a>
       </div>
     </div>

--- a/de/index.html
+++ b/de/index.html
@@ -5758,13 +5758,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/de/" target="_blank" rel="noopener" style="color:var(--brand)">In Aktion sehen →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> Oszillatoren stimmen ab.</strong> Signale erscheinen nur, wenn mehrere Momentum-Indikatoren übereinstimmen:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> Komponenten stimmen ab.</strong> Signale erscheinen nur, wenn mehrere Momentum-Indikatoren übereinstimmen:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Live-Abstimmungszähler zeigt Echtzeit-Aufschlüsselung (z.B. „3 Bullish, 2 Neutral")</li>
-                <li>• X/5 Bewertungssystem — höhere Punktzahl = mehr Übereinstimmung</li>
-                <li>• Composite-Linie kombiniert alle fünf Oszillatoren für einfache Ansicht</li>
+                <li>• Live-Abstimmungszähler zeigt Echtzeit-Aufschlüsselung (z.B. „5 Bullish, 2 Neutral")</li>
+                <li>• X/7 Bewertungssystem — höhere Punktzahl = mehr Übereinstimmung</li>
+                <li>• Composite-Linie kombiniert alle sieben Komponenten für einfache Ansicht</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = alle 5 stimmen überein (hohes Vertrauen). Geteilte Abstimmung = unklare Bedingungen.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = alle 7 stimmen überein (hohes Vertrauen). Geteilte Abstimmung = unklare Bedingungen.</p>
             </div>
           </article>
 

--- a/es/index.html
+++ b/es/index.html
@@ -6039,13 +6039,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/es/" target="_blank" rel="noopener" style="color:var(--brand)">Ver en acción →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> osciladores votan.</strong> Las señales solo aparecen cuando múltiples indicadores de impulso están de acuerdo:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> componentes votan.</strong> Las señales solo aparecen cuando múltiples indicadores de impulso están de acuerdo:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Conteo de votos en vivo muestra desglose en tiempo real (ej., "3 Alcistas, 2 Neutrales")</li>
-                <li>• Sistema de puntuación X/5 — mayor puntuación = más acuerdo</li>
-                <li>• Línea compuesta combina los cinco osciladores para fácil visualización</li>
+                <li>• Conteo de votos en vivo muestra desglose en tiempo real (ej., "5 Alcistas, 2 Neutrales")</li>
+                <li>• Sistema de puntuación X/7 — mayor puntuación = más acuerdo</li>
+                <li>• Línea compuesta combina los siete componentes para fácil visualización</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = los 5 de acuerdo (alta confianza). Voto dividido = condiciones poco claras.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = los 7 de acuerdo (alta confianza). Voto dividido = condiciones poco claras.</p>
             </div>
           </article>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -5926,13 +5926,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/fr/" target="_blank" rel="noopener" style="color:var(--brand)">Voir en action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> oscillateurs votent.</strong> Les signaux n'apparaissent que lorsque plusieurs indicateurs de momentum sont d'accord :</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> composants votent.</strong> Les signaux n'apparaissent que lorsque plusieurs indicateurs de momentum sont d'accord :</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Comptage des votes en direct avec répartition en temps réel (ex: « 3 Haussiers, 2 Neutres »)</li>
-                <li>• Système de notation X/5 — score plus élevé = plus d'accord</li>
-                <li>• Ligne composite combine les cinq oscillateurs pour une visualisation facile</li>
+                <li>• Comptage des votes en direct avec répartition en temps réel (ex: « 5 Haussiers, 2 Neutres »)</li>
+                <li>• Système de notation X/7 — score plus élevé = plus d'accord</li>
+                <li>• Ligne composite combine les sept composants pour une visualisation facile</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = les 5 sont d'accord (haute confiance). Vote divisé = conditions incertaines.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = les 7 sont d'accord (haute confiance). Vote divisé = conditions incertaines.</p>
             </div>
           </article>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -5763,13 +5763,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/hu/" target="_blank" rel="noopener" style="color:var(--brand)">Nézd meg működés közben →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> oszcillátor szavaz.</strong> A jelek csak akkor jelennek meg, ha több momentum indikátor egyetért:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> komponens szavaz.</strong> A jelek csak akkor jelennek meg, ha több momentum indikátor egyetért:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Élő szavazatszámláló valós idejű lebontással (pl. „3 Bikás, 2 Semleges")</li>
-                <li>• X/5 értékelési rendszer — magasabb pontszám = nagyobb egyetértés</li>
-                <li>• Kompozit vonal mind az öt oszcillátort egyesíti a könnyű megtekintéshez</li>
+                <li>• Élő szavazatszámláló valós idejű lebontással (pl. „5 Bikás, 2 Semleges")</li>
+                <li>• X/7 értékelési rendszer — magasabb pontszám = nagyobb egyetértés</li>
+                <li>• Kompozit vonal mind a hét komponenst egyesíti a könnyű megtekintéshez</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = mind az 5 egyetért (magas bizalom). Megosztott szavazat = bizonytalan feltételek.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = mind a 7 egyetért (magas bizalom). Megosztott szavazat = bizonytalan feltételek.</p>
             </div>
           </article>
 

--- a/index.html
+++ b/index.html
@@ -4677,13 +4677,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/" target="_blank" rel="noopener" style="color:var(--brand)">See It In Action →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> oscillators vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> components vote.</strong> Signals only appear when multiple momentum indicators agree:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Live vote count shows real-time breakdown (e.g., "3 Bulls, 2 Neutral")</li>
-                <li>• X/5 rating system — higher score = more agreement</li>
-                <li>• Composite line combines all five oscillators for easy viewing</li>
+                <li>• Live vote count shows real-time breakdown (e.g., "5 Bulls, 2 Neutral")</li>
+                <li>• X/7 rating system — higher score = more agreement</li>
+                <li>• Composite line combines all seven components for easy viewing</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = all 5 agree (high confidence). Split vote = unclear conditions.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = all 7 agree (high confidence). Split vote = unclear conditions.</p>
             </div>
           </article>
 

--- a/it/index.html
+++ b/it/index.html
@@ -5680,13 +5680,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/it/" target="_blank" rel="noopener" style="color:var(--brand)">Vedi in azione →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> oscillatori votano.</strong> I segnali appaiono solo quando più indicatori di momentum concordano:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> componenti votano.</strong> I segnali appaiono solo quando più indicatori di momentum concordano:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Conteggio voti in tempo reale mostra la ripartizione in tempo reale (es. "3 Rialzisti, 2 Neutrali")</li>
-                <li>• Sistema di valutazione X/5 — punteggio più alto = più accordo</li>
-                <li>• Linea composita combina tutti e cinque gli oscillatori per una visualizzazione facile</li>
+                <li>• Conteggio voti in tempo reale mostra la ripartizione in tempo reale (es. "5 Rialzisti, 2 Neutrali")</li>
+                <li>• Sistema di valutazione X/7 — punteggio più alto = più accordo</li>
+                <li>• Linea composita combina tutti e sette i componenti per una visualizzazione facile</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = tutti e 5 concordano (alta fiducia). Voto diviso = condizioni poco chiare.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = tutti e 7 concordano (alta fiducia). Voto diviso = condizioni poco chiare.</p>
             </div>
           </article>
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -6025,13 +6025,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/ja/" target="_blank" rel="noopener" style="color:var(--brand)">実際の動作を見る →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span>つのオシレーターが投票。</strong> 複数のモメンタムインジケーターが一致した時のみシグナルが表示：</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span>つのコンポーネントが投票。</strong> 複数のモメンタムインジケーターが一致した時のみシグナルが表示：</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• ライブ投票カウントでリアルタイム内訳を表示（例：「3 強気、2 中立」）</li>
-                <li>• X/5評価システム — スコアが高いほど一致度が高い</li>
-                <li>• 複合ラインが5つのオシレーターすべてを統合し簡単に確認可能</li>
+                <li>• ライブ投票カウントでリアルタイム内訳を表示（例：「5 強気、2 中立」）</li>
+                <li>• X/7評価システム — スコアが高いほど一致度が高い</li>
+                <li>• 複合ラインが7つのコンポーネントすべてを統合し簡単に確認可能</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = 5つすべてが一致（高信頼度）。投票が分かれている = 不明瞭な状況。</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = 7つすべてが一致（高信頼度）。投票が分かれている = 不明瞭な状況。</p>
             </div>
           </article>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -5735,13 +5735,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/nl/" target="_blank" rel="noopener" style="color:var(--brand)">Zie het in actie →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> oscillatoren stemmen.</strong> Signalen verschijnen alleen wanneer meerdere momentum indicatoren het eens zijn:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> componenten stemmen.</strong> Signalen verschijnen alleen wanneer meerdere momentum indicatoren het eens zijn:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Live stem telling toont real-time uitsplitsing (bijv. "3 Stijgend, 2 Neutraal")</li>
-                <li>• X/5 beoordelingssysteem — hogere score = meer overeenstemming</li>
-                <li>• Samengestelde lijn combineert alle vijf oscillatoren voor gemakkelijk bekijken</li>
+                <li>• Live stem telling toont real-time uitsplitsing (bijv. "5 Stijgend, 2 Neutraal")</li>
+                <li>• X/7 beoordelingssysteem — hogere score = meer overeenstemming</li>
+                <li>• Samengestelde lijn combineert alle zeven componenten voor gemakkelijk bekijken</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = alle 5 zijn het eens (hoog vertrouwen). Gesplitste stem = onduidelijke condities.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = alle 7 zijn het eens (hoog vertrouwen). Gesplitste stem = onduidelijke condities.</p>
             </div>
           </article>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -6047,13 +6047,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/pt/" target="_blank" rel="noopener" style="color:var(--brand)">Ver em ação →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> osciladores votam.</strong> Sinais só aparecem quando múltiplos indicadores de momentum concordam:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> componentes votam.</strong> Sinais só aparecem quando múltiplos indicadores de momentum concordam:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Contagem de votos ao vivo mostra distribuição em tempo real (ex: "3 Altistas, 2 Neutros")</li>
-                <li>• Sistema de pontuação X/5 — maior pontuação = mais concordância</li>
-                <li>• Linha composta combina todos os cinco osciladores para fácil visualização</li>
+                <li>• Contagem de votos ao vivo mostra distribuição em tempo real (ex: "5 Altistas, 2 Neutros")</li>
+                <li>• Sistema de pontuação X/7 — maior pontuação = mais concordância</li>
+                <li>• Linha composta combina todos os sete componentes para fácil visualização</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = todos os 5 concordam (alta confiança). Voto dividido = condições incertas.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = todos os 7 concordam (alta confiança). Voto dividido = condições incertas.</p>
             </div>
           </article>
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -5670,13 +5670,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/ru/" target="_blank" rel="noopener" style="color:var(--brand)">Смотреть в действии →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> осцилляторов голосуют.</strong> Сигналы появляются только когда несколько индикаторов импульса согласны:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> компонентов голосуют.</strong> Сигналы появляются только когда несколько индикаторов импульса согласны:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Счёт голосов в реальном времени показывает разбивку (например, "3 Быка, 2 Нейтральных")</li>
-                <li>• Система оценки X/5 — выше балл = больше согласия</li>
-                <li>• Составная линия объединяет все пять осцилляторов для удобного просмотра</li>
+                <li>• Счёт голосов в реальном времени показывает разбивку (например, "5 Быков, 2 Нейтральных")</li>
+                <li>• Система оценки X/7 — выше балл = больше согласия</li>
+                <li>• Составная линия объединяет все семь компонентов для удобного просмотра</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = все 5 согласны (высокая уверенность). Разделённое голосование = неясные условия.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = все 7 согласны (высокая уверенность). Разделённое голосование = неясные условия.</p>
             </div>
           </article>
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -5761,13 +5761,13 @@
               <a class="btn btn-ghost btn-sm" href="https://blog.signalpilot.io/articles/when-to-ignore-divergence/tr/" target="_blank" rel="noopener" style="color:var(--brand)">İşte görün →</a>
             </div>
             <div id="harmonic-details" class="indicator-details" style="display:none;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)">
-              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="5" data-text-mode>5</span> osilatör oy kullanır.</strong> Sinyaller yalnızca birden fazla momentum göstergesi uyuştuğunda görünür:</p>
+              <p style="font-size:.95rem;line-height:1.7;color:var(--muted);margin-bottom:1rem"><strong><span data-count="7" data-text-mode>7</span> bileşen oy kullanır.</strong> Sinyaller yalnızca birden fazla momentum göstergesi uyuştuğunda görünür:</p>
               <ul style="font-size:.9rem;line-height:1.9;color:var(--muted-2);list-style:none;padding:0">
-                <li>• Canlı oy sayımı gerçek zamanlı dağılımı gösterir (ör. "3 Boğa, 2 Nötr")</li>
-                <li>• X/5 puanlama sistemi — daha yüksek puan = daha fazla uyum</li>
-                <li>• Bileşik çizgi beş osilatörün tamamını kolay görüntüleme için birleştirir</li>
+                <li>• Canlı oy sayımı gerçek zamanlı dağılımı gösterir (ör. "5 Boğa, 2 Nötr")</li>
+                <li>• X/7 puanlama sistemi — daha yüksek puan = daha fazla uyum</li>
+                <li>• Bileşik çizgi yedi bileşenin tamamını kolay görüntüleme için birleştirir</li>
               </ul>
-              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">5/5 = 5'inin tamamı hemfikir (yüksek güven). Bölünmüş oy = belirsiz koşullar.</p>
+              <p style="font-size:.9rem;color:var(--muted);margin-top:1rem">7/7 = 7'sinin tamamı hemfikir (yüksek güven). Bölünmüş oy = belirsiz koşullar.</p>
             </div>
           </article>
 


### PR DESCRIPTION
Changes the Harmonic Oscillator voting system documentation across all files to reflect the correct 7-component system instead of the previous 5-oscillator references.

Updated files include:
- Chronicle pages (the-arbiter, birth-of-the-elite-seven, etc.)
- Main index and all 11 language versions (including header text)
- Markdown documentation (lore, social media kits, guides)

Voting thresholds updated: 7/7 STRONG, 5/7 Bull/Bear, 3/7 NEUT