### PR TITLE
Add cache-busting headers to force reload after mobile fixes

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2,6 +2,10 @@
 <html lang="ar" dir="rtl" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 

--- a/de/index.html
+++ b/de/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>

--- a/es/index.html
+++ b/es/index.html
@@ -2,6 +2,10 @@
 <html lang="es" dir="ltr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -2,6 +2,10 @@
 <html lang="fr" dir="ltr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <!-- Detect Chrome for CTA animation fallback -->
   <script>

--- a/it/index.html
+++ b/it/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>

--- a/ja/index.html
+++ b/ja/index.html
@@ -2,6 +2,10 @@
 <html lang="ja" dir="ltr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>

--- a/pt/index.html
+++ b/pt/index.html
@@ -2,6 +2,10 @@
 <html lang="pt-BR" dir="ltr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>

--- a/tr/index.html
+++ b/tr/index.html
@@ -2,6 +2,10 @@
 <html lang="tr" dir="ltr" data-theme="dark">
 <head>
   <meta charset="utf-8" />
+  <!-- Cache bust v2 - force reload after mobile fixes -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 


### PR DESCRIPTION
Re-add no-cache meta tags temporarily so users see the latest CSS fixes for cookie popup, shimmer text, and image/video isolation.