### PR TITLE
Add complete hreflang tags to 240 pages for multilingual SEO

### DIFF
--- a/affiliates.html
+++ b/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/affiliates.html
+++ b/ar/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/ar/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/birth-of-the-elite-seven/index.html
+++ b/ar/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>ولادة النخبة السبعة — Signal Pilot</title>
   <meta name="description" content="قبل أن تحمل الأسواق أسماءً، قبل أن تروي الشموع قصصاً، لم يكن هناك سوى الضوضاء. هذه قصة أصل سبع إشارات سماوية ظهرت لتبحر في الفراغ.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/index.html
+++ b/ar/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>السجل — سجل SignalPilot</title>
   <meta name="description" content="رؤى معمقة حول دورات السوق وفلسفة التداول وقصة مؤشرات Elite Seven. تجاوز الضوضاء.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/meet-the-sovereign/index.html
+++ b/ar/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>تعرف على الحاكم: شرح Pentarch — Signal Pilot</title>
   <meta name="description" content="نظرة عميقة في Pentarch، المؤشر الرئيسي الذي يرسم المراحل الخمس لدورات السوق. فهم TD، IGN، WRN، CAP، و BDN.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ar/chronicle/the-arbiter/index.html
+++ b/ar/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>الحَكَم: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator يوحد أربعة مذبذبات في حكم واحد، يؤكد متى يجب الضرب. السابع والأخير من النخبة السبعة.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/the-cartographer/index.html
+++ b/ar/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>رسام الخرائط: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas يرسم خريطة التضاريس حيث تُخاض معارك السوق. فهم المستويات الرئيسية ومراسي VWAP ونقاط المرجعية المؤسسية.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/the-commander/index.html
+++ b/ar/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>القائد: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck يوحد عشرة أنظمة تداول متميزة في طبقة واحدة متماسكة. فهم المؤشر الشامل الذي ينهي فوضى الرسوم البيانية.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/the-council-assembles/index.html
+++ b/ar/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>المجلس يجتمع — Signal Pilot</title>
   <meta name="description" content="قابلت كل عضو. الآن شاهدهم يعملون كواحد. عندما تتحد النخبة السبعة، تصبح الفوضى وضوحاً والضوضاء إشارة.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/the-hierarchy-of-signals/index.html
+++ b/ar/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>التسلسل الهرمي للإشارات — Signal Pilot</title>
   <meta name="description" content="السبعة لا يوجدون في عزلة. يشكلون كوكبة—تسلسل هرمي من الغرض، كل واحد يخدم من فوقه بينما يمكّن من تحته.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/the-pilots-oath/index.html
+++ b/ar/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>قسم الطيار — Signal Pilot</title>
   <meta name="description" content="أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار. هذا هو القسم الذي يفصل بين أولئك الذين يبحرون وأولئك الذين يقامرون.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/the-prophet/index.html
+++ b/ar/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>النبي: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle يسمع ما لا يستطيع المتداولون العاديون سماعه—خطوات المؤسسات وهي تتحرك في الظلام. فهم التراكم والتوزيع قبل أن تعترف الرسوم البيانية.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ar/chronicle/the-scales/index.html
+++ b/ar/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>الميزان: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow يزن ضغط الشراء مقابل البيع ليكشف الحقيقة تحت السعر. فهم الدلتا التراكمية وإشارات التباعد.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/the-watchman/index.html
+++ b/ar/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>الحارس: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid يفحص ثمانية أسواق في وقت واحد، يرتب الفرص حسب القناعة ويفلتر الضوضاء من الإشارة. السادس من النخبة السبعة.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/chronicle/why-non-repainting-matters/index.html
+++ b/ar/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>لماذا عدم إعادة الرسم مهم — Signal Pilot</title>
   <meta name="description" content="معظم المؤشرات تكذب عليك بتغيير إشاراتها التاريخية. إليك لماذا عدم إعادة الرسم غير قابل للتفاوض، وكيف نضمنه.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/faq.html
+++ b/ar/faq.html
@@ -6,6 +6,21 @@
   <title>الأسئلة الشائعة الكاملة — Signal Pilot</title>
   <meta name="description" content="الأسئلة الشائعة الشاملة التي تغطي جميع جوانب مؤشرات Signal Pilot والتعليم والتسعير والدعم.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/manage-subscription.html
+++ b/ar/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>إدارة الاشتراك — Signal Pilot</title>
   <meta name="description" content="إدارة اشتراكك في Signal Pilot — إيقاف مؤقت، إلغاء، تحديث طرق الدفع، أو عرض سجل الفواتير.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/privacy.html
+++ b/ar/privacy.html
@@ -6,6 +6,21 @@
   <title>سياسة الخصوصية — Signal Pilot</title>
   <meta name="description" content="سياسة الخصوصية لـ Signal Pilot — كيف نجمع ونستخدم ونحمي بياناتك.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ar/refund.html
+++ b/ar/refund.html
@@ -6,6 +6,21 @@
   <title>سياسة الاسترداد — Signal Pilot</title>
   <meta name="description" content="سياسة الاسترداد لـ Signal Pilot — شروط استرداد بسيطة وعادلة.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ar/roadmap.html
+++ b/ar/roadmap.html
@@ -6,6 +6,21 @@
   <title>خارطة الطريق — Signal Pilot</title>
   <meta name="description" content="خارطة طريق Signal Pilot — ما هو متاح، ما القادم، وإلى أين نتجه. تطوير شفاف، تحسين مستمر.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ar/terms.html
+++ b/ar/terms.html
@@ -6,6 +6,21 @@
   <title>شروط الخدمة — Signal Pilot</title>
   <meta name="description" content="شروط الخدمة لـ Signal Pilot — القواعد والإرشادات لاستخدام مؤشرات التداول الخاصة بنا.">
   <link rel="canonical" href="https://www.signalpilot.io/ar/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/chronicle/birth-of-the-elite-seven/index.html
+++ b/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>The Birth of The Elite Seven — Signal Pilot</title>
   <meta name="description" content="Before the markets had names, before the candles told stories, there was only noise. This is the origin story of seven celestial signals that emerged to navigate the void.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/chronicle/index.html
+++ b/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Chronicle — The SignalPilot Chronicle</title>
   <meta name="description" content="The philosophy, lore, and origin stories behind The Elite Seven indicators.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/chronicle/meet-the-sovereign/index.html
+++ b/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Meet The Sovereign: Pentarch Explained — Signal Pilot</title>
   <meta name="description" content="A deep dive into Pentarch, the flagship indicator that maps the five phases of market cycles. Understanding TD, IGN, WRN, CAP, and BDN.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/chronicle/the-arbiter/index.html
+++ b/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>The Arbiter: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifies seven components into a single verdict, confirming when to strike. The seventh and final of The Elite Seven.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/chronicle/the-cartographer/index.html
+++ b/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>The Cartographer: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas maps the terrain where market battles are fought. Understanding key levels, VWAP anchors, and institutional reference points.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/chronicle/the-commander/index.html
+++ b/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>The Commander: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifies ten premium trading systems into one coherent overlay. Understanding the all-in-one indicator that ends chart chaos.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/chronicle/the-council-assembles/index.html
+++ b/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>The Council Assembles — Signal Pilot</title>
   <meta name="description" content="You've met each member. Now watch them work as one. When The Elite Seven unite, chaos becomes clarity and noise becomes signal.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/chronicle/the-hierarchy-of-signals/index.html
+++ b/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>The Hierarchy of Signals — Signal Pilot</title>
   <meta name="description" content="The Seven do not exist in isolation. They form a constellation—a hierarchy of purpose, each serving the one above while empowering those below.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/chronicle/the-pilots-oath/index.html
+++ b/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>The Pilot's Oath — Signal Pilot</title>
   <meta name="description" content="You who wield The Elite Seven are not a trader. You are a Pilot. This is the oath that separates those who navigate from those who gamble.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/chronicle/the-prophet/index.html
+++ b/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>The Prophet: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle hears what retail cannot—the footsteps of institutions moving in darkness. Understanding accumulation and distribution before the charts confess.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/chronicle/the-scales/index.html
+++ b/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>The Scales: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow weighs buying versus selling pressure to reveal the truth beneath price. Understanding cumulative delta and divergence signals.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/chronicle/the-watchman/index.html
+++ b/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>The Watchman: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scans eight markets simultaneously, ranking opportunities by conviction and filtering noise from signal. The sixth of The Elite Seven.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/chronicle/why-non-repainting-matters/index.html
+++ b/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Why Non-Repainting Matters — Signal Pilot</title>
   <meta name="description" content="Most indicators lie to you by changing their historical signals. Here's why non-repainting is non-negotiable, and how we guarantee it.">
   <link rel="canonical" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/affiliates.html
+++ b/de/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/de/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/chronicle/birth-of-the-elite-seven/index.html
+++ b/de/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>Die Geburt der Elite Sieben — Signal Pilot</title>
   <meta name="description" content="Bevor die Märkte Namen hatten, bevor die Kerzen Geschichten erzählten, gab es nur Rauschen. Dies ist die Entstehungsgeschichte von sieben himmlischen Signalen, die entstanden, um durch die Leere zu navigieren.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/chronicle/index.html
+++ b/de/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Chronik — Die SignalPilot Chronik</title>
   <meta name="description" content="Ausführliche Einblicke in Marktzyklen, Handelsphilosophie und die Geschichte hinter den Elite Sieben Indikatoren. Navigieren Sie durch das Rauschen.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/chronicle/meet-the-sovereign/index.html
+++ b/de/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Lerne den Herrscher kennen: Pentarch erklärt — Signal Pilot</title>
   <meta name="description" content="Ein tiefer Einblick in Pentarch, den Flaggschiff-Indikator, der die fünf Phasen der Marktzyklen kartiert. TD, IGN, WRN, CAP und BDN verstehen.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/chronicle/the-arbiter/index.html
