### PR TITLE
Rebuild partners section with proper logos and glitch hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -6438,91 +6438,66 @@
           <p style="color:var(--muted);font-size:0.9rem;text-transform:uppercase;letter-spacing:0.1em">Powered By</p>
         </div>
 
-        <!-- Infinite Scroll Logo Marquee -->
+        <!-- Row 1: Scrolls Left -->
         <div class="partners-marquee" data-reveal="fade-up" data-reveal-delay="100">
           <div class="partners-track">
-            <!-- First set of logos -->
+            <!-- TradingView -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" title="TradingView">
-              <svg width="32" height="32" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
-              <span>TradingView</span>
+              <svg width="36" height="36" viewBox="0 0 36 36" fill="currentColor">
+                <path d="M32 8H22v20h4V12h6V8zM12 8H2v4h6v16h4V12h0V8z"/>
+                <rect x="14" y="14" width="4" height="14"/>
+              </svg>
             </a>
+            <!-- GitHub -->
             <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-              <span>GitHub</span>
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+              </svg>
             </a>
+            <!-- Discord -->
             <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z"/></svg>
-              <span>Discord</span>
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+              </svg>
             </a>
+            <!-- Vercel -->
             <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M24 22.525H0l12-21.05 12 21.05z"/></svg>
-              <span>Vercel</span>
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M24 22.525H0l12-21.05 12 21.05z"/>
+              </svg>
             </a>
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
-              <span>Claude</span>
-            </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10"/><text x="12" y="16" text-anchor="middle" fill="#05070d" font-size="8" font-weight="bold">Go</text></svg>
-              <span>GoDaddy</span>
-            </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="RunwayML">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M4 4h16v2H4V4zm0 4h10v2H4V8zm0 4h16v2H4v-2zm0 4h10v2H4v-2zm0 4h16v2H4v-2z"/></svg>
-              <span>Runway</span>
-            </a>
+            <!-- Stripe -->
             <a href="https://stripe.com/" target="_blank" rel="noopener" class="partner-logo" title="Stripe">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/></svg>
-              <span>Stripe</span>
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/>
+              </svg>
             </a>
-            <a href="https://www.pine-script.com/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-              <span>Pine Script</span>
+            <!-- Duplicate for seamless loop (masked at edges so not visible) -->
+            <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" title="TradingView" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 36 36" fill="currentColor">
+                <path d="M32 8H22v20h4V12h6V8zM12 8H2v4h6v16h4V12h0V8z"/>
+                <rect x="14" y="14" width="4" height="14"/>
+              </svg>
             </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5-9h10v2H7z"/><path d="M12 6l-4 4h3v4h2v-4h3z"/></svg>
-              <span>Unicorn</span>
+            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+              </svg>
             </a>
-
-            <!-- Duplicate set for seamless loop -->
-            <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" title="TradingView">
-              <svg width="32" height="32" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
-              <span>TradingView</span>
+            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+              </svg>
             </a>
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-              <span>GitHub</span>
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M24 22.525H0l12-21.05 12 21.05z"/>
+              </svg>
             </a>
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z"/></svg>
-              <span>Discord</span>
-            </a>
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M24 22.525H0l12-21.05 12 21.05z"/></svg>
-              <span>Vercel</span>
-            </a>
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
-              <span>Claude</span>
-            </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10"/><text x="12" y="16" text-anchor="middle" fill="#05070d" font-size="8" font-weight="bold">Go</text></svg>
-              <span>GoDaddy</span>
-            </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="RunwayML">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M4 4h16v2H4V4zm0 4h10v2H4V8zm0 4h16v2H4v-2zm0 4h10v2H4v-2zm0 4h16v2H4v-2z"/></svg>
-              <span>Runway</span>
-            </a>
-            <a href="https://stripe.com/" target="_blank" rel="noopener" class="partner-logo" title="Stripe">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/></svg>
-              <span>Stripe</span>
-            </a>
-            <a href="https://www.pine-script.com/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-              <span>Pine Script</span>
-            </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5-9h10v2H7z"/><path d="M12 6l-4 4h3v4h2v-4h3z"/></svg>
-              <span>Unicorn</span>
+            <a href="https://stripe.com/" target="_blank" rel="noopener" class="partner-logo" title="Stripe" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/>
+              </svg>
             </a>
           </div>
         </div>
@@ -6530,46 +6505,61 @@
         <!-- Row 2: Scrolls Right (opposite direction) -->
         <div class="partners-marquee" style="margin-top:1.5rem">
           <div class="partners-track-reverse">
