### PR TITLE
Fix CTA button animations on mobile

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -854,7 +854,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1548,7 +1548,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4194,7 +4194,7 @@ html[lang="ar"] [style*="text-align:center"] {
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }

--- a/assets/deferred.css
+++ b/assets/deferred.css
@@ -597,6 +597,17 @@
         transition-duration: 0.1s !important;
       }
 
+      /* Preserve shiny-cta button animations - these need smooth continuous rotation */
+      .shiny-cta {
+        animation-duration: 4s !important;
+      }
+      .shiny-cta::before {
+        animation-duration: 4s !important;
+      }
+      .shiny-cta::after {
+        animation-duration: 6s !important;
+      }
+
       /* Simplify gradients to solid colors */
       .card {
         background: var(--bg-soft) !important;

--- a/assets/device-optimizations.css
+++ b/assets/device-optimizations.css
@@ -184,6 +184,16 @@
     transition-duration: 0.2s;
   }
 
+  /* Preserve shiny-cta button animations - smooth border rotation */
+  .shiny-cta,
+  .shiny-cta::before,
+  .shiny-cta::after {
+    animation-duration: 4s !important;
+  }
+  .shiny-cta::after {
+    animation-duration: 6s !important;
+  }
+
   /* Full-width sections */
   .section {
     padding: 3rem 1rem;

--- a/de/index.html
+++ b/de/index.html
@@ -837,7 +837,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1505,7 +1505,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4140,7 +4140,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4218,7 +4218,7 @@
       }
 
       /* Kill heavy transitions on mobile */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         transition-duration: 0.1s !important;
       }
 

--- a/es/index.html
+++ b/es/index.html
@@ -841,7 +841,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1610,7 +1610,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4345,7 +4345,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4423,7 +4423,7 @@
       }
 
       /* Kill heavy transitions on mobile */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         transition-duration: 0.1s !important;
       }
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -874,7 +874,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1619,7 +1619,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4342,7 +4342,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4420,7 +4420,7 @@
       }
 
       /* Kill heavy transitions on mobile */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         transition-duration: 0.1s !important;
       }
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -859,7 +859,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1561,7 +1561,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4121,7 +4121,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }

--- a/index.html
+++ b/index.html
@@ -653,10 +653,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      /* EXCLUDE: marquee carousels need their full animation duration */
-      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse),
-      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse)::before,
-      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse)::after {
+      /* EXCLUDE: marquee carousels and shiny-cta buttons need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }

--- a/it/index.html
+++ b/it/index.html
@@ -834,7 +834,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1499,7 +1499,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4086,7 +4086,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }

--- a/ja/index.html
+++ b/ja/index.html
@@ -919,7 +919,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1717,7 +1717,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4429,7 +4429,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }

--- a/nl/index.html
+++ b/nl/index.html
@@ -852,7 +852,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1546,7 +1546,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4143,7 +4143,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }

--- a/pt/index.html
+++ b/pt/index.html
@@ -797,7 +797,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1515,7 +1515,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4402,7 +4402,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }

--- a/ru/index.html
+++ b/ru/index.html
@@ -817,7 +817,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1515,7 +1515,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4091,7 +4091,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }

--- a/tr/index.html
+++ b/tr/index.html
@@ -855,7 +855,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1598,7 +1598,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4182,7 +4182,7 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *, *::before, *::after {
+      *:not(.shiny-cta), *:not(.shiny-cta)::before, *:not(.shiny-cta)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }


### PR DESCRIPTION
The blanket mobile performance optimization was overriding all animations to 0.1s, which broke the smooth shiny-cta border rotation. Added explicit exceptions to preserve the intended 4s/6s animation durations on mobile.