### PR TITLE
Fix mobile tap highlight making Elite Seven images go dark

### DIFF
--- a/index.html
+++ b/index.html
@@ -4912,6 +4912,38 @@
             aspect-ratio: 2 / 1;
           }
         }
+
+        /* Fix mobile tap highlight and hover states */
+        .elite-chart-card,
+        .elite-panel-card {
+          -webkit-tap-highlight-color: transparent;
+          -webkit-touch-callout: none;
+        }
+        /* Disable hover effects on touch devices */
+        @media (hover: none) and (pointer: coarse) {
+          .elite-chart-card:hover,
+          .elite-chart-card:active {
+            transform: none;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.05);
+          }
+          .elite-chart-card:hover::before,
+          .elite-chart-card:active::before {
+            background: linear-gradient(145deg, rgba(91,138,255,0.3), rgba(168,85,247,0.15), transparent 60%);
+          }
+          .elite-chart-card:hover::after,
+          .elite-chart-card:active::after {
+            left: -100%;
+          }
+          .elite-panel-card:hover,
+          .elite-panel-card:active {
+            transform: none;
+            box-shadow: 0 2px 15px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.05);
+          }
+          .elite-panel-card:hover::before,
+          .elite-panel-card:active::before {
+            background: linear-gradient(90deg, rgba(91,138,255,0.2), transparent 20%, transparent 80%, rgba(91,138,255,0.2));
+          }
+        }
       </style>
 
     </section>


### PR DESCRIPTION
- Added -webkit-tap-highlight-color: transparent
- Added -webkit-touch-callout: none
- Disabled hover/active transforms on touch devices
- Prevents iOS tap darkening effect on card images