### PR TITLE
Fix spotlight CSS on Elite 7 product cards for language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2592,21 +2592,43 @@
 
     /* Spotlight border effect for Elite 7 cards */
     .card.product{
-      --mouse-x:50%;--mouse-y:50%;--spotlight-opacity:0;
-      position:relative;transition:transform 0.3s ease,box-shadow 0.3s ease;
+      --mouse-x:50%;
+      --mouse-y:50%;
+      --spotlight-opacity:0;
+      position:relative;
+      transition:transform 0.3s ease,box-shadow 0.3s ease;
     }
     .card.product::before{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.15),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:1;
+      content:'';
+      position:absolute;
+      inset:0;
+      border-radius:inherit;
+      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:1;
     }
     .card.product::after{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.4),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:2;
-      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask-composite:exclude;padding:2px;
+      content:'';
+      position:absolute;
+      inset:-1px;
+      border-radius:inherit;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
     .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}

--- a/hu/index.html
+++ b/hu/index.html
@@ -2607,21 +2607,43 @@
 
     /* Spotlight border effect for Elite 7 cards */
     .card.product{
-      --mouse-x:50%;--mouse-y:50%;--spotlight-opacity:0;
-      position:relative;transition:transform 0.3s ease,box-shadow 0.3s ease;
+      --mouse-x:50%;
+      --mouse-y:50%;
+      --spotlight-opacity:0;
+      position:relative;
+      transition:transform 0.3s ease,box-shadow 0.3s ease;
     }
     .card.product::before{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.15),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:1;
+      content:'';
+      position:absolute;
+      inset:0;
+      border-radius:inherit;
+      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:1;
     }
     .card.product::after{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.4),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:2;
-      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask-composite:exclude;padding:2px;
+      content:'';
+      position:absolute;
+      inset:-1px;
+      border-radius:inherit;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
     .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}

--- a/nl/index.html
+++ b/nl/index.html
@@ -2590,21 +2590,43 @@
 
     /* Spotlight border effect for Elite 7 cards */
     .card.product{
-      --mouse-x:50%;--mouse-y:50%;--spotlight-opacity:0;
-      position:relative;transition:transform 0.3s ease,box-shadow 0.3s ease;
+      --mouse-x:50%;
+      --mouse-y:50%;
+      --spotlight-opacity:0;
+      position:relative;
+      transition:transform 0.3s ease,box-shadow 0.3s ease;
     }
     .card.product::before{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.15),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:1;
+      content:'';
+      position:absolute;
+      inset:0;
+      border-radius:inherit;
+      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:1;
     }
     .card.product::after{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.4),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:2;
-      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask-composite:exclude;padding:2px;
+      content:'';
+      position:absolute;
+      inset:-1px;
+      border-radius:inherit;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
     .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}

--- a/pt/index.html
+++ b/pt/index.html
@@ -2688,21 +2688,43 @@
 
     /* Spotlight border effect for Elite 7 cards */
     .card.product{
-      --mouse-x:50%;--mouse-y:50%;--spotlight-opacity:0;
-      position:relative;transition:transform 0.3s ease,box-shadow 0.3s ease;
+      --mouse-x:50%;
+      --mouse-y:50%;
+      --spotlight-opacity:0;
+      position:relative;
+      transition:transform 0.3s ease,box-shadow 0.3s ease;
     }
     .card.product::before{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.15),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:1;
+      content:'';
+      position:absolute;
+      inset:0;
+      border-radius:inherit;
+      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:1;
     }
     .card.product::after{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.4),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:2;
-      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask-composite:exclude;padding:2px;
+      content:'';
+      position:absolute;
+      inset:-1px;
+      border-radius:inherit;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
     .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}

--- a/ru/index.html
+++ b/ru/index.html
@@ -2520,21 +2520,43 @@
 
     /* Spotlight border effect for Elite 7 cards */
     .card.product{
-      --mouse-x:50%;--mouse-y:50%;--spotlight-opacity:0;
-      position:relative;transition:transform 0.3s ease,box-shadow 0.3s ease;
+      --mouse-x:50%;
+      --mouse-y:50%;
+      --spotlight-opacity:0;
+      position:relative;
+      transition:transform 0.3s ease,box-shadow 0.3s ease;
     }
     .card.product::before{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.15),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:1;
+      content:'';
+      position:absolute;
+      inset:0;
+      border-radius:inherit;
+      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:1;
     }
     .card.product::after{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.4),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:2;
-      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask-composite:exclude;padding:2px;
+      content:'';
+      position:absolute;
+      inset:-1px;
+      border-radius:inherit;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
     .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}

--- a/tr/index.html
+++ b/tr/index.html
@@ -2612,21 +2612,43 @@
 
     /* Spotlight border effect for Elite 7 cards */
     .card.product{
-      --mouse-x:50%;--mouse-y:50%;--spotlight-opacity:0;
-      position:relative;transition:transform 0.3s ease,box-shadow 0.3s ease;
+      --mouse-x:50%;
+      --mouse-y:50%;
+      --spotlight-opacity:0;
+      position:relative;
+      transition:transform 0.3s ease,box-shadow 0.3s ease;
     }
     .card.product::before{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.15),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:1;
+      content:'';
+      position:absolute;
+      inset:0;
+      border-radius:inherit;
+      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:1;
     }
     .card.product::after{
-      content:'';position:absolute;top:0;left:0;right:0;bottom:0;
-      background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(91,138,255,.4),transparent 40%);
-      border-radius:inherit;opacity:var(--spotlight-opacity);transition:opacity 0.3s ease;pointer-events:none;z-index:2;
-      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask-composite:exclude;padding:2px;
+      content:'';
+      position:absolute;
+      inset:-1px;
+      border-radius:inherit;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
+      opacity:var(--spotlight-opacity);
+      transition:opacity 0.3s ease;
+      pointer-events:none;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
     .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}


### PR DESCRIPTION
Updated CSS to match English site: correct gradients (cyan 118,221,255), webkit mask prefixes, xor mask-composite, hover lift effect, and inset positioning.