### PR TITLE
Add tag status to chronicle page

### DIFF
--- a/404.html
+++ b/404.html
@@ -54,5 +54,8 @@
       </div>
     </div>
   </main>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/affiliates.html
+++ b/affiliates.html
@@ -1381,5 +1381,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/affiliates.html
+++ b/ar/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/birth-of-the-elite-seven/index.html
+++ b/ar/chronicle/birth-of-the-elite-seven/index.html
@@ -1156,5 +1156,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/index.html
+++ b/ar/chronicle/index.html
@@ -1231,5 +1231,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/meet-the-sovereign/index.html
+++ b/ar/chronicle/meet-the-sovereign/index.html
@@ -428,5 +428,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-arbiter/index.html
+++ b/ar/chronicle/the-arbiter/index.html
@@ -1164,5 +1164,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-cartographer/index.html
+++ b/ar/chronicle/the-cartographer/index.html
@@ -1033,5 +1033,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-commander/index.html
+++ b/ar/chronicle/the-commander/index.html
@@ -1048,5 +1048,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-council-assembles/index.html
+++ b/ar/chronicle/the-council-assembles/index.html
@@ -1185,5 +1185,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-hierarchy-of-signals/index.html
+++ b/ar/chronicle/the-hierarchy-of-signals/index.html
@@ -1224,5 +1224,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-pilots-oath/index.html
+++ b/ar/chronicle/the-pilots-oath/index.html
@@ -1129,5 +1129,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-prophet/index.html
+++ b/ar/chronicle/the-prophet/index.html
@@ -594,5 +594,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-scales/index.html
+++ b/ar/chronicle/the-scales/index.html
@@ -1084,5 +1084,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/the-watchman/index.html
+++ b/ar/chronicle/the-watchman/index.html
@@ -1145,5 +1145,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/chronicle/why-non-repainting-matters/index.html
+++ b/ar/chronicle/why-non-repainting-matters/index.html
@@ -1150,5 +1150,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/faq.html
+++ b/ar/faq.html
@@ -1590,5 +1590,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/manage-subscription.html
+++ b/ar/manage-subscription.html
@@ -377,5 +377,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/privacy.html
+++ b/ar/privacy.html
@@ -443,5 +443,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/refund.html
+++ b/ar/refund.html
@@ -439,5 +439,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/roadmap.html
+++ b/ar/roadmap.html
@@ -1249,5 +1249,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ar/terms.html
+++ b/ar/terms.html
@@ -132,5 +132,8 @@
   <script>
     (function(){const KEY='sp_theme';const btn=document.getElementById('themeToggle');const system=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';setTheme(localStorage.getItem(KEY)||system);btn?.addEventListener('click',()=>{const cur=document.documentElement.getAttribute('data-theme')==='light'?'light':'dark';setTheme(cur==='light'?'dark':'light');});function setTheme(t){document.documentElement.setAttribute('data-theme',t);localStorage.setItem(KEY,t);let m=document.querySelector('meta[name="theme-color"]');if(!m){m=document.createElement('meta');m.setAttribute('name','theme-color');document.head.appendChild(m);}m.setAttribute('content',t==='light'?'#f6f8fc':'#05070d');}})();document.getElementById('year').textContent=new Date().getFullYear();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/birth-of-the-elite-seven/index.html
+++ b/chronicle/birth-of-the-elite-seven/index.html
@@ -1186,5 +1186,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/index.html
+++ b/chronicle/index.html
@@ -1436,5 +1436,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/meet-the-sovereign/index.html
+++ b/chronicle/meet-the-sovereign/index.html
@@ -1135,5 +1135,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-arbiter/index.html
+++ b/chronicle/the-arbiter/index.html
@@ -489,5 +489,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-cartographer/index.html
+++ b/chronicle/the-cartographer/index.html
@@ -424,5 +424,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-commander/index.html
+++ b/chronicle/the-commander/index.html
@@ -438,5 +438,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-council-assembles/index.html
+++ b/chronicle/the-council-assembles/index.html
@@ -490,5 +490,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-hierarchy-of-signals/index.html
+++ b/chronicle/the-hierarchy-of-signals/index.html
@@ -1325,5 +1325,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-pilots-oath/index.html
+++ b/chronicle/the-pilots-oath/index.html
@@ -1231,5 +1231,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-prophet/index.html
+++ b/chronicle/the-prophet/index.html
@@ -443,5 +443,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-scales/index.html
+++ b/chronicle/the-scales/index.html
@@ -397,5 +397,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/the-watchman/index.html
+++ b/chronicle/the-watchman/index.html
@@ -445,5 +445,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/chronicle/why-non-repainting-matters/index.html
+++ b/chronicle/why-non-repainting-matters/index.html
@@ -981,5 +981,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/affiliates.html
+++ b/de/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/birth-of-the-elite-seven/index.html
+++ b/de/chronicle/birth-of-the-elite-seven/index.html
@@ -1190,5 +1190,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/index.html
+++ b/de/chronicle/index.html
@@ -1228,5 +1228,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/meet-the-sovereign/index.html
+++ b/de/chronicle/meet-the-sovereign/index.html
@@ -888,5 +888,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-arbiter/index.html
+++ b/de/chronicle/the-arbiter/index.html
@@ -436,5 +436,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-cartographer/index.html
+++ b/de/chronicle/the-cartographer/index.html
@@ -413,5 +413,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-commander/index.html
+++ b/de/chronicle/the-commander/index.html
@@ -427,5 +427,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-council-assembles/index.html
+++ b/de/chronicle/the-council-assembles/index.html
@@ -504,5 +504,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-hierarchy-of-signals/index.html
+++ b/de/chronicle/the-hierarchy-of-signals/index.html
@@ -1148,5 +1148,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-pilots-oath/index.html
+++ b/de/chronicle/the-pilots-oath/index.html
@@ -1071,5 +1071,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-prophet/index.html
+++ b/de/chronicle/the-prophet/index.html
@@ -432,5 +432,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-scales/index.html
+++ b/de/chronicle/the-scales/index.html
@@ -423,5 +423,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/the-watchman/index.html
+++ b/de/chronicle/the-watchman/index.html
@@ -471,5 +471,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/chronicle/why-non-repainting-matters/index.html
+++ b/de/chronicle/why-non-repainting-matters/index.html
@@ -1140,5 +1140,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/faq.html
+++ b/de/faq.html
@@ -1598,5 +1598,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/manage-subscription.html
+++ b/de/manage-subscription.html
@@ -379,5 +379,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/privacy.html
+++ b/de/privacy.html
@@ -442,5 +442,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/refund.html
+++ b/de/refund.html
@@ -440,5 +440,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/roadmap.html
+++ b/de/roadmap.html
@@ -1249,5 +1249,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/de/terms.html
+++ b/de/terms.html
@@ -549,5 +549,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/debug-shuffle.html
+++ b/debug-shuffle.html
@@ -84,5 +84,8 @@
       }
     }, 500);
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/affiliates.html
+++ b/es/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/birth-of-the-elite-seven/index.html
+++ b/es/chronicle/birth-of-the-elite-seven/index.html
@@ -384,5 +384,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/index.html
+++ b/es/chronicle/index.html
@@ -1293,5 +1293,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/meet-the-sovereign/index.html
+++ b/es/chronicle/meet-the-sovereign/index.html
@@ -921,5 +921,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-arbiter/index.html
+++ b/es/chronicle/the-arbiter/index.html
@@ -431,5 +431,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-cartographer/index.html
+++ b/es/chronicle/the-cartographer/index.html
@@ -372,5 +372,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-commander/index.html
+++ b/es/chronicle/the-commander/index.html
@@ -386,5 +386,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-council-assembles/index.html
+++ b/es/chronicle/the-council-assembles/index.html
@@ -463,5 +463,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-hierarchy-of-signals/index.html
+++ b/es/chronicle/the-hierarchy-of-signals/index.html
@@ -1019,5 +1019,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-pilots-oath/index.html
+++ b/es/chronicle/the-pilots-oath/index.html
@@ -928,5 +928,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-prophet/index.html
+++ b/es/chronicle/the-prophet/index.html
@@ -391,5 +391,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-scales/index.html
+++ b/es/chronicle/the-scales/index.html
@@ -382,5 +382,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/the-watchman/index.html
+++ b/es/chronicle/the-watchman/index.html
@@ -430,5 +430,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/chronicle/why-non-repainting-matters/index.html
+++ b/es/chronicle/why-non-repainting-matters/index.html
@@ -948,5 +948,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/faq.html
+++ b/es/faq.html
@@ -1588,5 +1588,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/manage-subscription.html
+++ b/es/manage-subscription.html
@@ -379,5 +379,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/privacy.html
+++ b/es/privacy.html
@@ -442,5 +442,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/refund.html
+++ b/es/refund.html
@@ -440,5 +440,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/roadmap.html
+++ b/es/roadmap.html
@@ -1240,5 +1240,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/es/terms.html
+++ b/es/terms.html
@@ -549,5 +549,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -1788,5 +1788,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/affiliates.html
+++ b/fr/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/birth-of-the-elite-seven/index.html
+++ b/fr/chronicle/birth-of-the-elite-seven/index.html
@@ -416,5 +416,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/index.html
+++ b/fr/chronicle/index.html
@@ -1224,5 +1224,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/meet-the-sovereign/index.html
+++ b/fr/chronicle/meet-the-sovereign/index.html
@@ -410,5 +410,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-arbiter/index.html
+++ b/fr/chronicle/the-arbiter/index.html
@@ -426,5 +426,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-cartographer/index.html
+++ b/fr/chronicle/the-cartographer/index.html
@@ -368,5 +368,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-commander/index.html
+++ b/fr/chronicle/the-commander/index.html
@@ -382,5 +382,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-council-assembles/index.html
+++ b/fr/chronicle/the-council-assembles/index.html
@@ -459,5 +459,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-hierarchy-of-signals/index.html
+++ b/fr/chronicle/the-hierarchy-of-signals/index.html
@@ -472,5 +472,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-pilots-oath/index.html
+++ b/fr/chronicle/the-pilots-oath/index.html
@@ -415,5 +415,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-prophet/index.html
+++ b/fr/chronicle/the-prophet/index.html
@@ -387,5 +387,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-scales/index.html
+++ b/fr/chronicle/the-scales/index.html
@@ -378,5 +378,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/the-watchman/index.html
+++ b/fr/chronicle/the-watchman/index.html
@@ -426,5 +426,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/chronicle/why-non-repainting-matters/index.html
+++ b/fr/chronicle/why-non-repainting-matters/index.html
@@ -430,5 +430,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/faq.html
+++ b/fr/faq.html
@@ -1598,5 +1598,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/manage-subscription.html
+++ b/fr/manage-subscription.html
@@ -395,5 +395,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/privacy.html
+++ b/fr/privacy.html
@@ -453,5 +453,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/refund.html
+++ b/fr/refund.html
@@ -452,5 +452,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/roadmap.html
+++ b/fr/roadmap.html
@@ -1261,5 +1261,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/fr/terms.html
+++ b/fr/terms.html
@@ -564,5 +564,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/generate-preview.html
+++ b/generate-preview.html
@@ -188,5 +188,8 @@
       }
     }
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/affiliates.html
+++ b/hu/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/birth-of-the-elite-seven/index.html
+++ b/hu/chronicle/birth-of-the-elite-seven/index.html
@@ -422,5 +422,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/index.html
+++ b/hu/chronicle/index.html
@@ -1231,5 +1231,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/meet-the-sovereign/index.html
+++ b/hu/chronicle/meet-the-sovereign/index.html
@@ -910,5 +910,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-arbiter/index.html
+++ b/hu/chronicle/the-arbiter/index.html
@@ -432,5 +432,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-cartographer/index.html
+++ b/hu/chronicle/the-cartographer/index.html
@@ -359,5 +359,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-commander/index.html
+++ b/hu/chronicle/the-commander/index.html
@@ -374,5 +374,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-council-assembles/index.html
+++ b/hu/chronicle/the-council-assembles/index.html
@@ -451,5 +451,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-hierarchy-of-signals/index.html
+++ b/hu/chronicle/the-hierarchy-of-signals/index.html
@@ -1030,5 +1030,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-pilots-oath/index.html
+++ b/hu/chronicle/the-pilots-oath/index.html
@@ -1022,5 +1022,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-prophet/index.html
+++ b/hu/chronicle/the-prophet/index.html
@@ -379,5 +379,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-scales/index.html
+++ b/hu/chronicle/the-scales/index.html
@@ -370,5 +370,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/the-watchman/index.html
+++ b/hu/chronicle/the-watchman/index.html
@@ -412,5 +412,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/chronicle/why-non-repainting-matters/index.html
+++ b/hu/chronicle/why-non-repainting-matters/index.html
@@ -952,5 +952,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/faq.html
+++ b/hu/faq.html
@@ -1588,5 +1588,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/manage-subscription.html
+++ b/hu/manage-subscription.html
@@ -379,5 +379,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/privacy.html
+++ b/hu/privacy.html
@@ -442,5 +442,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/refund.html
+++ b/hu/refund.html
@@ -440,5 +440,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/roadmap.html
+++ b/hu/roadmap.html
@@ -1217,5 +1217,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/hu/terms.html
+++ b/hu/terms.html
@@ -549,5 +549,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/affiliates.html
+++ b/it/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/birth-of-the-elite-seven/index.html
+++ b/it/chronicle/birth-of-the-elite-seven/index.html
@@ -389,5 +389,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/index.html
+++ b/it/chronicle/index.html
@@ -467,5 +467,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/meet-the-sovereign/index.html
+++ b/it/chronicle/meet-the-sovereign/index.html
@@ -405,5 +405,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-arbiter/index.html
+++ b/it/chronicle/the-arbiter/index.html
@@ -442,5 +442,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-cartographer/index.html
+++ b/it/chronicle/the-cartographer/index.html
@@ -384,5 +384,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-commander/index.html
+++ b/it/chronicle/the-commander/index.html
@@ -398,5 +398,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-council-assembles/index.html
+++ b/it/chronicle/the-council-assembles/index.html
@@ -475,5 +475,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-hierarchy-of-signals/index.html
+++ b/it/chronicle/the-hierarchy-of-signals/index.html
@@ -424,5 +424,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-pilots-oath/index.html
+++ b/it/chronicle/the-pilots-oath/index.html
@@ -396,5 +396,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-prophet/index.html
+++ b/it/chronicle/the-prophet/index.html
@@ -403,5 +403,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-scales/index.html
+++ b/it/chronicle/the-scales/index.html
@@ -394,5 +394,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/the-watchman/index.html
+++ b/it/chronicle/the-watchman/index.html
@@ -442,5 +442,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/chronicle/why-non-repainting-matters/index.html
+++ b/it/chronicle/why-non-repainting-matters/index.html
@@ -448,5 +448,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/faq.html
+++ b/it/faq.html
@@ -1588,5 +1588,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/manage-subscription.html
+++ b/it/manage-subscription.html
@@ -379,5 +379,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/privacy.html
+++ b/it/privacy.html
@@ -442,5 +442,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/refund.html
+++ b/it/refund.html
@@ -440,5 +440,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/roadmap.html
+++ b/it/roadmap.html
@@ -1217,5 +1217,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/it/terms.html
+++ b/it/terms.html
@@ -549,5 +549,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/affiliates.html
+++ b/ja/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/birth-of-the-elite-seven/index.html
+++ b/ja/chronicle/birth-of-the-elite-seven/index.html
@@ -310,5 +310,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/index.html
+++ b/ja/chronicle/index.html
@@ -1231,5 +1231,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/meet-the-sovereign/index.html
+++ b/ja/chronicle/meet-the-sovereign/index.html
@@ -319,5 +319,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-arbiter/index.html
+++ b/ja/chronicle/the-arbiter/index.html
@@ -405,5 +405,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-cartographer/index.html
+++ b/ja/chronicle/the-cartographer/index.html
@@ -345,5 +345,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-commander/index.html
+++ b/ja/chronicle/the-commander/index.html
@@ -355,5 +355,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-council-assembles/index.html
+++ b/ja/chronicle/the-council-assembles/index.html
@@ -432,5 +432,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-hierarchy-of-signals/index.html
+++ b/ja/chronicle/the-hierarchy-of-signals/index.html
@@ -330,5 +330,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-pilots-oath/index.html
+++ b/ja/chronicle/the-pilots-oath/index.html
@@ -303,5 +303,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-prophet/index.html
+++ b/ja/chronicle/the-prophet/index.html
@@ -310,5 +310,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-scales/index.html
+++ b/ja/chronicle/the-scales/index.html
@@ -351,5 +351,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/the-watchman/index.html
+++ b/ja/chronicle/the-watchman/index.html
@@ -399,5 +399,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/chronicle/why-non-repainting-matters/index.html
+++ b/ja/chronicle/why-non-repainting-matters/index.html
@@ -306,5 +306,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/faq.html
+++ b/ja/faq.html
@@ -1600,5 +1600,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/manage-subscription.html
+++ b/ja/manage-subscription.html
@@ -390,5 +390,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/privacy.html
+++ b/ja/privacy.html
@@ -448,5 +448,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/refund.html
+++ b/ja/refund.html
@@ -447,5 +447,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/roadmap.html
+++ b/ja/roadmap.html
@@ -1222,5 +1222,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ja/terms.html
+++ b/ja/terms.html
@@ -561,5 +561,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/manage-subscription.html
+++ b/manage-subscription.html
@@ -386,5 +386,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/affiliates.html
+++ b/nl/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/birth-of-the-elite-seven/index.html
+++ b/nl/chronicle/birth-of-the-elite-seven/index.html
@@ -343,5 +343,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/index.html
+++ b/nl/chronicle/index.html
@@ -914,5 +914,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/meet-the-sovereign/index.html
+++ b/nl/chronicle/meet-the-sovereign/index.html
@@ -346,5 +346,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-arbiter/index.html
+++ b/nl/chronicle/the-arbiter/index.html
@@ -317,5 +317,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-cartographer/index.html
+++ b/nl/chronicle/the-cartographer/index.html
@@ -334,5 +334,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-commander/index.html
+++ b/nl/chronicle/the-commander/index.html
@@ -327,5 +327,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-council-assembles/index.html
+++ b/nl/chronicle/the-council-assembles/index.html
@@ -467,5 +467,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-hierarchy-of-signals/index.html
+++ b/nl/chronicle/the-hierarchy-of-signals/index.html
@@ -374,5 +374,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-pilots-oath/index.html
+++ b/nl/chronicle/the-pilots-oath/index.html
@@ -351,5 +351,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-prophet/index.html
+++ b/nl/chronicle/the-prophet/index.html
@@ -332,5 +332,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-scales/index.html
+++ b/nl/chronicle/the-scales/index.html
@@ -324,5 +324,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/the-watchman/index.html
+++ b/nl/chronicle/the-watchman/index.html
@@ -315,5 +315,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/chronicle/why-non-repainting-matters/index.html
+++ b/nl/chronicle/why-non-repainting-matters/index.html
@@ -349,5 +349,8 @@ const audio=document.getElementById('articleAudio'),playBtn=document.getElementB
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/faq.html
+++ b/nl/faq.html
@@ -1598,5 +1598,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/manage-subscription.html
+++ b/nl/manage-subscription.html
@@ -379,5 +379,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/privacy.html
+++ b/nl/privacy.html
@@ -442,5 +442,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/refund.html
+++ b/nl/refund.html
@@ -440,5 +440,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/roadmap.html
+++ b/nl/roadmap.html
@@ -1237,5 +1237,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/nl/terms.html
+++ b/nl/terms.html
@@ -549,5 +549,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -494,5 +494,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/affiliates.html
+++ b/pt/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/birth-of-the-elite-seven/index.html
+++ b/pt/chronicle/birth-of-the-elite-seven/index.html
@@ -928,5 +928,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/index.html
+++ b/pt/chronicle/index.html
@@ -467,5 +467,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/meet-the-sovereign/index.html
+++ b/pt/chronicle/meet-the-sovereign/index.html
@@ -364,5 +364,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-arbiter/index.html
+++ b/pt/chronicle/the-arbiter/index.html
@@ -406,5 +406,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-cartographer/index.html
+++ b/pt/chronicle/the-cartographer/index.html
@@ -347,5 +347,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-commander/index.html
+++ b/pt/chronicle/the-commander/index.html
@@ -361,5 +361,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-council-assembles/index.html
+++ b/pt/chronicle/the-council-assembles/index.html
@@ -438,5 +438,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-hierarchy-of-signals/index.html
+++ b/pt/chronicle/the-hierarchy-of-signals/index.html
@@ -437,5 +437,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-pilots-oath/index.html
+++ b/pt/chronicle/the-pilots-oath/index.html
@@ -394,5 +394,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-prophet/index.html
+++ b/pt/chronicle/the-prophet/index.html
@@ -367,5 +367,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-scales/index.html
+++ b/pt/chronicle/the-scales/index.html
@@ -359,5 +359,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/the-watchman/index.html
+++ b/pt/chronicle/the-watchman/index.html
@@ -407,5 +407,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/chronicle/why-non-repainting-matters/index.html
+++ b/pt/chronicle/why-non-repainting-matters/index.html
@@ -365,5 +365,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/faq.html
+++ b/pt/faq.html
@@ -1588,5 +1588,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/manage-subscription.html
+++ b/pt/manage-subscription.html
@@ -379,5 +379,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/privacy.html
+++ b/pt/privacy.html
@@ -446,5 +446,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/refund.html
+++ b/pt/refund.html
@@ -440,5 +440,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/roadmap.html
+++ b/pt/roadmap.html
@@ -1217,5 +1217,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/pt/terms.html
+++ b/pt/terms.html
@@ -549,5 +549,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/refund.html
+++ b/refund.html
@@ -398,5 +398,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/roadmap.html
+++ b/roadmap.html
@@ -1503,5 +1503,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/affiliates.html
+++ b/ru/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/birth-of-the-elite-seven/index.html
+++ b/ru/chronicle/birth-of-the-elite-seven/index.html
@@ -380,5 +380,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/index.html
+++ b/ru/chronicle/index.html
@@ -1231,5 +1231,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/meet-the-sovereign/index.html
+++ b/ru/chronicle/meet-the-sovereign/index.html
@@ -403,5 +403,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-arbiter/index.html
+++ b/ru/chronicle/the-arbiter/index.html
@@ -402,5 +402,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-cartographer/index.html
+++ b/ru/chronicle/the-cartographer/index.html
@@ -343,5 +343,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-commander/index.html
+++ b/ru/chronicle/the-commander/index.html
@@ -357,5 +357,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-council-assembles/index.html
+++ b/ru/chronicle/the-council-assembles/index.html
@@ -435,5 +435,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-hierarchy-of-signals/index.html
+++ b/ru/chronicle/the-hierarchy-of-signals/index.html
@@ -436,5 +436,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-pilots-oath/index.html
+++ b/ru/chronicle/the-pilots-oath/index.html
@@ -379,5 +379,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-prophet/index.html
+++ b/ru/chronicle/the-prophet/index.html
@@ -362,5 +362,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-scales/index.html
+++ b/ru/chronicle/the-scales/index.html
@@ -354,5 +354,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/the-watchman/index.html
+++ b/ru/chronicle/the-watchman/index.html
@@ -402,5 +402,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/chronicle/why-non-repainting-matters/index.html
+++ b/ru/chronicle/why-non-repainting-matters/index.html
@@ -387,5 +387,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/faq.html
+++ b/ru/faq.html
@@ -1781,5 +1781,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/manage-subscription.html
+++ b/ru/manage-subscription.html
@@ -379,5 +379,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/privacy.html
+++ b/ru/privacy.html
@@ -443,5 +443,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/refund.html
+++ b/ru/refund.html
@@ -439,5 +439,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/roadmap.html
+++ b/ru/roadmap.html
@@ -1492,5 +1492,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/ru/terms.html
+++ b/ru/terms.html
@@ -132,5 +132,8 @@
   <script>
     (function(){const KEY='sp_theme';const btn=document.getElementById('themeToggle');const system=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';setTheme(localStorage.getItem(KEY)||system);btn?.addEventListener('click',()=>{const cur=document.documentElement.getAttribute('data-theme')==='light'?'light':'dark';setTheme(cur==='light'?'dark':'light');});function setTheme(t){document.documentElement.setAttribute('data-theme',t);localStorage.setItem(KEY,t);let m=document.querySelector('meta[name="theme-color"]');if(!m){m=document.createElement('meta');m.setAttribute('name','theme-color');document.head.appendChild(m);}m.setAttribute('content',t==='light'?'#f6f8fc':'#05070d');}})();document.getElementById('year').textContent=new Date().getFullYear();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/subprocessors.html
+++ b/subprocessors.html
@@ -100,5 +100,8 @@
     </div>
   </footer>
   <script>document.getElementById('y').textContent = new Date().getFullYear();</script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -616,5 +616,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/thanks.html
+++ b/thanks.html
@@ -127,5 +127,8 @@
       document.getElementById('defaultRow').hidden = true;
     }
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tools/index.html
+++ b/tools/index.html
@@ -1960,5 +1960,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tools/quiz/index.html
+++ b/tools/quiz/index.html
@@ -957,5 +957,8 @@
     // Initialize
     renderQuestion();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/affiliates.html
+++ b/tr/affiliates.html
@@ -1372,5 +1372,8 @@
       updateCalculator();
     })();
   </script>
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/birth-of-the-elite-seven/index.html
+++ b/tr/chronicle/birth-of-the-elite-seven/index.html
@@ -314,5 +314,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/index.html
+++ b/tr/chronicle/index.html
@@ -1360,5 +1360,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/meet-the-sovereign/index.html
+++ b/tr/chronicle/meet-the-sovereign/index.html
@@ -335,5 +335,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-arbiter/index.html
+++ b/tr/chronicle/the-arbiter/index.html
@@ -401,5 +401,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-cartographer/index.html
+++ b/tr/chronicle/the-cartographer/index.html
@@ -342,5 +342,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-commander/index.html
+++ b/tr/chronicle/the-commander/index.html
@@ -357,5 +357,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-council-assembles/index.html
+++ b/tr/chronicle/the-council-assembles/index.html
@@ -434,5 +434,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-hierarchy-of-signals/index.html
+++ b/tr/chronicle/the-hierarchy-of-signals/index.html
@@ -365,5 +365,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-pilots-oath/index.html
+++ b/tr/chronicle/the-pilots-oath/index.html
@@ -325,5 +325,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-prophet/index.html
+++ b/tr/chronicle/the-prophet/index.html
@@ -328,5 +328,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-scales/index.html
+++ b/tr/chronicle/the-scales/index.html
@@ -353,5 +353,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/the-watchman/index.html
+++ b/tr/chronicle/the-watchman/index.html
@@ -401,5 +401,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/chronicle/why-non-repainting-matters/index.html
+++ b/tr/chronicle/why-non-repainting-matters/index.html
@@ -331,5 +331,8 @@
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>
 <script src="/assets/lenis.js"></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/faq.html
+++ b/tr/faq.html
@@ -1481,5 +1481,8 @@
   <!-- Scroll Reveal Animations -->
   <script src="/assets/scroll-reveal.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/manage-subscription.html
+++ b/tr/manage-subscription.html
@@ -378,5 +378,8 @@
     </div>
   </footer>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -441,5 +441,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/refund.html
+++ b/tr/refund.html
@@ -440,5 +440,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/roadmap.html
+++ b/tr/roadmap.html
@@ -1225,5 +1225,8 @@
   <!-- AI Chatbot -->
   <script src="/assets/chatbot.js" defer></script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>

--- a/tr/terms.html
+++ b/tr/terms.html
@@ -557,5 +557,8 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
+<!-- Cookie Consent System -->
+<script src="/assets/cookie-consent.js" defer></script>
+
 </body>
 </html>


### PR DESCRIPTION
Add the cookie-consent.js script to 247 HTML pages that were missing it, ensuring the GA4 property (G-3RCZ0JBB0V) is properly loaded with consent management across all pages on the site.

This fixes the "Not tagged" warnings in Google Tag Manager coverage report by ensuring all pages load the consent-managed analytics tag.