### PR TITLE
Fix shiny-cta animation on all language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2549,8 +2549,10 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
-    @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px){.shiny-cta{animation-duration:4s}.shiny-cta::after{animation-duration:6s}}
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/de/index.html
+++ b/de/index.html
@@ -2517,18 +2517,24 @@
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
     .shiny-cta>span{position:relative;z-index:1}
 
-    /* Use fallback animation on mobile */
+    /* Slow down shiny animations on mobile */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        -webkit-animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box;
+        animation-duration: 4s;
       }
-      .shiny-cta::before, .shiny-cta::after { display: none; }
-      @-webkit-keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
-      @keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
     }
-    @media (prefers-reduced-motion: reduce) { .shiny-cta { animation: none; } }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
 
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 

--- a/es/index.html
+++ b/es/index.html
@@ -2730,8 +2730,10 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
-    @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px){.shiny-cta{animation-duration:4s}.shiny-cta::after{animation-duration:6s}}
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/fr/index.html
+++ b/fr/index.html
@@ -1126,26 +1126,23 @@
     .shiny-cta span{position:relative;z-index:10;display:inline-flex;align-items:center;gap:.5rem}
     @keyframes shiny-spin{0%{--gradient-angle:0deg;--gradient-shine:#3b82f6}50%{--gradient-shine:#60a5fa}to{--gradient-angle:360deg;--gradient-shine:#3b82f6}}
 
-    /* Use fallback animation on mobile that doesn't rely on @property */
+    /* Slow down shiny animations on mobile */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        -webkit-animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
-                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box;
+        animation-duration: 4s;
       }
-      .shiny-cta::before, .shiny-cta::after { display: none; }
-      @-webkit-keyframes shiny-pulse {
-        0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); }
-        50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); }
-      }
-      @keyframes shiny-pulse {
-        0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); }
-        50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); }
+      .shiny-cta::after {
+        animation-duration: 6s;
       }
     }
+
+    /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {
-      .shiny-cta, .shiny-cta::before, .shiny-cta::after { animation: none; }
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
     }
 
     /* Micro-interactions: Success checkmark pop */
@@ -1870,26 +1867,23 @@
     .shiny-cta span{position:relative;z-index:10;display:inline-flex;align-items:center;gap:.5rem}
     @keyframes shiny-spin{0%{--gradient-angle:0deg;--gradient-shine:#3b82f6}50%{--gradient-shine:#60a5fa}to{--gradient-angle:360deg;--gradient-shine:#3b82f6}}
 
-    /* Use fallback animation on mobile that doesn't rely on @property */
+    /* Slow down shiny animations on mobile */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        -webkit-animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
-                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box;
+        animation-duration: 4s;
       }
-      .shiny-cta::before, .shiny-cta::after { display: none; }
-      @-webkit-keyframes shiny-pulse {
-        0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); }
-        50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); }
-      }
-      @keyframes shiny-pulse {
-        0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); }
-        50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); }
+      .shiny-cta::after {
+        animation-duration: 6s;
       }
     }
+
+    /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {
-      .shiny-cta, .shiny-cta::before, .shiny-cta::after { animation: none; }
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
     }
 
     /* Micro-interactions: Success checkmark pop */

--- a/hu/index.html
+++ b/hu/index.html
@@ -2563,8 +2563,10 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
-    @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px){.shiny-cta{animation-duration:4s}.shiny-cta::after{animation-duration:6s}}
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/it/index.html
+++ b/it/index.html
@@ -2489,8 +2489,10 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
-    @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px){.shiny-cta{animation-duration:4s}.shiny-cta::after{animation-duration:6s}}
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/ja/index.html
+++ b/ja/index.html
@@ -2763,8 +2763,10 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
-    @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px){.shiny-cta{animation-duration:4s}.shiny-cta::after{animation-duration:6s}}
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/nl/index.html
+++ b/nl/index.html
@@ -2567,25 +2567,13 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
-    /* Use fallback animation on mobile that doesn't rely on @property */
+    /* Slow down shiny animations on mobile */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        -webkit-animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
-                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box;
+        animation-duration: 4s;
       }
