### PR TITLE
Remove conflicting minified partner CSS breaking logo display

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2551,15 +2551,6 @@
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
-    .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
-    .partners-track{display:flex;gap:3rem;animation:partners-scroll 60s linear infinite;width:max-content}
-    .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
-    @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-    @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
-    .partner-logo:hover{opacity:1}
-    .partner-logo svg{width:100%;height:100%}
-
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/de/index.html
+++ b/de/index.html
@@ -2530,16 +2530,6 @@
     }
     @media (prefers-reduced-motion: reduce) { .shiny-cta { animation: none; } }
 
-    /* Partners carousel */
-    .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
-    .partners-track{display:flex;gap:3rem;animation:partners-scroll 60s linear infinite;width:max-content}
-    .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
-    @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-    @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
-    .partner-logo:hover{opacity:1}
-    .partner-logo svg{width:100%;height:100%}
-
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/es/index.html
+++ b/es/index.html
@@ -2732,15 +2732,6 @@
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
-    .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
-    .partners-track{display:flex;gap:3rem;animation:partners-scroll 60s linear infinite;width:max-content}
-    .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
-    @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-    @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
-    .partner-logo:hover{opacity:1}
-    .partner-logo svg{width:100%;height:100%}
-
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/hu/index.html
+++ b/hu/index.html
@@ -2565,15 +2565,6 @@
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
-    .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
-    .partners-track{display:flex;gap:3rem;animation:partners-scroll 60s linear infinite;width:max-content}
-    .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
-    @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-    @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
-    .partner-logo:hover{opacity:1}
-    .partner-logo svg{width:100%;height:100%}
-
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/it/index.html
+++ b/it/index.html
@@ -2491,15 +2491,6 @@
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
-    .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
-    .partners-track{display:flex;gap:3rem;animation:partners-scroll 60s linear infinite;width:max-content}
-    .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
-    @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-    @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
-    .partner-logo:hover{opacity:1}
-    .partner-logo svg{width:100%;height:100%}
-
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/ja/index.html
+++ b/ja/index.html
@@ -2765,15 +2765,6 @@
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
-    .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
-    .partners-track{display:flex;gap:3rem;animation:partners-scroll 60s linear infinite;width:max-content}
-    .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
-    @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-    @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
-    .partner-logo:hover{opacity:1}
-    .partner-logo svg{width:100%;height:100%}
-
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/pt/index.html
+++ b/pt/index.html
@@ -2616,15 +2616,6 @@
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
-    .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
-    .partners-track{display:flex;gap:3rem;animation:partners-scroll 60s linear infinite;width:max-content}
-    .partners-track-reverse{display:flex;gap:3rem;animation:partners-scroll-reverse 55s linear infinite;width:max-content}
-    @keyframes partners-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-    @keyframes partners-scroll-reverse{0%{transform:translateX(-50%)}100%{transform:translateX(0)}}
-    .partner-logo{opacity:0.5;transition:opacity 0.3s ease;display:flex;align-items:center;justify-content:center;width:40px;height:40px;flex-shrink:0;color:rgba(255,255,255,0.6)}
-    .partner-logo:hover{opacity:1}
-    .partner-logo svg{width:100%;height:100%}
-
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}


### PR DESCRIPTION
The minified CSS at the top of language files had:
- width:40px;height:40px constraining logos
- Missing flex-direction:column
- Overriding the proper inline styles in the partner section

Removed from: ar, de, es, hu, it, ja, pt