+++ b/de/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>Der Schiedsrichter: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator vereint vier Oszillatoren zu einem einzigen Urteil und bestätigt, wann zugeschlagen werden soll. Der siebte und letzte der Elite Sieben.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/de/chronicle/the-cartographer/index.html
+++ b/de/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>Der Kartograph: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas kartiert das Terrain, auf dem Marktschlachten geschlagen werden. Verstehen Sie Schlüsselniveaus, VWAP-Anker und institutionelle Referenzpunkte.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/de/chronicle/the-commander/index.html
+++ b/de/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>Der Kommandant: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck vereint zehn Premium-Handelssysteme zu einem kohärenten Overlay. Verstehen Sie den All-in-One-Indikator, der das Chart-Chaos beendet.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/de/chronicle/the-council-assembles/index.html
+++ b/de/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>Der Rat versammelt sich — Signal Pilot</title>
   <meta name="description" content="Sie haben jedes Mitglied kennengelernt. Jetzt sehen Sie, wie sie als Einheit arbeiten. Wenn sich die Elite Sieben vereinen, wird Chaos zu Klarheit und Rauschen zu Signal.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/de/chronicle/the-hierarchy-of-signals/index.html
+++ b/de/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>Die Hierarchie der Signale — Signal Pilot</title>
   <meta name="description" content="Die Sieben existieren nicht isoliert. Sie bilden ein Sternbild—eine Hierarchie des Zwecks, jeder dient dem über ihm, während er jene unter ihm ermächtigt.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/chronicle/the-pilots-oath/index.html
+++ b/de/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>Der Eid des Piloten — Signal Pilot</title>
   <meta name="description" content="Du, der die Elite Sieben führst, bist kein Händler. Du bist ein Pilot. Dies ist der Eid, der diejenigen, die navigieren, von denen trennt, die spielen.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/chronicle/the-prophet/index.html
+++ b/de/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>Der Prophet: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle hört, was der Retail nicht kann – die Schritte der Institutionen, die sich im Dunkeln bewegen. Akkumulation und Distribution verstehen, bevor die Charts es gestehen.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/de/chronicle/the-scales/index.html
+++ b/de/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>Die Waage: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow wiegt Kauf- gegen Verkaufsdruck, um die Wahrheit unter dem Preis zu enthüllen. Verstehen Sie kumulatives Delta und Divergenzsignale.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/de/chronicle/the-watchman/index.html
+++ b/de/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>Der Wächter: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scannt acht Märkte gleichzeitig, bewertet Chancen nach Überzeugung und filtert Rauschen von Signal. Der sechste der Elite Sieben.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/de/chronicle/why-non-repainting-matters/index.html
+++ b/de/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Warum Non-Repainting wichtig ist — Signal Pilot</title>
   <meta name="description" content="Die meisten Indikatoren belügen Sie, indem sie ihre historischen Signale ändern. Hier erfahren Sie, warum Non-Repainting unverzichtbar ist und wie wir es garantieren.">
   <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/faq.html
+++ b/de/faq.html
@@ -6,6 +6,21 @@
   <title>Häufig gestellte Fragen — Signal Pilot</title>
   <meta name="description" content="Umfassende Häufig gestellte Fragen zu Signal Pilot Indikatoren, Bildung, Preisgestaltung und Support.">
   <link rel="canonical" href="https://www.signalpilot.io/de/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/manage-subscription.html
+++ b/de/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>Abonnement verwalten — Signal Pilot</title>
   <meta name="description" content="Verwalten Sie Ihr Signal Pilot-Abonnement – Pausieren, Kündigen, Zahlungsmethoden aktualisieren oder Abrechnungsverlauf anzeigen.">
   <link rel="canonical" href="https://www.signalpilot.io/de/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/privacy.html
+++ b/de/privacy.html
@@ -6,6 +6,21 @@
   <title>Datenschutzrichtlinie — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Datenschutzrichtlinie — Wie wir Ihre Daten sammeln, verwenden und schützen.">
   <link rel="canonical" href="https://www.signalpilot.io/de/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/refund.html
+++ b/de/refund.html
@@ -6,6 +6,21 @@
   <title>Rückgaberichtlinie — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Rückgaberichtlinie — Klare und faire Rückgabebedingungen für unsere Indikator-Abonnements.">
   <link rel="canonical" href="https://www.signalpilot.io/de/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/roadmap.html
+++ b/de/roadmap.html
@@ -6,6 +6,21 @@
   <title>Projektplan — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Projektplan — Was live ist, was kommt und wohin wir gehen. Transparente Entwicklung, kontinuierliche Verbesserung.">
   <link rel="canonical" href="https://www.signalpilot.io/de/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/de/terms.html
+++ b/de/terms.html
@@ -6,6 +6,21 @@
   <title>Allgemeine Geschäftsbedingungen — Signal Pilot</title>
   <meta name="description" content="Allgemeine Geschäftsbedingungen von Signal Pilot — Regeln und Richtlinien für die Nutzung unserer Trading-Indikatoren.">
   <link rel="canonical" href="https://www.signalpilot.io/de/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/affiliates.html
+++ b/es/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/es/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/chronicle/birth-of-the-elite-seven/index.html
+++ b/es/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>El Nacimiento de Los Siete de Élite — Signal Pilot</title>
   <meta name="description" content="Antes de que los mercados tuvieran nombres, antes de que las velas contaran historias, solo había ruido. Esta es la historia del origen de siete señales celestiales que emergieron para navegar el vacío.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/es/chronicle/index.html
+++ b/es/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Crónica — La Crónica de SignalPilot</title>
   <meta name="description" content="Análisis profundos sobre ciclos de mercado, filosofía de trading y la historia detrás de los indicadores Elite Siete. Navega a través del ruido.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/chronicle/meet-the-sovereign/index.html
+++ b/es/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Conoce al Soberano: Pentarch Explicado — Signal Pilot</title>
   <meta name="description" content="Una inmersión profunda en Pentarch, el indicador insignia que mapea las cinco fases de los ciclos de mercado. Entendiendo TD, IGN, WRN, CAP y BDN.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/chronicle/the-arbiter/index.html
+++ b/es/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>El Árbitro: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifica cuatro osciladores en un solo veredicto, confirmando cuándo atacar. El séptimo y último de Los Siete de Élite.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/es/chronicle/the-cartographer/index.html
+++ b/es/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>El Cartógrafo: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas mapea el terreno donde se libran las batallas del mercado. Entendiendo niveles clave, anclas VWAP y puntos de referencia institucionales.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/es/chronicle/the-commander/index.html
+++ b/es/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>El Comandante: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifica diez sistemas de trading premium en una superposición coherente. Entendiendo el indicador todo-en-uno que termina con el caos de gráficos.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/es/chronicle/the-council-assembles/index.html
+++ b/es/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>El Consejo Se Reúne — Signal Pilot</title>
   <meta name="description" content="Has conocido a cada miembro. Ahora obsérvalos trabajar como uno. Cuando Los Siete de Élite se unen, el caos se convierte en claridad y el ruido en señal.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/es/chronicle/the-hierarchy-of-signals/index.html
+++ b/es/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>La Jerarquía de Señales — Signal Pilot</title>
   <meta name="description" content="Los Siete no existen en aislamiento. Forman una constelación—una jerarquía de propósito, cada uno sirviendo al de arriba mientras empodera a los de abajo.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/chronicle/the-pilots-oath/index.html
+++ b/es/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>El Juramento del Piloto — Signal Pilot</title>
   <meta name="description" content="Tú que empuñas a Los Siete de Élite no eres un trader. Eres un Piloto. Este es el juramento que separa a quienes navegan de quienes apuestan.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/chronicle/the-prophet/index.html
+++ b/es/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>El Profeta: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle escucha lo que el retail no puede—los pasos de las instituciones moviéndose en la oscuridad. Entendiendo la acumulación y distribución antes de que los gráficos lo confiesen.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/es/chronicle/the-scales/index.html
+++ b/es/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>La Balanza: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow pesa la presión de compra versus venta para revelar la verdad bajo el precio. Entendiendo el delta acumulativo y las señales de divergencia.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/es/chronicle/the-watchman/index.html
+++ b/es/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>El Vigilante: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid escanea ocho mercados simultáneamente, clasificando oportunidades por convicción y filtrando el ruido de la señal. El sexto de Los Siete de Élite.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/es/chronicle/why-non-repainting-matters/index.html
+++ b/es/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Por Qué Importa el No-Repintado — Signal Pilot</title>
   <meta name="description" content="La mayoría de los indicadores te mienten cambiando sus señales históricas. Aquí está por qué el no-repintado es innegociable, y cómo lo garantizamos.">
   <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/faq.html
+++ b/es/faq.html
@@ -6,6 +6,21 @@
   <title>Preguntas Frecuentes Completas — Signal Pilot</title>
   <meta name="description" content="Preguntas frecuentes completas que cubren todos los aspectos de los indicadores, educación, precios y soporte de Signal Pilot.">
   <link rel="canonical" href="https://www.signalpilot.io/es/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/manage-subscription.html
+++ b/es/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>Gestionar Suscripción — Signal Pilot</title>
   <meta name="description" content="Gestione su suscripción de Signal Pilot — pausar, cancelar, actualizar métodos de pago o ver historial de facturación.">
   <link rel="canonical" href="https://www.signalpilot.io/es/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/privacy.html
+++ b/es/privacy.html
@@ -6,6 +6,21 @@
   <title>Política de Privacidad — Signal Pilot</title>
   <meta name="description" content="Política de Privacidad de Signal Pilot — Cómo recopilamos, utilizamos y protegemos sus datos.">
   <link rel="canonical" href="https://www.signalpilot.io/es/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/refund.html
