### PR TITLE
Fix shiny-cta button animation on English site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1609,7 +1609,7 @@
       border:2px solid transparent;box-shadow:inset 0 0 0 1px rgba(255,255,255,0.1);cursor:pointer;isolation:isolate;z-index:0;
       animation:shiny-spin 2.5s linear infinite;width:100%;display:flex;align-items:center;justify-content:center;height:48px;
     }
-    @keyframes shiny-spin{to{--gradient-angle:360deg}}
+    @keyframes shiny-spin{0%{--gradient-angle:0deg}100%{--gradient-angle:360deg}}
     .shiny-cta:active{transform:translateY(1px)}
     .shiny-cta::before{
       content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:0;


### PR DESCRIPTION
Add explicit 0% keyframe to shiny-spin animation - required for CSS @property animations to work correctly in all browsers