### PR TITLE
Redesign pricing cards with clean glass-morphism template

### DIFF
--- a/index.html
+++ b/index.html
@@ -5938,212 +5938,183 @@
 
 
           <!-- MONTHLY -->
-
-          <article class="card plan relative overflow-hidden ring-1 ring-black/5 text-white bg-gray-900 bg-cover rounded-2xl p-6 shadow-sm" id="plan-monthly" data-plan="monthly" role="group" aria-labelledby="plan-monthly-title" style="background-image:url(https://hoirqrkdgbmvpwutwuwj.supabase.co/storage/v1/object/public/assets/assets/046f0e74-64ae-4e71-ae2d-67940e33e9bc_1600w.jpg)">
-            <div class="flex items-center justify-between">
-              <div class="text-sm font-medium" style="opacity:.95;">Monthly</div>
-              <span class="inline-flex items-center gap-1 text-xs uppercase border border-white/70 rounded px-2 py-1" style="opacity:.95;">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg>
-                Flexible
-              </span>
+          <article class="card plan bg-white/5 ring-1 ring-white/10 rounded-3xl p-8" id="plan-monthly" data-plan="monthly" role="group" aria-labelledby="plan-monthly-title">
+            <div class="mb-6">
+              <h3 id="plan-monthly-title" class="text-xl tracking-tight text-white font-semibold">Monthly</h3>
+              <p class="mt-2 text-sm text-white/60">Pay as you go. Cancel anytime.</p>
+            </div>
+            <div class="mb-6">
+              <div class="flex items-baseline gap-2">
+                <span class="text-5xl tracking-tight text-white font-semibold">$99</span>
+                <span class="text-white/50">/month</span>
+              </div>
             </div>
 
-            <div class="mt-3">
-              <h2 id="plan-monthly-title" class="text-2xl font-semibold tracking-tight">Pay as you go</h2>
-              <p class="text-sm text-white/85 mt-1">Cancel anytime. No commitment required.</p>
-            </div>
-
-            <div class="mt-5 flex items-baseline gap-2">
-              <span class="text-5xl font-semibold tracking-tight">$99</span>
-              <span class="text-sm text-white/90">/month</span>
-            </div>
-
-            <div class="mt-4 flex items-center gap-3">
-              <button type="button" id="btn-monthly-paypal" class="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-black text-white shadow-sm hover:bg-gray-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
-                <span class="font-medium">Subscribe</span>
-              </button>
-              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/272cee92-d8d5-4259-866b-e7cf95f5d7ee" class="inline-flex gap-2 ring-1 ring-white/20 hover:bg-white/15 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 text-white bg-white/10 rounded-xl py-3 px-4 backdrop-blur-lg items-center" target="_blank" rel="noopener">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
-                <span class="text-sm font-medium">Pay with Card</span>
-              </a>
-            </div>
-
-            <div class="mt-5 h-px bg-white/50"></div>
-
-            <ul class="mt-4 space-y-2.5 text-white text-sm">
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                Full access to all 7 indicators
-              </li>
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                Real-time alerts &amp; signals
-              </li>
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                Cancel anytime, no lock-in
-              </li>
-            </ul>
-
-            <!-- TradingView Username (hidden, shown on click) -->
-            <div class="mt-4 hidden" id="monthly-checkout">
-              <label class="text-sm font-medium text-white/90 mb-2 block">TradingView Username</label>
+            <!-- TradingView Username -->
+            <div class="mb-4">
+              <label class="text-sm font-medium text-white/80 mb-2 block">TradingView Username</label>
               <div class="input-wrapper relative">
-                <input id="tv-monthly" placeholder="@your.tradingview" required class="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-white/50" style="padding-right:3rem">
+                <input id="tv-monthly" placeholder="@your.tradingview" required class="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-indigo-400/50" style="padding-right:3rem">
                 <div class="checkmark absolute right-3 top-1/2 -translate-y-1/2">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5"><polyline points="20 6 9 17 4 12"></polyline></svg>
                 </div>
               </div>
               <div id="error-tv-monthly" style="display:none" class="text-red-400 text-sm mt-2 font-medium">TradingView username required</div>
