### PR TITLE
Fix spotlight CSS on Elite 7 cards for de, es, fr, it, ja sites

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -2558,19 +2558,23 @@
     .card.product::after{
       content:'';
       position:absolute;
-      inset:0;
+      inset:-1px;
       border-radius:inherit;
-      padding:1px;
-      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),transparent 40%);
-      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
-      -webkit-mask-composite:xor;
-      mask-composite:exclude;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);
       transition:opacity 0.3s ease;
       pointer-events:none;
-      z-index:2;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
 
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}

--- a/es/index.html
+++ b/es/index.html
@@ -2794,19 +2794,23 @@
     .card.product::after{
       content:'';
       position:absolute;
-      inset:0;
+      inset:-1px;
       border-radius:inherit;
-      padding:1px;
-      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),transparent 40%);
-      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
-      -webkit-mask-composite:xor;
-      mask-composite:exclude;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);
       transition:opacity 0.3s ease;
       pointer-events:none;
-      z-index:2;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
 
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}

--- a/fr/index.html
+++ b/fr/index.html
@@ -2647,19 +2647,23 @@
     .card.product::after{
       content:'';
       position:absolute;
-      inset:0;
+      inset:-1px;
       border-radius:inherit;
-      padding:1px;
-      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),transparent 40%);
-      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
-      -webkit-mask-composite:xor;
-      mask-composite:exclude;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);
       transition:opacity 0.3s ease;
       pointer-events:none;
-      z-index:2;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
 
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}

--- a/it/index.html
+++ b/it/index.html
@@ -2553,19 +2553,23 @@
     .card.product::after{
       content:'';
       position:absolute;
-      inset:0;
+      inset:-1px;
       border-radius:inherit;
-      padding:1px;
-      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),transparent 40%);
-      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
-      -webkit-mask-composite:xor;
-      mask-composite:exclude;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);
       transition:opacity 0.3s ease;
       pointer-events:none;
-      z-index:2;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
 
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}

--- a/ja/index.html
+++ b/ja/index.html
@@ -2827,19 +2827,23 @@
     .card.product::after{
       content:'';
       position:absolute;
-      inset:0;
+      inset:-1px;
       border-radius:inherit;
-      padding:1px;
-      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),transparent 40%);
-      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
-      -webkit-mask-composite:xor;
-      mask-composite:exclude;
+      background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);
       transition:opacity 0.3s ease;
       pointer-events:none;
-      z-index:2;
+      z-index:-1;
+      mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      mask-composite:xor;
+      -webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);
+      -webkit-mask-composite:xor;
+      padding:1px;
     }
-    .card.product>*{position:relative;z-index:3}
+    .card.product:hover{
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(91,138,255,0.2);
+    }
 
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}


### PR DESCRIPTION
These 5 sites had incorrect spotlight CSS applied earlier:
- Wrong mask-composite:exclude instead of xor
- Missing .card.product:hover rule
- Wrong inset:0 instead of inset:-1px on ::after
- Wrong gradient colors

Now matches the working English site CSS exactly.