### PR TITLE
Add text labels and fix partner logos for better recognition

### DIFF
--- a/index.html
+++ b/index.html
@@ -6441,63 +6441,75 @@
         <!-- Row 1: Scrolls Left -->
         <div class="partners-marquee" data-reveal="fade-up" data-reveal-delay="100">
           <div class="partners-track">
-            <!-- TradingView -->
+            <!-- TradingView - chart bars icon -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" title="TradingView">
-              <svg width="36" height="36" viewBox="0 0 36 36" fill="currentColor">
-                <path d="M32 8H22v20h4V12h6V8zM12 8H2v4h6v16h4V12h0V8z"/>
-                <rect x="14" y="14" width="4" height="14"/>
+              <svg width="32" height="32" viewBox="0 0 32 32" fill="currentColor">
+                <rect x="4" y="12" width="5" height="16" rx="1"/>
+                <rect x="13" y="6" width="5" height="22" rx="1"/>
+                <rect x="22" y="2" width="5" height="26" rx="1"/>
               </svg>
+              <span>TradingView</span>
             </a>
-            <!-- GitHub -->
+            <!-- GitHub - octocat -->
             <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
               </svg>
+              <span>GitHub</span>
             </a>
             <!-- Discord -->
             <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
               </svg>
+              <span>Discord</span>
             </a>
             <!-- Vercel -->
             <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M24 22.525H0l12-21.05 12 21.05z"/>
               </svg>
+              <span>Vercel</span>
             </a>
             <!-- Stripe -->
             <a href="https://stripe.com/" target="_blank" rel="noopener" class="partner-logo" title="Stripe">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/>
               </svg>
+              <span>Stripe</span>
             </a>
-            <!-- Duplicate for seamless loop (masked at edges so not visible) -->
+            <!-- Duplicate for seamless loop -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" title="TradingView" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 36 36" fill="currentColor">
-                <path d="M32 8H22v20h4V12h6V8zM12 8H2v4h6v16h4V12h0V8z"/>
-                <rect x="14" y="14" width="4" height="14"/>
+              <svg width="32" height="32" viewBox="0 0 32 32" fill="currentColor">
+                <rect x="4" y="12" width="5" height="16" rx="1"/>
+                <rect x="13" y="6" width="5" height="22" rx="1"/>
+                <rect x="22" y="2" width="5" height="26" rx="1"/>
               </svg>
+              <span>TradingView</span>
             </a>
             <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
               </svg>
+              <span>GitHub</span>
             </a>
             <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
               </svg>
+              <span>Discord</span>
             </a>
             <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M24 22.525H0l12-21.05 12 21.05z"/>
               </svg>
+              <span>Vercel</span>
             </a>
             <a href="https://stripe.com/" target="_blank" rel="noopener" class="partner-logo" title="Stripe" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/>
               </svg>
+              <span>Stripe</span>
             </a>
           </div>
         </div>
@@ -6505,61 +6517,77 @@
         <!-- Row 2: Scrolls Right (opposite direction) -->
         <div class="partners-marquee" style="margin-top:1.5rem">
           <div class="partners-track-reverse">
-            <!-- Claude/Anthropic -->
+            <!-- Claude/Anthropic - Anthropic A mark -->
             <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M17.304 3.541l-5.357 16.918H8.696L3.34 3.541h3.93l3.428 12.39 3.427-12.39h3.18zM20.66 3.541L18.442 9.9h-2.386l2.218-6.358h2.386z"/>
+              <svg width="32" height="32" viewBox="0 0 46 32" fill="currentColor">
+                <path d="M32.73 0l-9.13 32h-7.24L7.27 0h7.27l6 22.57L26.46 0h6.27zm8.02 0l-4.71 13.43h5.06L46 0h-5.25z"/>
               </svg>
+              <span>Claude</span>
             </a>
-            <!-- Runway -->
+            <!-- Runway - horizontal bars -->
             <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M5 4h8a5 5 0 0 1 0 10h-3l6 6h-4l-6-6H5V4zm3 3v4h4a2 2 0 1 0 0-4H8z"/>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <rect x="2" y="5" width="20" height="3" rx="1.5"/>
+                <rect x="2" y="11" width="16" height="3" rx="1.5"/>
+                <rect x="2" y="17" width="12" height="3" rx="1.5"/>
               </svg>
+              <span>Runway</span>
             </a>
-            <!-- GoDaddy -->
+            <!-- GoDaddy - heart guy -->
             <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
               </svg>
+              <span>GoDaddy</span>
             </a>
-            <!-- Pine Script -->
+            <!-- Pine Script - tree -->
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 2L4 9h3l-3 5h3l-4 6h8v-4h2v4h8l-4-6h3l-3-5h3L12 2zm0 3.5L16 9h-2l2 4h-2l2.5 4H13v-4h-2v4H7.5L10 13H8l2-4H8l4-3.5z"/>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2L6 10h3l-3 6h3l-4 6h14l-4-6h3l-3-6h3L12 2z"/>
+                <rect x="10" y="20" width="4" height="2"/>
               </svg>
+              <span>Pine Script</span>
             </a>
