### PR TITLE
Fix canonical tag issues across pages

### DIFF
--- a/ar/chronicle/birth-of-the-elite-seven/index.html
+++ b/ar/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>ولادة النخبة السبعة — Signal Pilot</title>
   <meta name="description" content="قبل أن تحمل الأسواق أسماءً، قبل أن تروي الشموع قصصاً، لم يكن هناك سوى الضوضاء. هذه قصة أصل سبع إشارات سماوية ظهرت لتبحر في الفراغ.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="ولادة النخبة السبعة">
   <meta property="og:description" content="قبل أن تحمل الأسواق أسماءً، قبل أن تروي الشموع قصصاً، لم يكن هناك سوى الضوضاء. هذه قصة أصل النخبة السبعة.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/meet-the-sovereign/index.html
+++ b/ar/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>تعرف على الحاكم: شرح Pentarch — Signal Pilot</title>
   <meta name="description" content="نظرة عميقة في Pentarch، المؤشر الرئيسي الذي يرسم المراحل الخمس لدورات السوق. فهم TD، IGN، WRN، CAP، و BDN.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="تعرف على الحاكم: شرح Pentarch">
   <meta property="og:description" content="نظرة عميقة في Pentarch، المؤشر الرئيسي الذي يرسم المراحل الخمس لدورات السوق.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="تعرف على الحاكم: شرح Pentarch">

--- a/ar/chronicle/the-arbiter/index.html
+++ b/ar/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>الحَكَم: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator يوحد أربعة مذبذبات في حكم واحد، يؤكد متى يجب الضرب. السابع والأخير من النخبة السبعة.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="الحَكَم: Harmonic Oscillator">
   <meta property="og:description" content="أربعة أصوات. حكم واحد. أنا أقرر متى يُضغط الزناد.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/the-cartographer/index.html
+++ b/ar/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>رسام الخرائط: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas يرسم خريطة التضاريس حيث تُخاض معارك السوق. فهم المستويات الرئيسية ومراسي VWAP ونقاط المرجعية المؤسسية.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="رسام الخرائط: Janus Atlas">
   <meta property="og:description" content="لكل ساحة معركة تضاريسها. أنا أرسم خريطة أين ستُخاض الحروب.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/the-commander/index.html
+++ b/ar/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>القائد: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck يوحد عشرة أنظمة تداول متميزة في طبقة واحدة متماسكة. فهم المؤشر الشامل الذي ينهي فوضى الرسوم البيانية.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="القائد: OmniDeck">
   <meta property="og:description" content="عشرة أنظمة. رؤية واحدة. وضوح تام.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/the-council-assembles/index.html
+++ b/ar/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>المجلس يجتمع — Signal Pilot</title>
   <meta name="description" content="قابلت كل عضو. الآن شاهدهم يعملون كواحد. عندما تتحد النخبة السبعة، تصبح الفوضى وضوحاً والضوضاء إشارة.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="المجلس يجتمع">
   <meta property="og:description" content="قابلت كل عضو. الآن شاهدهم يعملون كواحد.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/the-hierarchy-of-signals/index.html
+++ b/ar/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>التسلسل الهرمي للإشارات — Signal Pilot</title>
   <meta name="description" content="السبعة لا يوجدون في عزلة. يشكلون كوكبة—تسلسل هرمي من الغرض، كل واحد يخدم من فوقه بينما يمكّن من تحته.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="التسلسل الهرمي للإشارات">
   <meta property="og:description" content="السبعة لا يوجدون في عزلة. يشكلون كوكبة—تسلسل هرمي من الغرض.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/the-pilots-oath/index.html
+++ b/ar/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>قسم الطيار — Signal Pilot</title>
   <meta name="description" content="أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار. هذا هو القسم الذي يفصل بين أولئك الذين يبحرون وأولئك الذين يقامرون.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="قسم الطيار">
   <meta property="og:description" content="أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار. هذا هو القسم الذي يفصل بين أولئك الذين يبحرون وأولئك الذين يقامرون.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/the-prophet/index.html
+++ b/ar/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>النبي: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle يسمع ما لا يستطيع المتداولون العاديون سماعه—خطوات المؤسسات وهي تتحرك في الظلام. فهم التراكم والتوزيع قبل أن تعترف الرسوم البيانية.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="النبي: Volume Oracle">
   <meta property="og:description" content="Volume Oracle يسمع ما لا يستطيع المتداولون العاديون سماعه—خطوات المؤسسات وهي تتحرك في الظلام.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="النبي: Volume Oracle">

--- a/ar/chronicle/the-scales/index.html
+++ b/ar/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>الميزان: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow يزن ضغط الشراء مقابل البيع ليكشف الحقيقة تحت السعر. فهم الدلتا التراكمية وإشارات التباعد.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="الميزان: Plutus Flow">
   <meta property="og:description" content="أزن ما لا يُرى. الضغط لا يكذب.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/the-watchman/index.html
+++ b/ar/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>الحارس: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid يفحص ثمانية أسواق في وقت واحد، يرتب الفرص حسب القناعة ويفلتر الضوضاء من الإشارة. السادس من النخبة السبعة.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="الحارس: Augury Grid">
   <meta property="og:description" content="بينما تراقب رسماً بيانياً واحداً، أنا أراقبها كلها.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/ar/chronicle/why-non-repainting-matters/index.html
+++ b/ar/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>لماذا عدم إعادة الرسم مهم — Signal Pilot</title>
   <meta name="description" content="معظم المؤشرات تكذب عليك بتغيير إشاراتها التاريخية. إليك لماذا عدم إعادة الرسم غير قابل للتفاوض، وكيف نضمنه.">
-  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="لماذا عدم إعادة الرسم مهم">
   <meta property="og:description" content="معظم المؤشرات تكذب عليك بتغيير إشاراتها التاريخية. إليك لماذا عدم إعادة الرسم غير قابل للتفاوض.">
-  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/chronicle/birth-of-the-elite-seven/index.html
+++ b/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Birth of The Elite Seven — Signal Pilot</title>
   <meta name="description" content="Before the markets had names, before the candles told stories, there was only noise. This is the origin story of seven celestial signals that emerged to navigate the void.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Birth of The Elite Seven">
   <meta property="og:description" content="Before the markets had names, before the candles told stories, there was only noise. This is the origin story of The Elite Seven.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/meet-the-sovereign/index.html
+++ b/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Meet The Sovereign: Pentarch Explained — Signal Pilot</title>
   <meta name="description" content="A deep dive into Pentarch, the flagship indicator that maps the five phases of market cycles. Understanding TD, IGN, WRN, CAP, and BDN.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Meet The Sovereign: Pentarch Explained">
   <meta property="og:description" content="A deep dive into Pentarch, the flagship indicator that maps the five phases of market cycles.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-arbiter/index.html
+++ b/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Arbiter: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifies seven components into a single verdict, confirming when to strike. The seventh and final of The Elite Seven.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Arbiter: Harmonic Oscillator">
   <meta property="og:description" content="Seven voices. One verdict. I decide when the trigger is pulled.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-cartographer/index.html
+++ b/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Cartographer: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas maps the terrain where market battles are fought. Understanding key levels, VWAP anchors, and algorithmic reference points.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Cartographer: Janus Atlas">
   <meta property="og:description" content="Every battlefield has its terrain. Janus Atlas maps where the wars will be fought.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-commander/index.html
+++ b/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Commander: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifies ten premium trading systems into one coherent overlay. Understanding the all-in-one indicator that ends chart chaos.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Commander: OmniDeck">
   <meta property="og:description" content="Ten systems. One vision. Total clarity.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-council-assembles/index.html
+++ b/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Council Assembles — Signal Pilot</title>
   <meta name="description" content="You've met each member. Now watch them work as one. When The Elite Seven unite, chaos becomes clarity and noise becomes signal.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Council Assembles">
   <meta property="og:description" content="You've met each member. Now watch them work as one.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-hierarchy-of-signals/index.html
+++ b/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Hierarchy of Signals — Signal Pilot</title>
   <meta name="description" content="The Seven do not exist in isolation. They form a constellation—a hierarchy of purpose, each serving the one above while empowering those below.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Hierarchy of Signals">
   <meta property="og:description" content="The Seven do not exist in isolation. They form a constellation—a hierarchy of purpose.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-pilots-oath/index.html
+++ b/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Pilot's Oath — Signal Pilot</title>
   <meta name="description" content="You who wield The Elite Seven are not a trader. You are a Pilot. This is the oath that separates those who navigate from those who gamble.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Pilot's Oath">
   <meta property="og:description" content="You who wield The Elite Seven are not a trader. You are a Pilot. This is the oath that separates those who navigate from those who gamble.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-prophet/index.html
+++ b/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Prophet: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle hears what retail cannot—the footsteps of institutions moving in darkness. Understanding accumulation and distribution before the charts confess.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Prophet: Volume Oracle">
   <meta property="og:description" content="Volume Oracle hears what retail cannot—the footsteps of institutions moving in darkness.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-scales/index.html
