### PR TITLE
Fix pricing section mobile overflow on all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -876,6 +876,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/de/index.html
+++ b/de/index.html
@@ -849,6 +849,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/es/index.html
+++ b/es/index.html
@@ -852,6 +852,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/fr/index.html
+++ b/fr/index.html
@@ -885,6 +885,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/hu/index.html
+++ b/hu/index.html
@@ -881,6 +881,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/index.html
+++ b/index.html
@@ -809,6 +809,35 @@
         margin-top: auto !important;
       }
 
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     /* Portrait desktop screens - center conduit video */

--- a/it/index.html
+++ b/it/index.html
@@ -856,6 +856,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/ja/index.html
+++ b/ja/index.html
@@ -938,6 +938,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/nl/index.html
+++ b/nl/index.html
@@ -871,6 +871,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/pt/index.html
+++ b/pt/index.html
@@ -816,6 +816,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/ru/index.html
+++ b/ru/index.html
@@ -836,6 +836,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{

--- a/tr/index.html
+++ b/tr/index.html
@@ -874,6 +874,35 @@
         animation-duration: 0.3s !important;
         transition-duration: 0.3s !important;
       }
+      /* PRICING SECTION MOBILE FIX - prevent horizontal overflow */
+      #pricing .container {
+        overflow-x: hidden !important;
+      }
+
+      /* Trust bar - stack vertically on mobile */
+      #pricing [style*="max-width:fit-content"] {
+        max-width: 100% !important;
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+        padding: 1rem !important;
+      }
+
+      /* Hide bullet separators on mobile */
+      #pricing [style*="max-width:fit-content"] > span[style*="color:var(--muted-2)"] {
+        display: none !important;
+      }
+
+      /* "What's Included" box - single column grid on mobile */
+      #pricing [style*="max-width:900px"] {
+        max-width: 100% !important;
+        padding: 1.25rem 1rem !important;
+      }
+
+      #pricing [style*="minmax(200px"] {
+        grid-template-columns: 1fr !important;
+        gap: 0.5rem !important;
+      }
+
     }
 
     img, video, iframe{


### PR DESCRIPTION
- Trust bar now stacks vertically on mobile instead of overflowing
- "What's Included" grid switches to single column on mobile
- Hidden bullet separators on mobile for cleaner layout
- Container overflow-x hidden to prevent horizontal scroll
- Applied to all 12 language versions