+++ b/es/refund.html
@@ -6,6 +6,21 @@
   <title>Política de Reembolso — Signal Pilot</title>
   <meta name="description" content="Política de Reembolso de Signal Pilot — Términos de reembolso claros y justos para nuestras suscripciones de indicadores.">
   <link rel="canonical" href="https://www.signalpilot.io/es/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/roadmap.html
+++ b/es/roadmap.html
@@ -6,6 +6,21 @@
   <title>Hoja de Ruta del Proyecto — Signal Pilot</title>
   <meta name="description" content="Hoja de Ruta del Proyecto Signal Pilot — Lo que está activo, lo que viene y hacia dónde nos dirigimos. Desarrollo transparente, mejora continua.">
   <link rel="canonical" href="https://www.signalpilot.io/es/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/es/terms.html
+++ b/es/terms.html
@@ -6,6 +6,21 @@
   <title>Términos de Servicio — Signal Pilot</title>
   <meta name="description" content="Términos de Servicio de Signal Pilot — Normas y directrices para el uso de nuestros indicadores de trading.">
   <link rel="canonical" href="https://www.signalpilot.io/es/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/faq.html
+++ b/faq.html
@@ -6,6 +6,21 @@
   <title>Complete FAQ — Signal Pilot</title>
   <meta name="description" content="Comprehensive FAQ covering all aspects of Signal Pilot indicators, education, pricing, and support.">
   <link rel="canonical" href="https://www.signalpilot.io/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/fr/affiliates.html
+++ b/fr/affiliates.html
@@ -17,22 +17,28 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/fr/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- Favicons -->
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="/monogram-square-favicon_32x32.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/monogram-square-favicon_180x180.png">
-
-  <!-- Hreflang Tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
-
-  <!-- OpenGraph -->
+  <link rel="apple-touch-icon" sizes="180x180" href="/monogram-square-favicon_180x180.png"><!-- OpenGraph -->
   <meta property="og:site_name" content="Signal Pilot">
   <meta property="og:type" content="website">
   <meta property="og:locale" content="fr_FR">

--- a/fr/chronicle/birth-of-the-elite-seven/index.html
+++ b/fr/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>La Naissance des Sept d'Élite — Signal Pilot</title>
   <meta name="description" content="Avant que les marchés n'aient des noms, avant que les bougies ne racontent des histoires, il n'y avait que du bruit. Voici l'histoire d'origine de sept signaux célestes qui ont émergé pour naviguer dans le vide.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/index.html
+++ b/fr/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Chronique — La Chronique SignalPilot</title>
   <meta name="description" content="Analyses approfondies sur les cycles de marché, la philosophie du trading et l'histoire derrière les indicateurs Elite Sept. Naviguez à travers le bruit.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/fr/chronicle/meet-the-sovereign/index.html
+++ b/fr/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Rencontre Le Souverain : Pentarch Expliqué — Signal Pilot</title>
   <meta name="description" content="Une plongée profonde dans Pentarch, l'indicateur phare qui cartographie les cinq phases des cycles de marché. Comprendre TD, IGN, WRN, CAP et BDN.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-arbiter/index.html
+++ b/fr/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>L'Arbitre : Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifie quatre oscillateurs en un seul verdict, confirmant quand frapper. Le septième et dernier des Sept d'Élite.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-cartographer/index.html
+++ b/fr/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>Le Cartographe : Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas cartographie le terrain où les batailles de marché sont livrées. Comprendre les niveaux clés, les ancres VWAP et les points de référence institutionnels.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-commander/index.html
+++ b/fr/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>Le Commandant : OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifie dix systèmes de trading premium en une seule superposition cohérente. Comprendre l'indicateur tout-en-un qui met fin au chaos des graphiques.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-council-assembles/index.html
+++ b/fr/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>Le Conseil S'Assemble — Signal Pilot</title>
   <meta name="description" content="Vous avez rencontré chaque membre. Maintenant regardez-les travailler comme un seul. Quand Les Sept d'Élite s'unissent, le chaos devient clarté et le bruit devient signal.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-hierarchy-of-signals/index.html
+++ b/fr/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>La Hiérarchie des Signaux — Signal Pilot</title>
   <meta name="description" content="Les Sept n'existent pas isolément. Ils forment une constellation—une hiérarchie de but, chacun servant celui au-dessus tout en renforçant ceux en dessous.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-pilots-oath/index.html
+++ b/fr/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>Le Serment du Pilote — Signal Pilot</title>
   <meta name="description" content="Toi qui manies Les Sept d'Élite n'es pas un trader. Tu es un Pilote. Voici le serment qui sépare ceux qui naviguent de ceux qui parient.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-prophet/index.html
+++ b/fr/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>Le Prophète : Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle entend ce que les particuliers ne peuvent pas—les pas des institutions se déplaçant dans l'obscurité. Comprendre l'accumulation et la distribution avant que les graphiques ne confessent.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-scales/index.html
+++ b/fr/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>La Balance : Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow pèse la pression d'achat contre la pression de vente pour révéler la vérité sous le prix. Comprendre le delta cumulatif et les signaux de divergence.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/the-watchman/index.html
+++ b/fr/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>Le Vigilant : Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scanne huit marchés simultanément, classant les opportunités par conviction et filtrant le bruit du signal. Le sixième des Sept d'Élite.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/chronicle/why-non-repainting-matters/index.html
+++ b/fr/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Pourquoi Le Non-Repaint Est Important — Signal Pilot</title>
   <meta name="description" content="La plupart des indicateurs vous mentent en modifiant leurs signaux historiques. Voici pourquoi le non-repaint est non négociable, et comment nous le garantissons.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/fr/faq.html
+++ b/fr/faq.html
@@ -6,6 +6,21 @@
   <title>Questions Fréquentes Complètes — Signal Pilot</title>
   <meta name="description" content="Questions fréquentes complètes couvrant tous les aspects des indicateurs Signal Pilot, formation, tarifs et support.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
@@ -14,16 +29,7 @@
   <meta property="og:url" content="https://www.signalpilot.io/fr/faq.html">
   <meta property="og:title" content="Questions Fréquentes Complètes — Signal Pilot">
   <meta property="og:description" content="Questions fréquentes complètes couvrant tous les aspects des indicateurs Signal Pilot, formation, tarifs et support.">
-  <meta property="og:locale" content="fr_FR">
-
-  <!-- Hreflang Tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
-
-  <!-- Fonts -->
+  <meta property="og:locale" content="fr_FR"><!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Gugi&display=swap" rel="stylesheet">

--- a/fr/manage-subscription.html
+++ b/fr/manage-subscription.html
@@ -5,16 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Gérer Votre Abonnement — Signal Pilot</title>
   <meta name="description" content="Gérez votre abonnement Signal Pilot — mettre en pause, annuler, mettre à jour les méthodes de paiement ou consulter l'historique de facturation.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/manage-subscription.html"><meta name="robots" content="index,follow">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
   <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
-
-  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- OpenGraph / Twitter -->

--- a/fr/privacy.html
+++ b/fr/privacy.html
@@ -6,17 +6,23 @@
   <title>Politique de Confidentialité - Signal Pilot</title>
   <meta name="description" content="Politique de Confidentialité de Signal Pilot — Comment nous collectons, utilisons et protégeons vos données.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/privacy.html">
-  <meta name="robots" content="index,follow">
-  <meta name="theme-color" content="#05070d">
 
-  <!-- Hreflang Tags -->
+  <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
   <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
-
-  <!-- Open Graph -->
+  <meta name="robots" content="index,follow">
+  <meta name="theme-color" content="#05070d"><!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Politique de Confidentialité - Signal Pilot">
   <meta property="og:description" content="Politique de Confidentialité de Signal Pilot — Comment nous collectons, utilisons et protégeons vos données.">

--- a/fr/refund.html
+++ b/fr/refund.html
@@ -5,16 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Politique de Remboursement - Signal Pilot</title>
   <meta name="description" content="Politique de Remboursement de Signal Pilot — Conditions de remboursement claires et équitables pour nos abonnements aux indicateurs.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/refund.html">
-
-  <!-- Hreflang Tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
-
-  <!-- Open Graph -->
+  <link rel="canonical" href="https://www.signalpilot.io/fr/refund.html"><!-- Open Graph -->
   <meta property="og:title" content="Politique de Remboursement - Signal Pilot">
   <meta property="og:description" content="Politique de Remboursement de Signal Pilot — Conditions de remboursement claires et équitables pour nos abonnements aux indicateurs.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/refund.html">
@@ -23,6 +14,21 @@
   <meta property="og:type" content="website">
 
   <meta name="robots" content="index,follow">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="theme-color" content="#05070d">
 
   <!-- Fonts -->

--- a/fr/roadmap.html
+++ b/fr/roadmap.html
@@ -6,6 +6,21 @@
   <title>Feuille de Route - Signal Pilot</title>
   <meta name="description" content="Feuille de Route du Projet Signal Pilot — Ce qui est actif, ce qui arrive et où nous allons. Développement transparent, amélioration continue.">
   <link rel="canonical" href="https://www.signalpilot.io/fr/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
@@ -14,16 +29,7 @@
   <meta property="og:description" content="Feuille de Route du Projet Signal Pilot — Ce qui est actif, ce qui arrive et où nous allons. Développement transparent, amélioration continue.">
   <meta property="og:url" content="https://www.signalpilot.io/fr/roadmap.html">
   <meta property="og:type" content="website">
-  <meta property="og:locale" content="fr_FR">
-
-  <!-- Hreflang Tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
-
-  <!-- Fonts -->
+  <meta property="og:locale" content="fr_FR"><!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Gugi&display=swap" rel="stylesheet">

--- a/fr/terms.html
+++ b/fr/terms.html
@@ -5,16 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Conditions d'Utilisation — Signal Pilot</title>
   <meta name="description" content="Conditions d'Utilisation de Signal Pilot — Règles et directives pour l'utilisation de nos indicateurs de trading.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/terms.html"><meta name="robots" content="index,follow">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
   <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