-            <!-- Unicorn Studio -->
+            <!-- Unicorn Studio - sparkle/star -->
             <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M19.5 9.5c-.17 0-.34.02-.5.05V8c0-2.76-2.24-5-5-5-.17 0-.34.01-.5.03V2l-3 3 3 3V6.5c.17-.01.34-.01.5-.01 1.93 0 3.5 1.57 3.5 3.5v1.55c-.16-.03-.33-.05-.5-.05-1.93 0-3.5 1.57-3.5 3.5s1.57 3.5 3.5 3.5c.17 0 .34-.02.5-.05V20h-8v-3c0-1.1-.9-2-2-2H6v-3.5c0-.83-.67-1.5-1.5-1.5S3 10.67 3 11.5V15H2v7h7v-2c0-.55.45-1 1-1h4c.55 0 1 .45 1 1v2h7v-7c0-2.76-2.24-5-5-5zm0 7c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 1l2.5 7.5L22 12l-7.5 2.5L12 22l-2.5-7.5L2 12l7.5-2.5L12 1z"/>
               </svg>
+              <span>Unicorn</span>
             </a>
             <!-- Duplicate for seamless loop -->
             <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M17.304 3.541l-5.357 16.918H8.696L3.34 3.541h3.93l3.428 12.39 3.427-12.39h3.18zM20.66 3.541L18.442 9.9h-2.386l2.218-6.358h2.386z"/>
+              <svg width="32" height="32" viewBox="0 0 46 32" fill="currentColor">
+                <path d="M32.73 0l-9.13 32h-7.24L7.27 0h7.27l6 22.57L26.46 0h6.27zm8.02 0l-4.71 13.43h5.06L46 0h-5.25z"/>
               </svg>
+              <span>Claude</span>
             </a>
             <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M5 4h8a5 5 0 0 1 0 10h-3l6 6h-4l-6-6H5V4zm3 3v4h4a2 2 0 1 0 0-4H8z"/>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <rect x="2" y="5" width="20" height="3" rx="1.5"/>
+                <rect x="2" y="11" width="16" height="3" rx="1.5"/>
+                <rect x="2" y="17" width="12" height="3" rx="1.5"/>
               </svg>
+              <span>Runway</span>
             </a>
             <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
               </svg>
+              <span>GoDaddy</span>
             </a>
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 2L4 9h3l-3 5h3l-4 6h8v-4h2v4h8l-4-6h3l-3-5h3L12 2zm0 3.5L16 9h-2l2 4h-2l2.5 4H13v-4h-2v4H7.5L10 13H8l2-4H8l4-3.5z"/>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2L6 10h3l-3 6h3l-4 6h14l-4-6h3l-3-6h3L12 2z"/>
+                <rect x="10" y="20" width="4" height="2"/>
               </svg>
+              <span>Pine Script</span>
             </a>
             <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M19.5 9.5c-.17 0-.34.02-.5.05V8c0-2.76-2.24-5-5-5-.17 0-.34.01-.5.03V2l-3 3 3 3V6.5c.17-.01.34-.01.5-.01 1.93 0 3.5 1.57 3.5 3.5v1.55c-.16-.03-.33-.05-.5-.05-1.93 0-3.5 1.57-3.5 3.5s1.57 3.5 3.5 3.5c.17 0 .34-.02.5-.05V20h-8v-3c0-1.1-.9-2-2-2H6v-3.5c0-.83-.67-1.5-1.5-1.5S3 10.67 3 11.5V15H2v7h7v-2c0-.55.45-1 1-1h4c.55 0 1 .45 1 1v2h7v-7c0-2.76-2.24-5-5-5zm0 7c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 1l2.5 7.5L22 12l-7.5 2.5L12 22l-2.5-7.5L2 12l7.5-2.5L12 1z"/>
               </svg>
+              <span>Unicorn</span>
             </a>
           </div>
         </div>
@@ -6607,8 +6635,10 @@
 
         .partner-logo {
           display: flex;
+          flex-direction: column;
           align-items: center;
           justify-content: center;
+          gap: 0.4rem;
           color: var(--muted);
           text-decoration: none;
           transition: all 0.15s ease;
@@ -6619,9 +6649,17 @@
         }
 
         .partner-logo svg {
-          width: 36px;
-          height: 36px;
+          width: 32px;
+          height: 32px;
           transition: all 0.15s ease;
+        }
+
+        .partner-logo span {
+          font-size: 0.7rem;
+          font-weight: 500;
+          letter-spacing: 0.02em;
+          white-space: nowrap;
+          opacity: 0.8;
         }
 
         /* Glitch effect on hover */
@@ -6652,12 +6690,16 @@
         @media (max-width: 768px) {
           .partners-track,
           .partners-track-reverse {
-            gap: 3rem;
+            gap: 2.5rem;
           }
 
           .partner-logo svg {
-            width: 28px;
-            height: 28px;
+            width: 24px;
+            height: 24px;
+          }
+
+          .partner-logo span {
+            font-size: 0.6rem;
           }
         }
       </style>


### PR DESCRIPTION
- Added text labels below each icon (TradingView, GitHub, Discord, etc.)
- Fixed TradingView icon to recognizable chart bars
- Fixed Claude icon to proper Anthropic A mark
- Fixed Runway icon to horizontal bars style
- Fixed Pine Script to proper tree shape
- Fixed Unicorn Studio to sparkle/star
- Styled labels small and sleek (0.7rem, 500 weight)