### PR TITLE
Fix indicator title glitch hover effect to match English site

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2633,11 +2633,12 @@
     }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
-    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}
-    .indicator-title::before{color:#ff006e;z-index:-1}
-    .indicator-title::after{color:#00f5ff;z-index:-1}
-    .indicator-title:hover::before{animation:glitch-1 0.4s ease-in-out;opacity:0.8}
-    .indicator-title:hover::after{animation:glitch-2 0.4s ease-in-out;opacity:0.8}
+    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0}
+    .indicator-title::before{color:#0ff;z-index:-1}
+    .indicator-title::after{color:#f0f;z-index:-2}
+    .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
     /* Magnetic button */
     .btn-magnetic{transition:transform 0.2s cubic-bezier(0.33,1,0.68,1);will-change:transform}
     /* Glitch keyframes */

--- a/de/index.html
+++ b/de/index.html
@@ -2593,7 +2593,8 @@
     .indicator-title::before{color:#0ff;z-index:-1}
     .indicator-title::after{color:#f0f;z-index:-2}
     .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
-    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) reverse both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
 
     /* Magnetic button */
     .btn-magnetic{

--- a/es/index.html
+++ b/es/index.html
@@ -2829,7 +2829,8 @@
     .indicator-title::before{color:#0ff;z-index:-1}
     .indicator-title::after{color:#f0f;z-index:-2}
     .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
-    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) reverse both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
 
     /* Magnetic button */
     .btn-magnetic{

--- a/fr/index.html
+++ b/fr/index.html
@@ -2682,7 +2682,8 @@
     .indicator-title::before{color:#0ff;z-index:-1}
     .indicator-title::after{color:#f0f;z-index:-2}
     .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
-    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) reverse both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
 
     /* Magnetic button */
     .btn-magnetic{

--- a/hu/index.html
+++ b/hu/index.html
@@ -2648,11 +2648,12 @@
     }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
-    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}
-    .indicator-title::before{color:#ff006e;z-index:-1}
-    .indicator-title::after{color:#00f5ff;z-index:-1}
-    .indicator-title:hover::before{animation:glitch-1 0.4s ease-in-out;opacity:0.8}
-    .indicator-title:hover::after{animation:glitch-2 0.4s ease-in-out;opacity:0.8}
+    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0}
+    .indicator-title::before{color:#0ff;z-index:-1}
+    .indicator-title::after{color:#f0f;z-index:-2}
+    .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
     /* Magnetic button */
     .btn-magnetic{transition:transform 0.2s cubic-bezier(0.33,1,0.68,1);will-change:transform}
     /* Glitch keyframes */

--- a/it/index.html
+++ b/it/index.html
@@ -2588,7 +2588,8 @@
     .indicator-title::before{color:#0ff;z-index:-1}
     .indicator-title::after{color:#f0f;z-index:-2}
     .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
-    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) reverse both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
 
     /* Magnetic button */
     .btn-magnetic{

--- a/ja/index.html
+++ b/ja/index.html
@@ -2862,7 +2862,8 @@
     .indicator-title::before{color:#0ff;z-index:-1}
     .indicator-title::after{color:#f0f;z-index:-2}
     .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
-    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) reverse both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
 
     /* Magnetic button */
     .btn-magnetic{

--- a/nl/index.html
+++ b/nl/index.html
@@ -2631,11 +2631,12 @@
     }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
-    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}
-    .indicator-title::before{color:#ff006e;z-index:-1}
-    .indicator-title::after{color:#00f5ff;z-index:-1}
-    .indicator-title:hover::before{animation:glitch-1 0.4s ease-in-out;opacity:0.8}
-    .indicator-title:hover::after{animation:glitch-2 0.4s ease-in-out;opacity:0.8}
+    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0}
+    .indicator-title::before{color:#0ff;z-index:-1}
+    .indicator-title::after{color:#f0f;z-index:-2}
+    .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
     /* Magnetic button */
     .btn-magnetic{transition:transform 0.2s cubic-bezier(0.33,1,0.68,1);will-change:transform}
     /* Glitch keyframes */

--- a/pt/index.html
+++ b/pt/index.html
@@ -2729,11 +2729,12 @@
     }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
-    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}
-    .indicator-title::before{color:#ff006e;z-index:-1}
-    .indicator-title::after{color:#00f5ff;z-index:-1}
-    .indicator-title:hover::before{animation:glitch-1 0.4s ease-in-out;opacity:0.8}
-    .indicator-title:hover::after{animation:glitch-2 0.4s ease-in-out;opacity:0.8}
+    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0}
+    .indicator-title::before{color:#0ff;z-index:-1}
+    .indicator-title::after{color:#f0f;z-index:-2}
+    .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
     /* Magnetic button */
     .btn-magnetic{transition:transform 0.2s cubic-bezier(0.33,1,0.68,1);will-change:transform}
     /* Glitch keyframes */

--- a/ru/index.html
+++ b/ru/index.html
@@ -2561,11 +2561,12 @@
     }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
-    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}
-    .indicator-title::before{color:#ff006e;z-index:-1}
-    .indicator-title::after{color:#00f5ff;z-index:-1}
-    .indicator-title:hover::before{animation:glitch-1 0.4s ease-in-out;opacity:0.8}
-    .indicator-title:hover::after{animation:glitch-2 0.4s ease-in-out;opacity:0.8}
+    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0}
+    .indicator-title::before{color:#0ff;z-index:-1}
+    .indicator-title::after{color:#f0f;z-index:-2}
+    .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
     /* Magnetic button */
     .btn-magnetic{transition:transform 0.2s cubic-bezier(0.33,1,0.68,1);will-change:transform}
     /* Glitch keyframes */

--- a/tr/index.html
+++ b/tr/index.html
@@ -2653,11 +2653,12 @@
     }
     /* Indicator title glitch effect */
     .indicator-title{position:relative;display:inline-block;cursor:default}
-    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;pointer-events:none}
-    .indicator-title::before{color:#ff006e;z-index:-1}
-    .indicator-title::after{color:#00f5ff;z-index:-1}
-    .indicator-title:hover::before{animation:glitch-1 0.4s ease-in-out;opacity:0.8}
-    .indicator-title:hover::after{animation:glitch-2 0.4s ease-in-out;opacity:0.8}
+    .indicator-title::before,.indicator-title::after{content:attr(data-text);position:absolute;top:0;left:0;width:100%;height:100%;opacity:0}
+    .indicator-title::before{color:#0ff;z-index:-1}
+    .indicator-title::after{color:#f0f;z-index:-2}
+    .indicator-title:hover::before{animation:glitch-1 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover::after{animation:glitch-2 0.4s cubic-bezier(0.25,0.46,0.45,0.94) both}
+    .indicator-title:hover{animation:glitch-skew 0.4s ease;text-shadow:0 0 8px rgba(118,221,255,0.6)}
     /* Magnetic button */
     .btn-magnetic{transition:transform 0.2s cubic-bezier(0.33,1,0.68,1);will-change:transform}
     /* Glitch keyframes */


### PR DESCRIPTION
Added missing .indicator-title:hover rule with:
- animation: glitch-skew 0.4s ease
- text-shadow: 0 0 8px rgba(118,221,255,0.6)

Also fixed:
- Colors: #0ff (cyan) and #f0f (magenta) to match English
- z-index: -2 for ::after (was -1)
- Animation timing: cubic-bezier(0.25,0.46,0.45,0.94) both
- Removed opacity:0.8 from hover rules (animation handles it)