-      .shiny-cta::before,
       .shiny-cta::after {
-        display: none;
-      }
-      @-webkit-keyframes shiny-pulse {
-        0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); }
-        50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); }
-      }
-      @keyframes shiny-pulse {
-        0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); }
-        50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); }
+        animation-duration: 6s;
       }
     }
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -2614,8 +2614,10 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
-    @media (prefers-reduced-motion: reduce){.shiny-cta{animation:none}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px){.shiny-cta{animation-duration:4s}.shiny-cta::after{animation-duration:6s}}
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/ru/index.html
+++ b/ru/index.html
@@ -1077,18 +1077,24 @@
     .shiny-cta:active{transform:translateY(0)}
     .shiny-cta>span{position:relative;z-index:1}
     @keyframes shiny-spin{0%{--gradient-angle:0deg}100%{--gradient-angle:360deg}}
-    /* Use fallback animation on mobile */
+    /* Slow down shiny animations on mobile */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        -webkit-animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box;
+        animation-duration: 4s;
       }
-      .shiny-cta::before, .shiny-cta::after { display: none; }
-      @-webkit-keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
-      @keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
     }
-    @media (prefers-reduced-motion: reduce) { .shiny-cta { animation: none; } }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
 
     /* Partners carousel */
     .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
@@ -1774,18 +1780,24 @@
     .shiny-cta:active{transform:translateY(0)}
     .shiny-cta>span{position:relative;z-index:1}
     @keyframes shiny-spin{0%{--gradient-angle:0deg}100%{--gradient-angle:360deg}}
-    /* Use fallback animation on mobile */
+    /* Slow down shiny animations on mobile */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        -webkit-animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box;
+        animation-duration: 4s;
       }
-      .shiny-cta::before, .shiny-cta::after { display: none; }
-      @-webkit-keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
-      @keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
     }
-    @media (prefers-reduced-motion: reduce) { .shiny-cta { animation: none; } }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
 
     /* Partners carousel */
     .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}

--- a/tr/index.html
+++ b/tr/index.html
@@ -1123,18 +1123,24 @@
     .shiny-cta:active{transform:translateY(0)}
     .shiny-cta>span{position:relative;z-index:1}
     @keyframes shiny-spin{0%{--gradient-angle:0deg}100%{--gradient-angle:360deg}}
-    /* Use fallback animation on mobile */
+    /* Slow down shiny animations on mobile */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        -webkit-animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box;
+        animation-duration: 4s;
       }
-      .shiny-cta::before, .shiny-cta::after { display: none; }
-      @-webkit-keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
-      @keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
     }
-    @media (prefers-reduced-motion: reduce) { .shiny-cta { animation: none; } }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
 
     /* Partners carousel */
     .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}
@@ -1865,18 +1871,24 @@
     .shiny-cta:active{transform:translateY(0)}
     .shiny-cta>span{position:relative;z-index:1}
     @keyframes shiny-spin{0%{--gradient-angle:0deg}100%{--gradient-angle:360deg}}
-    /* Use fallback animation on mobile */
+    /* Slow down shiny animations on mobile */
     @media (max-width: 768px) {
       .shiny-cta {
-        animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        -webkit-animation: shiny-pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box, linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box;
+        animation-duration: 4s;
       }
-      .shiny-cta::before, .shiny-cta::after { display: none; }
-      @-webkit-keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
-      @keyframes shiny-pulse { 0%, 100% { box-shadow: 0 0 12px rgba(59,130,246,0.25), inset 0 0 0 1px rgba(255,255,255,0.08); } 50% { box-shadow: 0 0 25px rgba(59,130,246,0.4), inset 0 0 0 1px rgba(255,255,255,0.15); } }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
     }
-    @media (prefers-reduced-motion: reduce) { .shiny-cta { animation: none; } }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
 
     /* Partners carousel */
     .partners-marquee{position:relative;width:100%;overflow:hidden;mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);-webkit-mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);touch-action:pan-y;-webkit-overflow-scrolling:auto}


### PR DESCRIPTION
Replace non-working shiny-pulse fallback with animation-duration slowdown. This ensures the spinning blue lines animate on mobile, matching the main site.

Fixed: ar, de, es, fr, hu, it, ja, nl, pt, ru, tr