### PR TITLE
Fix spotlight effect: add explicit height to override conflicting CSS

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2602,6 +2602,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2613,6 +2614,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/de/index.html
+++ b/de/index.html
@@ -2548,6 +2548,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2559,6 +2560,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/es/index.html
+++ b/es/index.html
@@ -2784,6 +2784,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2795,6 +2796,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/fr/index.html
+++ b/fr/index.html
@@ -2637,6 +2637,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2648,6 +2649,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/hu/index.html
+++ b/hu/index.html
@@ -2617,6 +2617,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2628,6 +2629,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/it/index.html
+++ b/it/index.html
@@ -2543,6 +2543,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2554,6 +2555,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/ja/index.html
+++ b/ja/index.html
@@ -2817,6 +2817,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2828,6 +2829,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/nl/index.html
+++ b/nl/index.html
@@ -2600,6 +2600,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2611,6 +2612,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/pt/index.html
+++ b/pt/index.html
@@ -2698,6 +2698,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2709,6 +2710,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/ru/index.html
+++ b/ru/index.html
@@ -2530,6 +2530,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2541,6 +2542,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);

--- a/tr/index.html
+++ b/tr/index.html
@@ -2622,6 +2622,7 @@
       content:'';
       position:absolute;
       inset:0;
+      height:100%;
       border-radius:inherit;
       background:radial-gradient(600px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.15),transparent 40%);
       opacity:var(--spotlight-opacity);
@@ -2633,6 +2634,7 @@
       content:'';
       position:absolute;
       inset:-1px;
+      height:calc(100% + 2px);
       border-radius:inherit;
       background:radial-gradient(400px circle at var(--mouse-x) var(--mouse-y),rgba(118,221,255,0.4),rgba(91,138,255,0.1) 40%,transparent 60%);
       opacity:var(--spotlight-opacity);


### PR DESCRIPTION
The language sites have a .card::before rule with height:2px for a gradient line hover effect. This conflicted with the spotlight CSS because 'inset:0' doesn't override explicit height values.

Added:
- height:100% to .card.product::before (inner glow)
- height:calc(100% + 2px) to .card.product::after (border glow)

This ensures the spotlight pseudo-elements cover the full card height instead of being clipped to 2px.