-
-  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- OpenGraph -->

--- a/hu/affiliates.html
+++ b/hu/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/hu/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/chronicle/birth-of-the-elite-seven/index.html
+++ b/hu/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>Az Elit Hetek Születése — Signal Pilot</title>
   <meta name="description" content="Mielőtt a piacoknak nevük lett volna, mielőtt a gyertyák történeteket meséltek volna, csak zaj volt. Ez a hét égi jel eredettörténete.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/hu/chronicle/index.html
+++ b/hu/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Krónika — A SignalPilot Krónika</title>
   <meta name="description" content="Mélyreható betekintések a piaci ciklusokról, kereskedési filozófiáról és az Elite Seven indikátorok történetéről. Navigálj a zajon át.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/chronicle/meet-the-sovereign/index.html
+++ b/hu/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Ismerd Meg a Szuverént: A Pentarch Bemutatása — Signal Pilot</title>
   <meta name="description" content="Mély betekintés a Pentarchba, a zászlóshajó indikátorba, amely feltérképezi a piaci ciklusok öt fázisát. A TD, IGN, WRN, CAP és BDN megértése.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/chronicle/the-arbiter/index.html
+++ b/hu/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>A Döntőbíró: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="A Harmonic Oscillator négy oszcillátort egyesít egyetlen ítéletbe, megerősítve, mikor kell csapni. Az Elit Hetek hetedik és utolsó tagja.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/hu/chronicle/the-cartographer/index.html
+++ b/hu/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>A Kartográfus: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="A Janus Atlas feltérképezi a terepet, ahol a piaci csaták zajlanak. A kulcsszintek, VWAP horgonyok és intézményi referenciapontok megértése.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/hu/chronicle/the-commander/index.html
+++ b/hu/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>A Parancsnok: OmniDeck — Signal Pilot</title>
   <meta name="description" content="Az OmniDeck tíz prémium kereskedési rendszert egyesít egyetlen koherens overlay-be. Az all-in-one indikátor megértése, amely véget vet a chart káosznak.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/hu/chronicle/the-council-assembles/index.html
+++ b/hu/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>A Konsey Toplanyor — Signal Pilot</title>
   <meta name="description" content="Megismerted minden tagot. Most nézd, hogyan dolgoznak egyként. Amikor az Elit Hetek egyesülnek, a káosz tisztánlátássá és a zaj jelzéssé válik.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/hu/chronicle/the-hierarchy-of-signals/index.html
+++ b/hu/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>A Jelek Hierarchiája — Signal Pilot</title>
   <meta name="description" content="A Hetek nem elszigetelten léteznek. Csillagképet alkotnak—célok hierarchiáját, ahol mindegyik a fölötte lévőt szolgálja, miközben az alatta lévőket erősíti.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/chronicle/the-pilots-oath/index.html
+++ b/hu/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>A Pilóta Esküje — Signal Pilot</title>
   <meta name="description" content="Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy. Ez az eskü választja el azokat, akik navigálnak, azoktól, akik szerencsejátékot űznek.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/chronicle/the-prophet/index.html
+++ b/hu/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>A Próféta: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="A Volume Oracle hallja, amit a kisbefektetők nem—az intézmények lépteit, amint a sötétségben mozognak. Az akkumuláció és disztribúció megértése, mielőtt a chartok bevallják.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/hu/chronicle/the-scales/index.html
+++ b/hu/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>A Mérleg: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="A Plutus Flow méri a vételi és eladási nyomást, hogy feltárja az igazságot az ár alatt. A kumulatív delta és divergencia jelzések megértése.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/hu/chronicle/the-watchman/index.html
+++ b/hu/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>Az Őrszem: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Az Augury Grid nyolc piacot pásztáz egyidejűleg, meggyőződés szerint rangsorolva a lehetőségeket és kiszűrve a zajt a jelből. Az Elit Hetek hatodikja.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/hu/chronicle/why-non-repainting-matters/index.html
+++ b/hu/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Miért Fontos a Nem-Újrafestés — Signal Pilot</title>
   <meta name="description" content="A legtöbb indikátor hazudik, mert megváltoztatja a történelmi jelzéseit. Íme, miért elfogadhatatlan ez, és hogyan garantáljuk az ellenkezőjét.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/faq.html
+++ b/hu/faq.html
@@ -6,6 +6,21 @@
   <title>Teljes GYIK — Signal Pilot</title>
   <meta name="description" content="Átfogó GYIK amely lefedi a Signal Pilot indikátorok, oktatás, árazás és támogatás minden aspektusát.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/manage-subscription.html
+++ b/hu/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>Előfizetés Kezelése — Signal Pilot</title>
   <meta name="description" content="Kezeld a Signal Pilot előfizetésedet — szüneteltesd, mondd le, frissítsd a fizetési módokat vagy tekintsd meg a számlázási előzményeket.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/privacy.html
+++ b/hu/privacy.html
@@ -6,6 +6,21 @@
   <title>Adatvédelmi Irányelvek — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Adatvédelmi Irányelvek — Hogyan gyűjtjük, használjuk és védjük az adataidat.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/refund.html
+++ b/hu/refund.html
@@ -6,6 +6,21 @@
   <title>Visszatérítési Politika — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Visszatérítési Politika — Világos, tisztességes visszatérítési feltételek indikátor előfizetéseinkre.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/roadmap.html
+++ b/hu/roadmap.html
@@ -6,6 +6,21 @@
   <title>Projekt Ütemterv — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Projekt Ütemterv — Mi már elérhető, mi jön, és hova tartunk. Átlátható fejlesztés, folyamatos fejlődés.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/hu/terms.html
+++ b/hu/terms.html
@@ -6,6 +6,21 @@
   <title>Szolgáltatási Feltételek — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Szolgáltatási Feltételek — Szabályok és irányelvek kereskedési indikátoraink használatához.">
   <link rel="canonical" href="https://www.signalpilot.io/hu/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/it/affiliates.html
+++ b/it/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/it/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/it/chronicle/birth-of-the-elite-seven/index.html
+++ b/it/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>La Nascita dei Sette d'Élite — Signal Pilot</title>
   <meta name="description" content="In un'epoca di caos, sette indicatori si sono forgiati dal rumore. Questa è la loro storia di origine—e la tua iniziazione nella costellazione.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/index.html
+++ b/it/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Cronaca — La Cronaca di SignalPilot</title>
   <meta name="description" content="Approfondimenti sui cicli di mercato, filosofia di trading e la storia dietro gli indicatori Elite Sette. Naviga attraverso il rumore.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/it/chronicle/meet-the-sovereign/index.html
+++ b/it/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Incontra Il Sovrano: Pentarch Spiegato — Signal Pilot</title>
   <meta name="description" content="Un'immersione profonda nell'indicatore ammiraglia che mappa le cinque fasi dei cicli di mercato. Comprendi le cinque fasi di Pentarch.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-arbiter/index.html
+++ b/it/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>L'Arbitro: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifica quattro oscillatori in un singolo verdetto, confermando quando colpire. Il settimo e ultimo dei Sette d'Élite.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-cartographer/index.html
+++ b/it/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>Il Cartografo: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas mappa il terreno dove si combattono le battaglie di mercato. Comprendere i livelli chiave, gli anchor VWAP e i punti di riferimento istituzionali.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-commander/index.html
+++ b/it/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>Il Comandante: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifica dieci sistemi di trading premium in un'unica overlay coerente. Comprendere l'indicatore all-in-one che pone fine al caos dei grafici.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-council-assembles/index.html
+++ b/it/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>Il Consiglio Si Riunisce — Signal Pilot</title>
   <meta name="description" content="Hai incontrato ogni membro. Ora guardali lavorare come uno. Quando I Sette d'Élite si uniscono, il caos diventa chiarezza e il rumore diventa segnale.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-hierarchy-of-signals/index.html
+++ b/it/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>La Gerarchia dei Segnali — Signal Pilot</title>
   <meta name="description" content="Non tutti i segnali sono uguali. Impara come I Sette d'Élite formano una costellazione di scopo—e perché l'ordine conta.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-pilots-oath/index.html
+++ b/it/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>Il Giuramento del Pilota — Signal Pilot</title>
   <meta name="description" content="Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota. Questo è il giuramento che fai—e la filosofia che ti guida.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-prophet/index.html
+++ b/it/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>Il Profeta: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle sente quello che i retail non possono—i passi delle istituzioni che si muovono nell'oscurità. Comprendere accumulo e distribuzione prima che i grafici confessino.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-scales/index.html
+++ b/it/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>La Bilancia: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow pesa la pressione di acquisto contro quella di vendita per rivelare la verità sotto il prezzo. Comprendere il delta cumulativo e i segnali di divergenza.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/the-watchman/index.html
+++ b/it/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>La Sentinella: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scansiona otto mercati simultaneamente, classificando le opportunità per convinzione e filtrando il rumore dal segnale. Il sesto dei Sette d'Élite.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/chronicle/why-non-repainting-matters/index.html
+++ b/it/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Perché il Non-Repainting È Importante — Signal Pilot</title>
   <meta name="description" content="La maggior parte degli indicatori ti mente cambiando i loro segnali storici. Ecco perché il non-repainting non è negoziabile, e come lo garantiamo.">
   <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/it/faq.html
+++ b/it/faq.html
@@ -6,6 +6,21 @@
   <title>FAQ Completa — Signal Pilot</title>
   <meta name="description" content="FAQ completa che copre tutti gli aspetti degli indicatori Signal Pilot, formazione, prezzi e supporto.">
   <link rel="canonical" href="https://www.signalpilot.io/it/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/it/manage-subscription.html
