### PR TITLE
Fix pricing card alignment + reduce Lenis duration to 6s

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1954,6 +1954,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/assets/lenis.js
+++ b/assets/lenis.js
@@ -7,7 +7,7 @@
 
   // Initialize Lenis smooth scrolling
   const lenis = new Lenis({
-    duration: 10,
+    duration: 6,
     easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)), // easeOutExpo
     orientation: 'vertical',
     smoothWheel: true,

--- a/de/index.html
+++ b/de/index.html
@@ -1885,6 +1885,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/es/index.html
+++ b/es/index.html
@@ -2087,6 +2087,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/fr/index.html
+++ b/fr/index.html
@@ -2112,6 +2112,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/hu/index.html
+++ b/hu/index.html
@@ -1969,6 +1969,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/index.html
+++ b/index.html
@@ -1099,6 +1099,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/it/index.html
+++ b/it/index.html
@@ -1899,6 +1899,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/ja/index.html
+++ b/ja/index.html
@@ -2167,6 +2167,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/nl/index.html
+++ b/nl/index.html
@@ -1954,6 +1954,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/pt/index.html
+++ b/pt/index.html
@@ -1984,6 +1984,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/ru/index.html
+++ b/ru/index.html
@@ -2054,6 +2054,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;

--- a/tr/index.html
+++ b/tr/index.html
@@ -2136,6 +2136,27 @@
 
     .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;align-items:stretch}
 
+    /* Fix pricing card alignment - ensure all cards align at top */
+    #plan-monthly > .relative,
+    #plan-lifetime > .relative {
+      padding-top: 24px; /* Same height as "Most Popular" label */
+    }
+
+    /* Ensure buttons stay at bottom */
+    #plan-monthly > .relative,
+    #plan-yearly > .relative,
+    #plan-lifetime > .relative {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    #plan-monthly > .relative > div:last-child,
+    #plan-yearly > .relative > div:last-child,
+    #plan-lifetime > .relative > div:last-child {
+      margin-top: auto;
+    }
+
     /* Force pricing cards to be exactly the same height */
     .pricing-grid .card.plan {
       display:grid;


### PR DESCRIPTION
- Add padding-top to Monthly/Lifetime cards to align with Yearly's "Most Popular" label
- Use flexbox to push action buttons to bottom of all cards
- Reduce desktop scroll duration from 10s to 6s for better usability
- Applied to all 12 language versions