### PR TITLE
Fix remaining 7-day references in affiliates and documentation

### DIFF
--- a/COMPLETE_30_DAY_GUIDE.md
+++ b/COMPLETE_30_DAY_GUIDE.md
@@ -686,7 +686,7 @@ THE ELITE SEVEN ARE LIVE.
 
 + 82 free lessons at education.signalpilot.io
 + Full documentation at docs.signalpilot.io
-+ 7-day free trial. No credit card.
++ 14-day free trial. No credit card.
 
 Navigate the noise.
 
@@ -748,7 +748,7 @@ WHAT'S INCLUDED:
 → 82 free educational lessons
 → Full documentation
 → Email support
-→ 7-day free trial (no credit card)
+→ 14-day free trial (no credit card)
 ```
 
 **Post 5:**
@@ -827,7 +827,7 @@ Harmonic Oscillator — confirms the strike
 
 Non-repainting. Audited. $100 bounty.
 
-7-day free trial. No credit card.
+14-day free trial. No credit card.
 
 Link in bio.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A fast, static marketing website for Signal Pilot — 7 non-repainting TradingVi
 
 ### Hero Section
 - **Headline:** "The edge isn't seeing more. It's seeing what matters."
-- **Trust badges:** 100% Non-Repainting (Audited) | 7-Day Money-Back Guarantee
+- **Trust badges:** 100% Non-Repainting (Audited) | 14-Day Money-Back Guarantee
 - **Hero video:** Live chart demo showcasing Pentarch cycle detection
 - **CTA:** Get Started button linking to pricing
 
@@ -85,7 +85,7 @@ A fast, static marketing website for Signal Pilot — 7 non-repainting TradingVi
 - TradingView invite process
 - Access delivery speed (1-8 hours)
 - Support response times
-- Refund policy (7-day money-back)
+- Refund policy (14-day money-back)
 
 ### Footer
 - **Product:** Indicators, Pricing, Documentation, FAQ

--- a/SOCIAL_MEDIA_KIT.md
+++ b/SOCIAL_MEDIA_KIT.md
@@ -799,7 +799,7 @@ THE ELITE SEVEN ARE LIVE.
 
 + 82 free lessons at education.signalpilot.io
 + Full documentation at docs.signalpilot.io
-+ 7-day free trial. No credit card.
++ 14-day free trial. No credit card.
 
 Navigate the noise.
 
@@ -861,7 +861,7 @@ WHAT'S INCLUDED:
 → 82 free educational lessons
 → Full documentation
 → Email support
-→ 7-day free trial (no credit card)
+→ 14-day free trial (no credit card)
 ```
 
 **Post 5:**
@@ -940,7 +940,7 @@ Harmonic Oscillator — confirms the strike
 
 Non-repainting. Audited. $100 bounty.
 
-7-day free trial. No credit card.
+14-day free trial. No credit card.
 
 Link in bio.
 

--- a/it/affiliates.html
+++ b/it/affiliates.html
@@ -567,7 +567,7 @@
         <div class="card">
           <div style="font-size:2.5rem;margin-bottom:1rem">🔁</div>
           <h3 style="font-size:1.35rem;margin-bottom:1rem;color:var(--text)">
-            Prova Gratuita di 7 Giorni
+            Prova Gratuita di 14 Giorni
           </h3>
           <p style="color:var(--muted);line-height:1.7">
             <strong style="color:var(--good)">Nessuna carta di credito richiesta.</strong>

--- a/ru/affiliates.html
+++ b/ru/affiliates.html
@@ -567,7 +567,7 @@
         <div class="card">
           <div style="font-size:2.5rem;margin-bottom:1rem">🔁</div>
           <h3 style="font-size:1.35rem;margin-bottom:1rem;color:var(--text)">
-            7-дневный бесплатный пробный период
+            14-дневный бесплатный пробный период
           </h3>
           <p style="color:var(--muted);line-height:1.7">
             <strong style="color:var(--good)">Кредитная карта не требуется.</strong>

--- a/tr/affiliates.html
+++ b/tr/affiliates.html
@@ -565,7 +565,7 @@
         <div class="card">
           <div style="font-size:2.5rem;margin-bottom:1rem">🔁</div>
           <h3 style="font-size:1.35rem;margin-bottom:1rem;color:var(--text)">
-            7 Günlük Ücretsiz Deneme
+            14 Günlük Ücretsiz Deneme
           </h3>
           <p style="color:var(--muted);line-height:1.7">
             <strong style="color:var(--good)">Kredi kartı gerekmez.</strong>


### PR DESCRIPTION
- tr/affiliates.html: "7 Günlük Ücretsiz Deneme" → "14 Günlük"
- ru/affiliates.html: "7-дневный бесплатный" → "14-дневный"
- it/affiliates.html: "Prova Gratuita di 7 Giorni" → "14 Giorni"
- README.md: Updated trust badge and refund policy references
- SOCIAL_MEDIA_KIT.md: Updated all "7-day free trial" → "14-day"
- COMPLETE_30_DAY_GUIDE.md: Updated all "7-day free trial" → "14-day"