+++ b/it/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>Gestisci Abbonamento — Signal Pilot</title>
   <meta name="description" content="Gestisci il tuo abbonamento Signal Pilot — metti in pausa, annulla, aggiorna i metodi di pagamento o visualizza la cronologia di fatturazione.">
   <link rel="canonical" href="https://www.signalpilot.io/it/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/it/privacy.html
+++ b/it/privacy.html
@@ -6,6 +6,21 @@
   <title>Informativa sulla Privacy — Signal Pilot</title>
   <meta name="description" content="Informativa sulla Privacy di Signal Pilot — Come raccogliamo, utilizziamo e proteggiamo i tuoi dati.">
   <link rel="canonical" href="https://www.signalpilot.io/it/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/it/refund.html
+++ b/it/refund.html
@@ -6,6 +6,21 @@
   <title>Politica di Rimborso — Signal Pilot</title>
   <meta name="description" content="Politica di Rimborso Signal Pilot — Termini di rimborso chiari ed equi per i nostri abbonamenti agli indicatori.">
   <link rel="canonical" href="https://www.signalpilot.io/it/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/it/roadmap.html
+++ b/it/roadmap.html
@@ -6,6 +6,21 @@
   <title>Roadmap del Progetto — Signal Pilot</title>
   <meta name="description" content="Roadmap del Progetto Signal Pilot — Cosa è attivo, cosa sta arrivando e dove stiamo andando. Sviluppo trasparente, miglioramento continuo.">
   <link rel="canonical" href="https://www.signalpilot.io/it/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/it/terms.html
+++ b/it/terms.html
@@ -6,6 +6,21 @@
   <title>Termini di Servizio — Signal Pilot</title>
   <meta name="description" content="Termini di Servizio di Signal Pilot — Regole e linee guida per l'utilizzo dei nostri indicatori di trading.">
   <link rel="canonical" href="https://www.signalpilot.io/it/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ja/affiliates.html
+++ b/ja/affiliates.html
@@ -17,24 +17,28 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/ja/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- Favicons -->
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="/monogram-square-favicon_32x32.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/monogram-square-favicon_180x180.png">
-
-  <!-- Hreflang Tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
-  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
-  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
-
-  <!-- OpenGraph -->
+  <link rel="apple-touch-icon" sizes="180x180" href="/monogram-square-favicon_180x180.png"><!-- OpenGraph -->
   <meta property="og:site_name" content="Signal Pilot">
   <meta property="og:type" content="website">
   <meta property="og:locale" content="ja_JP">

--- a/ja/chronicle/birth-of-the-elite-seven/index.html
+++ b/ja/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>エリートセブンの誕生 — Signal Pilot</title>
   <meta name="description" content="すべてはシグナルの混乱から始まった。あるパイロットの旅が7つのインジケーターを結集し、混沌を明晰さに変えた。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/index.html
+++ b/ja/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>クロニクル — SignalPilotクロニクル</title>
   <meta name="description" content="市場サイクル、トレード哲学、Elite Sevenインジケーターの物語に関する詳細な洞察。ノイズを見抜く。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ja/chronicle/meet-the-sovereign/index.html
+++ b/ja/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>ソブリンに会う：Pentarch — Signal Pilot</title>
   <meta name="description" content="Pentarch - エリートセブンの第一人者。サイクルとフェーズを通じて市場を読み解くソブリンインジケーターの仕組みを深く探る。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-arbiter/index.html
+++ b/ja/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>アービター：Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillatorは4つのオシレーターを単一の判定に統合し、いつストライクすべきかを確認します。エリートセブンの第七にして最後。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-cartographer/index.html
+++ b/ja/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>カートグラファー：Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlasは市場の戦いが繰り広げられる地形をマッピングします。重要なレベル、VWAPアンカー、機関投資家の基準点を理解する。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-commander/index.html
+++ b/ja/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>コマンダー：OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeckは10のプレミアム取引システムを一つの統一されたオーバーレイに統合します。チャートの混沌を終わらせるオールインワンインジケーターを理解する。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-council-assembles/index.html
+++ b/ja/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>評議会は集う — Signal Pilot</title>
   <meta name="description" content="各メンバーと会いました。今、彼らが一つとして働くのを見てください。エリートセブンが団結するとき、混沌は明晰さになり、ノイズはシグナルになります。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-hierarchy-of-signals/index.html
+++ b/ja/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>シグナルの階層 — Signal Pilot</title>
   <meta name="description" content="エリートセブンがどのように目的の星座として協力するかを理解する。各インジケーターの役割、階層、シグナルが流れる方法。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-pilots-oath/index.html
+++ b/ja/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>パイロットの誓い — Signal Pilot</title>
   <meta name="description" content="すべてのパイロットが従う規律の核心にあるもの。これらの原則はトレーダーをパイロットに変える。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-prophet/index.html
+++ b/ja/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>プロフェット：Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracleは機関投資家のボリュームの真実を明らかにする。彼らがどこで蓄積し、どこで分配しているか—小売トレーダーの目に見えないもの。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-scales/index.html
+++ b/ja/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>スケール：Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flowは買い圧力と売り圧力を量り、価格の下にある真実を明らかにします。累積デルタとダイバージェンスシグナルを理解する。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/the-watchman/index.html
+++ b/ja/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>ウォッチマン：Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Gridは8つの市場を同時にスキャンし、確信度で機会をランク付けし、ノイズからシグナルをフィルタリングします。エリートセブンの第六。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/chronicle/why-non-repainting-matters/index.html
+++ b/ja/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>なぜノンリペイントが重要か — Signal Pilot</title>
   <meta name="description" content="リペイントするインジケーターはバックテストでは美しく見えるが、実際のトレードでは失敗する。Signal Pilotのノンリペイント保証の背後にある真実を学ぶ。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ja/faq.html
+++ b/ja/faq.html
@@ -6,6 +6,21 @@
   <title>よくある質問 — Signal Pilot</title>
   <meta name="description" content="Signal Pilotインジケーター、教育、価格設定、サポートのすべての側面をカバーする包括的なFAQ。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
@@ -20,18 +35,7 @@
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="https://www.signalpilot.io/ja/faq.html">
   <meta property="twitter:title" content="よくある質問 — Signal Pilot">
-  <meta property="twitter:description" content="Signal Pilotインジケーター、教育、価格設定、サポートのすべての側面をカバーする包括的なFAQ。">
-
-  <!-- Hreflang Tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
-  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
-  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
-
-  <!-- Fonts -->
+  <meta property="twitter:description" content="Signal Pilotインジケーター、教育、価格設定、サポートのすべての側面をカバーする包括的なFAQ。"><!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Gugi&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">

--- a/ja/manage-subscription.html
+++ b/ja/manage-subscription.html
@@ -5,18 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>サブスクリプション管理 — Signal Pilot</title>
   <meta name="description" content="Signal Pilotのサブスクリプションを管理 — 一時停止、キャンセル、支払い方法の更新、または請求履歴の確認が可能です。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/manage-subscription.html"><meta name="robots" content="index,follow">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
   <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
-
-  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- OpenGraph / Twitter -->

--- a/ja/privacy.html
+++ b/ja/privacy.html
@@ -6,19 +6,23 @@
   <title>プライバシーポリシー — Signal Pilot</title>
   <meta name="description" content="Signal Pilot プライバシーポリシー — 個人データの収集、使用、保護について">
   <link rel="canonical" href="https://www.signalpilot.io/ja/privacy.html">
-  <meta name="robots" content="index,follow">
-  <meta name="theme-color" content="#05070d">
 
-  <!-- Hreflang Tags -->
+  <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
   <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
-
-  <!-- Open Graph -->
+  <meta name="robots" content="index,follow">
+  <meta name="theme-color" content="#05070d"><!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="プライバシーポリシー — Signal Pilot">
   <meta property="og:description" content="Signal Pilot プライバシーポリシー — 個人データの収集、使用、保護について">

--- a/ja/refund.html
+++ b/ja/refund.html
@@ -5,18 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>返金ポリシー — Signal Pilot</title>
   <meta name="description" content="Signal Pilotの返金ポリシー — インジケーターサブスクリプションに関する明確で公正な返金規約。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/refund.html">
-
-  <!-- Hreflang Tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
-  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
-  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
-
-  <!-- Open Graph -->
+  <link rel="canonical" href="https://www.signalpilot.io/ja/refund.html"><!-- Open Graph -->
   <meta property="og:title" content="返金ポリシー — Signal Pilot">
   <meta property="og:description" content="Signal Pilotの返金ポリシー — インジケーターサブスクリプションに関する明確で公正な返金規約。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/refund.html">
@@ -25,6 +14,21 @@
   <meta property="og:type" content="website">
 
   <meta name="robots" content="index,follow">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="theme-color" content="#05070d">
 
   <!-- Fonts -->

--- a/ja/roadmap.html
+++ b/ja/roadmap.html
@@ -6,6 +6,21 @@
   <title>ロードマップ — Signal Pilot</title>
   <meta name="description" content="Signal Pilot プロジェクトロードマップ — 現在提供中の機能、今後の予定、そして私たちの方向性。透明性のある開発、継続的な改善。">
   <link rel="canonical" href="https://www.signalpilot.io/ja/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
@@ -14,18 +29,7 @@
   <meta property="og:description" content="Signal Pilot プロジェクトロードマップ — 現在提供中の機能、今後の予定、そして私たちの方向性。透明性のある開発、継続的な改善。">
   <meta property="og:url" content="https://www.signalpilot.io/ja/roadmap.html">
   <meta property="og:type" content="website">
-  <meta property="og:locale" content="ja_JP">
-
-  <!-- Hreflang Tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
-  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
-  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
-
-  <!-- Fonts -->
+  <meta property="og:locale" content="ja_JP"><!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Gugi&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">

