### PR TITLE
Fix Chrome mobile CTA with clean glow, add smaller panel card text on…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1708,36 +1708,27 @@
       }
     }
 
-    /* Chrome ONLY: Spinning border that traces the full button */
-    @keyframes chrome-border-spin {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: none !important;
-        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
-                    conic-gradient(from 0deg, transparent 0%, #1e3a8a 10%, #3b82f6 20%, #60a5fa 30%, #3b82f6 40%, #1e3a8a 50%, transparent 60%) border-box !important;
-        border: 2px solid transparent !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
         border-radius: 9999px !important;
-        position: relative !important;
-        overflow: hidden !important;
       }
-      html.is-chrome .shiny-cta::before {
-        content: '' !important;
-        position: absolute !important;
-        inset: -50% !important;
-        background: conic-gradient(from 0deg, transparent 0%, #1e3a8a 10%, #3b82f6 20%, #60a5fa 30%, #3b82f6 40%, #1e3a8a 50%, transparent 60%) !important;
-        animation: chrome-border-spin 3s linear infinite !important;
-        z-index: -2 !important;
-      }
+      html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {
-        content: '' !important;
-        position: absolute !important;
-        inset: 2px !important;
-        background: #0a0a0f !important;
-        border-radius: 9999px !important;
-        z-index: -1 !important;
+        display: none !important;
       }
     }
 
@@ -4116,6 +4107,24 @@
             font-size: 0.5rem;
             padding: 0.15rem 0.4rem;
           }
+          /* Panel cards (horizontal) need even smaller text */
+          .elite-panel-card .elite-card-content {
+            bottom: 0.3rem;
+            left: 0.5rem;
+          }
+          .elite-panel-card .elite-card-title {
+            font-size: 0.65rem !important;
+          }
+          .elite-panel-card .elite-card-subtitle {
+            font-size: 0.45rem !important;
+          }
+          .elite-panel-card .elite-card-link {
+            font-size: 0.45rem !important;
+          }
+          .elite-panel-card .elite-card-badge {
+            font-size: 0.4rem !important;
+            padding: 0.1rem 0.3rem;
+          }
         }
         @media (max-width: 480px) {
           .elite-panel-card {
@@ -4143,6 +4152,24 @@
           .elite-card-badge {
             font-size: 0.45rem;
             padding: 0.1rem 0.3rem;
+          }
+          /* Panel cards (horizontal) need even smaller text */
+          .elite-panel-card .elite-card-content {
+            bottom: 0.2rem;
+            left: 0.4rem;
+          }
+          .elite-panel-card .elite-card-title {
+            font-size: 0.55rem !important;
+          }
+          .elite-panel-card .elite-card-subtitle {
+            font-size: 0.4rem !important;
+          }
+          .elite-panel-card .elite-card-link {
+            font-size: 0.4rem !important;
+          }
+          .elite-panel-card .elite-card-badge {
+            font-size: 0.35rem !important;
+            padding: 0.08rem 0.25rem;
           }
         }
       </style>


### PR DESCRIPTION
… mobile

- Replace broken spinning border with smooth pulsing glow animation
- Add specific smaller text sizes for horizontal panel indicator cards
- Panel cards now have 0.65rem title (768px) and 0.55rem (480px) vs regular cards