### PR TITLE
Add NUCLEAR filter reset to early mobile CSS in all language files

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -815,6 +815,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1509,6 +1518,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/de/index.html
+++ b/de/index.html
@@ -799,6 +799,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers - keep constellations ABOVE aurora */
       .bg-stars {
         z-index: -3 !important;
@@ -1467,6 +1476,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers - keep constellations ABOVE aurora */
       .bg-stars {
         z-index: -3 !important;

--- a/es/index.html
+++ b/es/index.html
@@ -799,6 +799,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1568,6 +1577,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/fr/index.html
+++ b/fr/index.html
@@ -835,6 +835,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1617,6 +1626,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/hu/index.html
+++ b/hu/index.html
@@ -820,6 +820,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1522,6 +1531,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/it/index.html
+++ b/it/index.html
@@ -792,6 +792,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1457,6 +1466,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/ja/index.html
+++ b/ja/index.html
@@ -872,6 +872,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1670,6 +1679,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/nl/index.html
+++ b/nl/index.html
@@ -813,6 +813,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1507,6 +1516,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/pt/index.html
+++ b/pt/index.html
@@ -758,6 +758,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1476,6 +1485,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/ru/index.html
+++ b/ru/index.html
@@ -778,6 +778,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1522,6 +1531,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;

--- a/tr/index.html
+++ b/tr/index.html
@@ -816,6 +816,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
@@ -1601,6 +1610,15 @@
 
     /* MOBILE: Simple, clean mobile setup - NO forced positioning */
     @media (max-width: 768px) {
+      /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */
+      html, body, main, section, .section, article, div.container, .hero {
+        transform: none !important;
+        -webkit-transform: none !important;
+        will-change: auto !important;
+        contain: none !important;
+        filter: none !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;


### PR DESCRIPTION
The English site had a critical mobile CSS block at the start that explicitly sets filter: none !important on main containers. This removes any filter effects (brightness, blur, etc.) that could cause a washed-out appearance.

The non-English sites were missing this reset in their first mobile media query - it only appeared much later in the file where it could be overridden by more specific selectors.

This adds the NUCLEAR reset block to the first mobile media query in all 11 language sites (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr).

Languages fixed: ar, de, es, fr, hu, it, ja, nl, pt, ru, tr