### PR TITLE
Fix header CTA button animation not spinning

### DIFF
--- a/index.html
+++ b/index.html
@@ -1628,13 +1628,21 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
-    /* Slow down shiny animations on mobile */
+    /* Simplify shiny animations on mobile - disable spinning, use static gradient */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation-duration: 4s;
+        animation: none;
+        background: linear-gradient(#0a0a0f,#0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a, #3b82f6, #1e3a8a) border-box;
       }
+      .shiny-cta::before,
       .shiny-cta::after {
-        animation-duration: 6s;
+        animation: none;
+        display: none;
+      }
+      /* Header CTA just fades in, no spin */
+      .shiny-cta.cta-header {
+        animation: fadeInUp 0.4s ease 0.5s forwards;
+        opacity: 0;
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -661,6 +661,20 @@
         transition-duration: 0.2s !important;
       }
 
+      /* KILL shiny-cta animations completely on mobile - static gradient looks better and no flicker */
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none !important;
+      }
+      .shiny-cta {
+        background: linear-gradient(#0a0a0f,#0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a, #3b82f6, #1e3a8a) border-box !important;
+      }
+      .shiny-cta::before,
+      .shiny-cta::after {
+        display: none !important;
+      }
+
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
       .sp-chatbot-window,
@@ -1627,24 +1641,6 @@
     }
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
-
-    /* Simplify shiny animations on mobile - disable spinning, use static gradient */
-    @media (max-width: 768px) {
-      .shiny-cta {
-        animation: none;
-        background: linear-gradient(#0a0a0f,#0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a, #3b82f6, #1e3a8a) border-box;
-      }
-      .shiny-cta::before,
-      .shiny-cta::after {
-        animation: none;
-        display: none;
-      }
-      /* Header CTA just fades in, no spin */
-      .shiny-cta.cta-header {
-        animation: fadeInUp 0.4s ease 0.5s forwards;
-        opacity: 0;
-      }
-    }
 
     /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {

--- a/index.html
+++ b/index.html
@@ -661,20 +661,6 @@
         transition-duration: 0.2s !important;
       }
 
-      /* KILL shiny-cta animations completely on mobile - static gradient looks better and no flicker */
-      .shiny-cta,
-      .shiny-cta::before,
-      .shiny-cta::after {
-        animation: none !important;
-      }
-      .shiny-cta {
-        background: linear-gradient(#0a0a0f,#0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a, #3b82f6, #1e3a8a) border-box !important;
-      }
-      .shiny-cta::before,
-      .shiny-cta::after {
-        display: none !important;
-      }
-
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
       .sp-chatbot-window,
@@ -1641,6 +1627,16 @@
     }
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
+
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px) {
+      .shiny-cta {
+        animation-duration: 4s;
+      }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
+    }
 
     /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {

--- a/index.html
+++ b/index.html
@@ -592,9 +592,8 @@
       }
 
       /* Header needs high z-index for dropdown menus but FULLY transparent bg */
-      /* EXCLUDE shiny-cta from background reset - it needs its animated gradient */
       header,
-      header *:not(.shiny-cta):not(.shiny-cta *),
+      header *,
       header .container,
       header .container.nav,
       header .nav-backdrop,
@@ -603,7 +602,7 @@
       header .nav-spacer,
       header .menu-toggle,
       header .lang-dropdown,
-      header .btn:not(.shiny-cta) {
+      header .btn {
         background: none !important;
         background-color: transparent !important;
         background-image: none !important;

--- a/index.html
+++ b/index.html
@@ -592,8 +592,9 @@
       }
 
       /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      /* EXCLUDE shiny-cta from background reset - it needs its animated gradient */
       header,
-      header *,
+      header *:not(.shiny-cta):not(.shiny-cta *),
       header .container,
       header .container.nav,
       header .nav-backdrop,
@@ -602,7 +603,7 @@
       header .nav-spacer,
       header .menu-toggle,
       header .lang-dropdown,
-      header .btn {
+      header .btn:not(.shiny-cta) {
         background: none !important;
         background-color: transparent !important;
         background-image: none !important;
@@ -1910,7 +1911,8 @@
     nav[aria-label="Main"] ul li:nth-child(3){animation:fadeInUp 0.4s ease 0.3s forwards;opacity:0}
     nav[aria-label="Main"] ul li:nth-child(4){animation:fadeInUp 0.4s ease 0.4s forwards;opacity:0}
     nav[aria-label="Main"] ul li:nth-child(5){animation:fadeInUp 0.4s ease 0.45s forwards;opacity:0}
-    .lang-dropdown,.cta-header{animation:fadeInUp 0.4s ease 0.5s forwards;opacity:0}
+    .lang-dropdown,.cta-header:not(.shiny-cta){animation:fadeInUp 0.4s ease 0.5s forwards;opacity:0}
+    .shiny-cta.cta-header{animation:fadeInUp 0.4s ease 0.5s forwards, shiny-spin 2.5s linear infinite;opacity:0}
     .menu-toggle{animation:fadeInUp 0.4s ease 0.5s forwards;opacity:0}
 
     /* Allow brand to shrink slightly on very constrained screens with translations */

--- a/index.html
+++ b/index.html
@@ -2247,7 +2247,7 @@
 
     /* Hide CTA on smaller tablets/phones - will show in mobile menu instead */
     @media (max-width:1100px){
-      .cta-header{display:none}
+      .cta-header{display:none !important}
     }
 
     /* More compact for medium screens */


### PR DESCRIPTION
The shiny-cta animation was being overridden by fadeInUp animation on .cta-header class. Now uses combined animations so both work.

Also excluded shiny-cta from mobile header background reset that was killing the animated gradient border.