### PR TITLE
Fix partner logo stroke animation flickering on mobile

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6538,7 +6538,18 @@ html[lang="ar"] [style*="text-align:center"] {
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/de/index.html
+++ b/de/index.html
@@ -6896,7 +6896,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/es/index.html
+++ b/es/index.html
@@ -6961,7 +6961,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/fr/index.html
+++ b/fr/index.html
@@ -7123,7 +7123,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/hu/index.html
+++ b/hu/index.html
@@ -6473,7 +6473,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/index.html
+++ b/index.html
@@ -5978,6 +5978,17 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }
         }
       </style>
 

--- a/it/index.html
+++ b/it/index.html
@@ -6379,7 +6379,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/ja/index.html
+++ b/ja/index.html
@@ -6710,7 +6710,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/nl/index.html
+++ b/nl/index.html
@@ -6424,7 +6424,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/pt/index.html
+++ b/pt/index.html
@@ -6627,7 +6627,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/ru/index.html
+++ b/ru/index.html
@@ -6462,7 +6462,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">

--- a/tr/index.html
+++ b/tr/index.html
@@ -6528,7 +6528,18 @@
           .partners-track { gap: 2.5rem; }
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
-        }
+
+
+          /* Disable complex stroke animation on mobile - causes flickering */
+          .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
+            stroke-dasharray: none !important;
+            stroke-dashoffset: 0 !important;
+            animation: partnerPulse 3s ease-in-out infinite !important;
+          }
+          @keyframes partnerPulse {
+            0%, 100% { opacity: 0.6; }
+            50% { opacity: 1; }
+          }        }
       </style>
 
       <div class="container">


### PR DESCRIPTION
Replace complex stroke-dashoffset animation with simple opacity pulse on mobile devices to prevent GPU flickering issues