### PR TITLE
Fix Google Search Console 404 errors

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1512,4 +1512,17 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <!-- Tools -->
+  <url>
+    <loc>https://www.signalpilot.io/tools/</loc>
+    <lastmod>2026-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.signalpilot.io/tools/quiz/</loc>
+    <lastmod>2026-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/tools/index.html
+++ b/tools/index.html
@@ -15,20 +15,20 @@
   <title>Free Trading Tools | Position Size, Risk & Kelly Calculator</title>
   <meta name="description" content="14 free trading calculators: position sizing, risk/reward, drawdown recovery, Kelly criterion, and more. No signup required.">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://signalpilot.io/tools/">
+  <link rel="canonical" href="https://www.signalpilot.io/tools/">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Free Trading Tools | 14 Essential Calculators">
   <meta property="og:description" content="Position size, risk/reward, drawdown recovery, Kelly criterion & more. Free, no signup.">
-  <meta property="og:url" content="https://signalpilot.io/tools/">
+  <meta property="og:url" content="https://www.signalpilot.io/tools/">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://signalpilot.io/assets/og-tools.png">
+  <meta property="og:image" content="https://www.signalpilot.io/assets/og-tools.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Free Trading Tools | 14 Essential Calculators">
   <meta name="twitter:description" content="Position size, risk/reward, drawdown recovery, Kelly criterion & more. Free, no signup.">
-  <meta name="twitter:image" content="https://signalpilot.io/assets/og-tools.png">
+  <meta name="twitter:image" content="https://www.signalpilot.io/assets/og-tools.png">
 
   <link rel="icon" href="/favicon.ico">
 
@@ -888,11 +888,11 @@
       <p>Professional calculators for position sizing, risk management, and performance analysis</p>
 
       <div class="share-bar">
-        <a href="https://twitter.com/intent/tweet?text=Free%20trading%20calculators%20for%20position%20sizing%2C%20risk%20management%20%26%20Kelly%20criterion&url=https://signalpilot.io/tools/" target="_blank" rel="noopener" class="share-btn">
+        <a href="https://twitter.com/intent/tweet?text=Free%20trading%20calculators%20for%20position%20sizing%2C%20risk%20management%20%26%20Kelly%20criterion&url=https://www.signalpilot.io/tools/" target="_blank" rel="noopener" class="share-btn">
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           Share
         </a>
-        <a href="https://reddit.com/submit?url=https://signalpilot.io/tools/&title=Free%20Trading%20Tools%20-%20Position%20Size%20%26%20Risk%20Calculators" target="_blank" rel="noopener" class="share-btn">
+        <a href="https://reddit.com/submit?url=https://www.signalpilot.io/tools/&title=Free%20Trading%20Tools%20-%20Position%20Size%20%26%20Risk%20Calculators" target="_blank" rel="noopener" class="share-btn">
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
           Reddit
         </a>
@@ -1375,7 +1375,7 @@
     <div class="embed-section">
       <h3>🔗 Embed on Your Site</h3>
       <p>Share these calculators with your community. Free backlinks welcome!</p>
-      <div class="embed-code" id="embed-code">&lt;iframe src="https://signalpilot.io/tools/" width="100%" height="800" frameborder="0" style="border-radius:16px"&gt;&lt;/iframe&gt;</div>
+      <div class="embed-code" id="embed-code">&lt;iframe src="https://www.signalpilot.io/tools/" width="100%" height="800" frameborder="0" style="border-radius:16px"&gt;&lt;/iframe&gt;</div>
       <button class="embed-btn" onclick="copyEmbed()">Copy Embed Code</button>
     </div>
 
@@ -1388,7 +1388,7 @@
 
     <footer class="footer">
       <a href="https://education.signalpilot.io/calculators.html" target="_blank" class="see-all">See all 14 calculators on Education Hub →</a>
-      <p>Built by <a href="https://signalpilot.io">Signal Pilot</a> — Professional trading indicators for TradingView</p>
+      <p>Built by <a href="https://www.signalpilot.io">Signal Pilot</a> — Professional trading indicators for TradingView</p>
     </footer>
   </div>
 
