### PR TITLE
Fix carousel/partner animation speed on mobile language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -838,6 +838,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1525,6 +1536,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4208,6 +4230,17 @@ html[lang="ar"] [style*="text-align:center"] {
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/de/index.html
+++ b/de/index.html
@@ -811,6 +811,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1463,6 +1474,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4134,6 +4156,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/es/index.html
+++ b/es/index.html
@@ -814,6 +814,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1566,6 +1577,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4329,6 +4351,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/fr/index.html
+++ b/fr/index.html
@@ -847,6 +847,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1612,6 +1623,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4344,6 +4366,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/hu/index.html
+++ b/hu/index.html
@@ -843,6 +843,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1538,6 +1549,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4136,6 +4158,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/it/index.html
+++ b/it/index.html
@@ -818,6 +818,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1477,6 +1488,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4105,6 +4127,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/ja/index.html
+++ b/ja/index.html
@@ -903,6 +903,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1695,6 +1706,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4448,6 +4470,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/nl/index.html
+++ b/nl/index.html
@@ -836,6 +836,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1523,6 +1534,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4146,6 +4168,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/pt/index.html
+++ b/pt/index.html
@@ -781,6 +781,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1492,6 +1503,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4416,6 +4438,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/ru/index.html
+++ b/ru/index.html
@@ -801,6 +801,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1538,6 +1549,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4160,6 +4182,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */

--- a/tr/index.html
+++ b/tr/index.html
@@ -839,6 +839,17 @@
         transition-duration: 0.2s !important;
       }
 
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
+      }
+
       /* Preserve partner logo stroke animations - these need their full 8s duration */
       .stroke-animate,
       .stroke-animate *,
@@ -1617,6 +1628,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */
@@ -4226,6 +4248,17 @@
       *:not(.testimonials-track):not(.partners-track):not(.partners-track-reverse):not(.shiny-cta):not(.char):not(.shimmer-text):not([class*="partner"])::after {
         animation-duration: 0.2s !important;
         transition-duration: 0.2s !important;
+      }
+
+      /* Restore carousel animations on mobile */
+      .testimonials-track {
+        animation-duration: 30s !important;
+      }
+      .partners-track {
+        animation-duration: 50s !important;
+      }
+      .partners-track-reverse {
+        animation-duration: 45s !important;
       }
 
       /* Preserve partner logo stroke animations - these need their full 8s duration */


### PR DESCRIPTION
Added "Restore carousel animations on mobile" rules that were missing from language sites but present in English:
- .testimonials-track: 30s
- .partners-track: 50s
- .partners-track-reverse: 45s

These override the 0.2s animation reduction applied for performance.