--- a/ja/terms.html
+++ b/ja/terms.html
@@ -5,18 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>利用規約 — Signal Pilot</title>
   <meta name="description" content="Signal Pilot 利用規約 — 当社のトレーディングインジケーターを使用するためのルールとガイドライン。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/terms.html"><meta name="robots" content="index,follow">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
   <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
-
-  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- OpenGraph -->

--- a/manage-subscription.html
+++ b/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>Manage Subscription — Signal Pilot</title>
   <meta name="description" content="Manage your Signal Pilot subscription — pause, cancel, update payment methods, or view billing history.">
   <link rel="canonical" href="https://www.signalpilot.io/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/nl/affiliates.html
+++ b/nl/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/nl/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/nl/chronicle/birth-of-the-elite-seven/index.html
+++ b/nl/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>De Geboorte van de Elite Zeven — Signal Pilot</title>
   <meta name="description" content="In het hart van marktchaos werd een visie geboren. De oorsprong van de zeven indicatoren die alles veranderden.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/index.html
+++ b/nl/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Kroniek — De SignalPilot Kroniek</title>
   <meta name="description" content="Diepgaande inzichten over marktcycli, handelsfilosofie en het verhaal achter de Elite Zeven indicatoren. Navigeer door de ruis.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/nl/chronicle/meet-the-sovereign/index.html
+++ b/nl/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Ontmoet de Soeverein: Pentarch — Signal Pilot</title>
   <meta name="description" content="Pentarch is de leider van de Elite Zeven. Het leest marktcycli en bepaalt de koers. De eerste en machtigste.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-arbiter/index.html
+++ b/nl/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>De Arbiter: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unificeert vier oscillatoren in één oordeel, bevestigend wanneer te slaan. De zevende en laatste van de Elite Zeven.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-cartographer/index.html
+++ b/nl/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>De Cartograaf: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas brengt het terrein in kaart waar marktveldslagen worden uitgevochten. Begrijp sleutelniveaus, VWAP-ankers en institutionele referentiepunten.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-commander/index.html
+++ b/nl/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>De Commandant: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unificeert tien premium handelssystemen in één coherente overlay. Begrijp de alles-in-één indicator die grafiekchaos beëindigt.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-council-assembles/index.html
+++ b/nl/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>De Raad Komt Bijeen — Signal Pilot</title>
   <meta name="description" content="Je hebt elk lid ontmoet. Nu zie je hoe ze als één werken. Wanneer De Elite Zeven zich verenigen, wordt chaos helderheid en ruis wordt signaal.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-hierarchy-of-signals/index.html
+++ b/nl/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>De Hiërarchie van Signalen — Signal Pilot</title>
   <meta name="description" content="Niet alle signalen zijn gelijk. Leer hoe de Elite Zeven samenwerken in een gestructureerd systeem van prioriteit en validatie.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-pilots-oath/index.html
+++ b/nl/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>De Eed van de Piloot — Signal Pilot</title>
   <meta name="description" content="Een code van discipline die traders van gokkers onderscheidt. De principes die elke Signal Pilot-piloot geloven en volgen.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-prophet/index.html
+++ b/nl/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>De Profeet: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle hoort institutionele positionering. Het detecteert accumulatie en distributie voordat prijs onthult.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-scales/index.html
+++ b/nl/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>De Weegschaal: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow weegt koop- versus verkoopdruk om de waarheid onder prijs te onthullen. Begrijp cumulatieve delta en divergentiesignalen.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/the-watchman/index.html
+++ b/nl/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>De Wachter: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scant acht markten tegelijk, rankt kansen op overtuiging en filtert ruis van signaal. De zesde van de Elite Zeven.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/chronicle/why-non-repainting-matters/index.html
+++ b/nl/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Waarom Niet-Herpainting Belangrijk Is — Signal Pilot</title>
   <meta name="description" content="De fundamentele garantie die eerlijke analyse mogelijk maakt. Begrijp waarom herpainting indicatoren uw trading saboteren.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/nl/faq.html
+++ b/nl/faq.html
@@ -6,6 +6,21 @@
   <title>Veelgestelde Vragen — Signal Pilot</title>
   <meta name="description" content="Uitgebreide veelgestelde vragen over Signal Pilot indicatoren, onderwijs, prijzen en ondersteuning.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/nl/manage-subscription.html
+++ b/nl/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>Beheer abonnement — Signal Pilot</title>
   <meta name="description" content="Beheer uw Signal Pilot abonnement – Pauzeren, annuleren, betaalmethoden bijwerken of factureringsgeschiedenis bekijken.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/nl/privacy.html
+++ b/nl/privacy.html
@@ -6,6 +6,21 @@
   <title>Privacybeleid — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Privacybeleid — Hoe we uw gegevens verzamelen, gebruiken en beschermen.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/nl/refund.html
+++ b/nl/refund.html
@@ -6,6 +6,21 @@
   <title>Restitutiebeleid — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Restitutiebeleid — Duidelijke en eerlijke restitutievoorwaarden voor onze indicator abonnementen.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/nl/roadmap.html
+++ b/nl/roadmap.html
@@ -6,6 +6,21 @@
   <title>Roadmap — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Roadmap — Wat live is, wat komt en waar we naartoe gaan. Transparante ontwikkeling, continue verbetering.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/nl/terms.html
+++ b/nl/terms.html
@@ -6,6 +6,21 @@
   <title>Algemene Voorwaarden — Signal Pilot</title>
   <meta name="description" content="Algemene Voorwaarden van Signal Pilot — Regels en richtlijnen voor het gebruik van onze handelsindicatoren.">
   <link rel="canonical" href="https://www.signalpilot.io/nl/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/privacy.html
+++ b/privacy.html
@@ -6,6 +6,21 @@
   <title>Privacy Policy — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Privacy Policy — How we collect, use, and protect your data.">
   <link rel="canonical" href="https://www.signalpilot.io/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/affiliates.html
+++ b/pt/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/pt/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/chronicle/birth-of-the-elite-seven/index.html
+++ b/pt/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>O Nascimento dos Sete de Elite — Signal Pilot</title>
   <meta name="description" content="Antes que os mercados tivessem nomes, antes que as velas contassem histórias, havia apenas ruído. Esta é a história de origem de sete sinais celestiais que emergiram para navegar o vazio.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/chronicle/index.html
+++ b/pt/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Crônica — A Crônica SignalPilot</title>
   <meta name="description" content="Análises aprofundadas sobre ciclos de mercado, filosofia de trading e a história por trás dos indicadores Elite Sete. Navegue através do ruído.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/chronicle/meet-the-sovereign/index.html
+++ b/pt/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Conheça O Soberano: Pentarch Explicado — Signal Pilot</title>
   <meta name="description" content="Um mergulho profundo no Pentarch, o indicador principal que mapeia as cinco fases dos ciclos de mercado. Entendendo TD, IGN, WRN, CAP e BDN.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/chronicle/the-arbiter/index.html
+++ b/pt/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>O Árbitro: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifica quatro osciladores em um único veredito, confirmando quando atacar. O sétimo e último dos Elite Sete.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/pt/chronicle/the-cartographer/index.html
+++ b/pt/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>O Cartógrafo: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas mapeia o terreno onde as batalhas do mercado são travadas. Compreendendo níveis-chave, âncoras VWAP e pontos de referência institucionais.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/pt/chronicle/the-commander/index.html
+++ b/pt/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>O Comandante: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifica dez sistemas de trading premium em uma sobreposição coerente. Compreendendo o indicador tudo-em-um que acaba com o caos dos gráficos.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/pt/chronicle/the-council-assembles/index.html
+++ b/pt/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>O Conselho Se Reúne — Signal Pilot</title>
   <meta name="description" content="Você conheceu cada membro. Agora veja-os trabalhar como um só. Quando os Elite Sete se unem, caos se torna clareza e ruído se torna sinal.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/pt/chronicle/the-hierarchy-of-signals/index.html
+++ b/pt/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>A Hierarquia dos Sinais — Signal Pilot</title>
   <meta name="description" content="Os Sete não existem isoladamente. Eles formam uma constelação—uma hierarquia de propósito, cada um servindo aquele acima enquanto capacita aqueles abaixo.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/chronicle/the-pilots-oath/index.html
+++ b/pt/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>O Juramento do Piloto — Signal Pilot</title>
   <meta name="description" content="Você que empunha Os Sete de Elite não é um trader. Você é um Piloto. Este é o juramento que separa aqueles que navegam daqueles que apostam.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/chronicle/the-prophet/index.html
+++ b/pt/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>O Profeta: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle ouve o que o varejo não consegue—os passos das instituições movendo-se na escuridão. Entendendo acumulação e distribuição antes dos gráficos confessarem.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/pt/chronicle/the-scales/index.html
+++ b/pt/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>A Balança: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow pesa a pressão de compra versus venda para revelar a verdade sob o preço. Compreendendo delta cumulativo e sinais de divergência.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/pt/chronicle/the-watchman/index.html
+++ b/pt/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>A Sentinela: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid escaneia oito mercados simultaneamente, classificando oportunidades por convicção e filtrando ruído do sinal. O sexto dos Elite Sete.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/pt/chronicle/why-non-repainting-matters/index.html
+++ b/pt/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Por Que Não Repintar Importa — Signal Pilot</title>
   <meta name="description" content="A maioria dos indicadores mente para você mudando seus sinais históricos. Aqui está por que não repintar não é negociável, e como nós o garantimos.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/faq.html
+++ b/pt/faq.html
@@ -6,6 +6,21 @@
   <title>Perguntas Frequentes Completas — Signal Pilot</title>
   <meta name="description" content="Perguntas frequentes abrangentes cobrindo todos os aspectos dos indicadores Signal Pilot, educação, preços e suporte.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/manage-subscription.html
+++ b/pt/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>Gerenciar Assinatura — Signal Pilot</title>
   <meta name="description" content="Gerencie sua assinatura do Signal Pilot — pause, cancele, atualize métodos de pagamento ou visualize o histórico de cobrança.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/privacy.html
