### PR TITLE
Fix Elite Seven panel card image positioning in all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5118,7 +5118,7 @@ html[lang="ar"] [style*="text-align:center"] {
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}

--- a/de/index.html
+++ b/de/index.html
@@ -5212,7 +5212,7 @@
           width: 100%;
           height: 100%;
           object-fit: cover;
-          object-position: center;
+          object-position: top;
         }
         .elite-panel-overlay {
           position: absolute;

--- a/es/index.html
+++ b/es/index.html
@@ -5335,7 +5335,7 @@
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}

--- a/fr/index.html
+++ b/fr/index.html
@@ -5414,7 +5414,7 @@
           width: 100%;
           height: 100%;
           object-fit: cover;
-          object-position: center;
+          object-position: top;
         }
         .elite-panel-overlay {
           position: absolute;

--- a/hu/index.html
+++ b/hu/index.html
@@ -5045,7 +5045,7 @@
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}

--- a/it/index.html
+++ b/it/index.html
@@ -5010,7 +5010,7 @@
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}

--- a/ja/index.html
+++ b/ja/index.html
@@ -5355,7 +5355,7 @@
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}

--- a/nl/index.html
+++ b/nl/index.html
@@ -5069,7 +5069,7 @@
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}

--- a/pt/index.html
+++ b/pt/index.html
@@ -5329,7 +5329,7 @@
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}

--- a/ru/index.html
+++ b/ru/index.html
@@ -5021,7 +5021,7 @@
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}

--- a/tr/index.html
+++ b/tr/index.html
@@ -5112,7 +5112,7 @@
         .elite-panel-card::before{content:'';position:absolute;inset:0;border-radius:12px;padding:1px;background:linear-gradient(90deg,rgba(91,138,255,0.2),transparent 30%,transparent 70%,rgba(168,85,247,0.2));-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
         .elite-panel-card:hover{transform:translateY(-4px);box-shadow:0 12px 35px rgba(91,138,255,0.2),0 0 25px rgba(91,138,255,0.08)}
         .elite-panel-card:hover::before{background:linear-gradient(90deg,rgba(91,138,255,0.5),rgba(168,85,247,0.2) 30%,rgba(168,85,247,0.2) 70%,rgba(91,138,255,0.5))}
-        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:center}
+        .elite-panel-card img{width:100%;height:100%;object-fit:cover;object-position:top}
         .elite-panel-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(10,14,24,0.85) 0%,rgba(10,14,24,0.3) 30%,transparent 60%)}
         .elite-card-badge{position:absolute;top:.75rem;right:.75rem;font-size:.65rem;color:rgba(255,255,255,0.95);background:rgba(10,14,24,0.7);border:1px solid rgba(255,255,255,0.1);padding:.25rem .75rem;border-radius:9999px;backdrop-filter:blur(12px);text-transform:uppercase;letter-spacing:0.05em}
         .elite-card-badge.flagship{background:linear-gradient(135deg,var(--brand),var(--brand-2));border:none;color:#fff;font-weight:600;box-shadow:0 4px 15px rgba(91,138,255,0.4)}


### PR DESCRIPTION
Change object-position from center to top for .elite-panel-card img to properly show the indicator panel stats in the top-right area, matching the English site positioning.