### PR TITLE
Fix brightness filter on non-English sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4671,7 +4671,7 @@ html[lang="ar"] [style*="text-align:center"] {
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">رسم بياني مباشر</span>
               </div>

--- a/de/index.html
+++ b/de/index.html
@@ -4665,7 +4665,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">LIVE-CHART</span>
               </div>

--- a/es/index.html
+++ b/es/index.html
@@ -4864,7 +4864,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">GRÁFICO EN VIVO</span>
               </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -4900,7 +4900,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">GRAPHIQUE EN DIRECT</span>
               </div>

--- a/hu/index.html
+++ b/hu/index.html
@@ -4598,7 +4598,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">ÉLŐ GRAFIKON</span>
               </div>

--- a/it/index.html
+++ b/it/index.html
@@ -4563,7 +4563,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">GRAFICO LIVE</span>
               </div>

--- a/ja/index.html
+++ b/ja/index.html
@@ -4908,7 +4908,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">ライブチャート</span>
               </div>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4608,7 +4608,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">LIVE CHART</span>
               </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -4882,7 +4882,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">GRÁFICO AO VIVO</span>
               </div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -4622,7 +4622,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">ЖИВОЙ ГРАФИК</span>
               </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4707,7 +4707,7 @@
               </video>
               
               <!-- Overlay Badge - Reduced Opacity -->
-              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.6);backdrop-filter:blur(8px);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem;opacity:0.85">
+              <div style="position:absolute;top:1rem;right:1rem;background:rgba(12,16,27,.92);padding:.5rem .8rem;border-radius:8px;border:1px solid rgba(91,138,255,.25);display:flex;align-items:center;gap:.5rem">
                 <span style="width:6px;height:6px;border-radius:50%;background:#3ed598;box-shadow:0 0 8px rgba(62,213,152,.6)"></span>
                 <span style="font-size:.8rem;font-weight:700;color:#3ed598">CANLI GRAFİK</span>
               </div>


### PR DESCRIPTION
Remove reduced opacity and backdrop blur filter from LIVE CHART badge on all language versions to match English site styling. Changed from rgba(12,16,27,.6) with blur and 0.85 opacity to rgba(12,16,27,.92) which provides a cleaner, non-washed-out appearance on mobile.

Languages fixed: ar, de, es, fr, hu, it, ja, nl, pt, ru, tr