+++ b/pt/privacy.html
@@ -6,6 +6,21 @@
   <title>Política de Privacidade — Signal Pilot</title>
   <meta name="description" content="Política de Privacidade do Signal Pilot — Como coletamos, usamos e protegemos seus dados.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/refund.html
+++ b/pt/refund.html
@@ -6,6 +6,21 @@
   <title>Política de Reembolso — Signal Pilot</title>
   <meta name="description" content="Política de Reembolso do Signal Pilot — Termos de reembolso claros e justos para nossas assinaturas de indicadores.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/roadmap.html
+++ b/pt/roadmap.html
@@ -6,6 +6,21 @@
   <title>Roteiro do Projeto — Signal Pilot</title>
   <meta name="description" content="Roteiro do Projeto Signal Pilot — O que está ativo, o que está chegando e para onde estamos indo. Desenvolvimento transparente, melhoria contínua.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/pt/terms.html
+++ b/pt/terms.html
@@ -6,6 +6,21 @@
   <title>Termos de Serviço — Signal Pilot</title>
   <meta name="description" content="Termos de Serviço do Signal Pilot — Regras e diretrizes para uso de nossos indicadores de negociação.">
   <link rel="canonical" href="https://www.signalpilot.io/pt/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/refund.html
+++ b/refund.html
@@ -6,6 +6,21 @@
   <title>Refund Policy — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Refund Policy — Clear, fair refund terms for our indicator subscriptions.">
   <link rel="canonical" href="https://www.signalpilot.io/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -6,6 +6,21 @@
   <title>Project Roadmap — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Project Roadmap — What's live, what's coming, and where we're headed. Transparent development, continuous improvement.">
   <link rel="canonical" href="https://www.signalpilot.io/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ru/affiliates.html
+++ b/ru/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/ru/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ru/chronicle/birth-of-the-elite-seven/index.html
+++ b/ru/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>Рождение Элитной Семёрки — Signal Pilot</title>
   <meta name="description" content="До того как рынки получили названия, до того как свечи рассказывали истории, был только шум. Это история происхождения семи небесных сигналов, которые появились, чтобы проложить путь сквозь пустоту.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/index.html
+++ b/ru/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Хроника — Хроника SignalPilot</title>
   <meta name="description" content="Аналитические статьи о рыночных циклах, торговой философии и истории индикаторов Elite Seven. Преодолевайте рыночный шум.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ru/chronicle/meet-the-sovereign/index.html
+++ b/ru/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Познакомьтесь с Сувереном: Pentarch — Signal Pilot</title>
   <meta name="description" content="Глубокое погружение в Pentarch, флагманский индикатор, который картирует пять фаз рыночных циклов. Понимание TD, IGN, WRN, CAP и BDN.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-arbiter/index.html
+++ b/ru/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>Арбитр: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator объединяет четыре осциллятора в единый вердикт, подтверждая, когда наносить удар. Седьмой и последний из Элитной Семёрки.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-cartographer/index.html
+++ b/ru/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>Картограф: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas картографирует местность, где ведутся рыночные сражения. Понимание ключевых уровней, якорей VWAP и институциональных точек отсчёта.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-commander/index.html
+++ b/ru/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>Командир: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck объединяет десять премиальных торговых систем в один согласованный оверлей. Понимание индикатора всё-в-одном, который положит конец хаосу на графиках.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-council-assembles/index.html
+++ b/ru/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>Совет Собирается — Signal Pilot</title>
   <meta name="description" content="Вы познакомились с каждым участником. Теперь смотрите, как они работают как единое целое. Когда Элитная Семёрка объединяется, хаос становится ясностью, а шум становится сигналом.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-hierarchy-of-signals/index.html
+++ b/ru/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>Иерархия Сигналов — Signal Pilot</title>
   <meta name="description" content="Семёрка не существует в изоляции. Они образуют созвездие — иерархию целей, где каждый служит тому, кто выше, наделяя силой тех, кто ниже.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-pilots-oath/index.html
+++ b/ru/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>Клятва Пилота — Signal Pilot</title>
   <meta name="description" content="Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот. Это клятва, которая отделяет тех, кто навигирует, от тех, кто играет.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-prophet/index.html
+++ b/ru/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>Пророк: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle слышит то, что недоступно розничным — шаги институций, движущихся во тьме. Понимание накопления и распределения до того, как графики признаются.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-scales/index.html
+++ b/ru/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>Весы: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow взвешивает давление покупок против продаж, чтобы раскрыть истину под ценой. Понимание кумулятивной дельты и сигналов дивергенции.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/the-watchman/index.html
+++ b/ru/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>Страж: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid сканирует восемь рынков одновременно, ранжируя возможности по убеждённости и отфильтровывая шум от сигнала. Шестой из Элитной Семёрки.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/chronicle/why-non-repainting-matters/index.html
+++ b/ru/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Почему Отсутствие Перерисовки Важно — Signal Pilot</title>
   <meta name="description" content="Большинство индикаторов лгут вам, изменяя свои исторические сигналы. Вот почему отсутствие перерисовки не подлежит обсуждению, и как мы это гарантируем.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/ru/faq.html
+++ b/ru/faq.html
@@ -6,6 +6,21 @@
   <title>Полный FAQ — Signal Pilot</title>
   <meta name="description" content="Исчерпывающий FAQ, охватывающий все аспекты индикаторов Signal Pilot, обучения, ценообразования и поддержки.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/faq.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ru/manage-subscription.html
+++ b/ru/manage-subscription.html
@@ -6,6 +6,21 @@
   <title>Управление подпиской — Signal Pilot</title>
   <meta name="description" content="Управляйте своей подпиской Signal Pilot — приостановка, отмена, обновление способа оплаты или просмотр истории счетов.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/manage-subscription.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ru/privacy.html
+++ b/ru/privacy.html
@@ -6,6 +6,21 @@
   <title>Политика конфиденциальности — Signal Pilot</title>
   <meta name="description" content="Политика конфиденциальности Signal Pilot — как мы собираем, используем и защищаем ваши данные.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/privacy.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ru/refund.html
+++ b/ru/refund.html
@@ -6,6 +6,21 @@
   <title>Политика возврата — Signal Pilot</title>
   <meta name="description" content="Политика возврата Signal Pilot — простые и справедливые условия возврата.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/refund.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ru/roadmap.html
+++ b/ru/roadmap.html
@@ -6,6 +6,21 @@
   <title>Дорожная карта проекта — Signal Pilot</title>
   <meta name="description" content="Дорожная карта проекта Signal Pilot — Что доступно, что готовится, и куда мы движемся. Прозрачная разработка, постоянное улучшение.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/ru/terms.html
+++ b/ru/terms.html
@@ -6,6 +6,21 @@
   <title>Условия обслуживания — Signal Pilot</title>
   <meta name="description" content="Условия обслуживания Signal Pilot — правила и рекомендации по использованию наших торговых сигналов.">
   <link rel="canonical" href="https://www.signalpilot.io/ru/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/terms.html
+++ b/terms.html
@@ -6,6 +6,21 @@
   <title>Terms of Service — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Terms of Service — Rules and guidelines for using our trading indicators.">
   <link rel="canonical" href="https://www.signalpilot.io/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/tr/affiliates.html
+++ b/tr/affiliates.html
@@ -17,6 +17,21 @@
   <meta name="author" content="Signal Pilot Labs">
 
   <link rel="canonical" href="https://www.signalpilot.io/tr/affiliates.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/affiliates.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/affiliates.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/affiliates.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/affiliates.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/affiliates.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
@@ -31,19 +46,7 @@
   <meta property="og:title" content="Ortak Programı — %30 Tekrarlayan Komisyon Kazanın">
   <meta property="og:description" content="Trading eğitmenleri için mükemmel. Signal Pilot'u tanıtın ve her abone için ömür boyu tekrarlayan komisyon kazanın.">
   <meta property="og:url" content="https://www.signalpilot.io/tr/affiliates.html">
-  <meta property="og:image" content="https://www.signalpilot.io/preview.png">
-
-  <!-- Hreflang tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/affiliates.html">
-  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/affiliates.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/affiliates.html">
-  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/affiliates.html">
-  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/affiliates.html">
-  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/affiliates.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/affiliates.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/affiliates.html">
-
-  <!-- Fonts -->
+  <meta property="og:image" content="https://www.signalpilot.io/preview.png"><!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Gugi&family=EB+Garamond:wght@400;500;600&display=swap" rel="stylesheet">

--- a/tr/chronicle/birth-of-the-elite-seven/index.html
+++ b/tr/chronicle/birth-of-the-elite-seven/index.html
@@ -6,6 +6,21 @@
   <title>Elit Yedilinin Doğuşu — Signal Pilot</title>
   <meta name="description" content="Signal Pilot'un imza göstergelerine güç veren devrimci sistem olan Elite Seven'ın başlangıç hikayesini keşfedin.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/index.html
+++ b/tr/chronicle/index.html
@@ -6,6 +6,21 @@
   <title>Kronik — SignalPilot Kroniği</title>
   <meta name="description" content="Piyasa döngüleri, ticaret felsefesi ve Elite Seven göstergelerinin hikayesi hakkında kapsamlı içgörüler. Gürültüyü aşın.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 

--- a/tr/chronicle/meet-the-sovereign/index.html
+++ b/tr/chronicle/meet-the-sovereign/index.html
@@ -6,6 +6,21 @@
   <title>Hükümdar ile Tanışın: Pentarch — Signal Pilot</title>
   <meta name="description" content="Piyasa döngülerinin usta okuyucusu Pentarch'ı keşfedin. ACC, IGN, TD ve DIST fazlarını anlayın—piyasa ritimlerini ustalıkla okumanın anahtarı.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-arbiter/index.html
