### PR TITLE
Update Japanese site with latest product links

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5767,12 +5767,12 @@ html[lang="ar"] [style*="text-align:center"] {
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">الموافقة مطلوبة</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      اشترك مع PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      ادفع بالبطاقة
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>اشترك - $99/شهر</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      ادفع مع PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5825,12 +5825,12 @@ html[lang="ar"] [style*="text-align:center"] {
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">الموافقة مطلوبة</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      اشترك مع PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      ادفع بالبطاقة
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>اشترك - $699/سنة</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      ادفع مع PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5885,12 +5885,12 @@ html[lang="ar"] [style*="text-align:center"] {
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">الموافقة مطلوبة</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta">
-                      <span>اشترِ الآن مع PayPal</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      ادفع بالبطاقة
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>شراء مدى الحياة - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      ادفع مع PayPal
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">العرض مدى الحياة نفد. قائمة الانتظار متاحة أدناه.</div>

--- a/es/index.html
+++ b/es/index.html
@@ -6178,12 +6178,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">Consentimiento requerido</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Suscribirse con PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Pagar con Tarjeta
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Suscribirse - $99/mes</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Pagar con PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -6240,12 +6240,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">Consentimiento requerido</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Suscribirse con PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Pagar con Tarjeta
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Suscribirse - $699/año</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Pagar con PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -6300,12 +6300,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">Consentimiento requerido</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta" style="width:100%">
-                      <span>Comprar Ahora con PayPal</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Pagar con Tarjeta
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Comprar de por Vida - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Pagar con PayPal
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">Acceso de por vida agotado. Lista de espera disponible abajo.</div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -6307,12 +6307,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">Consentement requis</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      S'abonner avec PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Payer par Carte
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>S'abonner - $99/mois</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Payer avec PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -6369,12 +6369,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">Consentement requis</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      S'abonner avec PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Payer par Carte
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>S'abonner - $699/an</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Payer avec PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -6429,12 +6429,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">Consentement requis</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta">
-                      <span>Acheter Maintenant avec PayPal</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Payer par Carte
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Acheter à Vie - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Payer avec PayPal
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">L'accès à vie est épuisé. Liste d'attente disponible ci-dessous.</div>

--- a/hu/index.html
+++ b/hu/index.html
@@ -5699,12 +5699,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">Beleegyezés szükséges</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Feliratkozás PayPal-lal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Fizetés kártyával
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Feliratkozás - $99/hó</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Fizetés PayPal-lal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5761,12 +5761,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">Beleegyezés szükséges</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Feliratkozás PayPal-lal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Fizetés kártyával
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Feliratkozás - $699/év</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Fizetés PayPal-lal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5821,12 +5821,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">Beleegyezés szükséges</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta" style="width:100%">
-                      <span>Vásárlás PayPal-lal</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Fizetés kártyával
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Élethosszig Vásárlás - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Fizetés PayPal-lal
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">Az élethosszig tartó hozzáférés elfogyott. Várólista elérhető lent.</div>

--- a/it/index.html
+++ b/it/index.html
@@ -5719,12 +5719,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">Consenso richiesto</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Abbonati con PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Paga con Carta
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Abbonati - $99/mese</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Paga con PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5781,12 +5781,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">Consenso richiesto</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Abbonati con PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Paga con Carta
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Abbonati - $699/anno</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Paga con PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5841,12 +5841,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">Consenso richiesto</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta">
-                      <span>Acquista Ora con PayPal</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Paga con Carta
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Acquista a Vita - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Paga con PayPal
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">L'accesso a vita è esaurito. Lista d'attesa disponibile sotto.</div>

--- a/ja/index.html
+++ b/ja/index.html
@@ -6015,12 +6015,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">同意が必要です</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      PayPalで購読
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      カードで支払う
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>購読 - $99/月</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      PayPalで支払う
+                    </button>
                   </div>
                 </div>
               </div>
@@ -6077,12 +6077,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">同意が必要です</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      PayPalで購読
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      カードで支払う
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>購読 - $699/年</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      PayPalで支払う
+                    </button>
                   </div>
                 </div>
               </div>
@@ -6137,12 +6137,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">同意が必要です</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta" style="width:100%">
-                      <span>PayPalで今すぐ購入</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      カードで支払う
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>ライフタイム購入 - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      PayPalで支払う
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">ライフタイムプランは完売しました。以下のウェイトリストをご利用ください。</div>

--- a/nl/index.html
+++ b/nl/index.html
@@ -5717,12 +5717,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">Toestemming vereist</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Abonneer met PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Betaal met Kaart
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Abonneren - $99/maand</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Betaal met PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5779,12 +5779,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">Toestemming vereist</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Abonneer met PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Betaal met Kaart
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Abonneren - $699/jaar</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Betaal met PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5839,12 +5839,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">Toestemming vereist</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta">
-                      <span>Koop Nu met PayPal</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Betaal met Kaart
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Koop Levenslang - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Betaal met PayPal
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">Levenslang is uitverkocht. Wachtlijst is hieronder beschikbaar.</div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -5898,12 +5898,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">Consentimento obrigatório</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Assinar com PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Pagar com Cartão
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Assinar - $99/mês</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Pagar com PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5960,12 +5960,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">Consentimento obrigatório</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Assinar com PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Pagar com Cartão
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Assinar - $699/ano</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Pagar com PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -6020,12 +6020,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">Consentimento obrigatório</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta" style="width:100%">
-                      <span>Comprar Agora com PayPal</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Pagar com Cartão
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Comprar Vitalício - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Pagar com PayPal
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">Vitalício esgotado. Lista de espera disponível abaixo.</div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -5707,12 +5707,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">Требуется согласие</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Подписаться через PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Оплатить картой
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Подписаться - $99/мес</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Оплатить через PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5769,12 +5769,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">Требуется согласие</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Подписаться через PayPal
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Оплатить картой
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Подписаться - $699/год</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Оплатить через PayPal
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5829,12 +5829,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">Требуется согласие</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta">
-                      <span>Купить через PayPal</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Оплатить картой
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Купить Навсегда - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      Оплатить через PayPal
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">Пожизненный доступ распродан. Лист ожидания доступен ниже.</div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -5781,12 +5781,12 @@
                   <div id="error-consent-monthly" style="display:none" class="text-red-400 text-xs mt-1.5">Onay gerekli</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-monthly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      PayPal ile abone ol
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Kartla öde
+                    <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Abone Ol - $99/ay</span>
                     </a>
+                    <button type="button" id="btn-monthly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      PayPal ile Öde
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5843,12 +5843,12 @@
                   <div id="error-consent-yearly" style="display:none" class="text-red-400 text-xs mt-1.5">Onay gerekli</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-yearly-paypal" class="group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      PayPal ile abone ol
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Kartla öde
+                    <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Abone Ol - $699/yıl</span>
                     </a>
+                    <button type="button" id="btn-yearly-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      PayPal ile Öde
+                    </button>
                   </div>
                 </div>
               </div>
@@ -5903,12 +5903,12 @@
                   <div id="error-consent-lifetime" style="display:none" class="text-red-400 text-xs mt-1.5">Onay gerekli</div>
 
                   <div class="mt-6">
-                    <button type="button" id="btn-lifetime-paypal" class="shiny-cta">
-                      <span>PayPal ile şimdi satın al</span>
-                    </button>
-                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
-                      Kartla öde
+                    <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
+                      <span>Ömür Boyu Satın Al - $1,799</span>
                     </a>
+                    <button type="button" id="btn-lifetime-paypal" class="mt-2 group relative inline-flex items-center justify-center w-full h-12 px-6 py-3 text-sm font-semibold tracking-tight cursor-pointer overflow-hidden rounded-full border border-white/15 bg-white/5 text-neutral-300 transition-all duration-300 hover:-translate-y-[2px] hover:text-white hover:bg-white/10">
+                      PayPal ile Öde
+                    </button>
                   </div>
 
                   <div id="error-soldout-lifetime" style="display:none" class="text-red-400 text-xs mt-3 text-center">Ömür boyu erişim tükendi. Aşağıda bekleme listesi mevcuttur.</div>


### PR DESCRIPTION
Reorder buttons so Gumroad CTA button appears first with shiny-cta styling and price display, with PayPal button second. This matches the correct format used in English and German versions.

Updated languages: ar, es, fr, hu, it, ja, nl, pt, ru, tr