### PR TITLE
Add Chrome mobile fix for CTA button flickering

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2542,6 +2542,20 @@
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
+    /* Chrome mobile: Disable all animations, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02)),#0a0e18;border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/de/index.html
+++ b/de/index.html
@@ -2501,6 +2501,20 @@
       }
     }
 
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {
       .shiny-cta,

--- a/es/index.html
+++ b/es/index.html
@@ -2705,6 +2705,20 @@
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
+    /* Chrome mobile: Disable all animations, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02)),#0a0e18;border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/fr/index.html
+++ b/fr/index.html
@@ -1099,6 +1099,20 @@
       }
     }
 
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {
       .shiny-cta,
@@ -1833,6 +1847,20 @@
       }
       .shiny-cta::after {
         animation-duration: 6s;
+      }
+    }
+
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
       }
     }
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -2556,6 +2556,20 @@
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
+    /* Chrome mobile: Disable all animations, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02)),#0a0e18;border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/index.html
+++ b/index.html
@@ -1708,6 +1708,20 @@
       }
     }
 
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02)),var(--bg);border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible}
 
     .card:hover{border-color:rgba(91,138,255,0.3)}

--- a/it/index.html
+++ b/it/index.html
@@ -2507,6 +2507,20 @@
     }
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
+    /* Chrome mobile: Disable all animations, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02)),#0a0e18;border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/ja/index.html
+++ b/ja/index.html
@@ -2762,6 +2762,20 @@
 @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
+    /* Chrome mobile: Disable all animations, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02)),#0a0e18;border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/nl/index.html
+++ b/nl/index.html
@@ -2569,6 +2569,20 @@
       }
     }
 
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {
       .shiny-cta,

--- a/pt/index.html
+++ b/pt/index.html
@@ -2606,6 +2606,20 @@
 @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
+    /* Chrome mobile: Disable all animations, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     .card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02)),#0a0e18;border-radius:16px;padding:1.05rem;box-shadow:var(--shadow);min-width:0;position:relative;overflow:visible;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1)}
 
     .card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--brand),var(--accent));transform:scaleX(0);transition:transform 0.3s ease;overflow:hidden}

--- a/ru/index.html
+++ b/ru/index.html
@@ -1060,6 +1060,20 @@
       }
     }
 
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {
       .shiny-cta,
@@ -1766,6 +1780,20 @@
       }
       .shiny-cta::after {
         animation-duration: 6s;
+      }
+    }
+
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
       }
     }
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -1106,6 +1106,20 @@
       }
     }
 
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
+      }
+    }
+
     /* Respect reduced motion preference */
     @media (prefers-reduced-motion: reduce) {
       .shiny-cta,
@@ -1857,6 +1871,20 @@
       }
       .shiny-cta::after {
         animation-duration: 6s;
+      }
+    }
+
+    /* Chrome mobile: Disable flickery @property animation, use static gradient border */
+    @media (max-width: 768px) {
+      html.is-chrome .shiny-cta {
+        animation: none !important;
+        background: linear-gradient(#0a0a0f, #0a0a0f) padding-box,
+                    linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #1e3a8a 100%) border-box !important;
+        border: 2px solid transparent !important;
+      }
+      html.is-chrome .shiny-cta::before,
+      html.is-chrome .shiny-cta::after {
+        display: none !important;
       }
     }
 


### PR DESCRIPTION
On Chrome mobile, the @property-based animations cause flickering. This adds a Chrome-specific override (html.is-chrome) that:
- Disables all shiny-cta animations
- Uses a static blue gradient border instead
- Hides the ::before and ::after pseudo-elements

Safari continues to use the beautiful animated version.