-              <label class="consent flex items-start gap-2 mt-4 text-sm text-white/70 cursor-pointer">
-                <input class="tick mt-0.5" type="checkbox" id="consent-monthly">
-                <span>I understand <span class="font-semibold text-white">Signal Pilot</span> is educational. No financial advice.</span>
-              </label>
-              <div id="error-consent-monthly" style="display:none" class="text-red-400 text-sm mt-2 font-medium">Consent required</div>
             </div>
+
+            <!-- Consent -->
+            <label class="consent flex items-start gap-2 mb-4 text-sm text-white/60 cursor-pointer">
+              <input class="tick mt-0.5" type="checkbox" id="consent-monthly">
+              <span>I understand <span class="font-semibold text-white">Signal Pilot</span> is educational. No financial advice.</span>
+            </label>
+            <div id="error-consent-monthly" style="display:none" class="text-red-400 text-sm mb-4 font-medium">Consent required</div>
+
+            <button type="button" id="btn-monthly-paypal" class="block w-full text-center text-sm font-medium text-white bg-white/5 ring-1 ring-white/10 rounded-full py-3 px-4 hover:bg-white/10 transition mb-3">
+              Subscribe with PayPal
+            </button>
+            <a href="https://signalpilotlabs.lemonsqueezy.com/buy/272cee92-d8d5-4259-866b-e7cf95f5d7ee" class="block w-full text-center text-sm font-medium text-white bg-white/5 ring-1 ring-white/10 rounded-full py-3 px-4 hover:bg-white/10 transition" target="_blank" rel="noopener">
+              Pay with Card
+            </a>
+
+            <ul class="mt-8 space-y-4">
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-indigo-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>Full access to all 7 indicators</span>
+              </li>
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-indigo-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>Real-time alerts &amp; signals</span>
+              </li>
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-indigo-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>Cancel anytime, no lock-in</span>
+              </li>
+            </ul>
           </article>
 
 
 
 
-          <!-- YEARLY -->
-
-          <article class="card plan relative overflow-hidden ring-1 ring-black/5 text-white bg-gray-900 bg-cover rounded-2xl p-6 shadow-sm" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="transform:scale(1.03);z-index:2;background-image:url(https://hoirqrkdgbmvpwutwuwj.supabase.co/storage/v1/object/public/assets/assets/046f0e74-64ae-4e71-ae2d-67940e33e9bc_1600w.jpg)">
-            <div class="flex items-center justify-between">
-              <div class="text-sm font-medium" style="opacity:.95;">Yearly</div>
-              <span class="inline-flex items-center gap-1 text-xs uppercase border border-white/70 rounded px-2 py-1" style="opacity:.95;">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5"><path d="M11.562 3.266a.5.5 0 0 1 .876 0L15.39 8.87a1 1 0 0 0 1.516.294L21.183 5.5a.5.5 0 0 1 .798.519l-2.834 10.246a1 1 0 0 1-.956.734H5.81a1 1 0 0 1-.957-.734L2.02 6.02a.5.5 0 0 1 .798-.519l4.276 3.664a1 1 0 0 0 1.516-.294z"/><path d="M5 21h14"/></svg>
+          <!-- YEARLY (Featured) -->
+          <article class="card plan bg-gradient-to-br from-indigo-500/10 via-fuchsia-500/10 to-amber-400/10 ring-2 ring-indigo-400/50 rounded-3xl p-8 relative" id="plan-yearly" data-plan="yearly" role="group" aria-labelledby="plan-yearly-title" style="transform:scale(1.02);z-index:2">
+            <div class="absolute -top-4 left-1/2 -translate-x-1/2">
+              <span class="inline-flex items-center gap-1 text-xs font-medium text-black bg-gradient-to-r from-indigo-400 via-fuchsia-400 to-amber-400 rounded-full px-3 py-1">
+                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3 h-3"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"></path></svg>
                 Most Popular
               </span>
             </div>