+++ b/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Scales: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow weighs buying versus selling pressure to reveal the truth beneath price. Understanding cumulative delta and divergence signals.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Scales: Plutus Flow">
   <meta property="og:description" content="I weigh the invisible. Pressure does not lie.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/the-watchman/index.html
+++ b/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>The Watchman: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scans eight markets simultaneously, ranking opportunities by conviction and filtering noise from signal. The sixth of The Elite Seven.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="The Watchman: Augury Grid">
   <meta property="og:description" content="While you watch one chart, I watch them all.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/chronicle/why-non-repainting-matters/index.html
+++ b/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Why Non-Repainting Matters — Signal Pilot</title>
   <meta name="description" content="Most indicators lie to you by changing their historical signals. Here's why non-repainting is non-negotiable, and how we guarantee it.">
-  <link rel="canonical" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Why Non-Repainting Matters">
   <meta property="og:description" content="Most indicators lie to you by changing their historical signals. Here's why non-repainting is non-negotiable.">
-  <meta property="og:url" content="https://www.signalpilot.io/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/de/chronicle/birth-of-the-elite-seven/index.html
+++ b/de/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Die Geburt der Elite Sieben — Signal Pilot</title>
   <meta name="description" content="Bevor die Märkte Namen hatten, bevor die Kerzen Geschichten erzählten, gab es nur Rauschen. Dies ist die Entstehungsgeschichte von sieben himmlischen Signalen, die entstanden, um durch die Leere zu navigieren.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Die Geburt der Elite Sieben">
   <meta property="og:description" content="Bevor die Märkte Namen hatten, bevor die Kerzen Geschichten erzählten, gab es nur Rauschen. Dies ist die Entstehungsgeschichte der Elite Sieben.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/de/chronicle/meet-the-sovereign/index.html
+++ b/de/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Lerne den Herrscher kennen: Pentarch erklärt — Signal Pilot</title>
   <meta name="description" content="Ein tiefer Einblick in Pentarch, den Flaggschiff-Indikator, der die fünf Phasen der Marktzyklen kartiert. TD, IGN, WRN, CAP und BDN verstehen.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -28,7 +28,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Lerne den Herrscher kennen: Pentarch erklärt">
   <meta property="og:description" content="Ein tiefer Einblick in Pentarch, den Flaggschiff-Indikator, der die fünf Phasen der Marktzyklen kartiert.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Lerne den Herrscher kennen: Pentarch erklärt">

--- a/de/chronicle/the-arbiter/index.html
+++ b/de/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Der Schiedsrichter: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator vereint vier Oszillatoren zu einem einzigen Urteil und bestätigt, wann zugeschlagen werden soll. Der siebte und letzte der Elite Sieben.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Der Schiedsrichter: Harmonic Oscillator">
   <meta property="og:description" content="Vier Stimmen. Ein Urteil. Ich entscheide, wann der Abzug gedrückt wird.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Der Schiedsrichter: Harmonic Oscillator">

--- a/de/chronicle/the-cartographer/index.html
+++ b/de/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Der Kartograph: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas kartiert das Terrain, auf dem Marktschlachten geschlagen werden. Verstehen Sie Schlüsselniveaus, VWAP-Anker und institutionelle Referenzpunkte.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Der Kartograph: Janus Atlas">
   <meta property="og:description" content="Jedes Schlachtfeld hat sein Terrain. Janus Atlas kartiert, wo die Kriege geführt werden.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Der Kartograph: Janus Atlas">

--- a/de/chronicle/the-commander/index.html
+++ b/de/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Der Kommandant: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck vereint zehn Premium-Handelssysteme zu einem kohärenten Overlay. Verstehen Sie den All-in-One-Indikator, der das Chart-Chaos beendet.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Der Kommandant: OmniDeck">
   <meta property="og:description" content="Zehn Systeme. Eine Vision. Totale Klarheit.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Der Kommandant: OmniDeck">

--- a/de/chronicle/the-council-assembles/index.html
+++ b/de/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Der Rat versammelt sich — Signal Pilot</title>
   <meta name="description" content="Sie haben jedes Mitglied kennengelernt. Jetzt sehen Sie, wie sie als Einheit arbeiten. Wenn sich die Elite Sieben vereinen, wird Chaos zu Klarheit und Rauschen zu Signal.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Der Rat versammelt sich">
   <meta property="og:description" content="Sie haben jedes Mitglied kennengelernt. Jetzt sehen Sie, wie sie als Einheit arbeiten.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Der Rat versammelt sich">

--- a/de/chronicle/the-hierarchy-of-signals/index.html
+++ b/de/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Die Hierarchie der Signale — Signal Pilot</title>
   <meta name="description" content="Die Sieben existieren nicht isoliert. Sie bilden ein Sternbild—eine Hierarchie des Zwecks, jeder dient dem über ihm, während er jene unter ihm ermächtigt.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Die Hierarchie der Signale">
   <meta property="og:description" content="Die Sieben existieren nicht isoliert. Sie bilden ein Sternbild—eine Hierarchie des Zwecks.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/de/chronicle/the-pilots-oath/index.html
+++ b/de/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Der Eid des Piloten — Signal Pilot</title>
   <meta name="description" content="Du, der die Elite Sieben führst, bist kein Händler. Du bist ein Pilot. Dies ist der Eid, der diejenigen, die navigieren, von denen trennt, die spielen.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Der Eid des Piloten">
   <meta property="og:description" content="Du, der die Elite Sieben führst, bist kein Händler. Du bist ein Pilot. Dies ist der Eid, der diejenigen, die navigieren, von denen trennt, die spielen.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2024-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/de/chronicle/the-prophet/index.html
+++ b/de/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Der Prophet: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle hört, was der Retail nicht kann – die Schritte der Institutionen, die sich im Dunkeln bewegen. Akkumulation und Distribution verstehen, bevor die Charts es gestehen.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Der Prophet: Volume Oracle">
   <meta property="og:description" content="Volume Oracle hört, was der Retail nicht kann – die Schritte der Institutionen, die sich im Dunkeln bewegen.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Der Prophet: Volume Oracle">

--- a/de/chronicle/the-scales/index.html
+++ b/de/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Die Waage: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow wiegt Kauf- gegen Verkaufsdruck, um die Wahrheit unter dem Preis zu enthüllen. Verstehen Sie kumulatives Delta und Divergenzsignale.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Die Waage: Plutus Flow">
   <meta property="og:description" content="Ich wiege das Unsichtbare. Druck lügt nicht.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Die Waage: Plutus Flow">

--- a/de/chronicle/the-watchman/index.html
+++ b/de/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Der Wächter: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scannt acht Märkte gleichzeitig, bewertet Chancen nach Überzeugung und filtert Rauschen von Signal. Der sechste der Elite Sieben.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Der Wächter: Augury Grid">
   <meta property="og:description" content="Während Sie einen Chart beobachten, beobachte ich alle.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Der Wächter: Augury Grid">

--- a/de/chronicle/why-non-repainting-matters/index.html
+++ b/de/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Warum Non-Repainting wichtig ist — Signal Pilot</title>
   <meta name="description" content="Die meisten Indikatoren belügen Sie, indem sie ihre historischen Signale ändern. Hier erfahren Sie, warum Non-Repainting unverzichtbar ist und wie wir es garantieren.">
-  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Warum Non-Repainting wichtig ist">
   <meta property="og:description" content="Die meisten Indikatoren belügen Sie, indem sie ihre historischen Signale ändern. Hier erfahren Sie, warum Non-Repainting unverzichtbar ist.">
-  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/es/chronicle/birth-of-the-elite-seven/index.html
+++ b/es/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>El Nacimiento de Los Siete de Élite — Signal Pilot</title>
   <meta name="description" content="Antes de que los mercados tuvieran nombres, antes de que las velas contaran historias, solo había ruido. Esta es la historia del origen de siete señales celestiales que emergieron para navegar el vacío.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="El Nacimiento de Los Siete de Élite">
   <meta property="og:description" content="Antes de que los mercados tuvieran nombres, antes de que las velas contaran historias, solo había ruido. Esta es la historia del origen de Los Siete de Élite.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/es/chronicle/meet-the-sovereign/index.html
+++ b/es/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Conoce al Soberano: Pentarch Explicado — Signal Pilot</title>
   <meta name="description" content="Una inmersión profunda en Pentarch, el indicador insignia que mapea las cinco fases de los ciclos de mercado. Entendiendo TD, IGN, WRN, CAP y BDN.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Conoce al Soberano: Pentarch Explicado">
   <meta property="og:description" content="Una inmersión profunda en Pentarch, el indicador insignia que mapea las cinco fases de los ciclos de mercado.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/es/chronicle/the-arbiter/index.html