+++ b/tr/chronicle/the-arbiter/index.html
@@ -6,6 +6,21 @@
   <title>Hakem: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator dört osilatörü tek bir karara birleştirir, ne zaman vuracağınızı onaylar. Elit Yedili'nin yedincisi ve sonuncusu.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-arbiter">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-cartographer/index.html
+++ b/tr/chronicle/the-cartographer/index.html
@@ -6,6 +6,21 @@
   <title>Kartograf: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas, piyasa savaşlarının yapıldığı araziyi haritalandırır. Önemli seviyeleri, VWAP çapalarını ve kurumsal referans noktalarını anlama.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-cartographer">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-commander/index.html
+++ b/tr/chronicle/the-commander/index.html
@@ -6,6 +6,21 @@
   <title>Komutan: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck on premium işlem sistemini tek tutarlı bir katmanda birleştirir. Grafik kaosunu sona erdiren hepsi bir arada göstergeyi anlama.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-commander">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-commander/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-commander/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-commander/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-council-assembles/index.html
+++ b/tr/chronicle/the-council-assembles/index.html
@@ -6,6 +6,21 @@
   <title>Konsey Toplanıyor — Signal Pilot</title>
   <meta name="description" content="Her üyeyle tanıştınız. Şimdi birlikte çalışmalarını izleyin. Elit Yedili birleştiğinde, kaos netliğe ve gürültü sinyale dönüşür.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-hierarchy-of-signals/index.html
+++ b/tr/chronicle/the-hierarchy-of-signals/index.html
@@ -6,6 +6,21 @@
   <title>Sinyallerin Hiyerarşisi — Signal Pilot</title>
   <meta name="description" content="Elit Yedili'nin nasıl bir amaç takım yıldızı olarak birlikte çalıştığını anlayın. Her bir göstergenin yetkiden yürütmeye kadar katmanlı yapıdaki rolünü keşfedin.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-pilots-oath/index.html
+++ b/tr/chronicle/the-pilots-oath/index.html
@@ -6,6 +6,21 @@
   <title>Pilotun Yemini — Signal Pilot</title>
   <meta name="description" content="Gerçek Pilotları çaylak spekülatörlerden ayıran yedi prensip. Elit bir trader olma yolculuğunuzda sizi yönlendirecek kurallar.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-prophet/index.html
+++ b/tr/chronicle/the-prophet/index.html
@@ -6,6 +6,21 @@
   <title>Peygamber: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Kurumsal faaliyetin dinleyicisi Volume Oracle'ı keşfedin. Büyük sermayenin ne zaman hareket ettiğini ve ne zaman perakendecileri tuzağa düşürdüğünü anlayın.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-prophet">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-scales/index.html
+++ b/tr/chronicle/the-scales/index.html
@@ -6,6 +6,21 @@
   <title>Terazi: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow, fiyatın altındaki gerçeği ortaya çıkarmak için alım baskısını satış baskısına karşı tartar. Kümülatif delta ve sapma sinyallerini anlama.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-scales">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-scales/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-scales/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-scales/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/the-watchman/index.html
+++ b/tr/chronicle/the-watchman/index.html
@@ -6,6 +6,21 @@
   <title>Nöbetçi: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid sekiz piyasayı aynı anda tarar, fırsatları kararlılığa göre sıralar ve gürültüyü sinyalden ayırır. Elit Yedili'nin altıncısı.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-watchman">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/chronicle/why-non-repainting-matters/index.html
+++ b/tr/chronicle/why-non-repainting-matters/index.html
@@ -6,6 +6,21 @@
   <title>Neden Non-Repainting Önemlidir — Signal Pilot</title>
   <meta name="description" content="Geçmişi değiştiren göstergelerin tehlikesini ve Signal Pilot'un non-repainting garantisinin neden önemli olduğunu anlayın.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
   <meta property="og:site_name" content="Signal Pilot">

--- a/tr/faq.html
+++ b/tr/faq.html
@@ -5,19 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Eksiksiz SSS — Signal Pilot</title>
   <meta name="description" content="Signal Pilot göstergeleri, eğitim, fiyatlandırma ve destek hakkında tüm konuları kapsayan kapsamlı SSS.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/faq.html">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/faq.html"><meta name="robots" content="index,follow">
 
-  <!-- Hreflang tags -->
+  <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/faq.html">
-  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/faq.html">
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/faq.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/faq.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/faq.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/faq.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/faq.html">
   <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/faq.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/faq.html">
   <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/faq.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/faq.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/faq.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/faq.html">
-
-  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- Fonts -->

--- a/tr/manage-subscription.html
+++ b/tr/manage-subscription.html
@@ -5,19 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Aboneliği Yönet — Signal Pilot</title>
   <meta name="description" content="Signal Pilot aboneliğinizi yönetin — ödeme yöntemlerini güncelleyin, duraklatın/devam ettirin, iptal edin veya fatura geçmişini görüntüleyin—hepsi self-service.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/manage-subscription.html">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/manage-subscription.html"><meta name="robots" content="index,follow">
 
-  <!-- Hreflang tags -->
+  <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/manage-subscription.html">
-  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/manage-subscription.html">
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/manage-subscription.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/manage-subscription.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/manage-subscription.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/manage-subscription.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/manage-subscription.html">
   <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/manage-subscription.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/manage-subscription.html">
   <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/manage-subscription.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/manage-subscription.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/manage-subscription.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/manage-subscription.html">
-
-  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- Fonts -->

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -5,19 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Gizlilik Politikası — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Gizlilik Politikası — Verilerinizi nasıl topladığımız, kullandığımız ve koruduğumuz.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/privacy.html">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/privacy.html"><meta name="robots" content="index,follow">
 
-  <!-- Hreflang tags -->
+  <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/privacy.html">
-  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/privacy.html">
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/privacy.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/privacy.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/privacy.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/privacy.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/privacy.html">
   <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/privacy.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/privacy.html">
   <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/privacy.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/privacy.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/privacy.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/privacy.html">
-
-  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- Fonts -->

--- a/tr/refund.html
+++ b/tr/refund.html
@@ -5,19 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>İade Politikası — Signal Pilot</title>
   <meta name="description" content="Signal Pilot İade Politikası — Gösterge aboneliklerimiz için açık, adil iade şartları.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/refund.html">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/refund.html"><meta name="robots" content="index,follow">
 
-  <!-- Hreflang tags -->
+  <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/refund.html">
-  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
-  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/refund.html">
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/refund.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/refund.html">
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/refund.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/refund.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/refund.html">
   <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/refund.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/refund.html">
   <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/refund.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/refund.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/refund.html">
   <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/refund.html">
-
-  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
 
   <!-- Fonts -->

--- a/tr/roadmap.html
+++ b/tr/roadmap.html
@@ -6,11 +6,24 @@
   <title>Proje Yol Haritası — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Proje Yol Haritası — Yayında olanlar, gelenler ve nereye gittiğimiz. Şeffaf geliştirme, sürekli iyileştirme.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/roadmap.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/roadmap.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/roadmap.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/roadmap.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/roadmap.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/roadmap.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/roadmap.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/roadmap.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/roadmap.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/roadmap.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
-
-  <!-- Hreflang tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html" />
+<link rel="alternate" hreflang="en" href="https://www.signalpilot.io/roadmap.html" />
   <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/roadmap.html" />
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/roadmap.html" />
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/roadmap.html" />

--- a/tr/terms.html
+++ b/tr/terms.html
@@ -6,11 +6,24 @@
   <title>Hizmet Şartları — Signal Pilot</title>
   <meta name="description" content="Signal Pilot Hizmet Şartları — Ticaret göstergelerimizi kullanmak için kurallar ve yönergeler.">
   <link rel="canonical" href="https://www.signalpilot.io/tr/terms.html">
+
+  <!-- Hreflang tags for language versions -->
+  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html">
+  <link rel="alternate" hreflang="ar" href="https://www.signalpilot.io/ar/terms.html">
+  <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html">
+  <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html">
+  <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html">
+  <link rel="alternate" hreflang="hu" href="https://www.signalpilot.io/hu/terms.html">
+  <link rel="alternate" hreflang="it" href="https://www.signalpilot.io/it/terms.html">
+  <link rel="alternate" hreflang="ja" href="https://www.signalpilot.io/ja/terms.html">
+  <link rel="alternate" hreflang="nl" href="https://www.signalpilot.io/nl/terms.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://www.signalpilot.io/pt/terms.html">
+  <link rel="alternate" hreflang="ru" href="https://www.signalpilot.io/ru/terms.html">
+  <link rel="alternate" hreflang="tr" href="https://www.signalpilot.io/tr/terms.html">
+  <link rel="alternate" hreflang="x-default" href="https://www.signalpilot.io/terms.html">
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#05070d">
-
-  <!-- Hreflang tags -->
-  <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html" />
+<link rel="alternate" hreflang="en" href="https://www.signalpilot.io/terms.html" />
   <link rel="alternate" hreflang="es" href="https://www.signalpilot.io/es/terms.html" />
   <link rel="alternate" hreflang="de" href="https://www.signalpilot.io/de/terms.html" />
   <link rel="alternate" hreflang="fr" href="https://www.signalpilot.io/fr/terms.html" />


### PR DESCRIPTION
- Add hreflang tags to 7 English root pages (faq, affiliates, privacy, etc.)
- Add hreflang tags to 77 language sub-pages (AR, DE, ES, FR, HU, IT, JA, NL, PT, RU, TR)
- Fix incomplete hreflang on French/Japanese/Turkish pages (expanded from 5-8 to 13 tags)
- Add hreflang tags to 156 chronicle pages across all languages

Each page now includes complete hreflang block with all 12 languages + x-default: en, ar, de, es, fr, hu, it, ja, nl, pt-BR, ru, tr