### PR TITLE
Fix chronicle card blue glow on language sites

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5922,7 +5922,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to left,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ الأصل</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">ولادة Elite Seven</h3>
               <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">كيف ولدت الإشارات السماوية من رياضيات السعر — ولماذا ظهرت لتوجيه الطيارين عبر فوضى الأسواق.</p>

--- a/de/index.html
+++ b/de/index.html
@@ -6055,7 +6055,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Ursprung</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">Die Geburt der Elite Sieben</h3>
               <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Wie himmlische Signale aus der Mathematik des Preises selbst entstanden — und warum sie kamen, um Piloten durch das Chaos der Märkte zu führen.</p>

--- a/es/index.html
+++ b/es/index.html
@@ -6119,7 +6119,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Origen</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">El Nacimiento de los Elite Siete</h3>
               <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Cómo las señales celestiales nacieron de las matemáticas del precio — y por qué emergieron para guiar a los pilotos a través del caos de los mercados.</p>

--- a/fr/index.html
+++ b/fr/index.html
@@ -6255,7 +6255,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Origine</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">La Naissance des Elite Sept</h3>
               <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Comment des signaux célestes sont nés des mathématiques du prix — et pourquoi ils ont émergé pour guider les pilotes à travers le chaos des marchés.</p>

--- a/hu/index.html
+++ b/hu/index.html
@@ -5850,7 +5850,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Eredet</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">Az Elite Seven születése</h3>
               <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Hogyan születtek az égi jelek az ár matematikájából — és miért jelentek meg, hogy végigvezessék a pilótákat a piacok káoszán.</p>

--- a/it/index.html
+++ b/it/index.html
@@ -5822,7 +5822,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Origine</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">La Nascita degli Elite Sette</h3>
               <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Come i segnali celesti sono nati dalla matematica del prezzo — e perché sono emersi per guidare i piloti attraverso il caos dei mercati.</p>

--- a/ja/index.html
+++ b/ja/index.html
@@ -6153,7 +6153,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ 起源</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">Elite Sevenの誕生</h3>
               <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">天空のシグナルが価格の数学から生まれた方法 — そしてなぜ彼らは市場の混沌を通じてパイロットを導くために現れたのか。</p>

--- a/nl/index.html
+++ b/nl/index.html
@@ -5848,7 +5848,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;transition:transform 0.5s ease">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.9) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,var(--brand),var(--accent));color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Oorsprong</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.8rem;font-weight:500;line-height:1.2;margin-bottom:0.75rem;color:var(--text)">De Geboorte van de Elite Zeven</h3>
               <p style="color:var(--muted);font-size:1rem;line-height:1.6;margin-bottom:1.25rem">Hoe hemelse signalen geboren werden uit de wiskunde van de prijs — en waarom ze opdoken om piloten door de chaos van de markten te leiden.</p>

--- a/pt/index.html
+++ b/pt/index.html
@@ -6054,7 +6054,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.8">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,#f59e0b,#fbbf24);color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Em Destaque</span>
               <span style="font-size:0.8rem;color:#f59e0b;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Origem</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.75rem;font-weight:500;line-height:1.3;margin-bottom:1rem">O Nascimento dos Sete de Elite</h3>

--- a/ru/index.html
+++ b/ru/index.html
@@ -5871,7 +5871,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.8">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,#f59e0b,#fbbf24);color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Избранное</span>
               <span style="font-size:0.8rem;color:#f59e0b;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Происхождение</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.75rem;font-weight:500;line-height:1.3;margin-bottom:1rem">Рождение Элитной Семёрки</h3>

--- a/tr/index.html
+++ b/tr/index.html
@@ -5937,7 +5937,7 @@
               <img class="chronicle-img" src="/chronicle/elite-seven-council-preview.jpg" alt="Birth of the Elite Seven" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0.8">
               <div style="position:absolute;top:0;right:0;bottom:0;left:0;background:linear-gradient(to right,transparent 60%,rgba(5,7,13,0.95) 100%)"></div>
             </div>
-            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center">
+            <div style="padding:2.5rem;display:flex;flex-direction:column;justify-content:center;background:rgba(5,7,13,0.95)">
               <span style="display:inline-flex;align-items:center;gap:0.4rem;background:linear-gradient(115deg,#f59e0b,#fbbf24);color:#fff;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;padding:0.3rem 0.6rem;border-radius:4px;margin-bottom:1rem;width:fit-content">★ Öne Çıkan</span>
               <span style="font-size:0.8rem;color:#f59e0b;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem">Köken</span>
               <h3 style="font-family:'EB Garamond',Georgia,serif;font-size:1.75rem;font-weight:500;line-height:1.3;margin-bottom:1rem">Elit Yedilinin Doğuşu</h3>


### PR DESCRIPTION
Add background:rgba(5,7,13,0.95) to text container div to block the gradient glow from showing through (matching English)