+++ b/es/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>El Árbitro: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifica cuatro osciladores en un solo veredicto, confirmando cuándo atacar. El séptimo y último de Los Siete de Élite.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="El Árbitro: Harmonic Oscillator">
   <meta property="og:description" content="Cuatro voces. Un veredicto. Yo decido cuándo se aprieta el gatillo.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="El Árbitro: Harmonic Oscillator">

--- a/es/chronicle/the-cartographer/index.html
+++ b/es/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>El Cartógrafo: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas mapea el terreno donde se libran las batallas del mercado. Entendiendo niveles clave, anclas VWAP y puntos de referencia institucionales.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="El Cartógrafo: Janus Atlas">
   <meta property="og:description" content="Cada campo de batalla tiene su terreno. Janus Atlas mapea dónde se librarán las guerras.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="El Cartógrafo: Janus Atlas">

--- a/es/chronicle/the-commander/index.html
+++ b/es/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>El Comandante: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifica diez sistemas de trading premium en una superposición coherente. Entendiendo el indicador todo-en-uno que termina con el caos de gráficos.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="El Comandante: OmniDeck">
   <meta property="og:description" content="Diez sistemas. Una visión. Claridad total.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="El Comandante: OmniDeck">

--- a/es/chronicle/the-council-assembles/index.html
+++ b/es/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>El Consejo Se Reúne — Signal Pilot</title>
   <meta name="description" content="Has conocido a cada miembro. Ahora obsérvalos trabajar como uno. Cuando Los Siete de Élite se unen, el caos se convierte en claridad y el ruido en señal.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="El Consejo Se Reúne">
   <meta property="og:description" content="Has conocido a cada miembro. Ahora obsérvalos trabajar como uno.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="El Consejo Se Reúne">

--- a/es/chronicle/the-hierarchy-of-signals/index.html
+++ b/es/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Jerarquía de Señales — Signal Pilot</title>
   <meta name="description" content="Los Siete no existen en aislamiento. Forman una constelación—una jerarquía de propósito, cada uno sirviendo al de arriba mientras empodera a los de abajo.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Jerarquía de Señales">
   <meta property="og:description" content="Los Siete no existen en aislamiento. Forman una constelación—una jerarquía de propósito.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/es/chronicle/the-pilots-oath/index.html
+++ b/es/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>El Juramento del Piloto — Signal Pilot</title>
   <meta name="description" content="Tú que empuñas a Los Siete de Élite no eres un trader. Eres un Piloto. Este es el juramento que separa a quienes navegan de quienes apuestan.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="El Juramento del Piloto">
   <meta property="og:description" content="Tú que empuñas a Los Siete de Élite no eres un trader. Eres un Piloto. Este es el juramento que separa a quienes navegan de quienes apuestan.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/es/chronicle/the-prophet/index.html
+++ b/es/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>El Profeta: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle escucha lo que el retail no puede—los pasos de las instituciones moviéndose en la oscuridad. Entendiendo la acumulación y distribución antes de que los gráficos lo confiesen.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="El Profeta: Volume Oracle">
   <meta property="og:description" content="Volume Oracle escucha lo que el retail no puede—los pasos de las instituciones moviéndose en la oscuridad.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="El Profeta: Volume Oracle">

--- a/es/chronicle/the-scales/index.html
+++ b/es/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Balanza: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow pesa la presión de compra versus venta para revelar la verdad bajo el precio. Entendiendo el delta acumulativo y las señales de divergencia.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Balanza: Plutus Flow">
   <meta property="og:description" content="Peso lo invisible. La presión no miente.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="La Balanza: Plutus Flow">

--- a/es/chronicle/the-watchman/index.html
+++ b/es/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>El Vigilante: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid escanea ocho mercados simultáneamente, clasificando oportunidades por convicción y filtrando el ruido de la señal. El sexto de Los Siete de Élite.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="El Vigilante: Augury Grid">
   <meta property="og:description" content="Mientras tú observas un gráfico, yo los observo todos.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="El Vigilante: Augury Grid">

--- a/es/chronicle/why-non-repainting-matters/index.html
+++ b/es/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Por Qué Importa el No-Repintado — Signal Pilot</title>
   <meta name="description" content="La mayoría de los indicadores te mienten cambiando sus señales históricas. Aquí está por qué el no-repintado es innegociable, y cómo lo garantizamos.">
-  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Por Qué Importa el No-Repintado">
   <meta property="og:description" content="La mayoría de los indicadores te mienten cambiando sus señales históricas. Aquí está por qué el no-repintado es innegociable.">
-  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/fr/chronicle/birth-of-the-elite-seven/index.html
+++ b/fr/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Naissance des Sept d'Élite — Signal Pilot</title>
   <meta name="description" content="Avant que les marchés n'aient des noms, avant que les bougies ne racontent des histoires, il n'y avait que du bruit. Voici l'histoire d'origine de sept signaux célestes qui ont émergé pour naviguer dans le vide.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Naissance des Sept d'Élite">
   <meta property="og:description" content="Avant que les marchés n'aient des noms, avant que les bougies ne racontent des histoires, il n'y avait que du bruit.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="La Naissance des Sept d'Élite">

--- a/fr/chronicle/meet-the-sovereign/index.html
+++ b/fr/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Rencontre Le Souverain : Pentarch Expliqué — Signal Pilot</title>
   <meta name="description" content="Une plongée profonde dans Pentarch, l'indicateur phare qui cartographie les cinq phases des cycles de marché. Comprendre TD, IGN, WRN, CAP et BDN.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Rencontre Le Souverain : Pentarch Expliqué">
   <meta property="og:description" content="Une plongée profonde dans Pentarch, l'indicateur phare qui cartographie les cinq phases des cycles de marché.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Rencontre Le Souverain : Pentarch Expliqué">

--- a/fr/chronicle/the-arbiter/index.html
+++ b/fr/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>L'Arbitre : Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifie quatre oscillateurs en un seul verdict, confirmant quand frapper. Le septième et dernier des Sept d'Élite.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="L'Arbitre : Harmonic Oscillator">
   <meta property="og:description" content="Quatre voix. Un verdict. Je décide quand la gâchette est tirée.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="L'Arbitre : Harmonic Oscillator">

--- a/fr/chronicle/the-cartographer/index.html
+++ b/fr/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Le Cartographe : Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas cartographie le terrain où les batailles de marché sont livrées. Comprendre les niveaux clés, les ancres VWAP et les points de référence institutionnels.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Le Cartographe : Janus Atlas">
   <meta property="og:description" content="Chaque champ de bataille a son terrain. Janus Atlas cartographie où les guerres seront livrées.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Le Cartographe : Janus Atlas">

--- a/fr/chronicle/the-commander/index.html
+++ b/fr/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Le Commandant : OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifie dix systèmes de trading premium en une seule superposition cohérente. Comprendre l'indicateur tout-en-un qui met fin au chaos des graphiques.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Le Commandant : OmniDeck">
   <meta property="og:description" content="Dix systèmes. Une vision. Clarté totale.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Le Commandant : OmniDeck">

--- a/fr/chronicle/the-council-assembles/index.html
+++ b/fr/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Le Conseil S'Assemble — Signal Pilot</title>
   <meta name="description" content="Vous avez rencontré chaque membre. Maintenant regardez-les travailler comme un seul. Quand Les Sept d'Élite s'unissent, le chaos devient clarté et le bruit devient signal.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Le Conseil S'Assemble">
   <meta property="og:description" content="Vous avez rencontré chaque membre. Maintenant regardez-les travailler comme un seul.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Le Conseil S'Assemble">

--- a/fr/chronicle/the-hierarchy-of-signals/index.html
+++ b/fr/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Hiérarchie des Signaux — Signal Pilot</title>
   <meta name="description" content="Les Sept n'existent pas isolément. Ils forment une constellation—une hiérarchie de but, chacun servant celui au-dessus tout en renforçant ceux en dessous.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Hiérarchie des Signaux">
   <meta property="og:description" content="Les Sept n'existent pas isolément. Ils forment une constellation—une hiérarchie de but.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="La Hiérarchie des Signaux">

--- a/fr/chronicle/the-pilots-oath/index.html
+++ b/fr/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Le Serment du Pilote — Signal Pilot</title>
   <meta name="description" content="Toi qui manies Les Sept d'Élite n'es pas un trader. Tu es un Pilote. Voici le serment qui sépare ceux qui naviguent de ceux qui parient.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Le Serment du Pilote">
   <meta property="og:description" content="Toi qui manies Les Sept d'Élite n'es pas un trader. Tu es un Pilote.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Le Serment du Pilote">

--- a/fr/chronicle/the-prophet/index.html
+++ b/fr/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Le Prophète : Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle entend ce que les particuliers ne peuvent pas—les pas des institutions se déplaçant dans l'obscurité. Comprendre l'accumulation et la distribution avant que les graphiques ne confessent.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Le Prophète : Volume Oracle">
   <meta property="og:description" content="Volume Oracle entend ce que les particuliers ne peuvent pas—les pas des institutions se déplaçant dans l'obscurité.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Le Prophète : Volume Oracle">