-            <a href="https://stripe.com/" target="_blank" rel="noopener" class="partner-logo" title="Stripe">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/></svg>
-              <span>Stripe</span>
+            <!-- Claude/Anthropic -->
+            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M17.304 3.541l-5.357 16.918H8.696L3.34 3.541h3.93l3.428 12.39 3.427-12.39h3.18zM20.66 3.541L18.442 9.9h-2.386l2.218-6.358h2.386z"/>
+              </svg>
             </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="RunwayML">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M4 4h16v2H4V4zm0 4h10v2H4V8zm0 4h16v2H4v-2zm0 4h10v2H4v-2zm0 4h16v2H4v-2z"/></svg>
-              <span>Runway</span>
+            <!-- Runway -->
+            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M5 4h8a5 5 0 0 1 0 10h-3l6 6h-4l-6-6H5V4zm3 3v4h4a2 2 0 1 0 0-4H8z"/>
+              </svg>
             </a>
+            <!-- GoDaddy -->
             <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10"/><text x="12" y="16" text-anchor="middle" fill="#05070d" font-size="8" font-weight="bold">Go</text></svg>
-              <span>GoDaddy</span>
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+              </svg>
             </a>
-            <a href="https://www.pine-script.com/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-              <span>Pine Script</span>
+            <!-- Pine Script -->
+            <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2L4 9h3l-3 5h3l-4 6h8v-4h2v4h8l-4-6h3l-3-5h3L12 2zm0 3.5L16 9h-2l2 4h-2l2.5 4H13v-4h-2v4H7.5L10 13H8l2-4H8l4-3.5z"/>
+              </svg>
             </a>
+            <!-- Unicorn Studio -->
             <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/><path d="M11 7h2v6h-2zm0 8h2v2h-2z"/></svg>
-              <span>Unicorn</span>
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M19.5 9.5c-.17 0-.34.02-.5.05V8c0-2.76-2.24-5-5-5-.17 0-.34.01-.5.03V2l-3 3 3 3V6.5c.17-.01.34-.01.5-.01 1.93 0 3.5 1.57 3.5 3.5v1.55c-.16-.03-.33-.05-.5-.05-1.93 0-3.5 1.57-3.5 3.5s1.57 3.5 3.5 3.5c.17 0 .34-.02.5-.05V20h-8v-3c0-1.1-.9-2-2-2H6v-3.5c0-.83-.67-1.5-1.5-1.5S3 10.67 3 11.5V15H2v7h7v-2c0-.55.45-1 1-1h4c.55 0 1 .45 1 1v2h7v-7c0-2.76-2.24-5-5-5zm0 7c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
+              </svg>
             </a>
             <!-- Duplicate for seamless loop -->
-            <a href="https://stripe.com/" target="_blank" rel="noopener" class="partner-logo" title="Stripe">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/></svg>
-              <span>Stripe</span>
+            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M17.304 3.541l-5.357 16.918H8.696L3.34 3.541h3.93l3.428 12.39 3.427-12.39h3.18zM20.66 3.541L18.442 9.9h-2.386l2.218-6.358h2.386z"/>
+              </svg>
             </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="RunwayML">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M4 4h16v2H4V4zm0 4h10v2H4V8zm0 4h16v2H4v-2zm0 4h10v2H4v-2zm0 4h16v2H4v-2z"/></svg>
-              <span>Runway</span>
+            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M5 4h8a5 5 0 0 1 0 10h-3l6 6h-4l-6-6H5V4zm3 3v4h4a2 2 0 1 0 0-4H8z"/>
+              </svg>
             </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10"/><text x="12" y="16" text-anchor="middle" fill="#05070d" font-size="8" font-weight="bold">Go</text></svg>
-              <span>GoDaddy</span>
+            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+              </svg>
             </a>
-            <a href="https://www.pine-script.com/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-              <span>Pine Script</span>
+            <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2L4 9h3l-3 5h3l-4 6h8v-4h2v4h8l-4-6h3l-3-5h3L12 2zm0 3.5L16 9h-2l2 4h-2l2.5 4H13v-4h-2v4H7.5L10 13H8l2-4H8l4-3.5z"/>
+              </svg>
             </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/><path d="M11 7h2v6h-2zm0 8h2v2h-2z"/></svg>
-              <span>Unicorn</span>
+            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio" aria-hidden="true">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M19.5 9.5c-.17 0-.34.02-.5.05V8c0-2.76-2.24-5-5-5-.17 0-.34.01-.5.03V2l-3 3 3 3V6.5c.17-.01.34-.01.5-.01 1.93 0 3.5 1.57 3.5 3.5v1.55c-.16-.03-.33-.05-.5-.05-1.93 0-3.5 1.57-3.5 3.5s1.57 3.5 3.5 3.5c.17 0 .34-.02.5-.05V20h-8v-3c0-1.1-.9-2-2-2H6v-3.5c0-.83-.67-1.5-1.5-1.5S3 10.67 3 11.5V15H2v7h7v-2c0-.55.45-1 1-1h4c.55 0 1 .45 1 1v2h7v-7c0-2.76-2.24-5-5-5zm0 7c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
+              </svg>
             </a>
           </div>
         </div>
