### PR TITLE
Add lightbox functionality to Elite Seven cards (all languages)

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5056,9 +5056,9 @@ html[lang="ar"] [style*="text-align:center"] {
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="كشف دورة Pentarch على رسم BTC البياني" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="كشف دورة Pentarch على رسم BTC البياني" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Pentarch Screenshot</p>
@@ -5093,9 +5093,9 @@ html[lang="ar"] [style*="text-align:center"] {
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="مؤشر OmniDeck الشامل" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="مؤشر OmniDeck الشامل" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add OmniDeck Screenshot</p>
@@ -5129,9 +5129,9 @@ html[lang="ar"] [style*="text-align:center"] {
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="تتبع التدفق المؤسسي لـ Volume Oracle" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="تتبع التدفق المؤسسي لـ Volume Oracle" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Volume Oracle Screenshot</p>
@@ -5166,7 +5166,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5202,9 +5202,9 @@ html[lang="ar"] [style*="text-align:center"] {
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="المستويات الرئيسية متعددة الأطر الزمنية لـ Janus Atlas" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="المستويات الرئيسية متعددة الأطر الزمنية لـ Janus Atlas" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Janus Atlas Screenshot</p>
@@ -5239,9 +5239,9 @@ html[lang="ar"] [style*="text-align:center"] {
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Augury Grid Screenshot</p>
@@ -5275,9 +5275,9 @@ html[lang="ar"] [style*="text-align:center"] {
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="توقيت التأكيد المتعدد لـ Harmonic Oscillator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="توقيت التأكيد المتعدد لـ Harmonic Oscillator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Harmonic Oscillator Screenshot</p>

--- a/de/index.html
+++ b/de/index.html
@@ -5059,9 +5059,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch-Zykluserkennung auf BTC-Chart" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Pentarch-Zykluserkennung auf BTC-Chart" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Pentarch-Screenshot hinzufügen</p>
@@ -5096,9 +5096,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="OmniDeck Alles-in-einem-Indikator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="OmniDeck Alles-in-einem-Indikator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">OmniDeck-Screenshot hinzufügen</p>
@@ -5132,9 +5132,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle institutionelle Flussverfolgung" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Volume Oracle institutionelle Flussverfolgung" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Volume Oracle-Screenshot hinzufügen</p>
@@ -5169,7 +5169,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5205,9 +5205,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas Mehrzeitrahmen-Schlüsselniveaus" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Janus Atlas Mehrzeitrahmen-Schlüsselniveaus" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Janus Atlas-Screenshot hinzufügen</p>
@@ -5242,9 +5242,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid Mehrsymbol-Tracking-Tabelle" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid Mehrsymbol-Tracking-Tabelle" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Augury Grid-Screenshot hinzufügen</p>
@@ -5278,9 +5278,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator Multi-Bestätigungs-Timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Harmonic Oscillator Multi-Bestätigungs-Timing" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Harmonic Oscillator-Screenshot hinzufügen</p>

--- a/es/index.html
+++ b/es/index.html
@@ -5263,9 +5263,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Pentarch Screenshot</p>
@@ -5300,9 +5300,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Agregar captura de pantalla de OmniDeck</p>
@@ -5336,9 +5336,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Volume Oracle Screenshot</p>
@@ -5373,7 +5373,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5409,9 +5409,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Janus Atlas Screenshot</p>
@@ -5446,9 +5446,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Augury Grid Screenshot</p>
@@ -5482,9 +5482,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Harmonic Oscillator Screenshot</p>

--- a/fr/index.html
+++ b/fr/index.html
@@ -5255,9 +5255,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Pentarch Screenshot</p>
@@ -5292,9 +5292,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add OmniDeck Screenshot</p>
@@ -5328,9 +5328,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Volume Oracle Screenshot</p>
@@ -5365,7 +5365,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5401,9 +5401,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Janus Atlas Screenshot</p>
@@ -5438,9 +5438,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Augury Grid Screenshot</p>
@@ -5474,9 +5474,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Harmonic Oscillator Screenshot</p>

--- a/hu/index.html
+++ b/hu/index.html
@@ -4983,9 +4983,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Pentarch Screenshot</p>
@@ -5020,9 +5020,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add OmniDeck Screenshot</p>
@@ -5055,9 +5055,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Volume Oracle Screenshot</p>
@@ -5092,7 +5092,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5128,9 +5128,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Janus Atlas Screenshot</p>
@@ -5165,9 +5165,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Augury Grid Screenshot</p>
@@ -5201,9 +5201,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Harmonic Oscillator Screenshot</p>

--- a/it/index.html
+++ b/it/index.html
@@ -4948,9 +4948,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Rilevamento ciclo Pentarch su grafico BTC" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Rilevamento ciclo Pentarch su grafico BTC" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Aggiungi Screenshot Pentarch</p>
@@ -4985,9 +4985,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="Indicatore tutto-in-uno OmniDeck" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="Indicatore tutto-in-uno OmniDeck" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Aggiungi Screenshot OmniDeck</p>
@@ -5020,9 +5020,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Tracciamento flusso istituzionale Volume Oracle" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Tracciamento flusso istituzionale Volume Oracle" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Aggiungi Screenshot Volume Oracle</p>
@@ -5057,7 +5057,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5093,9 +5093,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Livelli chiave multi-timeframe Janus Atlas" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Livelli chiave multi-timeframe Janus Atlas" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Aggiungi Screenshot Janus Atlas</p>
@@ -5130,9 +5130,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Tabella tracciamento multi-simbolo Augury Grid" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Tabella tracciamento multi-simbolo Augury Grid" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Aggiungi Screenshot Augury Grid</p>
@@ -5166,9 +5166,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Timing multi-conferma Harmonic Oscillator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Timing multi-conferma Harmonic Oscillator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Aggiungi Screenshot Harmonic Oscillator</p>

--- a/ja/index.html
+++ b/ja/index.html
@@ -5293,9 +5293,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Pentarchスクリーンショットを追加</p>
@@ -5330,9 +5330,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">OmniDeckスクリーンショットを追加</p>
@@ -5365,9 +5365,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Volume Oracleスクリーンショットを追加</p>
@@ -5402,7 +5402,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5438,9 +5438,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Janus Atlasスクリーンショットを追加</p>
@@ -5475,9 +5475,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Augury Gridスクリーンショットを追加</p>
@@ -5511,9 +5511,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Harmonic Oscillatorスクリーンショットを追加</p>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4998,9 +4998,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cyclusdetectie op BTC grafiek" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Pentarch cyclusdetectie op BTC grafiek" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Voeg Pentarch Screenshot toe</p>
@@ -5035,9 +5035,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Voeg OmniDeck Screenshot toe</p>
@@ -5070,9 +5070,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle institutionele flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Volume Oracle institutionele flow tracking" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Voeg Volume Oracle Screenshot toe</p>
@@ -5107,7 +5107,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5143,9 +5143,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Voeg Janus Atlas Screenshot toe</p>
@@ -5180,9 +5180,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbool tracking tabel" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid multi-symbool tracking tabel" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Voeg Augury Grid Screenshot toe</p>
@@ -5216,9 +5216,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Voeg Harmonic Oscillator Screenshot toe</p>

--- a/pt/index.html
+++ b/pt/index.html
@@ -5267,9 +5267,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Detecção de ciclo Pentarch no gráfico BTC" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Detecção de ciclo Pentarch no gráfico BTC" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Pentarch Screenshot</p>
@@ -5304,9 +5304,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="Indicador tudo-em-um OmniDeck" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="Indicador tudo-em-um OmniDeck" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add OmniDeck Screenshot</p>
@@ -5340,9 +5340,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Rastreamento de fluxo institucional Volume Oracle" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Rastreamento de fluxo institucional Volume Oracle" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Volume Oracle Screenshot</p>
@@ -5377,7 +5377,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5413,9 +5413,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Níveis-chave multi-período Janus Atlas" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Níveis-chave multi-período Janus Atlas" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Janus Atlas Screenshot</p>
@@ -5450,9 +5450,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Tabela de rastreamento multi-símbolo Augury Grid" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Tabela de rastreamento multi-símbolo Augury Grid" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Augury Grid Screenshot</p>
@@ -5486,9 +5486,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Timing de multi-confirmação Harmonic Oscillator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Timing de multi-confirmação Harmonic Oscillator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Harmonic Oscillator Screenshot</p>

--- a/ru/index.html
+++ b/ru/index.html
@@ -4950,9 +4950,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="Pentarch cycle detection on BTC chart" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Добавить скриншот Pentarch</p>
@@ -4987,9 +4987,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="OmniDeck all-in-one indicator" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Добавить скриншот OmniDeck</p>
@@ -5022,9 +5022,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Volume Oracle volume flow tracking" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Добавить скриншот Volume Oracle</p>
@@ -5059,7 +5059,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5095,9 +5095,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Janus Atlas multi-timeframe key levels" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Добавить скриншот Janus Atlas</p>
@@ -5132,9 +5132,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid multi-symbol tracking table" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Добавить скриншот Augury Grid</p>
@@ -5168,9 +5168,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Harmonic Oscillator multi-confirmation timing" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Добавить скриншот Harmonic Oscillator</p>

--- a/tr/index.html
+++ b/tr/index.html
@@ -5041,9 +5041,9 @@
 
             <!-- Screenshot Box - READY FOR YOUR IMAGE -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px dashed rgba(91,138,255,.4);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.12),rgba(118,221,255,.06))">
-              <img src="/assets/screenshots/pentarch-screenshot.jpg" alt="BTC grafiğinde Pentarch döngü tespiti" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/pentarch.png" alt="BTC grafiğinde Pentarch döngü tespiti" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay (remove 'display:flex' when you add real image, or delete this div entirely) -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Pentarch Screenshot</p>
@@ -5078,9 +5078,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/omnideck-screenshot.jpg" alt="OmniDeck hepsi bir arada göstergesi" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/omnideck.png" alt="OmniDeck hepsi bir arada göstergesi" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add OmniDeck Screenshot</p>
@@ -5113,9 +5113,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/volume-oracle-screenshot.jpg" alt="Volume Oracle kurumsal akış takibi" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/volume-oracle.png" alt="Volume Oracle kurumsal akış takibi" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Volume Oracle Screenshot</p>
@@ -5150,7 +5150,7 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/plutus-flow-screenshot.jpg" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/plutus-flow.png" alt="Plutus Flow" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
               <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
@@ -5186,9 +5186,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/janus-atlas-screenshot.jpg" alt="Janus Atlas çoklu zaman dilimi anahtar seviyeleri" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/janus-atlas.png" alt="Janus Atlas çoklu zaman dilimi anahtar seviyeleri" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Janus Atlas Screenshot</p>
@@ -5223,9 +5223,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/augury-grid-screenshot.jpg" alt="Augury Grid çoklu sembol takip tablosu" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/augury-grid.png" alt="Augury Grid çoklu sembol takip tablosu" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Augury Grid Screenshot</p>
@@ -5259,9 +5259,9 @@
 
             <!-- Screenshot Box -->
             <div style="position:relative;width:100%;max-width:280px;margin:0 auto 1.5rem;aspect-ratio:16/9;border-radius:8px;overflow:hidden;border:2px solid rgba(91,138,255,.3);box-shadow:0 4px 16px rgba(91,138,255,.2);background:linear-gradient(135deg,rgba(91,138,255,.08),rgba(118,221,255,.04))">
-              <img src="/assets/screenshots/harmonic-oscillator-screenshot.jpg" alt="Harmonic Oscillator çoklu onay zamanlaması" style="width:100%;height:100%;object-fit:cover;display:none" loading="eager" class="indicator-screenshot">
+              <img src="/assets/images/elite7/harmonic-oscillator.png" alt="Harmonic Oscillator çoklu onay zamanlaması" style="width:100%;height:100%;object-fit:cover" loading="eager" class="indicator-screenshot">
               <!-- Placeholder overlay -->
-              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
+              <div class="screenshot-placeholder" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(10,14,24,.85);backdrop-filter:blur(4px)">
                 <div style="text-align:center;padding:1rem">
                   <svg viewBox="0 0 24 24" fill="none" stroke="#5b8aff" stroke-width="2" style="width:56px;height:56px;margin:0 auto .75rem"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
                   <p style="font-size:.85rem;font-weight:600;color:var(--brand);margin:0 0 .25rem 0">Add Harmonic Oscillator Screenshot</p>


### PR DESCRIPTION
- Updated image paths from /assets/screenshots/ to /assets/images/elite7/
- Made indicator images visible (removed display:none)
- Hidden placeholder divs
- Existing lightbox JS now works with visible images