### PR TITLE
Fix carousel animation speed on all language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -874,6 +874,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1576,6 +1579,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4310,6 +4316,9 @@ html[lang="ar"] [style*="text-align:center"] {
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/ar/index.html
+++ b/ar/index.html
@@ -854,7 +854,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -866,6 +869,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1548,7 +1562,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1560,6 +1577,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4196,7 +4224,10 @@ html[lang="ar"] [style*="text-align:center"] {
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4208,6 +4239,17 @@ html[lang="ar"] [style*="text-align:center"] {
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/ar/index.html
+++ b/ar/index.html
@@ -2580,7 +2580,24 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px) {
+      .shiny-cta {
+        animation-duration: 4s;
+      }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
+    }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
     /* Chrome ONLY: Replace @property with transform-based rotation */
@@ -4415,14 +4432,12 @@ html[lang="ar"] [style*="text-align:center"] {
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/de/index.html
+++ b/de/index.html
@@ -837,7 +837,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -849,6 +852,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1505,7 +1519,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1517,6 +1534,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4146,7 +4174,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4158,6 +4189,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/de/index.html
+++ b/de/index.html
@@ -857,6 +857,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1533,6 +1536,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4262,6 +4268,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/de/index.html
+++ b/de/index.html
@@ -4409,14 +4409,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/es/index.html
+++ b/es/index.html
@@ -2761,7 +2761,24 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px) {
+      .shiny-cta {
+        animation-duration: 4s;
+      }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
+    }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
     /* Chrome ONLY: Replace @property with transform-based rotation */
@@ -4608,14 +4625,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/es/index.html
+++ b/es/index.html
@@ -841,7 +841,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -853,6 +856,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1610,7 +1624,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1622,6 +1639,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4347,7 +4375,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4359,6 +4390,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/es/index.html
+++ b/es/index.html
@@ -861,6 +861,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1638,6 +1641,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4461,6 +4467,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/fr/index.html
+++ b/fr/index.html
@@ -4639,14 +4639,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/fr/index.html
+++ b/fr/index.html
@@ -874,7 +874,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -886,6 +889,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1616,7 +1630,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1628,6 +1645,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4336,7 +4364,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4348,6 +4379,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -894,6 +894,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1684,6 +1687,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4492,6 +4498,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/hu/index.html
+++ b/hu/index.html
@@ -879,6 +879,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1589,6 +1592,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4237,6 +4243,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/hu/index.html
+++ b/hu/index.html
@@ -2594,7 +2594,24 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-    @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
+    /* Slow down shiny animations on mobile */
+    @media (max-width: 768px) {
+      .shiny-cta {
+        animation-duration: 4s;
+      }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
+    }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
     /* Chrome ONLY: Replace @property with transform-based rotation */
@@ -4342,14 +4359,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/hu/index.html
+++ b/hu/index.html
@@ -859,7 +859,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -871,6 +874,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1561,7 +1575,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1573,6 +1590,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4123,7 +4151,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4135,6 +4166,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/it/index.html
+++ b/it/index.html
@@ -834,7 +834,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -846,6 +849,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1499,7 +1513,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1511,6 +1528,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4088,7 +4116,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4100,6 +4131,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/it/index.html
+++ b/it/index.html
@@ -854,6 +854,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1527,6 +1530,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4202,6 +4208,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/it/index.html
+++ b/it/index.html
@@ -2520,7 +2520,24 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-@media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
+/* Slow down shiny animations on mobile */
+    @media (max-width: 768px) {
+      .shiny-cta {
+        animation-duration: 4s;
+      }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
+    }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
     /* Chrome ONLY: Replace @property with transform-based rotation */
@@ -4307,14 +4324,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/ja/index.html
+++ b/ja/index.html
@@ -939,6 +939,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1745,6 +1748,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4545,6 +4551,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/ja/index.html
+++ b/ja/index.html
@@ -919,7 +919,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -931,6 +934,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1717,7 +1731,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1729,6 +1746,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4431,7 +4459,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4443,6 +4474,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -2794,7 +2794,24 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-@media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
+/* Slow down shiny animations on mobile */
+    @media (max-width: 768px) {
+      .shiny-cta {
+        animation-duration: 4s;
+      }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
+    }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
     /* Chrome ONLY: Replace @property with transform-based rotation */
@@ -4650,14 +4667,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/nl/index.html
+++ b/nl/index.html
@@ -872,6 +872,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1574,6 +1577,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4245,6 +4251,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/nl/index.html
+++ b/nl/index.html
@@ -852,7 +852,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -864,6 +867,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1546,7 +1560,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1558,6 +1575,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4131,7 +4159,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4143,6 +4174,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -4350,14 +4350,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/pt/index.html
+++ b/pt/index.html
@@ -817,6 +817,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1543,6 +1546,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4518,6 +4524,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/pt/index.html
+++ b/pt/index.html
@@ -797,7 +797,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -809,6 +812,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1515,7 +1529,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1527,6 +1544,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4404,7 +4432,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4416,6 +4447,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -2645,7 +2645,24 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
-@media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
+/* Slow down shiny animations on mobile */
+    @media (max-width: 768px) {
+      .shiny-cta {
+        animation-duration: 4s;
+      }
+      .shiny-cta::after {
+        animation-duration: 6s;
+      }
+    }
+
+    /* Respect reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      .shiny-cta,
+      .shiny-cta::before,
+      .shiny-cta::after {
+        animation: none;
+      }
+    }
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
     /* Chrome ONLY: Replace @property with transform-based rotation */
@@ -4623,14 +4640,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/ru/index.html
+++ b/ru/index.html
@@ -837,6 +837,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1589,6 +1592,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4259,6 +4265,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/ru/index.html
+++ b/ru/index.html
@@ -817,7 +817,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -829,6 +832,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1521,7 +1535,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1533,6 +1550,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4103,7 +4131,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4115,6 +4146,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -4364,14 +4364,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4449,14 +4449,12 @@
     }
 
     /* Ensure ALL parent elements up to body are transparent for blend to work */
-    /* CRITICAL: z-index: auto removes stacking context so mix-blend-mode can reach starfield */
     .hero,
     #main-content,
     main#main,
     main {
       background: transparent !important;
       background-color: transparent !important;
-      z-index: auto !important;
     }
 
   </style>

--- a/tr/index.html
+++ b/tr/index.html
@@ -875,6 +875,9 @@
       .partners-track-reverse {
         animation-duration: 50s !important;
       }
+      .shimmer-text {
+        animation-duration: 30s !important;
+      }
 
       /* Ensure modals can still animate */
       #cookie-preferences-modal,
@@ -1668,6 +1671,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */
@@ -4344,6 +4350,9 @@
       }
       .partners-track-reverse {
         animation-duration: 50s !important;
+      }
+      .shimmer-text {
+        animation-duration: 30s !important;
       }
 
       /* Ensure modals can still animate */

--- a/tr/index.html
+++ b/tr/index.html
@@ -855,7 +855,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -867,6 +870,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -1604,7 +1618,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -1616,6 +1633,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 
@@ -4194,7 +4222,10 @@
       }
 
       /* Reduce animations for performance - but don't kill them entirely */
-      *:not(.shiny-cta):not(.char), *:not(.shiny-cta):not(.char)::before, *:not(.shiny-cta):not(.char)::after {
+      /* EXCLUDE: marquee carousels, shiny-cta buttons, and text-stagger chars need their full animation duration */
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char),
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::before,
+      *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char)::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
       }
@@ -4206,6 +4237,17 @@
       [id*="modal"] {
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 50s !important;
       }
     }
 


### PR DESCRIPTION
The 0.2s animation-duration override was affecting carousel animations, making them spin at insane speeds. Added exclusions for .testimonials-track, .partners-track, and .partners-track-reverse, plus explicit restore rules.

Fixed: ar, de, es, fr, hu, it, ja, nl, pt, ru, tr