--- a/fr/chronicle/the-scales/index.html
+++ b/fr/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Balance : Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow pèse la pression d'achat contre la pression de vente pour révéler la vérité sous le prix. Comprendre le delta cumulatif et les signaux de divergence.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Balance : Plutus Flow">
   <meta property="og:description" content="Je pèse l'invisible. La pression ne ment pas.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="La Balance : Plutus Flow">

--- a/fr/chronicle/the-watchman/index.html
+++ b/fr/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Le Vigilant : Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scanne huit marchés simultanément, classant les opportunités par conviction et filtrant le bruit du signal. Le sixième des Sept d'Élite.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Le Vigilant : Augury Grid">
   <meta property="og:description" content="Pendant que vous regardez un graphique, je les regarde tous.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Le Vigilant : Augury Grid">

--- a/fr/chronicle/why-non-repainting-matters/index.html
+++ b/fr/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Pourquoi Le Non-Repaint Est Important — Signal Pilot</title>
   <meta name="description" content="La plupart des indicateurs vous mentent en modifiant leurs signaux historiques. Voici pourquoi le non-repaint est non négociable, et comment nous le garantissons.">
-  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Pourquoi Le Non-Repaint Est Important">
   <meta property="og:description" content="La plupart des indicateurs vous mentent en modifiant leurs signaux historiques. Voici pourquoi le non-repaint est non négociable.">
-  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/hu/chronicle/birth-of-the-elite-seven/index.html
+++ b/hu/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Az Elit Hetek Születése — Signal Pilot</title>
   <meta name="description" content="Mielőtt a piacoknak nevük lett volna, mielőtt a gyertyák történeteket meséltek volna, csak zaj volt. Ez a hét égi jel eredettörténete.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Az Elit Hetek Születése">
   <meta property="og:description" content="Mielőtt a piacoknak nevük lett volna, mielőtt a gyertyák történeteket meséltek volna, csak zaj volt.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Az Elit Hetek Születése">

--- a/hu/chronicle/meet-the-sovereign/index.html
+++ b/hu/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Ismerd Meg a Szuverént: A Pentarch Bemutatása — Signal Pilot</title>
   <meta name="description" content="Mély betekintés a Pentarchba, a zászlóshajó indikátorba, amely feltérképezi a piaci ciklusok öt fázisát. A TD, IGN, WRN, CAP és BDN megértése.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Ismerd Meg a Szuverént: A Pentarch Bemutatása">
   <meta property="og:description" content="Mély betekintés a Pentarchba, a zászlóshajó indikátorba, amely feltérképezi a piaci ciklusok öt fázisát.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/hu/chronicle/the-arbiter/index.html
+++ b/hu/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Döntőbíró: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="A Harmonic Oscillator négy oszcillátort egyesít egyetlen ítéletbe, megerősítve, mikor kell csapni. Az Elit Hetek hetedik és utolsó tagja.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Döntőbíró: Harmonic Oscillator">
   <meta property="og:description" content="Négy hang. Egy ítélet. Én döntöm el, mikor húzzuk meg a ravaszt.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="A Döntőbíró: Harmonic Oscillator">

--- a/hu/chronicle/the-cartographer/index.html
+++ b/hu/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Kartográfus: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="A Janus Atlas feltérképezi a terepet, ahol a piaci csaták zajlanak. A kulcsszintek, VWAP horgonyok és intézményi referenciapontok megértése.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Kartográfus: Janus Atlas">
   <meta property="og:description" content="Minden csatatérnek megvan a terepje. A Janus Atlas térképezi, hol zajlanak a háborúk.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="A Kartográfus: Janus Atlas">

--- a/hu/chronicle/the-commander/index.html
+++ b/hu/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Parancsnok: OmniDeck — Signal Pilot</title>
   <meta name="description" content="Az OmniDeck tíz prémium kereskedési rendszert egyesít egyetlen koherens overlay-be. Az all-in-one indikátor megértése, amely véget vet a chart káosznak.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Parancsnok: OmniDeck">
   <meta property="og:description" content="Tíz rendszer. Egy vízió. Teljes tisztánlátás.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="A Parancsnok: OmniDeck">

--- a/hu/chronicle/the-council-assembles/index.html
+++ b/hu/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Konsey Toplanyor — Signal Pilot</title>
   <meta name="description" content="Megismerted minden tagot. Most nézd, hogyan dolgoznak egyként. Amikor az Elit Hetek egyesülnek, a káosz tisztánlátássá és a zaj jelzéssé válik.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Konsey Toplanyor">
   <meta property="og:description" content="Megismerted minden tagot. Most nézd, hogyan dolgoznak egyként.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="A Konsey Toplanyor">

--- a/hu/chronicle/the-hierarchy-of-signals/index.html
+++ b/hu/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Jelek Hierarchiája — Signal Pilot</title>
   <meta name="description" content="A Hetek nem elszigetelten léteznek. Csillagképet alkotnak—célok hierarchiáját, ahol mindegyik a fölötte lévőt szolgálja, miközben az alatta lévőket erősíti.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Jelek Hierarchiája">
   <meta property="og:description" content="A Hetek nem elszigetelten léteznek. Csillagképet alkotnak—célok hierarchiáját.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/hu/chronicle/the-pilots-oath/index.html
+++ b/hu/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Pilóta Esküje — Signal Pilot</title>
   <meta name="description" content="Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy. Ez az eskü választja el azokat, akik navigálnak, azoktól, akik szerencsejátékot űznek.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Pilóta Esküje">
   <meta property="og:description" content="Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy. Ez az eskü választja el azokat, akik navigálnak, azoktól, akik szerencsejátékot űznek.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/hu/chronicle/the-prophet/index.html
+++ b/hu/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Próféta: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="A Volume Oracle hallja, amit a kisbefektetők nem—az intézmények lépteit, amint a sötétségben mozognak. Az akkumuláció és disztribúció megértése, mielőtt a chartok bevallják.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Próféta: Volume Oracle">
   <meta property="og:description" content="A Volume Oracle hallja, amit a kisbefektetők nem—az intézmények lépteit, amint a sötétségben mozognak.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="A Próféta: Volume Oracle">

--- a/hu/chronicle/the-scales/index.html
+++ b/hu/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Mérleg: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="A Plutus Flow méri a vételi és eladási nyomást, hogy feltárja az igazságot az ár alatt. A kumulatív delta és divergencia jelzések megértése.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Mérleg: Plutus Flow">
   <meta property="og:description" content="Mérem a láthatatlant. A nyomás nem hazudik.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="A Mérleg: Plutus Flow">

--- a/hu/chronicle/the-watchman/index.html
+++ b/hu/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Az Őrszem: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Az Augury Grid nyolc piacot pásztáz egyidejűleg, meggyőződés szerint rangsorolva a lehetőségeket és kiszűrve a zajt a jelből. Az Elit Hetek hatodikja.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Az Őrszem: Augury Grid">
   <meta property="og:description" content="Míg te egy chartot figyelsz, én mindegyiket figyelem.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Az Őrszem: Augury Grid">

--- a/hu/chronicle/why-non-repainting-matters/index.html
+++ b/hu/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Miért Fontos a Nem-Újrafestés — Signal Pilot</title>
   <meta name="description" content="A legtöbb indikátor hazudik, mert megváltoztatja a történelmi jelzéseit. Íme, miért elfogadhatatlan ez, és hogyan garantáljuk az ellenkezőjét.">
-  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Miért Fontos a Nem-Újrafestés">
   <meta property="og:description" content="A legtöbb indikátor hazudik, mert megváltoztatja a történelmi jelzéseit.">
-  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/it/chronicle/birth-of-the-elite-seven/index.html
+++ b/it/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Nascita dei Sette d'Élite — Signal Pilot</title>
   <meta name="description" content="In un'epoca di caos, sette indicatori si sono forgiati dal rumore. Questa è la loro storia di origine—e la tua iniziazione nella costellazione.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Nascita dei Sette d'Élite">
   <meta property="og:description" content="In un'epoca di caos, sette indicatori si sono forgiati dal rumore.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="La Nascita dei Sette d'Élite">

--- a/it/chronicle/meet-the-sovereign/index.html
+++ b/it/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Incontra Il Sovrano: Pentarch Spiegato — Signal Pilot</title>
   <meta name="description" content="Un'immersione profonda nell'indicatore ammiraglia che mappa le cinque fasi dei cicli di mercato. Comprendi le cinque fasi di Pentarch.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Incontra Il Sovrano: Pentarch Spiegato">
   <meta property="og:description" content="L'indicatore ammiraglia che mappa le cinque fasi dei cicli di mercato.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Incontra Il Sovrano: Pentarch Spiegato">

