### PR TITLE
Add missing CSS for cta-header button text spans

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2993,6 +2993,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/de/index.html
+++ b/de/index.html
@@ -3012,6 +3012,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/es/index.html
+++ b/es/index.html
@@ -3233,6 +3233,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/fr/index.html
+++ b/fr/index.html
@@ -3137,6 +3137,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/hu/index.html
+++ b/hu/index.html
@@ -2999,6 +2999,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/it/index.html
+++ b/it/index.html
@@ -2973,6 +2973,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/ja/index.html
+++ b/ja/index.html
@@ -3310,6 +3310,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/nl/index.html
+++ b/nl/index.html
@@ -3023,6 +3023,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/pt/index.html
+++ b/pt/index.html
@@ -3110,6 +3110,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/ru/index.html
+++ b/ru/index.html
@@ -2968,6 +2968,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;

--- a/tr/index.html
+++ b/tr/index.html
@@ -3060,6 +3060,11 @@
       overflow:hidden;
       transition:box-shadow 0.3s ease;
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
     .cta-header:not(.shiny-cta)::before{
       content:'';
       position:absolute;


### PR DESCRIPTION
- Added .cta-header .cta-short{display:none} to all language sites
- Added media query to show short text at narrower widths
- Fixes button showing both text spans simultaneously