### PR TITLE
Fix invisible partner logo SVGs in 7 language files

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2556,7 +2556,7 @@
     .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
     @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
     @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0}
+    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
     .partner-logo:hover{opacity:1}
     .partner-logo svg{width:100%;height:100%}
 

--- a/de/index.html
+++ b/de/index.html
@@ -2536,7 +2536,7 @@
     .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
     @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
     @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0}
+    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
     .partner-logo:hover{opacity:1}
     .partner-logo svg{width:100%;height:100%}
 

--- a/es/index.html
+++ b/es/index.html
@@ -2737,7 +2737,7 @@
     .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
     @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
     @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0}
+    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
     .partner-logo:hover{opacity:1}
     .partner-logo svg{width:100%;height:100%}
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -2570,7 +2570,7 @@
     .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
     @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
     @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0}
+    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
     .partner-logo:hover{opacity:1}
     .partner-logo svg{width:100%;height:100%}
 

--- a/it/index.html
+++ b/it/index.html
@@ -2496,7 +2496,7 @@
     .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
     @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
     @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0}
+    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
     .partner-logo:hover{opacity:1}
     .partner-logo svg{width:100%;height:100%}
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -2770,7 +2770,7 @@
     .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
     @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
     @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0}
+    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
     .partner-logo:hover{opacity:1}
     .partner-logo svg{width:100%;height:100%}
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -2621,7 +2621,7 @@
     .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
     @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
     @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0}
+    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
     .partner-logo:hover{opacity:1}
     .partner-logo svg{width:100%;height:100%}
 


### PR DESCRIPTION
Added missing color property to .partner-logo CSS. SVGs use fill="currentColor" but the color was not set, making them invisible on dark backgrounds.