--- a/it/chronicle/the-arbiter/index.html
+++ b/it/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>L'Arbitro: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifica quattro oscillatori in un singolo verdetto, confermando quando colpire. Il settimo e ultimo dei Sette d'Élite.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="L'Arbitro: Harmonic Oscillator">
   <meta property="og:description" content="Quattro voci. Un verdetto. Io decido quando premere il grilletto.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="L'Arbitro: Harmonic Oscillator">

--- a/it/chronicle/the-cartographer/index.html
+++ b/it/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Il Cartografo: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas mappa il terreno dove si combattono le battaglie di mercato. Comprendere i livelli chiave, gli anchor VWAP e i punti di riferimento istituzionali.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Il Cartografo: Janus Atlas">
   <meta property="og:description" content="Ogni campo di battaglia ha il suo terreno. Janus Atlas mappa dove verranno combattute le guerre.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Il Cartografo: Janus Atlas">

--- a/it/chronicle/the-commander/index.html
+++ b/it/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Il Comandante: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifica dieci sistemi di trading premium in un'unica overlay coerente. Comprendere l'indicatore all-in-one che pone fine al caos dei grafici.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Il Comandante: OmniDeck">
   <meta property="og:description" content="Dieci sistemi. Una visione. Chiarezza totale.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Il Comandante: OmniDeck">

--- a/it/chronicle/the-council-assembles/index.html
+++ b/it/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Il Consiglio Si Riunisce — Signal Pilot</title>
   <meta name="description" content="Hai incontrato ogni membro. Ora guardali lavorare come uno. Quando I Sette d'Élite si uniscono, il caos diventa chiarezza e il rumore diventa segnale.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Il Consiglio Si Riunisce">
   <meta property="og:description" content="Hai incontrato ogni membro. Ora guardali lavorare come uno.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Il Consiglio Si Riunisce">

--- a/it/chronicle/the-hierarchy-of-signals/index.html
+++ b/it/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Gerarchia dei Segnali — Signal Pilot</title>
   <meta name="description" content="Non tutti i segnali sono uguali. Impara come I Sette d'Élite formano una costellazione di scopo—e perché l'ordine conta.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Gerarchia dei Segnali">
   <meta property="og:description" content="Non tutti i segnali sono uguali. Impara come I Sette formano una costellazione di scopo.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="La Gerarchia dei Segnali">

--- a/it/chronicle/the-pilots-oath/index.html
+++ b/it/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Il Giuramento del Pilota — Signal Pilot</title>
   <meta name="description" content="Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota. Questo è il giuramento che fai—e la filosofia che ti guida.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Il Giuramento del Pilota">
   <meta property="og:description" content="Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Il Giuramento del Pilota">

--- a/it/chronicle/the-prophet/index.html
+++ b/it/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Il Profeta: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle sente quello che i retail non possono—i passi delle istituzioni che si muovono nell'oscurità. Comprendere accumulo e distribuzione prima che i grafici confessino.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Il Profeta: Volume Oracle">
   <meta property="og:description" content="Volume Oracle sente quello che i retail non possono—i passi delle istituzioni che si muovono nell'oscurità.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Il Profeta: Volume Oracle">

--- a/it/chronicle/the-scales/index.html
+++ b/it/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Bilancia: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow pesa la pressione di acquisto contro quella di vendita per rivelare la verità sotto il prezzo. Comprendere il delta cumulativo e i segnali di divergenza.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Bilancia: Plutus Flow">
   <meta property="og:description" content="Peso l'invisibile. La pressione non mente.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="La Bilancia: Plutus Flow">

--- a/it/chronicle/the-watchman/index.html
+++ b/it/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>La Sentinella: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scansiona otto mercati simultaneamente, classificando le opportunità per convinzione e filtrando il rumore dal segnale. Il sesto dei Sette d'Élite.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="La Sentinella: Augury Grid">
   <meta property="og:description" content="Mentre tu guardi un grafico, io li guardo tutti.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="La Sentinella: Augury Grid">

--- a/it/chronicle/why-non-repainting-matters/index.html
+++ b/it/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Perché il Non-Repainting È Importante — Signal Pilot</title>
   <meta name="description" content="La maggior parte degli indicatori ti mente cambiando i loro segnali storici. Ecco perché il non-repainting non è negoziabile, e come lo garantiamo.">
-  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Perché il Non-Repainting È Importante">
   <meta property="og:description" content="La maggior parte degli indicatori ti mente cambiando i loro segnali storici. Ecco perché il non-repainting non è negoziabile.">
-  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/ja/chronicle/birth-of-the-elite-seven/index.html
+++ b/ja/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>エリートセブンの誕生 — Signal Pilot</title>
   <meta name="description" content="すべてはシグナルの混乱から始まった。あるパイロットの旅が7つのインジケーターを結集し、混沌を明晰さに変えた。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="エリートセブンの誕生">
   <meta property="og:description" content="すべてはシグナルの混乱から始まった。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="エリートセブンの誕生">

--- a/ja/chronicle/meet-the-sovereign/index.html
+++ b/ja/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>ソブリンに会う：Pentarch — Signal Pilot</title>
   <meta name="description" content="Pentarch - エリートセブンの第一人者。サイクルとフェーズを通じて市場を読み解くソブリンインジケーターの仕組みを深く探る。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="ソブリンに会う：Pentarch">
   <meta property="og:description" content="サイクルのマスター、シグナルの王。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="ソブリンに会う：Pentarch">

--- a/ja/chronicle/the-arbiter/index.html
+++ b/ja/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>アービター：Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillatorは4つのオシレーターを単一の判定に統合し、いつストライクすべきかを確認します。エリートセブンの第七にして最後。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="アービター：Harmonic Oscillator">
   <meta property="og:description" content="4つの声。一つの判定。私がトリガーを引くときを決める。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="アービター：Harmonic Oscillator">

--- a/ja/chronicle/the-cartographer/index.html
+++ b/ja/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>カートグラファー：Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlasは市場の戦いが繰り広げられる地形をマッピングします。重要なレベル、VWAPアンカー、機関投資家の基準点を理解する。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="カートグラファー：Janus Atlas">
   <meta property="og:description" content="すべての戦場には地形がある。私は戦いが行われる場所をマッピングする。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="カートグラファー：Janus Atlas">

--- a/ja/chronicle/the-commander/index.html
+++ b/ja/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>コマンダー：OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeckは10のプレミアム取引システムを一つの統一されたオーバーレイに統合します。チャートの混沌を終わらせるオールインワンインジケーターを理解する。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="コマンダー：OmniDeck">
   <meta property="og:description" content="10のシステム。一つのビジョン。完全な明晰さ。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="コマンダー：OmniDeck">

--- a/ja/chronicle/the-council-assembles/index.html
+++ b/ja/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>評議会は集う — Signal Pilot</title>
   <meta name="description" content="各メンバーと会いました。今、彼らが一つとして働くのを見てください。エリートセブンが団結するとき、混沌は明晰さになり、ノイズはシグナルになります。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="評議会は集う">
   <meta property="og:description" content="各メンバーと会いました。今、彼らが一つとして働くのを見てください。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="評議会は集う">

--- a/ja/chronicle/the-hierarchy-of-signals/index.html
+++ b/ja/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>シグナルの階層 — Signal Pilot</title>
   <meta name="description" content="エリートセブンがどのように目的の星座として協力するかを理解する。各インジケーターの役割、階層、シグナルが流れる方法。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="シグナルの階層">
   <meta property="og:description" content="エリートセブンがどのように統一されたシステムとして機能するか。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="シグナルの階層">

--- a/ja/chronicle/the-pilots-oath/index.html
+++ b/ja/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>パイロットの誓い — Signal Pilot</title>
   <meta name="description" content="すべてのパイロットが従う規律の核心にあるもの。これらの原則はトレーダーをパイロットに変える。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="パイロットの誓い">
   <meta property="og:description" content="すべてのパイロットが従う規律の核心にあるもの。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="パイロットの誓い">

--- a/ja/chronicle/the-prophet/index.html
+++ b/ja/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>プロフェット：Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracleは機関投資家のボリュームの真実を明らかにする。彼らがどこで蓄積し、どこで分配しているか—小売トレーダーの目に見えないもの。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="プロフェット：Volume Oracle">
   <meta property="og:description" content="私は小売が聞けないものを聞く。私は巨人が闇の中で動くのを見る。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="プロフェット：Volume Oracle">

--- a/ja/chronicle/the-scales/index.html
+++ b/ja/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>スケール：Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flowは買い圧力と売り圧力を量り、価格の下にある真実を明らかにします。累積デルタとダイバージェンスシグナルを理解する。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="スケール：Plutus Flow">
   <meta property="og:description" content="見えないものを量る。圧力は嘘をつかない。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="スケール：Plutus Flow">

--- a/ja/chronicle/the-watchman/index.html
+++ b/ja/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>ウォッチマン：Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Gridは8つの市場を同時にスキャンし、確信度で機会をランク付けし、ノイズからシグナルをフィルタリングします。エリートセブンの第六。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="ウォッチマン：Augury Grid">
   <meta property="og:description" content="あなたが一つのチャートを見ている間、私はすべてを見ている。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="ウォッチマン：Augury Grid">

