### PR TITLE
Make badge static on mobile devices

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -2622,6 +2622,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;

--- a/de/index.html
+++ b/de/index.html
@@ -2571,6 +2571,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;

--- a/es/index.html
+++ b/es/index.html
@@ -2785,6 +2785,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;

--- a/fr/index.html
+++ b/fr/index.html
@@ -1169,6 +1169,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;
@@ -1978,6 +1984,12 @@
       50% {
         box-shadow: 0 0 16px rgba(251,191,36,0.6), 0 0 32px rgba(91,138,255,0.4);
         border-color: rgba(251,191,36,0.7);
+      }
+    }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
       }
     }
     .founding-counter {

--- a/hu/index.html
+++ b/hu/index.html
@@ -2636,6 +2636,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;

--- a/index.html
+++ b/index.html
@@ -1711,15 +1711,9 @@
       height: 12px;
       flex-shrink: 0;
     }
-    /* Safari mobile: Slow down animation */
+    /* Mobile: Static gold gradient (no animation) */
     @media (max-width: 768px) {
       .founding-badge {
-        animation-duration: 8s;
-      }
-    }
-    /* Chrome mobile: Static gold gradient (no animation) */
-    @media (max-width: 768px) {
-      html.is-chrome .founding-badge {
         animation: none !important;
         background: linear-gradient(rgba(15,12,8,0.95), rgba(15,12,8,0.95)) padding-box,
                     linear-gradient(135deg, #92400e 0%, #fbbf24 50%, #92400e 100%) border-box !important;

--- a/it/index.html
+++ b/it/index.html
@@ -2587,6 +2587,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;

--- a/ja/index.html
+++ b/ja/index.html
@@ -2839,6 +2839,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;

--- a/nl/index.html
+++ b/nl/index.html
@@ -2636,6 +2636,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;

--- a/pt/index.html
+++ b/pt/index.html
@@ -2683,6 +2683,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;

--- a/ru/index.html
+++ b/ru/index.html
@@ -1128,6 +1128,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;
@@ -1910,6 +1916,12 @@
       50% {
         box-shadow: 0 0 16px rgba(251,191,36,0.6), 0 0 32px rgba(91,138,255,0.4);
         border-color: rgba(251,191,36,0.7);
+      }
+    }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
       }
     }
     .founding-counter {

--- a/tr/index.html
+++ b/tr/index.html
@@ -1174,6 +1174,12 @@
         border-color: rgba(251,191,36,0.7);
       }
     }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
+      }
+    }
     .founding-counter {
       display: flex;
       align-items: center;
@@ -2001,6 +2007,12 @@
       50% {
         box-shadow: 0 0 16px rgba(251,191,36,0.6), 0 0 32px rgba(91,138,255,0.4);
         border-color: rgba(251,191,36,0.7);
+      }
+    }
+    /* Mobile: Static badge (no animation) */
+    @media (max-width: 768px) {
+      .founding-badge {
+        animation: none !important;
       }
     }
     .founding-counter {


### PR DESCRIPTION
Disable animation for .founding-badge on screens <= 768px to improve performance and reduce visual noise on mobile devices.