-
-            <div class="mt-3">
-              <h2 id="plan-yearly-title" class="text-2xl font-semibold tracking-tight">Save $489/year</h2>
-              <p class="text-sm text-white/85 mt-1">Just $58/month. Best for committed traders.</p>
+            <div class="mb-6">
+              <h3 id="plan-yearly-title" class="text-xl tracking-tight text-white font-semibold">Yearly</h3>
+              <p class="mt-2 text-sm text-white/60">Save $489/year. Best value.</p>
+            </div>
+            <div class="mb-6">
+              <div class="flex items-baseline gap-2">
+                <span class="text-5xl tracking-tight text-white font-semibold">$699</span>
+                <span class="text-white/50">/year</span>
+              </div>
             </div>
 
-            <div class="mt-5 flex items-baseline gap-2">
-              <span class="text-5xl font-semibold tracking-tight">$699</span>
-              <span class="text-sm text-white/90">/year</span>
-            </div>
-
-            <div class="mt-4 flex items-center gap-3">
-              <button type="button" id="btn-yearly-paypal" class="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-black text-white shadow-sm hover:bg-gray-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
-                <span class="font-medium">Subscribe</span>
-              </button>
-              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/bb59d34b-20bb-478d-9db3-533b7e84930b" class="inline-flex gap-2 ring-1 ring-white/20 hover:bg-white/15 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 text-white bg-white/10 rounded-xl py-3 px-4 backdrop-blur-lg items-center" target="_blank" rel="noopener">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
-                <span class="text-sm font-medium">Pay with Card</span>
-              </a>
-            </div>
-
-            <div class="mt-5 h-px bg-white/50"></div>
-
-            <ul class="mt-4 space-y-2.5 text-white text-sm">
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                Everything in Monthly
-              </li>
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                Save $489 vs monthly billing
-              </li>
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                Priority email support
-              </li>
-            </ul>
-
-            <!-- TradingView Username (hidden, shown on click) -->
-            <div class="mt-4 hidden" id="yearly-checkout">
-              <label class="text-sm font-medium text-white/90 mb-2 block">TradingView Username</label>
+            <!-- TradingView Username -->
+            <div class="mb-4">
+              <label class="text-sm font-medium text-white/80 mb-2 block">TradingView Username</label>
               <div class="input-wrapper relative">
-                <input id="tv-yearly" placeholder="@your.tradingview" required class="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-white/50" style="padding-right:3rem">
+                <input id="tv-yearly" placeholder="@your.tradingview" required class="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-fuchsia-400/50" style="padding-right:3rem">
                 <div class="checkmark absolute right-3 top-1/2 -translate-y-1/2">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5"><polyline points="20 6 9 17 4 12"></polyline></svg>
                 </div>
               </div>
               <div id="error-tv-yearly" style="display:none" class="text-red-400 text-sm mt-2 font-medium">TradingView username required</div>
-              <label class="consent flex items-start gap-2 mt-4 text-sm text-white/70 cursor-pointer">
-                <input class="tick mt-0.5" type="checkbox" id="consent-yearly">
-                <span>I understand <span class="font-semibold text-white">Signal Pilot</span> is educational. No financial advice.</span>
-              </label>
-              <div id="error-consent-yearly" style="display:none" class="text-red-400 text-sm mt-2 font-medium">Consent required</div>
             </div>
