### PR TITLE
Add spotlight mouse tracking JS to all language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -9175,6 +9175,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/de/index.html
+++ b/de/index.html
@@ -9143,6 +9143,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/es/index.html
+++ b/es/index.html
@@ -9438,6 +9438,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/fr/index.html
+++ b/fr/index.html
@@ -9318,6 +9318,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/hu/index.html
+++ b/hu/index.html
@@ -9097,6 +9097,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/it/index.html
+++ b/it/index.html
@@ -8975,6 +8975,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/ja/index.html
+++ b/ja/index.html
@@ -9325,6 +9325,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/nl/index.html
+++ b/nl/index.html
@@ -8990,6 +8990,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/pt/index.html
+++ b/pt/index.html
@@ -9274,6 +9274,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/ru/index.html
+++ b/ru/index.html
@@ -8942,6 +8942,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {

--- a/tr/index.html
+++ b/tr/index.html
@@ -9038,6 +9038,25 @@ if ('serviceWorker' in navigator) {
     const indicatorCards = document.querySelectorAll('.card.product');
     indicatorCards.forEach(card => card.classList.add('scroll-fade-in'));
 
+    // Spotlight effect for product cards - mouse tracking
+    indicatorCards.forEach(card => {
+      card.addEventListener('mouseenter', () => {
+        card.style.setProperty('--spotlight-opacity', '1');
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--spotlight-opacity', '0');
+      });
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        requestAnimationFrame(() => {
+          card.style.setProperty('--mouse-x', x + 'px');
+          card.style.setProperty('--mouse-y', y + 'px');
+        });
+      });
+    });
+
     // Intersection Observer for scroll animations
     // Use lower threshold on mobile for better performance
     const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
The CSS was there but the JS event listeners for mouseenter, mouseleave, and mousemove were missing. Now all language sites have the same spotlight effect as the English site for Elite 7 product cards.