--- a/ja/chronicle/why-non-repainting-matters/index.html
+++ b/ja/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>なぜノンリペイントが重要か — Signal Pilot</title>
   <meta name="description" content="リペイントするインジケーターはバックテストでは美しく見えるが、実際のトレードでは失敗する。Signal Pilotのノンリペイント保証の背後にある真実を学ぶ。">
-  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="なぜノンリペイントが重要か">
   <meta property="og:description" content="あなたのインジケーターがリペイントするとき、あなたは嘘の上でトレードしている。">
-  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="なぜノンリペイントが重要か">

--- a/nl/chronicle/birth-of-the-elite-seven/index.html
+++ b/nl/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Geboorte van de Elite Zeven — Signal Pilot</title>
   <meta name="description" content="In het hart van marktchaos werd een visie geboren. De oorsprong van de zeven indicatoren die alles veranderden.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Geboorte van de Elite Zeven">
   <meta property="og:description" content="Waar het allemaal begon. Het oorsprongsverhaal.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Geboorte van de Elite Zeven">

--- a/nl/chronicle/meet-the-sovereign/index.html
+++ b/nl/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Ontmoet de Soeverein: Pentarch — Signal Pilot</title>
   <meta name="description" content="Pentarch is de leider van de Elite Zeven. Het leest marktcycli en bepaalt de koers. De eerste en machtigste.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Ontmoet de Soeverein: Pentarch">
   <meta property="og:description" content="De eerste en machtigste. De lezer van cycli.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Ontmoet de Soeverein: Pentarch">

--- a/nl/chronicle/the-arbiter/index.html
+++ b/nl/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Arbiter: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unificeert vier oscillatoren in één oordeel, bevestigend wanneer te slaan. De zevende en laatste van de Elite Zeven.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Arbiter: Harmonic Oscillator">
   <meta property="og:description" content="Vier stemmen. Eén oordeel. Ik beslis wanneer de trekker wordt overgehaald.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Arbiter: Harmonic Oscillator">

--- a/nl/chronicle/the-cartographer/index.html
+++ b/nl/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Cartograaf: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas brengt het terrein in kaart waar marktveldslagen worden uitgevochten. Begrijp sleutelniveaus, VWAP-ankers en institutionele referentiepunten.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Cartograaf: Janus Atlas">
   <meta property="og:description" content="Elk slagveld heeft zijn terrein. Ik kaart waar oorlogen worden uitgevochten.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Cartograaf: Janus Atlas">

--- a/nl/chronicle/the-commander/index.html
+++ b/nl/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Commandant: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unificeert tien premium handelssystemen in één coherente overlay. Begrijp de alles-in-één indicator die grafiekchaos beëindigt.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Commandant: OmniDeck">
   <meta property="og:description" content="Tien systemen. Eén visie. Totale helderheid.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Commandant: OmniDeck">

--- a/nl/chronicle/the-council-assembles/index.html
+++ b/nl/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Raad Komt Bijeen — Signal Pilot</title>
   <meta name="description" content="Je hebt elk lid ontmoet. Nu zie je hoe ze als één werken. Wanneer De Elite Zeven zich verenigen, wordt chaos helderheid en ruis wordt signaal.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Raad Komt Bijeen">
   <meta property="og:description" content="Je hebt elk lid ontmoet. Nu zie je hoe ze als één werken.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Raad Komt Bijeen">

--- a/nl/chronicle/the-hierarchy-of-signals/index.html
+++ b/nl/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Hiërarchie van Signalen — Signal Pilot</title>
   <meta name="description" content="Niet alle signalen zijn gelijk. Leer hoe de Elite Zeven samenwerken in een gestructureerd systeem van prioriteit en validatie.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Hiërarchie van Signalen">
   <meta property="og:description" content="Hoe de Zeven een constellatie van doel vormen.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Hiërarchie van Signalen">

--- a/nl/chronicle/the-pilots-oath/index.html
+++ b/nl/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Eed van de Piloot — Signal Pilot</title>
   <meta name="description" content="Een code van discipline die traders van gokkers onderscheidt. De principes die elke Signal Pilot-piloot geloven en volgen.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Eed van de Piloot">
   <meta property="og:description" content="Een code van discipline die traders van gokkers onderscheidt.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Eed van de Piloot">

--- a/nl/chronicle/the-prophet/index.html
+++ b/nl/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Profeet: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle hoort institutionele positionering. Het detecteert accumulatie en distributie voordat prijs onthult.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Profeet: Volume Oracle">
   <meta property="og:description" content="Ik hoor wat retail niet kan. Ik zie de giganten bewegen in duisternis.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Profeet: Volume Oracle">

--- a/nl/chronicle/the-scales/index.html
+++ b/nl/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Weegschaal: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow weegt koop- versus verkoopdruk om de waarheid onder prijs te onthullen. Begrijp cumulatieve delta en divergentiesignalen.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Weegschaal: Plutus Flow">
   <meta property="og:description" content="Ik weeg het onzichtbare. Druk liegt niet.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Weegschaal: Plutus Flow">

--- a/nl/chronicle/the-watchman/index.html
+++ b/nl/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>De Wachter: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid scant acht markten tegelijk, rankt kansen op overtuiging en filtert ruis van signaal. De zesde van de Elite Zeven.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="De Wachter: Augury Grid">
   <meta property="og:description" content="Terwijl jij één grafiek bekijkt, bekijk ik ze allemaal.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="De Wachter: Augury Grid">

--- a/nl/chronicle/why-non-repainting-matters/index.html
+++ b/nl/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Waarom Niet-Herpainting Belangrijk Is — Signal Pilot</title>
   <meta name="description" content="De fundamentele garantie die eerlijke analyse mogelijk maakt. Begrijp waarom herpainting indicatoren uw trading saboteren.">
-  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Waarom Niet-Herpainting Belangrijk Is">
   <meta property="og:description" content="De fundamentele garantie die eerlijke analyse mogelijk maakt.">
-  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Waarom Niet-Herpainting Belangrijk Is">

--- a/pt/chronicle/birth-of-the-elite-seven/index.html
+++ b/pt/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>O Nascimento dos Sete de Elite — Signal Pilot</title>
   <meta name="description" content="Antes que os mercados tivessem nomes, antes que as velas contassem histórias, havia apenas ruído. Esta é a história de origem de sete sinais celestiais que emergiram para navegar o vazio.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -29,7 +29,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="O Nascimento dos Sete de Elite">
   <meta property="og:description" content="Antes que os mercados tivessem nomes, antes que as velas contassem histórias, havia apenas ruído. Esta é a história de origem dos Sete de Elite.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/pt/chronicle/meet-the-sovereign/index.html
+++ b/pt/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Conheça O Soberano: Pentarch Explicado — Signal Pilot</title>
   <meta name="description" content="Um mergulho profundo no Pentarch, o indicador principal que mapeia as cinco fases dos ciclos de mercado. Entendendo TD, IGN, WRN, CAP e BDN.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -28,7 +28,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Conheça O Soberano: Pentarch Explicado">
   <meta property="og:description" content="Um mergulho profundo no Pentarch, o indicador principal que mapeia as cinco fases dos ciclos de mercado.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/pt/chronicle/the-arbiter/index.html
+++ b/pt/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>O Árbitro: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator unifica quatro osciladores em um único veredito, confirmando quando atacar. O sétimo e último dos Elite Sete.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="O Árbitro: Harmonic Oscillator">
   <meta property="og:description" content="Quatro vozes. Um veredito. Eu decido quando o gatilho é puxado.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="O Árbitro: Harmonic Oscillator">

--- a/pt/chronicle/the-cartographer/index.html
+++ b/pt/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>O Cartógrafo: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas mapeia o terreno onde as batalhas do mercado são travadas. Compreendendo níveis-chave, âncoras VWAP e pontos de referência institucionais.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="O Cartógrafo: Janus Atlas">
   <meta property="og:description" content="Todo campo de batalha tem seu terreno. Eu mapeio onde as guerras serão travadas.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="O Cartógrafo: Janus Atlas">

--- a/pt/chronicle/the-commander/index.html
+++ b/pt/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>O Comandante: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck unifica dez sistemas de trading premium em uma sobreposição coerente. Compreendendo o indicador tudo-em-um que acaba com o caos dos gráficos.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="O Comandante: OmniDeck">
   <meta property="og:description" content="Dez sistemas. Uma visão. Clareza total.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="O Comandante: OmniDeck">

--- a/pt/chronicle/the-council-assembles/index.html
+++ b/pt/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>O Conselho Se Reúne — Signal Pilot</title>
   <meta name="description" content="Você conheceu cada membro. Agora veja-os trabalhar como um só. Quando os Elite Sete se unem, caos se torna clareza e ruído se torna sinal.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="O Conselho Se Reúne">
   <meta property="og:description" content="Você conheceu cada membro. Agora veja-os trabalhar como um só.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="O Conselho Se Reúne">

