### PR TITLE
Fix 404 errors for missing language paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,21 @@
       "has": [{ "type": "host", "value": "signalpilot.io" }],
       "destination": "https://www.signalpilot.io/:path*",
       "permanent": true
+    },
+    {
+      "source": "/en",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/en/",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/en/:path*",
+      "destination": "/:path*",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
The site uses root (/) for English content, not /en/. Google discovered /en/ URLs that were returning 404. This adds permanent redirects:
- /en → /
- /en/ → /
- /en/* → /*

This will help resolve the 465 Not Found pages reported by Google Search Console for paths like www.signalpilot.io/en/