### PR TITLE
Fix Elite Seven image layering on all language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -891,8 +891,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1585,8 +1585,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/de/index.html
+++ b/de/index.html
@@ -874,8 +874,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1542,8 +1542,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/es/index.html
+++ b/es/index.html
@@ -878,8 +878,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1647,8 +1647,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/fr/index.html
+++ b/fr/index.html
@@ -911,8 +911,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1653,8 +1653,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/hu/index.html
+++ b/hu/index.html
@@ -896,8 +896,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1598,8 +1598,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/it/index.html
+++ b/it/index.html
@@ -871,8 +871,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1536,8 +1536,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/ja/index.html
+++ b/ja/index.html
@@ -956,8 +956,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1754,8 +1754,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/nl/index.html
+++ b/nl/index.html
@@ -889,8 +889,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1583,8 +1583,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/pt/index.html
+++ b/pt/index.html
@@ -834,8 +834,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1552,8 +1552,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/ru/index.html
+++ b/ru/index.html
@@ -854,8 +854,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1558,8 +1558,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */

--- a/tr/index.html
+++ b/tr/index.html
@@ -892,8 +892,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */
@@ -1641,8 +1641,8 @@
     main{
       position:relative;
       min-height:100vh;
-      z-index:1;
       background:transparent !important; /* Let constellations show through! */
+      /* Note: z-index removed to allow mix-blend-mode to work with starfield */
     }
 
     /* Make all sections transparent so constellations are visible throughout entire site */


### PR DESCRIPTION
Remove z-index:1 from main element to allow proper stacking with starfield. This fixes product images showing behind stars/constellations.

Fixed: ar, de, es, fr, hu, it, ja, nl, pt, ru, tr