--- a/pt/chronicle/the-hierarchy-of-signals/index.html
+++ b/pt/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Hierarquia dos Sinais — Signal Pilot</title>
   <meta name="description" content="Os Sete não existem isoladamente. Eles formam uma constelação—uma hierarquia de propósito, cada um servindo aquele acima enquanto capacita aqueles abaixo.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -28,7 +28,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Hierarquia dos Sinais">
   <meta property="og:description" content="Os Sete não existem isoladamente. Eles formam uma constelação—uma hierarquia de propósito.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/pt/chronicle/the-pilots-oath/index.html
+++ b/pt/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>O Juramento do Piloto — Signal Pilot</title>
   <meta name="description" content="Você que empunha Os Sete de Elite não é um trader. Você é um Piloto. Este é o juramento que separa aqueles que navegam daqueles que apostam.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -28,7 +28,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="O Juramento do Piloto">
   <meta property="og:description" content="Você que empunha Os Sete de Elite não é um trader. Você é um Piloto. Este é o juramento que separa aqueles que navegam daqueles que apostam.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta property="article:author" content="Signal Pilot Labs">

--- a/pt/chronicle/the-prophet/index.html
+++ b/pt/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>O Profeta: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle ouve o que o varejo não consegue—os passos das instituições movendo-se na escuridão. Entendendo acumulação e distribuição antes dos gráficos confessarem.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="O Profeta: Volume Oracle">
   <meta property="og:description" content="Volume Oracle ouve o que o varejo não consegue—os passos das instituições movendo-se na escuridão.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="O Profeta: Volume Oracle">

--- a/pt/chronicle/the-scales/index.html
+++ b/pt/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Balança: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow pesa a pressão de compra versus venda para revelar a verdade sob o preço. Compreendendo delta cumulativo e sinais de divergência.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Balança: Plutus Flow">
   <meta property="og:description" content="Eu peso o invisível. A pressão não mente.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="A Balança: Plutus Flow">

--- a/pt/chronicle/the-watchman/index.html
+++ b/pt/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>A Sentinela: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid escaneia oito mercados simultaneamente, classificando oportunidades por convicção e filtrando ruído do sinal. O sexto dos Elite Sete.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="A Sentinela: Augury Grid">
   <meta property="og:description" content="Enquanto você observa um gráfico, eu observo todos.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="A Sentinela: Augury Grid">

--- a/pt/chronicle/why-non-repainting-matters/index.html
+++ b/pt/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Por Que Não Repintar Importa — Signal Pilot</title>
   <meta name="description" content="A maioria dos indicadores mente para você mudando seus sinais históricos. Aqui está por que não repintar não é negociável, e como nós o garantimos.">
-  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -28,7 +28,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Por Que Não Repintar Importa">
   <meta property="og:description" content="A maioria dos indicadores mente para você mudando seus sinais históricos. Aqui está por que não repintar não é negociável.">
-  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta property="article:published_time" content="2025-12-24">
   <meta name="twitter:card" content="summary_large_image">

--- a/ru/chronicle/birth-of-the-elite-seven/index.html
+++ b/ru/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Рождение Элитной Семёрки — Signal Pilot</title>
   <meta name="description" content="До того как рынки получили названия, до того как свечи рассказывали истории, был только шум. Это история происхождения семи небесных сигналов, которые появились, чтобы проложить путь сквозь пустоту.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Рождение Элитной Семёрки">
   <meta property="og:description" content="До того как рынки получили названия, до того как свечи рассказывали истории, был только шум.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Рождение Элитной Семёрки">

--- a/ru/chronicle/meet-the-sovereign/index.html
+++ b/ru/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Познакомьтесь с Сувереном: Pentarch — Signal Pilot</title>
   <meta name="description" content="Глубокое погружение в Pentarch, флагманский индикатор, который картирует пять фаз рыночных циклов. Понимание TD, IGN, WRN, CAP и BDN.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Познакомьтесь с Сувереном: Pentarch">
   <meta property="og:description" content="Глубокое погружение в Pentarch, флагманский индикатор, который картирует пять фаз рыночных циклов.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Познакомьтесь с Сувереном: Pentarch">

--- a/ru/chronicle/the-arbiter/index.html
+++ b/ru/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Арбитр: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator объединяет четыре осциллятора в единый вердикт, подтверждая, когда наносить удар. Седьмой и последний из Элитной Семёрки.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Арбитр: Harmonic Oscillator">
   <meta property="og:description" content="Четыре голоса. Один вердикт. Я решаю, когда нажать на курок.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Арбитр: Harmonic Oscillator">

--- a/ru/chronicle/the-cartographer/index.html
+++ b/ru/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Картограф: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas картографирует местность, где ведутся рыночные сражения. Понимание ключевых уровней, якорей VWAP и институциональных точек отсчёта.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Картограф: Janus Atlas">
   <meta property="og:description" content="На каждом поле боя есть своя местность. Я картографирую места будущих сражений.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Картограф: Janus Atlas">

--- a/ru/chronicle/the-commander/index.html
+++ b/ru/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Командир: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck объединяет десять премиальных торговых систем в один согласованный оверлей. Понимание индикатора всё-в-одном, который положит конец хаосу на графиках.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Командир: OmniDeck">
   <meta property="og:description" content="Десять систем. Одно видение. Полная ясность.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Командир: OmniDeck">

--- a/ru/chronicle/the-council-assembles/index.html
+++ b/ru/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Совет Собирается — Signal Pilot</title>
   <meta name="description" content="Вы познакомились с каждым участником. Теперь смотрите, как они работают как единое целое. Когда Элитная Семёрка объединяется, хаос становится ясностью, а шум становится сигналом.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Совет Собирается">
   <meta property="og:description" content="Вы познакомились с каждым участником. Теперь смотрите, как они работают как единое целое.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Совет Собирается">

--- a/ru/chronicle/the-hierarchy-of-signals/index.html
+++ b/ru/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Иерархия Сигналов — Signal Pilot</title>
   <meta name="description" content="Семёрка не существует в изоляции. Они образуют созвездие — иерархию целей, где каждый служит тому, кто выше, наделяя силой тех, кто ниже.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Иерархия Сигналов">
   <meta property="og:description" content="Семёрка не существует в изоляции. Они образуют созвездие — иерархию целей.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Иерархия Сигналов">

--- a/ru/chronicle/the-pilots-oath/index.html
+++ b/ru/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Клятва Пилота — Signal Pilot</title>
   <meta name="description" content="Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот. Это клятва, которая отделяет тех, кто навигирует, от тех, кто играет.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Клятва Пилота">
   <meta property="og:description" content="Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Клятва Пилота">

--- a/ru/chronicle/the-prophet/index.html
+++ b/ru/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Пророк: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Volume Oracle слышит то, что недоступно розничным — шаги институций, движущихся во тьме. Понимание накопления и распределения до того, как графики признаются.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Пророк: Volume Oracle">
   <meta property="og:description" content="Volume Oracle слышит то, что недоступно розничным — шаги институций, движущихся во тьме.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Пророк: Volume Oracle">

--- a/ru/chronicle/the-scales/index.html
+++ b/ru/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Весы: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow взвешивает давление покупок против продаж, чтобы раскрыть истину под ценой. Понимание кумулятивной дельты и сигналов дивергенции.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Весы: Plutus Flow">
   <meta property="og:description" content="Я взвешиваю невидимое. Давление не лжёт.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Весы: Plutus Flow">

--- a/ru/chronicle/the-watchman/index.html
+++ b/ru/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Страж: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid сканирует восемь рынков одновременно, ранжируя возможности по убеждённости и отфильтровывая шум от сигнала. Шестой из Элитной Семёрки.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Страж: Augury Grid">
   <meta property="og:description" content="Пока вы смотрите на один график, я слежу за всеми.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Страж: Augury Grid">

--- a/ru/chronicle/why-non-repainting-matters/index.html
+++ b/ru/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Почему Отсутствие Перерисовки Важно — Signal Pilot</title>
   <meta name="description" content="Большинство индикаторов лгут вам, изменяя свои исторические сигналы. Вот почему отсутствие перерисовки не подлежит обсуждению, и как мы это гарантируем.">
-  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Почему Отсутствие Перерисовки Важно">
   <meta property="og:description" content="Большинство индикаторов лгут вам, изменяя свои исторические сигналы.">
