### PR TITLE
Fix mobile card text sizes + Chrome glow for all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2542,17 +2542,23 @@
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/de/index.html
+++ b/de/index.html
@@ -2510,17 +2510,23 @@
       }
     }
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/es/index.html
+++ b/es/index.html
@@ -2705,17 +2705,23 @@
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/fr/index.html
+++ b/fr/index.html
@@ -1108,17 +1108,23 @@
       }
     }
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {
@@ -1863,17 +1869,23 @@
       }
     }
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/hu/index.html
+++ b/hu/index.html
@@ -2556,17 +2556,23 @@
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/index.html
+++ b/index.html
@@ -4082,94 +4082,97 @@
           .elite-panel-card {
             aspect-ratio: 2 / 1;
           }
-          .elite-card-content {
-            bottom: 0.4rem;
-            left: 0.6rem;
+          /* Chart cards (vertical 4:3) - more space for text */
+          .elite-chart-card .elite-card-content {
+            bottom: 0.5rem !important;
+            left: 0.6rem !important;
           }
-          .elite-card-title {
-            font-size: 0.8rem;
-            margin-bottom: 0;
-            text-shadow: 0 1px 4px rgba(0,0,0,0.8);
+          .elite-chart-card .elite-card-title {
+            font-size: 0.7rem !important;
+            margin-bottom: 0.1rem !important;
+            text-shadow: 0 1px 4px rgba(0,0,0,0.9);
           }
-          .elite-card-subtitle {
-            font-size: 0.55rem;
-            opacity: 0.8;
+          .elite-chart-card .elite-card-subtitle {
+            font-size: 0.45rem !important;
           }
-          .elite-card-link {
-            margin-top: 0.2rem;
-            padding: 0;
-            font-size: 0.55rem;
-            background: transparent;
-            border: none;
-            color: var(--brand);
+          .elite-chart-card .elite-card-link {
+            margin-top: 0.15rem !important;
+            padding: 0 !important;
+            font-size: 0.45rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: var(--brand) !important;
           }
-          .elite-card-badge {
-            font-size: 0.5rem;
-            padding: 0.15rem 0.4rem;
+          .elite-chart-card .elite-card-badge {
+            font-size: 0.4rem !important;
+            padding: 0.1rem 0.3rem !important;
           }
-          /* Panel cards (horizontal) need even smaller text */
+          /* Panel cards (horizontal 2:1) - much smaller text */
           .elite-panel-card .elite-card-content {
-            bottom: 0.3rem;
-            left: 0.5rem;
+            bottom: 0.3rem !important;
+            left: 0.4rem !important;
           }
           .elite-panel-card .elite-card-title {
-            font-size: 0.65rem !important;
+            font-size: 0.5rem !important;
+            margin-bottom: 0 !important;
+            text-shadow: 0 1px 3px rgba(0,0,0,0.9);
           }
           .elite-panel-card .elite-card-subtitle {
-            font-size: 0.45rem !important;
+            font-size: 0.35rem !important;
           }
           .elite-panel-card .elite-card-link {
-            font-size: 0.45rem !important;
+            margin-top: 0.1rem !important;
+            padding: 0 !important;
+            font-size: 0.35rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: var(--brand) !important;
           }
           .elite-panel-card .elite-card-badge {
-            font-size: 0.4rem !important;
-            padding: 0.1rem 0.3rem;
+            font-size: 0.3rem !important;
+            padding: 0.08rem 0.2rem !important;
           }
         }
         @media (max-width: 480px) {
           .elite-panel-card {
             aspect-ratio: 2 / 1;
           }
-          .elite-card-content {
-            bottom: 0.3rem;
-            left: 0.5rem;
+          /* Chart cards (vertical) - smaller on tiny screens */
+          .elite-chart-card .elite-card-content {
+            bottom: 0.4rem !important;
+            left: 0.5rem !important;
           }
-          .elite-card-title {
-            font-size: 0.75rem;
-            margin-bottom: 0;
+          .elite-chart-card .elite-card-title {
+            font-size: 0.6rem !important;
+            margin-bottom: 0 !important;
           }
-          .elite-card-subtitle {
-            font-size: 0.5rem;
+          .elite-chart-card .elite-card-subtitle {
+            font-size: 0.4rem !important;
           }
-          .elite-card-link {
-            margin-top: 0.15rem;
-            padding: 0;
-            font-size: 0.5rem;
-            background: transparent;
-            border: none;
-            color: var(--brand);
+          .elite-chart-card .elite-card-link {
+            font-size: 0.4rem !important;
           }
-          .elite-card-badge {
-            font-size: 0.45rem;
-            padding: 0.1rem 0.3rem;
+          .elite-chart-card .elite-card-badge {
+            font-size: 0.35rem !important;
+            padding: 0.08rem 0.25rem !important;
           }
-          /* Panel cards (horizontal) need even smaller text */
+          /* Panel cards (horizontal) - tiny text */
           .elite-panel-card .elite-card-content {
-            bottom: 0.2rem;
-            left: 0.4rem;
+            bottom: 0.2rem !important;
+            left: 0.3rem !important;
           }
           .elite-panel-card .elite-card-title {
-            font-size: 0.55rem !important;
+            font-size: 0.45rem !important;
           }
           .elite-panel-card .elite-card-subtitle {
-            font-size: 0.4rem !important;
+            font-size: 0.3rem !important;
           }
           .elite-panel-card .elite-card-link {
-            font-size: 0.4rem !important;
+            font-size: 0.3rem !important;
           }
           .elite-panel-card .elite-card-badge {
-            font-size: 0.35rem !important;
-            padding: 0.08rem 0.25rem;
+            font-size: 0.25rem !important;
+            padding: 0.05rem 0.15rem !important;
           }
         }
       </style>

--- a/it/index.html
+++ b/it/index.html
@@ -2507,17 +2507,23 @@
     }
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/ja/index.html
+++ b/ja/index.html
@@ -2762,17 +2762,23 @@
 @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/nl/index.html
+++ b/nl/index.html
@@ -2578,17 +2578,23 @@
       }
     }
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/pt/index.html
+++ b/pt/index.html
@@ -2606,17 +2606,23 @@
 @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/ru/index.html
+++ b/ru/index.html
@@ -1069,17 +1069,23 @@
       }
     }
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {
@@ -1796,17 +1802,23 @@
       }
     }
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {

--- a/tr/index.html
+++ b/tr/index.html
@@ -1115,17 +1115,23 @@
       }
     }
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {
@@ -1887,17 +1893,23 @@
       }
     }
 
-    /* Chrome ONLY: Simple pulse fallback instead of @property animation */
-    @keyframes chrome-pulse {
-      0%, 100% { box-shadow: 0 0 15px rgba(59,130,246,0.4), inset 0 0 0 2px rgba(59,130,246,0.5); }
-      50% { box-shadow: 0 0 25px rgba(59,130,246,0.6), inset 0 0 0 2px rgba(59,130,246,0.8); }
+    /* Chrome ONLY: Clean pulse glow for mobile */
+    @keyframes chrome-glow {
+      0%, 100% {
+        box-shadow: 0 0 20px rgba(59,130,246,0.5), 0 0 40px rgba(59,130,246,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
+        border-color: rgba(59,130,246,0.6);
+      }
+      50% {
+        box-shadow: 0 0 30px rgba(59,130,246,0.7), 0 0 60px rgba(59,130,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+        border-color: rgba(96,165,250,0.8);
+      }
     }
     @media (max-width: 768px) {
       html.is-chrome .shiny-cta {
-        animation: chrome-pulse 2s ease-in-out infinite !important;
-        background: linear-gradient(135deg, #0a0a0f 0%, #111827 100%) !important;
-        border: 2px solid rgba(59,130,246,0.5) !important;
-        border-radius: inherit !important;
+        animation: chrome-glow 2s ease-in-out infinite !important;
+        background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%) !important;
+        border: 2px solid rgba(59,130,246,0.6) !important;
+        border-radius: 9999px !important;
       }
       html.is-chrome .shiny-cta::before,
       html.is-chrome .shiny-cta::after {


### PR DESCRIPTION
- Chart cards (vertical): 0.7rem title, 0.45rem subtitle on mobile
- Panel cards (horizontal): 0.5rem title, 0.35rem subtitle on mobile
- Even smaller at 480px breakpoint
- Applied chrome-glow animation to all 12 language files

Safari is smoother due to better @property CSS support. Chrome needs the glow fallback animation.