+
+            <!-- Consent -->
+            <label class="consent flex items-start gap-2 mb-4 text-sm text-white/60 cursor-pointer">
+              <input class="tick mt-0.5" type="checkbox" id="consent-yearly">
+              <span>I understand <span class="font-semibold text-white">Signal Pilot</span> is educational. No financial advice.</span>
+            </label>
+            <div id="error-consent-yearly" style="display:none" class="text-red-400 text-sm mb-4 font-medium">Consent required</div>
+
+            <button type="button" id="btn-yearly-paypal" class="block w-full text-center text-sm font-medium text-black bg-gradient-to-r from-indigo-400 via-fuchsia-400 to-amber-400 rounded-full py-3 px-4 hover:opacity-90 transition shadow-lg mb-3">
+              Subscribe with PayPal
+            </button>
+            <a href="https://signalpilotlabs.lemonsqueezy.com/buy/bb59d34b-20bb-478d-9db3-533b7e84930b" class="block w-full text-center text-sm font-medium text-white bg-white/5 ring-1 ring-white/10 rounded-full py-3 px-4 hover:bg-white/10 transition" target="_blank" rel="noopener">
+              Pay with Card
+            </a>
+
+            <ul class="mt-8 space-y-4">
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-fuchsia-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>Everything in Monthly</span>
+              </li>
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-fuchsia-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>Save $489 vs monthly billing</span>
+              </li>
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-fuchsia-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>Priority email support</span>
+              </li>
+            </ul>
           </article>
 
 
 
+
           <!-- LIFETIME -->
