### PR TITLE
Fix mobile whiteness: add header transparency and hide parallax-orbs

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -899,12 +899,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1190,7 +1214,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1236,8 +1260,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1667,12 +1690,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1957,7 +2004,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -2003,8 +2050,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/de/index.html
+++ b/de/index.html
@@ -882,12 +882,37 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      /* Header needs high z-index for dropdown menus */
+
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1162,8 +1187,8 @@
 
     /* Tablet optimizations */
     @media (max-width:1024px){
-      /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      /* Parallax orbs - completely hidden on mobile/tablet */
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1208,9 +1233,8 @@
       /* Reduce hero heading size on mobile */
       .headline.xl{font-size:2rem !important}
 
-      /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      /* Hide gradient orbs completely on mobile */
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1624,12 +1648,37 @@
         z-index: 1 !important;
         position: fixed !important;
       }
-      /* Header needs high z-index for dropdown menus */
+
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1903,8 +1952,8 @@
 
     /* Tablet optimizations */
     @media (max-width:1024px){
-      /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      /* Parallax orbs - completely hidden on mobile/tablet */
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1949,9 +1998,8 @@
       /* Reduce hero heading size on mobile */
       .headline.xl{font-size:2rem !important}
 
-      /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      /* Hide gradient orbs completely on mobile */
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/es/index.html
+++ b/es/index.html
@@ -886,12 +886,36 @@
         display: none !important; /* Hide aurora on mobile */
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile */
@@ -1266,7 +1290,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1312,8 +1336,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1729,12 +1752,36 @@
         display: none !important; /* Hide aurora on mobile */
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile */
@@ -2108,7 +2155,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -2154,8 +2201,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/fr/index.html
+++ b/fr/index.html
@@ -919,12 +919,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1278,7 +1302,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1324,8 +1348,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1775,12 +1798,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -2133,7 +2180,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -2179,8 +2226,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/hu/index.html
+++ b/hu/index.html
@@ -904,12 +904,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1195,7 +1219,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1241,8 +1265,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1680,12 +1703,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1970,7 +2017,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -2016,8 +2063,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/it/index.html
+++ b/it/index.html
@@ -879,12 +879,36 @@
         display: none !important; /* Hide aurora on mobile */
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1160,7 +1184,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1206,8 +1230,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1618,12 +1641,36 @@
         display: none !important; /* Hide aurora on mobile */
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1898,7 +1945,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1944,8 +1991,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/ja/index.html
+++ b/ja/index.html
@@ -956,12 +956,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1245,7 +1269,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
 
       /* Better text wrapping for Japanese on tablets */
       h1, h2, h3{word-break:normal;overflow-wrap:break-word;hyphens:none}
@@ -1309,8 +1333,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
 
       /* FIX: Comparison slider - constrain width on mobile to perfectly align images */
       #comparison-slider {
@@ -1828,12 +1851,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -2116,7 +2163,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
 
       /* Better text wrapping for Japanese on tablets */
       h1, h2, h3{word-break:normal;overflow-wrap:break-word;hyphens:none}
@@ -2180,8 +2227,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
 
       /* FIX: Comparison slider - constrain width on mobile to perfectly align images */
       #comparison-slider {

--- a/nl/index.html
+++ b/nl/index.html
@@ -897,12 +897,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1188,7 +1212,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1234,8 +1258,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1665,12 +1688,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1955,7 +2002,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -2001,8 +2048,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/pt/index.html
+++ b/pt/index.html
@@ -842,12 +842,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1160,7 +1184,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     
@@ -1240,8 +1264,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1634,12 +1657,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1951,7 +1998,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     
@@ -2031,8 +2078,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/ru/index.html
+++ b/ru/index.html
@@ -862,12 +862,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile */
@@ -1238,7 +1262,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1284,8 +1308,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1680,12 +1703,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile */
@@ -2055,7 +2102,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -2101,8 +2148,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */

--- a/tr/index.html
+++ b/tr/index.html
@@ -900,12 +900,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -1280,7 +1304,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -1326,8 +1350,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */
@@ -1759,12 +1782,36 @@
         position: fixed !important;
       }
 
-      /* Header needs high z-index for dropdown menus */
+      /* Header needs high z-index for dropdown menus but FULLY transparent bg */
+      header,
+      header *,
+      header .container,
+      header .container.nav,
+      header .nav-backdrop,
+      header .brand,
+      header nav,
+      header .nav-spacer,
+      header .menu-toggle,
+      header .lang-dropdown,
+      header .btn {
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
       header {
         position: relative;
         z-index: 100;
         overflow-x: hidden !important;
-        max-width: 100vw !important;
+        max-width: 100% !important;
+        border-bottom: none !important;
+      }
+
+      /* HIDE parallax orbs on mobile - they cause whiteness */
+      #parallax-orb-1, #parallax-orb-2 {
+        display: none !important;
+        opacity: 0 !important;
+        filter: none !important;
       }
 
       /* Prevent header content from overflowing on mobile with translated text */
@@ -2138,7 +2185,7 @@
     /* Tablet optimizations */
     @media (max-width:1024px){
       /* Reduce parallax intensity on tablets */
-      #parallax-orb-1,#parallax-orb-2{opacity:0.7}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important}
     }
 
     @media (max-width:768px){
@@ -2184,8 +2231,7 @@
       .headline.xl{font-size:2rem !important}
 
       /* Better spacing for gradient orbs on mobile */
-      #parallax-orb-1{width:350px;height:350px;filter:blur(50px) !important}
-      #parallax-orb-2{width:300px;height:300px;filter:blur(40px) !important}
+      #parallax-orb-1,#parallax-orb-2{display:none !important;opacity:0 !important;filter:none !important}
     }
 
     /* Desktop optimizations - ensure video shows 100% */


### PR DESCRIPTION
- Add FULLY transparent background CSS for all header elements on mobile
- Hide parallax-orbs completely on mobile (display:none, opacity:0, filter:none)
- Remove parallax-orb opacity:0.7 and blur filters that caused whiteness
- Match English version's mobile CSS for consistent dark backgrounds