### PR TITLE
Enable shimmer animation and fix stroke-animate flickering on mobile

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -719,6 +719,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -826,6 +837,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1386,6 +1401,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -1493,6 +1519,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4046,6 +4076,17 @@ html[lang="ar"] [style*="text-align:center"] {
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -4154,6 +4195,10 @@ html[lang="ar"] [style*="text-align:center"] {
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */

--- a/de/index.html
+++ b/de/index.html
@@ -810,6 +810,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1453,6 +1457,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4113,6 +4121,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4165,12 +4177,15 @@
         display: none !important;
       }
 
-      /* Disable shimmer animation on mobile - saves GPU */
+      /* Smooth slow shimmer animation on mobile */
       .shimmer-text {
-        animation: none !important;
-        background: linear-gradient(90deg, #9cc0ff, #86a8ff) !important;
-        -webkit-background-clip: text !important;
-        background-clip: text !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
       }
 
       /* Kill heavy transitions on mobile */

--- a/es/index.html
+++ b/es/index.html
@@ -813,6 +813,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1556,6 +1560,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4308,6 +4316,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4360,12 +4372,15 @@
         display: none !important;
       }
 
-      /* Disable shimmer animation on mobile - saves GPU */
+      /* Smooth slow shimmer animation on mobile */
       .shimmer-text {
-        animation: none !important;
-        background: linear-gradient(90deg, #9cc0ff, #86a8ff) !important;
-        -webkit-background-clip: text !important;
-        background-clip: text !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
       }
 
       /* Kill heavy transitions on mobile */

--- a/fr/index.html
+++ b/fr/index.html
@@ -846,6 +846,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1602,6 +1606,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4323,6 +4331,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4375,12 +4387,15 @@
         display: none !important;
       }
 
-      /* Disable shimmer animation on mobile - saves GPU */
+      /* Smooth slow shimmer animation on mobile */
       .shimmer-text {
-        animation: none !important;
-        background: linear-gradient(90deg, #9cc0ff, #86a8ff) !important;
-        -webkit-background-clip: text !important;
-        background-clip: text !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
       }
 
       /* Kill heavy transitions on mobile */

--- a/hu/index.html
+++ b/hu/index.html
@@ -724,6 +724,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -831,6 +842,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1399,6 +1414,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -1506,6 +1532,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -3974,6 +4004,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -4082,6 +4123,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */

--- a/index.html
+++ b/index.html
@@ -691,6 +691,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
     }
 
@@ -742,12 +746,15 @@
         background:transparent !important; /* Let particles show through on mobile! */
       }
 
-      /* Disable shimmer animation on mobile - saves GPU */
+      /* Smooth slow shimmer animation on mobile */
       .shimmer-text {
-        animation: none !important;
-        background: linear-gradient(90deg, #9cc0ff, #86a8ff) !important;
-        -webkit-background-clip: text !important;
-        background-clip: text !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
       }
 
       /* Kill heavy transitions on mobile */

--- a/it/index.html
+++ b/it/index.html
@@ -696,6 +696,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -806,6 +817,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1335,6 +1350,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -1445,6 +1471,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -3943,6 +3973,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -4051,6 +4092,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */

--- a/ja/index.html
+++ b/ja/index.html
@@ -776,6 +776,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -891,6 +902,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1548,6 +1563,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -1663,6 +1689,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4286,6 +4316,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -4394,6 +4435,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */

--- a/nl/index.html
+++ b/nl/index.html
@@ -717,6 +717,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -824,6 +835,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1384,6 +1399,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -1491,6 +1517,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -3984,6 +4014,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -4092,6 +4133,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */

--- a/pt/index.html
+++ b/pt/index.html
@@ -662,6 +662,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -769,6 +780,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1353,6 +1368,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -1460,6 +1486,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4255,6 +4285,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -4363,6 +4404,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */

--- a/ru/index.html
+++ b/ru/index.html
@@ -682,6 +682,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -789,6 +800,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1399,6 +1414,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -1506,6 +1532,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -3998,6 +4028,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -4106,6 +4147,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */

--- a/tr/index.html
+++ b/tr/index.html
@@ -720,6 +720,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -827,6 +838,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -1478,6 +1493,17 @@
         display: none !important;
       }
 
+      /* Smooth slow shimmer animation on mobile */
+      .shimmer-text {
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        isolation: isolate;
+        /* Much slower animation on mobile - subtle and smooth */
+        animation-duration: 30s !important;
+        z-index: 1;
+      }
+
       /* Main content - transparent so aura shows through */
       main {
         position: relative !important;
@@ -1585,6 +1611,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */
@@ -4183,6 +4213,10 @@
       .stroke-animate rect {
         animation-duration: 8s !important;
         transition-duration: 8s !important;
+        /* Force GPU acceleration to prevent flickering */
+        transform: translate3d(0, 0, 0);
+        -webkit-transform: translate3d(0, 0, 0);
+        will-change: stroke-dashoffset, opacity;
       }
 
       /* Ensure modals can still animate */


### PR DESCRIPTION
Shimmer text:
- Enable shimmer animation on mobile (was disabled)
- Use 30s duration for smooth, subtle effect
- Add GPU acceleration (translate3d, isolation)

Stroke-animate (partner logos):
- Add GPU acceleration to prevent flickering
- Add will-change hint for stroke-dashoffset and opacity
- Maintain 8s animation duration with staggered delays