-  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Почему Отсутствие Перерисовки Важно">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -62,73 +62,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -189,73 +189,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -316,73 +316,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/de/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -443,73 +443,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/es/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -570,73 +570,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -697,73 +697,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -824,73 +824,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/it/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -951,73 +951,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -1078,73 +1078,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -1205,73 +1205,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -1314,73 +1314,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -1441,73 +1441,73 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/meet-the-sovereign</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-arbiter</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-arbiter/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-cartographer</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-cartographer/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-commander</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-commander/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-council-assembles</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-council-assembles/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-pilots-oath</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-pilots-oath/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-prophet</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-prophet/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-scales</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-scales/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/the-watchman</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/the-watchman/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters</loc>
+    <loc>https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/</loc>
     <lastmod>2025-12-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/tr/chronicle/birth-of-the-elite-seven/index.html
+++ b/tr/chronicle/birth-of-the-elite-seven/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Elit Yedilinin Doğuşu — Signal Pilot</title>
   <meta name="description" content="Signal Pilot'un imza göstergelerine güç veren devrimci sistem olan Elite Seven'ın başlangıç hikayesini keşfedin.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Elit Yedilinin Doğuşu">
   <meta property="og:description" content="Her efsanenin bir başlangıcı vardır. Bu bizim hikayemiz.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/elite-seven-council-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Elit Yedilinin Doğuşu">

--- a/tr/chronicle/meet-the-sovereign/index.html
+++ b/tr/chronicle/meet-the-sovereign/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Hükümdar ile Tanışın: Pentarch — Signal Pilot</title>
   <meta name="description" content="Piyasa döngülerinin usta okuyucusu Pentarch'ı keşfedin. ACC, IGN, TD ve DIST fazlarını anlayın—piyasa ritimlerini ustalıkla okumanın anahtarı.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/meet-the-sovereign/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Hükümdar ile Tanışın: Pentarch">
   <meta property="og:description" content="Hiçbir şey döngüsüz var olmaz. Ben onları okurum.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/sovereign-pentarch-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Hükümdar ile Tanışın: Pentarch">

--- a/tr/chronicle/the-arbiter/index.html
+++ b/tr/chronicle/the-arbiter/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Hakem: Harmonic Oscillator — Signal Pilot</title>
   <meta name="description" content="Harmonic Oscillator dört osilatörü tek bir karara birleştirir, ne zaman vuracağınızı onaylar. Elit Yedili'nin yedincisi ve sonuncusu.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-arbiter">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-arbiter/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Hakem: Harmonic Oscillator">
   <meta property="og:description" content="Dört ses. Tek karar. Tetiğin ne zaman çekileceğine ben karar veririm.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-arbiter">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-arbiter/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/arbiter-harmonic-oscillator-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Hakem: Harmonic Oscillator">

--- a/tr/chronicle/the-cartographer/index.html
+++ b/tr/chronicle/the-cartographer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Kartograf: Janus Atlas — Signal Pilot</title>
   <meta name="description" content="Janus Atlas, piyasa savaşlarının yapıldığı araziyi haritalandırır. Önemli seviyeleri, VWAP çapalarını ve kurumsal referans noktalarını anlama.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-cartographer">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-cartographer/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Kartograf: Janus Atlas">
   <meta property="og:description" content="Her savaş alanının bir arazisi var. Savaşların nerede yapılacağını haritalandırıyorum.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-cartographer">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-cartographer/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/cartographer-janus-atlas-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Kartograf: Janus Atlas">

--- a/tr/chronicle/the-commander/index.html
+++ b/tr/chronicle/the-commander/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Komutan: OmniDeck — Signal Pilot</title>
   <meta name="description" content="OmniDeck on premium işlem sistemini tek tutarlı bir katmanda birleştirir. Grafik kaosunu sona erdiren hepsi bir arada göstergeyi anlama.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-commander">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-commander/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-commander/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Komutan: OmniDeck">
   <meta property="og:description" content="On sistem. Tek vizyon. Tam netlik.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-commander">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-commander/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/commander-omnideck-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Komutan: OmniDeck">

--- a/tr/chronicle/the-council-assembles/index.html
+++ b/tr/chronicle/the-council-assembles/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Konsey Toplanıyor — Signal Pilot</title>
   <meta name="description" content="Her üyeyle tanıştınız. Şimdi birlikte çalışmalarını izleyin. Elit Yedili birleştiğinde, kaos netliğe ve gürültü sinyale dönüşür.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-council-assembles/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Konsey Toplanıyor">
   <meta property="og:description" content="Her üyeyle tanıştınız. Şimdi birlikte çalışmalarını izleyin.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-council-assembles">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-council-assembles/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/council-assembles-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Konsey Toplanıyor">

--- a/tr/chronicle/the-hierarchy-of-signals/index.html
+++ b/tr/chronicle/the-hierarchy-of-signals/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Sinyallerin Hiyerarşisi — Signal Pilot</title>
   <meta name="description" content="Elit Yedili'nin nasıl bir amaç takım yıldızı olarak birlikte çalıştığını anlayın. Her bir göstergenin yetkiden yürütmeye kadar katmanlı yapıdaki rolünü keşfedin.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Sinyallerin Hiyerarşisi">
   <meta property="og:description" content="Göstergeler savaşır. Sistem uyum sağlar.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/hierarchy-of-signals-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Sinyallerin Hiyerarşisi">

--- a/tr/chronicle/the-pilots-oath/index.html
+++ b/tr/chronicle/the-pilots-oath/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Pilotun Yemini — Signal Pilot</title>
   <meta name="description" content="Gerçek Pilotları çaylak spekülatörlerden ayıran yedi prensip. Elit bir trader olma yolculuğunuzda sizi yönlendirecek kurallar.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-pilots-oath/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Pilotun Yemini">
   <meta property="og:description" content="Sabır ile giriş yapacağım. Disiplinle çıkış yapacağım.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-pilots-oath">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-pilots-oath/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/pilots-oath-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Pilotun Yemini">

--- a/tr/chronicle/the-prophet/index.html
+++ b/tr/chronicle/the-prophet/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Peygamber: Volume Oracle — Signal Pilot</title>
   <meta name="description" content="Kurumsal faaliyetin dinleyicisi Volume Oracle'ı keşfedin. Büyük sermayenin ne zaman hareket ettiğini ve ne zaman perakendecileri tuzağa düşürdüğünü anlayın.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-prophet">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-prophet/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-prophet/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Peygamber: Volume Oracle">
   <meta property="og:description" content="Perakendecilerin duyamadığını duyarım. Devlerin karanlıkta hareket ettiğini görürüm.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-prophet">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-prophet/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/prophet-volume-oracle-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Peygamber: Volume Oracle">

--- a/tr/chronicle/the-scales/index.html
+++ b/tr/chronicle/the-scales/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Terazi: Plutus Flow — Signal Pilot</title>
   <meta name="description" content="Plutus Flow, fiyatın altındaki gerçeği ortaya çıkarmak için alım baskısını satış baskısına karşı tartar. Kümülatif delta ve sapma sinyallerini anlama.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-scales">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-scales/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-scales/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Terazi: Plutus Flow">
   <meta property="og:description" content="Görünmezi tartıyorum. Baskı yalan söylemez.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-scales">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-scales/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/scales-plutus-flow-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Terazi: Plutus Flow">

--- a/tr/chronicle/the-watchman/index.html
+++ b/tr/chronicle/the-watchman/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Nöbetçi: Augury Grid — Signal Pilot</title>
   <meta name="description" content="Augury Grid sekiz piyasayı aynı anda tarar, fırsatları kararlılığa göre sıralar ve gürültüyü sinyalden ayırır. Elit Yedili'nin altıncısı.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-watchman">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/the-watchman/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/the-watchman/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Nöbetçi: Augury Grid">
   <meta property="og:description" content="Siz bir grafiği izlerken, ben hepsini izliyorum.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-watchman">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/the-watchman/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/watchman-augury-grid-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Nöbetçi: Augury Grid">

--- a/tr/chronicle/why-non-repainting-matters/index.html
+++ b/tr/chronicle/why-non-repainting-matters/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Neden Non-Repainting Önemlidir — Signal Pilot</title>
   <meta name="description" content="Geçmişi değiştiren göstergelerin tehlikesini ve Signal Pilot'un non-repainting garantisinin neden önemli olduğunu anlayın.">
-  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters">
+  <link rel="canonical" href="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
 
   <!-- Hreflang tags for language versions -->
   <link rel="alternate" hreflang="en" href="https://www.signalpilot.io/chronicle/why-non-repainting-matters/">
@@ -27,7 +27,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="Neden Non-Repainting Önemlidir">
   <meta property="og:description" content="500$'lık meydan okumamız. Dokunulmadan duruyor.">
-  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters">
+  <meta property="og:url" content="https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/">
   <meta property="og:image" content="https://www.signalpilot.io/chronicle/non-repainting-matters-preview.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Neden Non-Repainting Önemlidir">


### PR DESCRIPTION
Add trailing slashes to canonical and og:url tags in all 144 chronicle subpages to match hreflang URLs. Also update sitemap.xml for consistency.

This resolves GSC "Alternate page with proper canonical tag" warnings caused by URL mismatch between canonical (no slash) and hreflang (with slash).