@@ -1472,14 +1472,14 @@
     }
 
     function copyLink() {
-      navigator.clipboard.writeText('https://signalpilot.io/tools/');
+      navigator.clipboard.writeText('https://www.signalpilot.io/tools/');
       showToast('Link copied!');
     }
 
     function copyEmbed() {
       // Include affiliate ref if present
       const ref = getAffiliateRef();
-      const url = ref ? `https://signalpilot.io/tools/?ref=${ref}` : 'https://signalpilot.io/tools/';
+      const url = ref ? `https://www.signalpilot.io/tools/?ref=${ref}` : 'https://www.signalpilot.io/tools/';
       const code = `<iframe src="${url}" width="100%" height="800" frameborder="0" style="border-radius:16px"></iframe>`;
       navigator.clipboard.writeText(code);
       showToast('Embed code copied!');
@@ -1591,18 +1591,18 @@
 
     function shareToTwitter() {
       const text = `My ${currentShareData.label}: ${currentShareData.result} - ${currentShareData.verdict}`;
-      const url = 'https://signalpilot.io/tools/';
+      const url = 'https://www.signalpilot.io/tools/';
       window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`, '_blank');
     }
 
     function shareToReddit() {
       const title = `My ${currentShareData.label}: ${currentShareData.result}`;
-      const url = 'https://signalpilot.io/tools/';
+      const url = 'https://www.signalpilot.io/tools/';
       window.open(`https://reddit.com/submit?url=${encodeURIComponent(url)}&title=${encodeURIComponent(title)}`, '_blank');
     }
 
     function copyShareLink() {
-      navigator.clipboard.writeText('https://signalpilot.io/tools/');
+      navigator.clipboard.writeText('https://www.signalpilot.io/tools/');
       showToast('Link copied!');
       hideShareModal();
     }

--- a/tools/quiz/index.html
+++ b/tools/quiz/index.html
@@ -6,20 +6,20 @@
   <title>What's Your Trading Style? | Free Quiz</title>
   <meta name="description" content="Discover your ideal trading style in 2 minutes. Are you a scalper, day trader, swing trader, or position trader? Take the free quiz.">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://signalpilot.io/tools/quiz/">
+  <link rel="canonical" href="https://www.signalpilot.io/tools/quiz/">
 
   <!-- Open Graph -->
   <meta property="og:title" content="What's Your Trading Style? | Free Quiz">
   <meta property="og:description" content="Discover your ideal trading style in 2 minutes. Personalized recommendations included.">
-  <meta property="og:url" content="https://signalpilot.io/tools/quiz/">
+  <meta property="og:url" content="https://www.signalpilot.io/tools/quiz/">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://signalpilot.io/assets/og-quiz.png">
+  <meta property="og:image" content="https://www.signalpilot.io/assets/og-quiz.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="What's Your Trading Style? | Free Quiz">
   <meta name="twitter:description" content="Discover your ideal trading style in 2 minutes. Personalized recommendations included.">
-  <meta name="twitter:image" content="https://signalpilot.io/assets/og-quiz.png">
+  <meta name="twitter:image" content="https://www.signalpilot.io/assets/og-quiz.png">
 
   <link rel="icon" href="/favicon.ico">
 
@@ -892,7 +892,7 @@
     function shareResult() {
       const result = results[resultType];
       const text = `I'm ${result.title}! ${result.subtitle}. Discover your trading style:`;
-      const url = 'https://signalpilot.io/tools/quiz/';
+      const url = 'https://www.signalpilot.io/tools/quiz/';
       window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`, '_blank');
     }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "trailingSlash": true,
   "redirects": [
     {
       "source": "/:path*",
@@ -20,6 +21,11 @@
     {
       "source": "/en/:path*",
       "destination": "/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/index.html",
+      "destination": "/",
       "permanent": true
     }
   ],


### PR DESCRIPTION
- Add trailingSlash: true to vercel.json to prevent redirect chains for language routes (fixes /ar redirect loop error)
- Add /index.html → / redirect to handle duplicate content issue
- Fix canonical URLs in tools pages to use www.signalpilot.io
- Add tools pages to sitemap.xml

The /en/ 404 error was already handled by existing redirects in vercel.json - Google just needs to re-crawl after validation.