### PR TITLE
Enable conduit on mobile + disable jarring scroll reveal animations

### DIFF
--- a/assets/scroll-reveal.css
+++ b/assets/scroll-reveal.css
@@ -364,3 +364,27 @@
   0%, 100% { filter: drop-shadow(0 0 10px rgba(255, 100, 50, 0.3)); }
   50% { filter: drop-shadow(0 0 30px rgba(255, 100, 50, 0.6)); }
 }
+
+/* ============================================
+   MOBILE: Disable scroll reveal animations
+   They feel jarring on mobile - just show content
+   ============================================ */
+
+@media (max-width: 768px) {
+  [data-reveal],
+  [data-reveal-stagger] > *,
+  .section-reveal {
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+    clip-path: none !important;
+    transition: none !important;
+  }
+
+  [data-reveal].revealed,
+  [data-reveal-stagger].revealed > *,
+  .section-reveal.revealed {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -557,9 +557,11 @@
         mix-blend-mode: screen !important;
       }
 
-      /* HIDE conduit/energy beam video on mobile */
+      /* SHOW conduit/energy beam video on mobile - testing! */
       #energy-beam-video {
-        display: none !important;
+        display: block !important;
+        mix-blend-mode: screen !important;
+        opacity: 0.8 !important;
       }
 
       /* Main content - transparent so aura shows through */


### PR DESCRIPTION
- Re-enabled conduit/energy beam video on mobile with blend mode
- Disabled scroll reveal animations on mobile (they were too jarring)
- Content now shows immediately on mobile instead of bam bam bam