### PR TITLE
Add complete mobile CSS setup to early mobile block in all language f…

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -824,10 +824,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1527,10 +1592,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/de/index.html
+++ b/de/index.html
@@ -808,10 +808,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers - keep constellations ABOVE aurora */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1485,10 +1550,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers - keep constellations ABOVE aurora */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/es/index.html
+++ b/es/index.html
@@ -808,10 +808,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1586,10 +1651,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/fr/index.html
+++ b/fr/index.html
@@ -844,10 +844,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1635,10 +1700,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/hu/index.html
+++ b/hu/index.html
@@ -829,10 +829,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1540,10 +1605,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/it/index.html
+++ b/it/index.html
@@ -801,10 +801,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1475,10 +1540,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/ja/index.html
+++ b/ja/index.html
@@ -881,10 +881,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1688,10 +1753,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/nl/index.html
+++ b/nl/index.html
@@ -822,10 +822,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1525,10 +1590,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/pt/index.html
+++ b/pt/index.html
@@ -767,10 +767,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1494,10 +1559,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/ru/index.html
+++ b/ru/index.html
@@ -787,10 +787,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1540,10 +1605,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;

--- a/tr/index.html
+++ b/tr/index.html
@@ -825,10 +825,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;
@@ -1619,10 +1684,75 @@
         filter: none !important;
       }
 
+      /* CRITICAL: Make html/body transparent so unicorn aura shows through */
+      html, body {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Body needs relative positioning for absolute child */
+      body {
+        position: relative !important;
+      }
+
+      /* Unicorn Studio container - fixed background behind everything */
+      #unicorn-bg-container {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        z-index: -1 !important;
+        pointer-events: none !important;
+        overflow: hidden !important;
+        background: #05070d !important;
+      }
+
+      #unicorn-bg-container > div {
+        width: 100% !important;
+        height: 100% !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+      }
+
+      /* SHOW starfield on mobile */
+      #starfield-container {
+        display: block !important;
+        position: fixed !important;
+        z-index: 1 !important;
+        mix-blend-mode: screen !important;
+      }
+
+      /* Hide conduit on mobile - keep only on desktop */
+      #energy-beam-video {
+        display: none !important;
+      }
+
+      /* Main content - transparent so aura shows through */
+      main {
+        position: relative !important;
+        z-index: 1 !important;
+        background: transparent !important;
+      }
+
+      /* All sections transparent on mobile so aura shows through */
+      section, .section, article {
+        background: transparent !important;
+        background-color: transparent !important;
+      }
+
+      /* Override inline background styles on sections */
+      section[style*="background"] {
+        background: transparent !important;
+      }
+
       /* Background layers BEHIND everything */
       .bg-stars {
         z-index: -3 !important;
         position: fixed !important;
+        filter: none !important;
       }
       .sp-constellations {
         z-index: 1 !important;


### PR DESCRIPTION
…iles

The English site's first mobile media query had comprehensive CSS for:
- html/body transparent backgrounds
- Unicorn Studio container setup (display: block, fixed positioning)
- Starfield container setup with mix-blend-mode
- Energy beam video hidden on mobile
- Main content transparent backgrounds
- Section transparency overrides
- .bg-stars filter: none

The non-English sites were missing all of this in their first mobile media query - it only appeared later in the file where CSS cascade order could cause issues. This adds the complete mobile setup block to match the English version's structure.

This should fix the washed-out / brightness filter appearance on non-English mobile sites.

Languages fixed: ar, de, es, fr, hu, it, ja, nl, pt, ru, tr