-
-          <article class="card plan relative overflow-hidden ring-1 ring-black/5 text-white bg-gray-900 bg-cover rounded-2xl p-6 shadow-sm" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title" style="background-image:url(https://hoirqrkdgbmvpwutwuwj.supabase.co/storage/v1/object/public/assets/assets/046f0e74-64ae-4e71-ae2d-67940e33e9bc_1600w.jpg)">
-            <div class="flex items-center justify-between">
-              <div class="text-sm font-medium" style="opacity:.95;">Lifetime</div>
-              <span class="inline-flex items-center gap-1 text-xs uppercase border border-white/70 rounded px-2 py-1" style="opacity:.95;">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-                <span data-count="150">150</span> Left
-              </span>
+          <article class="card plan bg-white/5 ring-1 ring-white/10 rounded-3xl p-8" id="plan-lifetime" data-plan="lifetime" role="group" aria-labelledby="plan-lifetime-title">
+            <div class="mb-6">
+              <h3 id="plan-lifetime-title" class="text-xl tracking-tight text-white font-semibold">Lifetime</h3>
+              <p class="mt-2 text-sm text-white/60">Pay once, yours forever.</p>
+            </div>
+            <div class="mb-6">
+              <div class="flex items-baseline gap-2">
+                <span id="lifetime-display-price" class="text-5xl tracking-tight text-white font-semibold">$1,799</span>
+                <span class="text-white/50">one-time</span>
+              </div>
             </div>
 
-            <div class="mt-3">
-              <h2 id="plan-lifetime-title" class="text-2xl font-semibold tracking-tight">Pay once, yours forever</h2>
-              <p class="text-sm text-white/85 mt-1">Lock in lifetime access. $0/month after.</p>
-            </div>
-
-            <div class="mt-5 flex items-baseline gap-2">
-              <span id="lifetime-display-price" class="text-5xl font-semibold tracking-tight">$1,799</span>
-              <span class="text-sm text-white/90">one-time</span>
-            </div>
-
-            <div class="mt-4 flex items-center gap-3">
-              <button type="button" id="btn-lifetime-paypal" class="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-black text-white shadow-sm hover:bg-gray-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
-                <span class="font-medium">Buy Now</span>
-              </button>
-              <a href="https://signalpilotlabs.lemonsqueezy.com/buy/81822d54-6e08-4c26-b2f0-d5d5e3cdd25e" class="inline-flex gap-2 ring-1 ring-white/20 hover:bg-white/15 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 text-white bg-white/10 rounded-xl py-3 px-4 backdrop-blur-lg items-center" target="_blank" rel="noopener">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
-                <span class="text-sm font-medium">Pay with Card</span>
-              </a>
-            </div>
-
-            <div class="mt-5 h-px bg-white/50"></div>
-
-            <ul class="mt-4 space-y-2.5 text-white text-sm">
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                Everything in Yearly
-              </li>
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                Never pay again, ever
-              </li>
-              <li class="flex items-start gap-2.5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
-                All future updates included
-              </li>
-            </ul>
-
-            <!-- TradingView Username (hidden, shown on click) -->
-            <div class="mt-4 hidden" id="lifetime-checkout">
-              <label class="text-sm font-medium text-white/90 mb-2 block">TradingView Username</label>
+            <!-- TradingView Username -->
+            <div class="mb-4">
+              <label class="text-sm font-medium text-white/80 mb-2 block">TradingView Username</label>
               <div class="input-wrapper relative">
-                <input id="tv-lifetime" type="text" placeholder="@your.tradingview" required class="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-white/50" style="padding-right:3rem">
+                <input id="tv-lifetime" type="text" placeholder="@your.tradingview" required class="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-amber-400/50" style="padding-right:3rem">
                 <div class="checkmark absolute right-3 top-1/2 -translate-y-1/2">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5"><polyline points="20 6 9 17 4 12"></polyline></svg>
                 </div>
               </div>
               <div id="error-tv-lifetime" style="display:none" class="text-red-400 text-sm mt-2 font-medium">TradingView username required</div>
-              <label class="consent flex items-start gap-2 mt-4 text-sm text-white/70 cursor-pointer">
-                <input class="tick mt-0.5" type="checkbox" id="consent-lifetime">
-                <span>I understand <span class="font-semibold text-white">Signal Pilot</span> is educational. No financial advice.</span>
-              </label>
-              <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-sm mt-2 font-medium">Consent required</div>
             </div>
 
+            <!-- Consent -->
+            <label class="consent flex items-start gap-2 mb-4 text-sm text-white/60 cursor-pointer">
+              <input class="tick mt-0.5" type="checkbox" id="consent-lifetime">
+              <span>I understand <span class="font-semibold text-white">Signal Pilot</span> is educational. No financial advice.</span>
+            </label>
+            <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-sm mb-4 font-medium">Consent required</div>
+
+            <button type="button" id="btn-lifetime-paypal" class="block w-full text-center text-sm font-medium text-white bg-white/5 ring-1 ring-white/10 rounded-full py-3 px-4 hover:bg-white/10 transition mb-3">
+              Buy Now with PayPal
+            </button>
+            <a href="https://signalpilotlabs.lemonsqueezy.com/buy/81822d54-6e08-4c26-b2f0-d5d5e3cdd25e" class="block w-full text-center text-sm font-medium text-white bg-white/5 ring-1 ring-white/10 rounded-full py-3 px-4 hover:bg-white/10 transition" target="_blank" rel="noopener">
+              Pay with Card
+            </a>
+
+            <ul class="mt-8 space-y-4">
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>Everything in Yearly</span>
+              </li>
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>Never pay again, ever</span>
+              </li>
+              <li class="flex items-start gap-3 text-sm text-white/70">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400 flex-shrink-0 mt-0.5"><path d="M20 6 9 17l-5-5"></path></svg>
+                <span>All future updates included</span>
+              </li>
+            </ul>
+
             <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-sm mt-4 font-medium text-center">Lifetime is sold out. Waitlist is available below.</div>
-            <button class="btn btn-disabled w-full mt-3 py-3 rounded-xl bg-white/10 text-white/50 font-medium" id="lt-soldout" type="button" style="display:none">Sold out — join waitlist below</button>
+            <button class="hidden w-full mt-3 py-3 rounded-xl bg-white/10 text-white/50 font-medium" id="lt-soldout" type="button">Sold out — join waitlist below</button>
           </article>
 
 


### PR DESCRIPTION
- Monthly & Lifetime: bg-white/5 with subtle ring-white/10 border
- Yearly (featured): gradient background with ring-indigo-400/50
- Added floating "Most Popular" gradient badge on Yearly card
- TradingView username input and consent checkbox now visible
- Preserved PayPal button IDs and LemonSqueezy payment links
- Feature lists with colored checkmarks (indigo/fuchsia/amber)