### PR TITLE
Fix slider image paths for ru, tr, pt

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -4897,11 +4897,11 @@
           <div id="hero-slider-container" style="position:relative;max-width:900px;margin:0 auto;border-radius:12px;overflow:hidden;cursor:ew-resize;user-select:none;-webkit-user-select:none;aspect-ratio:16/9;background:#0a0e18" role="slider" aria-label="Slider de comparação de imagem" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0">
 
             <!-- After Image (Bottom Layer) -->
-            <img src="/assets/images/comparison-slider/after.webp" alt="Gráfico com indicadores Signal Pilot" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
+            <img src="/assets/showcase/chart-with.jpg" alt="Gráfico com indicadores Signal Pilot" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
 
             <!-- Before Image (Top Layer - Clipped) -->
             <div id="hero-before-container" style="position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden">
-              <img src="/assets/images/comparison-slider/before.webp" alt="Gráfico sem indicadores" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
+              <img src="/assets/showcase/chart-without.jpg" alt="Gráfico sem indicadores" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
             </div>
 
             <!-- Slider Handle -->

--- a/ru/index.html
+++ b/ru/index.html
@@ -4712,11 +4712,11 @@
           <div id="hero-slider-container" style="position:relative;max-width:900px;margin:0 auto;border-radius:12px;overflow:hidden;cursor:ew-resize;user-select:none;-webkit-user-select:none;aspect-ratio:16/9;background:#0a0e18" role="slider" aria-label="Слайдер сравнения изображений" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0">
 
             <!-- After Image (Bottom Layer) -->
-            <img src="/assets/images/comparison-slider/after.webp" alt="График с индикаторами Signal Pilot" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
+            <img src="/assets/showcase/chart-with.jpg" alt="График с индикаторами Signal Pilot" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
 
             <!-- Before Image (Top Layer - Clipped) -->
             <div id="hero-before-container" style="position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden">
-              <img src="/assets/images/comparison-slider/before.webp" alt="График без индикаторов" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
+              <img src="/assets/showcase/chart-without.jpg" alt="График без индикаторов" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
             </div>
 
             <!-- Slider Handle -->

--- a/tr/index.html
+++ b/tr/index.html
@@ -4786,11 +4786,11 @@
           <div id="hero-slider-container" style="position:relative;max-width:900px;margin:0 auto;border-radius:12px;overflow:hidden;cursor:ew-resize;user-select:none;-webkit-user-select:none;aspect-ratio:16/9;background:#0a0e18" role="slider" aria-label="Görsel karşılaştırma kaydırıcısı" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0">
 
             <!-- After Image (Bottom Layer) -->
-            <img src="/assets/images/comparison-slider/after.webp" alt="Signal Pilot göstergeleri ile grafik" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
+            <img src="/assets/showcase/chart-with.jpg" alt="Signal Pilot göstergeleri ile grafik" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
 
             <!-- Before Image (Top Layer - Clipped) -->
             <div id="hero-before-container" style="position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden">
-              <img src="/assets/images/comparison-slider/before.webp" alt="Göstergeler olmadan grafik" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
+              <img src="/assets/showcase/chart-without.jpg" alt="Göstergeler olmadan grafik" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none;display:block" loading="eager" fetchpriority="high">
             </div>
 
             <!-- Slider Handle -->


### PR DESCRIPTION
Changed from non-existent /assets/images/comparison-slider/*.webp to correct /assets/showcase/chart-with.jpg and chart-without.jpg