### PR TITLE
Simplify partner logos to plain horizontal scroll on mobile

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6544,12 +6544,10 @@ html[lang="ar"] [style*="text-align:center"] {
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/de/index.html
+++ b/de/index.html
@@ -6902,12 +6902,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/es/index.html
+++ b/es/index.html
@@ -6967,12 +6967,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/fr/index.html
+++ b/fr/index.html
@@ -7129,12 +7129,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/hu/index.html
+++ b/hu/index.html
@@ -6479,12 +6479,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/index.html
+++ b/index.html
@@ -5979,15 +5979,12 @@
           .partner-logo svg { width: 24px; height: 24px; }
           .partner-logo span { font-size: 0.6rem; }
 
-          /* Disable complex stroke animation on mobile - causes flickering */
+          /* Mobile: No animations, just simple horizontal scroll */
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
-          }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
+            animation: none !important;
+            opacity: 0.8 !important;
           }
         }
       </style>

--- a/it/index.html
+++ b/it/index.html
@@ -6385,12 +6385,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/ja/index.html
+++ b/ja/index.html
@@ -6716,12 +6716,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/nl/index.html
+++ b/nl/index.html
@@ -6430,12 +6430,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/pt/index.html
+++ b/pt/index.html
@@ -6633,12 +6633,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/ru/index.html
+++ b/ru/index.html
@@ -6468,12 +6468,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">

--- a/tr/index.html
+++ b/tr/index.html
@@ -6534,12 +6534,10 @@
           .stroke-animate path, .stroke-animate circle, .stroke-animate polygon, .stroke-animate rect, .stroke-animate line {
             stroke-dasharray: none !important;
             stroke-dashoffset: 0 !important;
-            animation: partnerPulse 3s ease-in-out infinite !important;
+            animation: none !important;
+            opacity: 0.8 !important;
           }
-          @keyframes partnerPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-          }        }
+          @keyframes        }
       </style>
 
       <div class="container">


### PR DESCRIPTION
Remove all stroke/pulse animations, just smooth marquee scroll with static opacity logos