### PR TITLE
Hide body grid lines overlay on mobile

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -830,6 +830,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1619,6 +1625,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4342,6 +4354,12 @@ html[lang="ar"] [style*="text-align:center"] {
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/de/index.html
+++ b/de/index.html
@@ -814,6 +814,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1578,6 +1584,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4296,6 +4308,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/es/index.html
+++ b/es/index.html
@@ -814,6 +814,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1678,6 +1684,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4493,6 +4505,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/fr/index.html
+++ b/fr/index.html
@@ -850,6 +850,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1727,6 +1733,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4510,6 +4522,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/hu/index.html
+++ b/hu/index.html
@@ -835,6 +835,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1632,6 +1638,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4269,6 +4281,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/index.html
+++ b/index.html
@@ -529,6 +529,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;

--- a/it/index.html
+++ b/it/index.html
@@ -807,6 +807,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1567,6 +1573,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4234,6 +4246,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/ja/index.html
+++ b/ja/index.html
@@ -887,6 +887,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1780,6 +1786,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4577,6 +4589,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/nl/index.html
+++ b/nl/index.html
@@ -828,6 +828,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1617,6 +1623,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4277,6 +4289,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/pt/index.html
+++ b/pt/index.html
@@ -773,6 +773,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1586,6 +1592,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4550,6 +4562,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/ru/index.html
+++ b/ru/index.html
@@ -793,6 +793,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1632,6 +1638,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */
@@ -4291,6 +4303,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */

--- a/tr/index.html
+++ b/tr/index.html
@@ -831,6 +831,12 @@
         background-color: transparent !important;
       }
 
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
+      }
+
       /* Body needs relative positioning for absolute child */
       body {
         position: relative !important;
@@ -1711,6 +1717,12 @@
       html, body {
         background: transparent !important;
         background-color: transparent !important;
+      }
+
+      /* HIDE grid lines overlay on mobile */
+      body::before, body::after {
+        display: none !important;
+        opacity: 0 !important;
       }
 
       /* Body needs relative positioning for absolute child */


### PR DESCRIPTION
- Add CSS to hide body::before and body::after on mobile (display:none)
- This removes the visible dot/grid pattern from the background
- Applied to all 12 language files (English + 11 translations)
- Grid lines were causing visual noise on mobile dark backgrounds