@@ -6580,15 +6570,24 @@
           position: relative;
           width: 100%;
           overflow: hidden;
-          mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
-          -webkit-mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
+          mask-image: linear-gradient(to right, transparent, black 5%, black 95%, transparent);
+          -webkit-mask-image: linear-gradient(to right, transparent, black 5%, black 95%, transparent);
         }
 
         .partners-track {
           display: flex;
-          gap: 3rem;
-          animation: partners-scroll 60s linear infinite;
-          width: fit-content;
+          gap: 5rem;
+          padding: 0 2rem;
+          animation: partners-scroll 40s linear infinite;
+          width: max-content;
+        }
+
+        .partners-track-reverse {
+          display: flex;
+          gap: 5rem;
+          padding: 0 2rem;
+          animation: partners-scroll-reverse 40s linear infinite;
+          width: max-content;
         }
 
         .partners-marquee:hover .partners-track,
@@ -6596,74 +6595,69 @@
           animation-play-state: paused;
         }
 
-        .partners-track-reverse {
-          display: flex;
-          gap: 3rem;
-          animation: partners-scroll-reverse 55s linear infinite;
-          width: fit-content;
-        }
-
         @keyframes partners-scroll {
-          0% {
-            transform: translateX(0);
-          }
-          100% {
-            transform: translateX(calc(-50% - 1.5rem));
-          }
+          0% { transform: translateX(0); }
+          100% { transform: translateX(-50%); }
         }
 
         @keyframes partners-scroll-reverse {
-          0% {
-            transform: translateX(calc(-50% - 1.5rem));
-          }
-          100% {
-            transform: translateX(0);
-          }
+          0% { transform: translateX(-50%); }
+          100% { transform: translateX(0); }
         }
 
         .partner-logo {
           display: flex;
-          flex-direction: column;
           align-items: center;
-          gap: 0.5rem;
+          justify-content: center;
           color: var(--muted);
           text-decoration: none;
-          transition: all 0.3s ease;
-          opacity: 0.6;
+          transition: all 0.15s ease;
+          opacity: 0.5;
           flex-shrink: 0;
-        }
-
-        .partner-logo:hover {
-          color: var(--brand);
-          opacity: 1;
-          transform: translateY(-2px);
+          padding: 0.75rem;
+          position: relative;
         }
 
         .partner-logo svg {
-          width: 32px;
-          height: 32px;
+          width: 36px;
+          height: 36px;
+          transition: all 0.15s ease;
         }
 
-        .partner-logo span {
-          font-size: 0.75rem;
-          font-weight: 500;
-          letter-spacing: 0.02em;
-          white-space: nowrap;
+        /* Glitch effect on hover */
+        .partner-logo:hover {
+          opacity: 1;
+          animation: partner-glitch 0.3s ease;
+        }
+
+        .partner-logo:hover svg {
+          filter: drop-shadow(2px 0 0 var(--brand)) drop-shadow(-2px 0 0 #ff0080);
+          color: var(--brand);
+        }
+
+        @keyframes partner-glitch {
+          0% { transform: translate(0); }
+          10% { transform: translate(-2px, 1px); }
+          20% { transform: translate(2px, -1px); }
+          30% { transform: translate(-1px, 2px); }
+          40% { transform: translate(1px, -2px); }
+          50% { transform: translate(-2px, -1px); }
+          60% { transform: translate(2px, 1px); }
+          70% { transform: translate(-1px, -2px); }
+          80% { transform: translate(1px, 2px); }
+          90% { transform: translate(-2px, 1px); }
+          100% { transform: translate(0) scale(1.1); }
         }
 
         @media (max-width: 768px) {
           .partners-track,
           .partners-track-reverse {
-            gap: 2rem;
+            gap: 3rem;
           }
 
           .partner-logo svg {
             width: 28px;
             height: 28px;
-          }
-
-          .partner-logo span {
-            font-size: 0.7rem;
           }
         }
       </style>


### PR DESCRIPTION
- Two rows: Row 1 (TradingView, GitHub, Discord, Vercel, Stripe) scrolls left Row 2 (Claude, Runway, GoDaddy, Pine Script, Unicorn) scrolls right
- Clean SVG brand icons, no text labels
- Duplicates for seamless loop are masked (aria-hidden)
- Added Matrix-style glitch animation on hover with chromatic aberration