### PR TITLE
Fix server errors on international pages

### DIFF
--- a/ar/chronicle/birth-of-the-elite-seven/index.html
+++ b/ar/chronicle/birth-of-the-elite-seven/index.html
@@ -825,7 +825,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -857,7 +857,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -871,7 +871,7 @@
 
   <!-- Article Header -->
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">قصة الأصل</span>
     <h1>ولادة النخبة السبعة</h1>
     <p class="article-subtitle">قبل أن تحمل الأسواق أسماءً، قبل أن تروي الشموع قصصاً، لم يكن هناك سوى الضوضاء.</p>
@@ -1042,13 +1042,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D9%88%D9%84%D8%A7%D8%AF%D8%A9%20%D8%A7%D9%84%D9%86%D8%AE%D8%A8%D8%A9%20%D8%A7%D9%84%D8%B3%D8%A8%D8%B9%D8%A9&url=https://signalpilot.io/ar/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D9%88%D9%84%D8%A7%D8%AF%D8%A9%20%D8%A7%D9%84%D9%86%D8%AE%D8%A8%D8%A9%20%D8%A7%D9%84%D8%B3%D8%A8%D8%B9%D8%A9&url=https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/birth-of-the-elite-seven')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/birth-of-the-elite-seven/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -1059,11 +1059,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/the-pilots-oath" class="related-card">
+        <a href="/ar/chronicle/the-pilots-oath/" class="related-card">
           <h4>قسم الطيار</h4>
           <p>أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار. هذا هو القسم.</p>
         </a>
-        <a href="/ar/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ar/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>التسلسل الهرمي للإشارات</h4>
           <p>كيف يعمل السبعة معاً ككوكبة—كل واحد يخدم غرضاً في النظام.</p>
         </a>
@@ -1074,7 +1074,7 @@
   <!-- Footer -->
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/index.html
+++ b/ar/chronicle/index.html
@@ -822,7 +822,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -852,7 +852,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">الموارد <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/ar/chronicle/" class="active">السجل</a></li>
+          <li><a href="/ar/chronicle//" class="active">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>

--- a/ar/chronicle/meet-the-sovereign/index.html
+++ b/ar/chronicle/meet-the-sovereign/index.html
@@ -179,7 +179,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -211,7 +211,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -224,7 +224,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">نظرة معمقة في المؤشر</span>
     <h1>تعرف على الحاكم: شرح Pentarch</h1>
     <p class="article-subtitle">"أنا الدورة. الدورة هي أنا."</p>
@@ -385,9 +385,9 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%AA%D8%B9%D8%B1%D9%81%20%D8%B9%D9%84%D9%89%20%D8%A7%D9%84%D8%AD%D8%A7%D9%83%D9%85&url=https://signalpilot.io/ar/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 نشر</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/meet-the-sovereign')" class="share-btn">نسخ الرابط</button>
+      <a href="https://twitter.com/intent/tweet?text=%D8%AA%D8%B9%D8%B1%D9%81%20%D8%B9%D9%84%D9%89%20%D8%A7%D9%84%D8%AD%D8%A7%D9%83%D9%85&url=https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 نشر</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/meet-the-sovereign/')" class="share-btn">نسخ الرابط</button>
     </div>
   </div>
 
@@ -395,11 +395,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ar/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>ولادة النخبة السبعة</h4>
           <p>قصة أصل سبع إشارات سماوية ظهرت لتبحر في الفراغ.</p>
         </a>
-        <a href="/ar/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ar/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>التسلسل الهرمي للإشارات</h4>
           <p>كيف يعمل السبعة معاً ككوكبة—كل واحد يخدم غرضاً في النظام.</p>
         </a>
@@ -409,7 +409,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-arbiter/index.html
+++ b/ar/chronicle/the-arbiter/index.html
@@ -835,7 +835,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -867,7 +867,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -880,7 +880,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">السابع من سبعة</span>
     <h1>الحَكَم: Harmonic Oscillator</h1>
     <p class="article-subtitle">"أربعة أصوات. حكم واحد. أنا أقرر متى يُضغط الزناد."</p>
@@ -1055,13 +1055,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D8%AD%D9%8E%D9%83%D9%8E%D9%85%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/ar/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D8%AD%D9%8E%D9%83%D9%8E%D9%85%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/ar/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-arbiter')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-arbiter/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -1071,11 +1071,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/the-watchman" class="related-card">
+        <a href="/ar/chronicle/the-watchman/" class="related-card">
           <h4>الحارس: Augury Grid</h4>
           <p>بينما تراقب رسماً بيانياً واحداً، أنا أراقبها كلها.</p>
         </a>
-        <a href="/ar/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ar/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>التسلسل الهرمي للإشارات</h4>
           <p>كيف تعمل النخبة السبعة معاً كنظام موحد.</p>
         </a>
@@ -1085,7 +1085,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-cartographer/index.html
+++ b/ar/chronicle/the-cartographer/index.html
@@ -747,7 +747,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -779,7 +779,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -792,7 +792,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">الثالث من سبعة</span>
     <h1>رسام الخرائط: Janus Atlas</h1>
     <p class="article-subtitle">"لكل ساحة معركة تضاريسها. أنا أرسم خريطة أين ستُخاض الحروب."</p>
@@ -924,13 +924,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%B1%D8%B3%D8%A7%D9%85%20%D8%A7%D9%84%D8%AE%D8%B1%D8%A7%D8%A6%D8%B7%3A%20Janus%20Atlas&url=https://signalpilot.io/ar/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D8%B1%D8%B3%D8%A7%D9%85%20%D8%A7%D9%84%D8%AE%D8%B1%D8%A7%D8%A6%D8%B7%3A%20Janus%20Atlas&url=https://www.signalpilot.io/ar/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-cartographer')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-cartographer/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -940,11 +940,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/the-prophet" class="related-card">
+        <a href="/ar/chronicle/the-prophet/" class="related-card">
           <h4>النبي: Volume Oracle</h4>
           <p>أسمع ما لا يستطيع المتداولون العاديون سماعه. أرى العمالقة يتحركون في الظلام.</p>
         </a>
-        <a href="/ar/chronicle/the-scales" class="related-card">
+        <a href="/ar/chronicle/the-scales/" class="related-card">
           <h4>الميزان: Plutus Flow</h4>
           <p>أزن ما لا يُرى. الضغط لا يكذب.</p>
         </a>
@@ -954,7 +954,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-commander/index.html
+++ b/ar/chronicle/the-commander/index.html
@@ -746,7 +746,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -778,7 +778,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -791,7 +791,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">الخامس من سبعة</span>
     <h1>القائد: OmniDeck</h1>
     <p class="article-subtitle">"عشرة أنظمة. رؤية واحدة. وضوح تام."</p>
@@ -937,13 +937,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D9%82%D8%A7%D8%A6%D8%AF%3A%20OmniDeck&url=https://signalpilot.io/ar/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D9%82%D8%A7%D8%A6%D8%AF%3A%20OmniDeck&url=https://www.signalpilot.io/ar/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-commander')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-commander/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -953,11 +953,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/the-scales" class="related-card">
+        <a href="/ar/chronicle/the-scales/" class="related-card">
           <h4>الميزان: Plutus Flow</h4>
           <p>أزن ما لا يُرى. الضغط لا يكذب.</p>
         </a>
-        <a href="/ar/chronicle/the-watchman" class="related-card">
+        <a href="/ar/chronicle/the-watchman/" class="related-card">
           <h4>الحارس: Augury Grid</h4>
           <p>بينما تراقب رسماً بيانياً واحداً، أنا أراقبها كلها.</p>
         </a>
@@ -967,7 +967,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-council-assembles/index.html
+++ b/ar/chronicle/the-council-assembles/index.html
@@ -818,7 +818,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -850,7 +850,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -863,7 +863,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">الختام</span>
     <h1>المجلس يجتمع</h1>
     <p class="article-subtitle">"قابلت كل عضو. الآن شاهدهم يعملون كواحد."</p>
@@ -1074,13 +1074,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D9%85%D8%AC%D9%84%D8%B3%20%D9%8A%D8%AC%D8%AA%D9%85%D8%B9&url=https://signalpilot.io/ar/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D9%85%D8%AC%D9%84%D8%B3%20%D9%8A%D8%AC%D8%AA%D9%85%D8%B9&url=https://www.signalpilot.io/ar/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-council-assembles')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-council-assembles/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -1090,11 +1090,11 @@
     <div class="container">
       <h3>ابدأ من البداية</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ar/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>ولادة النخبة السبعة</h4>
           <p>حيث بدأ كل شيء. قصة الأصل.</p>
         </a>
-        <a href="/ar/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ar/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>التسلسل الهرمي للإشارات</h4>
           <p>كيف يشكل السبعة كوكبة من الغرض.</p>
         </a>
@@ -1104,7 +1104,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-hierarchy-of-signals/index.html
+++ b/ar/chronicle/the-hierarchy-of-signals/index.html
@@ -853,7 +853,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -885,7 +885,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -898,7 +898,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">هندسة النظام</span>
     <h1>التسلسل الهرمي للإشارات</h1>
     <p class="article-subtitle">كيف يعمل السبعة معاً ككوكبة—كل واحد يخدم غرضاً في النظام الموحد.</p>
@@ -1113,13 +1113,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D8%AA%D8%B3%D9%84%D8%B3%D9%84%20%D8%A7%D9%84%D9%87%D8%B1%D9%85%D9%8A%20%D9%84%D9%84%D8%A5%D8%B4%D8%A7%D8%B1%D8%A7%D8%AA&url=https://signalpilot.io/ar/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D8%AA%D8%B3%D9%84%D8%B3%D9%84%20%D8%A7%D9%84%D9%87%D8%B1%D9%85%D9%8A%20%D9%84%D9%84%D8%A5%D8%B4%D8%A7%D8%B1%D8%A7%D8%AA&url=https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-hierarchy-of-signals')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-hierarchy-of-signals/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -1129,11 +1129,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ar/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>ولادة النخبة السبعة</h4>
           <p>قصة أصل سبع إشارات سماوية ظهرت لتبحر في الفراغ.</p>
         </a>
-        <a href="/ar/chronicle/the-pilots-oath" class="related-card">
+        <a href="/ar/chronicle/the-pilots-oath/" class="related-card">
           <h4>قسم الطيار</h4>
           <p>أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار. هذا هو القسم.</p>
         </a>
@@ -1143,7 +1143,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-pilots-oath/index.html
+++ b/ar/chronicle/the-pilots-oath/index.html
@@ -800,7 +800,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -832,7 +832,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -846,7 +846,7 @@
 
   <!-- Article Header -->
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">الفلسفة</span>
     <h1>قسم الطيار</h1>
     <p class="article-subtitle">أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار.</p>
@@ -1016,13 +1016,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D9%82%D8%B3%D9%85%20%D8%A7%D9%84%D8%B7%D9%8A%D8%A7%D8%B1&url=https://signalpilot.io/ar/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D9%82%D8%B3%D9%85%20%D8%A7%D9%84%D8%B7%D9%8A%D8%A7%D8%B1&url=https://www.signalpilot.io/ar/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-pilots-oath')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-pilots-oath/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -1033,11 +1033,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ar/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>ولادة النخبة السبعة</h4>
           <p>قصة أصل سبع إشارات سماوية ظهرت لتبحر في الفراغ.</p>
         </a>
-        <a href="/ar/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ar/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>التسلسل الهرمي للإشارات</h4>
           <p>كيف يعمل السبعة معاً ككوكبة—كل واحد يخدم غرضاً في النظام.</p>
         </a>
@@ -1048,7 +1048,7 @@
   <!-- Footer -->
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-prophet/index.html
+++ b/ar/chronicle/the-prophet/index.html
@@ -329,7 +329,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -361,7 +361,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -374,7 +374,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">الثاني من سبعة</span>
     <h1>النبي: Volume Oracle</h1>
     <p class="article-subtitle">"أسمع ما لا يستطيع المتداولون العاديون سماعه. أرى العمالقة يتحركون في الظلام."</p>
@@ -511,9 +511,9 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D9%86%D8%A8%D9%8A%3A%20Volume%20Oracle&url=https://signalpilot.io/ar/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 نشر</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-prophet')" class="share-btn">نسخ الرابط</button>
+      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D9%86%D8%A8%D9%8A%3A%20Volume%20Oracle&url=https://www.signalpilot.io/ar/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 نشر</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-prophet/')" class="share-btn">نسخ الرابط</button>
     </div>
   </div>
 
@@ -521,11 +521,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/ar/chronicle/meet-the-sovereign/" class="related-card">
           <h4>تعرف على الحاكم: Pentarch</h4>
           <p>المؤشر الرئيسي الذي يرسم المراحل الخمس لدورات السوق.</p>
         </a>
-        <a href="/ar/chronicle/the-cartographer" class="related-card">
+        <a href="/ar/chronicle/the-cartographer/" class="related-card">
           <h4>رسام الخرائط: Janus Atlas</h4>
           <p>لكل ساحة معركة تضاريسها. Janus Atlas يرسم أين ستُخاض الحروب.</p>
         </a>
@@ -535,7 +535,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-scales/index.html
+++ b/ar/chronicle/the-scales/index.html
@@ -794,7 +794,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -826,7 +826,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -839,7 +839,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">الرابع من سبعة</span>
     <h1>الميزان: Plutus Flow</h1>
     <p class="article-subtitle">"أزن ما لا يُرى. الضغط لا يكذب."</p>
@@ -974,13 +974,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D9%85%D9%8A%D8%B2%D8%A7%D9%86%3A%20Plutus%20Flow&url=https://signalpilot.io/ar/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D9%85%D9%8A%D8%B2%D8%A7%D9%86%3A%20Plutus%20Flow&url=https://www.signalpilot.io/ar/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-scales')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-scales/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -990,11 +990,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/the-cartographer" class="related-card">
+        <a href="/ar/chronicle/the-cartographer/" class="related-card">
           <h4>رسام الخرائط: Janus Atlas</h4>
           <p>لكل ساحة معركة تضاريسها. أنا أرسم خريطة أين ستُخاض الحروب.</p>
         </a>
-        <a href="/ar/chronicle/the-commander" class="related-card">
+        <a href="/ar/chronicle/the-commander/" class="related-card">
           <h4>القائد: OmniDeck</h4>
           <p>عشرة أنظمة. رؤية واحدة. وضوح تام.</p>
         </a>
@@ -1004,7 +1004,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/the-watchman/index.html
+++ b/ar/chronicle/the-watchman/index.html
@@ -814,7 +814,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -846,7 +846,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -859,7 +859,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">السادس من سبعة</span>
     <h1>الحارس: Augury Grid</h1>
     <p class="article-subtitle">"بينما تراقب رسماً بيانياً واحداً، أنا أراقبها كلها."</p>
@@ -1035,13 +1035,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D8%AD%D8%A7%D8%B1%D8%B3%3A%20Augury%20Grid&url=https://signalpilot.io/ar/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D8%A7%D9%84%D8%AD%D8%A7%D8%B1%D8%B3%3A%20Augury%20Grid&url=https://www.signalpilot.io/ar/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/the-watchman')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/the-watchman/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -1051,11 +1051,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/the-commander" class="related-card">
+        <a href="/ar/chronicle/the-commander/" class="related-card">
           <h4>القائد: OmniDeck</h4>
           <p>عشرة أنظمة. رؤية واحدة. وضوح تام.</p>
         </a>
-        <a href="/ar/chronicle/the-arbiter" class="related-card">
+        <a href="/ar/chronicle/the-arbiter/" class="related-card">
           <h4>الحَكَم: Harmonic Oscillator</h4>
           <p>أربعة أصوات. حكم واحد. أنا أقرر متى يُضغط الزناد.</p>
         </a>
@@ -1065,7 +1065,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/chronicle/why-non-repainting-matters/index.html
+++ b/ar/chronicle/why-non-repainting-matters/index.html
@@ -832,7 +832,7 @@
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+              <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="/tools/">أدوات</a></li>
@@ -864,7 +864,7 @@
           الموارد <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ar/chronicle/" style="color: var(--accent);">السجل</a></li>
+          <li><a href="/ar/chronicle//" style="color: var(--accent);">السجل</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">التوثيق</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">المدونة</a></li>
           <li><a href="/tools/">أدوات</a></li>
@@ -877,7 +877,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ar/chronicle/" class="back-link">العودة إلى السجل ←</a>
+    <a href="/ar/chronicle//" class="back-link">العودة إلى السجل ←</a>
     <span class="article-category">الثقة والتحقق</span>
     <h1>لماذا عدم إعادة الرسم مهم</h1>
     <p class="article-subtitle">معظم المؤشرات تكذب عليك بتغيير إشاراتها التاريخية. إليك لماذا هذا غير مقبول.</p>
@@ -1040,13 +1040,13 @@
   <div class="share-section">
     <h4>شارك هذا المقال</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D9%84%D9%85%D8%A7%D8%B0%D8%A7%20%D8%B9%D8%AF%D9%85%20%D8%A5%D8%B9%D8%A7%D8%AF%D8%A9%20%D8%A7%D9%84%D8%B1%D8%B3%D9%85%20%D9%85%D9%87%D9%85&url=https://signalpilot.io/ar/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=%D9%84%D9%85%D8%A7%D8%B0%D8%A7%20%D8%B9%D8%AF%D9%85%20%D8%A5%D8%B9%D8%A7%D8%AF%D8%A9%20%D8%A7%D9%84%D8%B1%D8%B3%D9%85%20%D9%85%D9%87%D9%85&url=https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         𝕏 نشر
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ar/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ar/chronicle/why-non-repainting-matters')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ar/chronicle/why-non-repainting-matters/')" class="share-btn">
         نسخ الرابط
       </button>
     </div>
@@ -1056,11 +1056,11 @@
     <div class="container">
       <h3>تابع القراءة</h3>
       <div class="related-grid">
-        <a href="/ar/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/ar/chronicle/meet-the-sovereign/" class="related-card">
           <h4>تعرف على الحاكم: شرح Pentarch</h4>
           <p>نظرة عميقة في المؤشر الرئيسي الذي يرسم المراحل الخمس لدورات السوق.</p>
         </a>
-        <a href="/ar/chronicle/the-pilots-oath" class="related-card">
+        <a href="/ar/chronicle/the-pilots-oath/" class="related-card">
           <h4>قسم الطيار</h4>
           <p>أنت الذي تمتلك النخبة السبعة لست متداولاً. أنت طيار. هذا هو القسم.</p>
         </a>
@@ -1070,7 +1070,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle/">جميع السجلات</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. جميع الحقوق محفوظة. | <a href="/ar/">الرئيسية</a> · <a href="/ar/chronicle//">جميع السجلات</a></p>
     </div>
   </footer>
 

--- a/ar/index.html
+++ b/ar/index.html
@@ -4568,7 +4568,7 @@ html[lang="ar"] [style*="text-align:center"] {
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">مجتمع Discord</a></li>
-              <li><a href="/ar/chronicle/">السجل</a></li>
+              <li><a href="/ar/chronicle//">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">الوثائق</a></li>
               <li><a href="https://blog.signalpilot.io/ar/" target="_blank" rel="noopener">المدونة</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">الآلات الحاسبة</a></li>
@@ -6069,7 +6069,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
         <!-- Explore All CTA -->
         <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-          <a href="/ar/chronicle/" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
+          <a href="/ar/chronicle//" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
             <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">استكشف جميع السجلات الـ 12</span>
           </a>
@@ -6801,7 +6801,7 @@ html[lang="ar"] [style*="text-align:center"] {
           <div class="mobile-nav-section-label">المنتج</div>
           <a href="#inside">ما بالداخل</a>
           <a href="#pricing">الأسعار</a>
-          <a href="/ar/chronicle/">السجل</a>
+          <a href="/ar/chronicle//">السجل</a>
           <a href="/tools/">أدوات</a>
         </div>
 

--- a/chronicle/birth-of-the-elite-seven/index.html
+++ b/chronicle/birth-of-the-elite-seven/index.html
@@ -843,7 +843,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -876,7 +876,7 @@
           Resources <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+          <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -891,7 +891,7 @@
 
   <!-- Article Header -->
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Origin Story</span>
     <h1>The Birth of The Elite Seven</h1>
     <p class="article-subtitle">Before the markets had names, before the candles told stories, there was only noise.</p>
@@ -1061,13 +1061,13 @@
   <div class="share-section">
     <h4>Share this transmission</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Birth%20of%20The%20Elite%20Seven&url=https://signalpilot.io/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=The%20Birth%20of%20The%20Elite%20Seven&url=https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/birth-of-the-elite-seven')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/birth-of-the-elite-seven/')" class="share-btn">
         Copy Link
       </button>
     </div>
@@ -1078,11 +1078,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/the-pilots-oath" class="related-card">
+        <a href="/chronicle/the-pilots-oath/" class="related-card">
           <h4>The Pilot's Oath</h4>
           <p>You who wield The Elite Seven are not a trader. You are a Pilot. This is the oath.</p>
         </a>
-        <a href="/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>The Hierarchy of Signals</h4>
           <p>How the seven work together as a constellation—each serving a purpose in the system.</p>
         </a>
@@ -1093,7 +1093,7 @@
   <!-- Footer -->
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/index.html
+++ b/chronicle/index.html
@@ -993,7 +993,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -1024,7 +1024,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Resources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/chronicle/" class="active">Chronicle</a></li>
+          <li><a href="/chronicle//" class="active">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -1055,7 +1055,7 @@
       <div class="articles-grid">
 
         <!-- Featured Article -->
-        <a href="/chronicle/birth-of-the-elite-seven" class="article-card featured-article cat-origin">
+        <a href="/chronicle/birth-of-the-elite-seven/" class="article-card featured-article cat-origin">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/elite-seven-council.png')"></div>
           </div>
@@ -1075,7 +1075,7 @@
         </a>
 
         <!-- Article 2 -->
-        <a href="/chronicle/the-pilots-oath" class="article-card cat-philosophy">
+        <a href="/chronicle/the-pilots-oath/" class="article-card cat-philosophy">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/pilots-oath.png')"></div>
           </div>
@@ -1094,7 +1094,7 @@
         </a>
 
         <!-- Article 3 -->
-        <a href="/chronicle/the-hierarchy-of-signals" class="article-card cat-system">
+        <a href="/chronicle/the-hierarchy-of-signals/" class="article-card cat-system">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/hierarchy-of-signals.png')"></div>
           </div>
@@ -1113,7 +1113,7 @@
         </a>
 
         <!-- Article 4: Meet The Sovereign -->
-        <a href="/chronicle/meet-the-sovereign" class="article-card cat-one">
+        <a href="/chronicle/meet-the-sovereign/" class="article-card cat-one">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/sovereign-pentarch.png')"></div>
           </div>
@@ -1132,7 +1132,7 @@
         </a>
 
         <!-- Article 5: The Prophet -->
-        <a href="/chronicle/the-prophet" class="article-card cat-two">
+        <a href="/chronicle/the-prophet/" class="article-card cat-two">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/prophet-volume-oracle.png')"></div>
           </div>
@@ -1151,7 +1151,7 @@
         </a>
 
         <!-- Article 6: The Cartographer -->
-        <a href="/chronicle/the-cartographer" class="article-card cat-three">
+        <a href="/chronicle/the-cartographer/" class="article-card cat-three">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/cartographer-janus-atlas.png')"></div>
           </div>
@@ -1170,7 +1170,7 @@
         </a>
 
         <!-- Article 7: The Scales -->
-        <a href="/chronicle/the-scales" class="article-card cat-four">
+        <a href="/chronicle/the-scales/" class="article-card cat-four">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/scales-plutus-flow.png')"></div>
           </div>
@@ -1189,7 +1189,7 @@
         </a>
 
         <!-- Article 8: The Commander -->
-        <a href="/chronicle/the-commander" class="article-card cat-five">
+        <a href="/chronicle/the-commander/" class="article-card cat-five">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/commander-omnideck.png')"></div>
           </div>
@@ -1208,7 +1208,7 @@
         </a>
 
         <!-- Article 9: The Watchman -->
-        <a href="/chronicle/the-watchman" class="article-card cat-six">
+        <a href="/chronicle/the-watchman/" class="article-card cat-six">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/watchman-augury-grid.png')"></div>
           </div>
@@ -1227,7 +1227,7 @@
         </a>
 
         <!-- Article 10: The Arbiter -->
-        <a href="/chronicle/the-arbiter" class="article-card cat-seven">
+        <a href="/chronicle/the-arbiter/" class="article-card cat-seven">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/arbiter-harmonic-oscillator.png')"></div>
           </div>
@@ -1246,7 +1246,7 @@
         </a>
 
         <!-- Article 11: The Council Assembles -->
-        <a href="/chronicle/the-council-assembles" class="article-card cat-finale">
+        <a href="/chronicle/the-council-assembles/" class="article-card cat-finale">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/council-assembles.png')"></div>
           </div>
@@ -1265,7 +1265,7 @@
         </a>
 
         <!-- Article 12: Why Non-Repainting Matters -->
-        <a href="/chronicle/why-non-repainting-matters" class="article-card cat-trust">
+        <a href="/chronicle/why-non-repainting-matters/" class="article-card cat-trust">
           <div class="article-image">
             <div class="article-image-inner" style="background-image:url('/chronicle/non-repainting-matters.png')"></div>
           </div>
@@ -1301,10 +1301,10 @@
         <div class="footer-section">
           <h4>Chronicle</h4>
           <ul>
-            <li><a href="/chronicle/birth-of-the-elite-seven">Origin Story</a></li>
-            <li><a href="/chronicle/the-pilots-oath">The Pilot's Oath</a></li>
-            <li><a href="/chronicle/the-hierarchy-of-signals">Signal Hierarchy</a></li>
-            <li><a href="/chronicle/the-council-assembles">The Council</a></li>
+            <li><a href="/chronicle/birth-of-the-elite-seven/">Origin Story</a></li>
+            <li><a href="/chronicle/the-pilots-oath/">The Pilot's Oath</a></li>
+            <li><a href="/chronicle/the-hierarchy-of-signals/">Signal Hierarchy</a></li>
+            <li><a href="/chronicle/the-council-assembles/">The Council</a></li>
           </ul>
         </div>
         <div class="footer-section">

--- a/chronicle/meet-the-sovereign/index.html
+++ b/chronicle/meet-the-sovereign/index.html
@@ -805,7 +805,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -838,7 +838,7 @@
           Resources <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+          <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -852,7 +852,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Indicator Deep-Dive</span>
     <h1>Meet The Sovereign: Pentarch Explained</h1>
     <p class="article-subtitle">"I am the cycle. The cycle is me."</p>
@@ -1015,13 +1015,13 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Meet%20The%20Sovereign%3A%20Pentarch%20Explained&url=https://signalpilot.io/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Meet%20The%20Sovereign%3A%20Pentarch%20Explained&url=https://www.signalpilot.io/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/meet-the-sovereign')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/meet-the-sovereign/')" class="share-btn">
         Copy Link
       </button>
     </div>
@@ -1031,11 +1031,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>The Birth of The Elite Seven</h4>
           <p>The origin story of seven celestial signals that emerged to navigate the void.</p>
         </a>
-        <a href="/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>The Hierarchy of Signals</h4>
           <p>How the seven work together as a constellation—each serving a purpose in the system.</p>
         </a>
@@ -1045,7 +1045,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-arbiter/index.html
+++ b/chronicle/the-arbiter/index.html
@@ -178,7 +178,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -211,7 +211,7 @@
           Resources <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+          <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -225,7 +225,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Seven of Seven</span>
     <h1>The Arbiter: Harmonic Oscillator</h1>
     <p class="article-subtitle">"Seven voices. One verdict. I decide when the trigger is pulled."</p>
@@ -398,9 +398,9 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Arbiter%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-arbiter')" class="share-btn">Copy Link</button>
+      <a href="https://twitter.com/intent/tweet?text=The%20Arbiter%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-arbiter/')" class="share-btn">Copy Link</button>
     </div>
   </div>
 
@@ -408,11 +408,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/the-watchman" class="related-card">
+        <a href="/chronicle/the-watchman/" class="related-card">
           <h4>The Watchman: Augury Grid</h4>
           <p>While you watch one chart, I watch them all.</p>
         </a>
-        <a href="/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>The Hierarchy of Signals</h4>
           <p>How The Elite Seven work together as a unified system.</p>
         </a>
@@ -422,7 +422,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-cartographer/index.html
+++ b/chronicle/the-cartographer/index.html
@@ -162,7 +162,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -195,7 +195,7 @@
           Resources <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+          <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -209,7 +209,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Three of Seven</span>
     <h1>The Cartographer: Janus Atlas</h1>
     <p class="article-subtitle">"Every battlefield has its terrain. I map where the wars will be fought."</p>
@@ -333,9 +333,9 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Cartographer%3A%20Janus%20Atlas&url=https://signalpilot.io/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-cartographer')" class="share-btn">Copy Link</button>
+      <a href="https://twitter.com/intent/tweet?text=The%20Cartographer%3A%20Janus%20Atlas&url=https://www.signalpilot.io/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-cartographer/')" class="share-btn">Copy Link</button>
     </div>
   </div>
 
@@ -343,11 +343,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/the-prophet" class="related-card">
+        <a href="/chronicle/the-prophet/" class="related-card">
           <h4>The Prophet: Volume Oracle</h4>
           <p>I hear what retail cannot. I see the giants move in darkness.</p>
         </a>
-        <a href="/chronicle/the-scales" class="related-card">
+        <a href="/chronicle/the-scales/" class="related-card">
           <h4>The Scales: Plutus Flow</h4>
           <p>I weigh the invisible. Pressure does not lie.</p>
         </a>
@@ -357,7 +357,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-commander/index.html
+++ b/chronicle/the-commander/index.html
@@ -162,7 +162,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -195,7 +195,7 @@
           Resources <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+          <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -209,7 +209,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Five of Seven</span>
     <h1>The Commander: OmniDeck</h1>
     <p class="article-subtitle">"Ten systems. One vision. Total clarity."</p>
@@ -347,9 +347,9 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Commander%3A%20OmniDeck&url=https://signalpilot.io/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-commander')" class="share-btn">Copy Link</button>
+      <a href="https://twitter.com/intent/tweet?text=The%20Commander%3A%20OmniDeck&url=https://www.signalpilot.io/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-commander/')" class="share-btn">Copy Link</button>
     </div>
   </div>
 
@@ -357,11 +357,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/the-scales" class="related-card">
+        <a href="/chronicle/the-scales/" class="related-card">
           <h4>The Scales: Plutus Flow</h4>
           <p>I weigh the invisible. Pressure does not lie.</p>
         </a>
-        <a href="/chronicle/the-watchman" class="related-card">
+        <a href="/chronicle/the-watchman/" class="related-card">
           <h4>The Watchman: Augury Grid</h4>
           <p>While you watch one chart, I watch them all.</p>
         </a>
@@ -371,7 +371,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-council-assembles/index.html
+++ b/chronicle/the-council-assembles/index.html
@@ -185,7 +185,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -216,7 +216,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Resources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/chronicle/" class="active">Chronicle</a></li>
+          <li><a href="/chronicle//" class="active">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -230,7 +230,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Finale</span>
     <h1>The Council Assembles</h1>
     <p class="article-subtitle">"You've met each member. Now watch them work as one."</p>
@@ -433,9 +433,9 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Council%20Assembles&url=https://signalpilot.io/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-council-assembles')" class="share-btn">Copy Link</button>
+      <a href="https://twitter.com/intent/tweet?text=The%20Council%20Assembles&url=https://www.signalpilot.io/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-council-assembles/')" class="share-btn">Copy Link</button>
     </div>
   </div>
 
@@ -443,11 +443,11 @@
     <div class="container">
       <h3>Start From The Beginning</h3>
       <div class="related-grid">
-        <a href="/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>The Birth of The Elite Seven</h4>
           <p>Where it all began. The origin story.</p>
         </a>
-        <a href="/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>The Hierarchy of Signals</h4>
           <p>How The Seven form a constellation of purpose.</p>
         </a>
@@ -457,7 +457,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-hierarchy-of-signals/index.html
+++ b/chronicle/the-hierarchy-of-signals/index.html
@@ -903,7 +903,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -934,7 +934,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Resources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/chronicle/" class="active">Chronicle</a></li>
+          <li><a href="/chronicle//" class="active">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -948,7 +948,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">System Architecture</span>
     <h1>The Hierarchy of Signals</h1>
     <p class="article-subtitle">How the seven work together as a constellation—each serving a purpose in the unified system.</p>
@@ -1163,13 +1163,13 @@
   <div class="share-section">
     <h4>Share this transmission</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Hierarchy%20of%20Signals&url=https://signalpilot.io/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=The%20Hierarchy%20of%20Signals&url=https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-hierarchy-of-signals')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-hierarchy-of-signals/')" class="share-btn">
         Copy Link
       </button>
     </div>
@@ -1179,11 +1179,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>The Birth of The Elite Seven</h4>
           <p>The origin story of seven celestial signals that emerged to navigate the void.</p>
         </a>
-        <a href="/chronicle/the-pilots-oath" class="related-card">
+        <a href="/chronicle/the-pilots-oath/" class="related-card">
           <h4>The Pilot's Oath</h4>
           <p>You who wield The Elite Seven are not a trader. You are a Pilot. This is the oath.</p>
         </a>
@@ -1193,7 +1193,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-pilots-oath/index.html
+++ b/chronicle/the-pilots-oath/index.html
@@ -851,7 +851,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -882,7 +882,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Resources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/chronicle/" class="active">Chronicle</a></li>
+          <li><a href="/chronicle//" class="active">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -897,7 +897,7 @@
 
   <!-- Article Header -->
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Philosophy</span>
     <h1>The Pilot's Oath</h1>
     <p class="article-subtitle">You who wield The Elite Seven are not a trader. You are a Pilot.</p>
@@ -1066,13 +1066,13 @@
   <div class="share-section">
     <h4>Share this transmission</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Pilot%27s%20Oath&url=https://signalpilot.io/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=The%20Pilot%27s%20Oath&url=https://www.signalpilot.io/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-pilots-oath')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-pilots-oath/')" class="share-btn">
         Copy Link
       </button>
     </div>
@@ -1083,11 +1083,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>The Birth of The Elite Seven</h4>
           <p>The origin story of seven celestial signals that emerged to navigate the void.</p>
         </a>
-        <a href="/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>The Hierarchy of Signals</h4>
           <p>How the seven work together as a constellation—each serving a purpose in the system.</p>
         </a>
@@ -1098,7 +1098,7 @@
   <!-- Footer -->
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-prophet/index.html
+++ b/chronicle/the-prophet/index.html
@@ -168,7 +168,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -201,7 +201,7 @@
           Resources <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+          <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -215,7 +215,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Two of Seven</span>
     <h1>The Prophet: Volume Oracle</h1>
     <p class="article-subtitle">"I hear what retail cannot. I see the giants move in darkness."</p>
@@ -352,9 +352,9 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Prophet%3A%20Volume%20Oracle&url=https://signalpilot.io/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-prophet')" class="share-btn">Copy Link</button>
+      <a href="https://twitter.com/intent/tweet?text=The%20Prophet%3A%20Volume%20Oracle&url=https://www.signalpilot.io/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-prophet/')" class="share-btn">Copy Link</button>
     </div>
   </div>
 
@@ -362,11 +362,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Meet The Sovereign: Pentarch</h4>
           <p>The flagship indicator that maps the five phases of market cycles.</p>
         </a>
-        <a href="/chronicle/the-cartographer" class="related-card">
+        <a href="/chronicle/the-cartographer/" class="related-card">
           <h4>The Cartographer: Janus Atlas</h4>
           <p>Every battlefield has its terrain. Janus Atlas maps where the wars will be fought.</p>
         </a>
@@ -376,7 +376,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-scales/index.html
+++ b/chronicle/the-scales/index.html
@@ -179,7 +179,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -210,7 +210,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Resources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/chronicle/" class="active">Chronicle</a></li>
+          <li><a href="/chronicle//" class="active">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -224,7 +224,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Four of Seven</span>
     <h1>The Scales: Plutus Flow</h1>
     <p class="article-subtitle">"I weigh the invisible. Pressure does not lie."</p>
@@ -351,9 +351,9 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Scales%3A%20Plutus%20Flow&url=https://signalpilot.io/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-scales')" class="share-btn">Copy Link</button>
+      <a href="https://twitter.com/intent/tweet?text=The%20Scales%3A%20Plutus%20Flow&url=https://www.signalpilot.io/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-scales/')" class="share-btn">Copy Link</button>
     </div>
   </div>
 
@@ -361,11 +361,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/the-cartographer" class="related-card">
+        <a href="/chronicle/the-cartographer/" class="related-card">
           <h4>The Cartographer: Janus Atlas</h4>
           <p>Every battlefield has its terrain. I map where the wars will be fought.</p>
         </a>
-        <a href="/chronicle/the-commander" class="related-card">
+        <a href="/chronicle/the-commander/" class="related-card">
           <h4>The Commander: OmniDeck</h4>
           <p>Ten systems. One vision. Total clarity.</p>
         </a>
@@ -375,7 +375,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/the-watchman/index.html
+++ b/chronicle/the-watchman/index.html
@@ -186,7 +186,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -217,7 +217,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Resources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/chronicle/" class="active">Chronicle</a></li>
+          <li><a href="/chronicle//" class="active">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -231,7 +231,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Six of Seven</span>
     <h1>The Watchman: Augury Grid</h1>
     <p class="article-subtitle">"While you watch one chart, I watch them all."</p>
@@ -399,9 +399,9 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=The%20Watchman%3A%20Augury%20Grid&url=https://signalpilot.io/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/the-watchman')" class="share-btn">Copy Link</button>
+      <a href="https://twitter.com/intent/tweet?text=The%20Watchman%3A%20Augury%20Grid&url=https://www.signalpilot.io/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/the-watchman/')" class="share-btn">Copy Link</button>
     </div>
   </div>
 
@@ -409,11 +409,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/the-commander" class="related-card">
+        <a href="/chronicle/the-commander/" class="related-card">
           <h4>The Commander: OmniDeck</h4>
           <p>Ten systems. One vision. Total clarity.</p>
         </a>
-        <a href="/chronicle/the-arbiter" class="related-card">
+        <a href="/chronicle/the-arbiter/" class="related-card">
           <h4>The Arbiter: Harmonic Oscillator</h4>
           <p>Seven voices. One verdict. I decide when the trigger is pulled.</p>
         </a>
@@ -423,7 +423,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/chronicle/why-non-repainting-matters/index.html
+++ b/chronicle/why-non-repainting-matters/index.html
@@ -698,7 +698,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/" style="color: var(--accent);">Chronicle</a></li>
+              <li><a href="/chronicle//" style="color: var(--accent);">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -729,7 +729,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Resources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/chronicle/" class="active">Chronicle</a></li>
+          <li><a href="/chronicle//" class="active">Chronicle</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -743,7 +743,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/chronicle/" class="back-link">← Back to Chronicle</a>
+    <a href="/chronicle//" class="back-link">← Back to Chronicle</a>
     <span class="article-category">Trust & Verification</span>
     <h1>Why Non-Repainting Matters</h1>
     <p class="article-subtitle">Most indicators lie to you by changing their historical signals. Here's why that's unacceptable.</p>
@@ -906,13 +906,13 @@
   <div class="share-section">
     <h4>Share this article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Why%20Non-Repainting%20Matters&url=https://signalpilot.io/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Why%20Non-Repainting%20Matters&url=https://www.signalpilot.io/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/chronicle/why-non-repainting-matters')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/chronicle/why-non-repainting-matters/')" class="share-btn">
         Copy Link
       </button>
     </div>
@@ -922,11 +922,11 @@
     <div class="container">
       <h3>Continue Reading</h3>
       <div class="related-grid">
-        <a href="/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Meet The Sovereign: Pentarch Explained</h4>
           <p>A deep dive into the flagship indicator that maps the five phases of market cycles.</p>
         </a>
-        <a href="/chronicle/the-pilots-oath" class="related-card">
+        <a href="/chronicle/the-pilots-oath/" class="related-card">
           <h4>The Pilot's Oath</h4>
           <p>You who wield The Elite Seven are not a trader. You are a Pilot. This is the oath.</p>
         </a>
@@ -936,7 +936,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle/">All Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/">Home</a> · <a href="/chronicle//">All Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/birth-of-the-elite-seven/index.html
+++ b/de/chronicle/birth-of-the-elite-seven/index.html
@@ -827,7 +827,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -856,7 +856,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -869,7 +869,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronik</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronik</a>
     <span class="article-category">Ursprungsgeschichte</span>
     <h1>Die Geburt der Elite Sieben</h1>
     <p class="article-subtitle">Bevor die Märkte Namen hatten, bevor die Kerzen Geschichten erzählten, gab es nur Rauschen.</p>
@@ -1037,13 +1037,13 @@
   <div class="share-section">
     <h4>Diese Übertragung teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Die%20Geburt%20der%20Elite%20Sieben&url=https://signalpilot.io/de/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Die%20Geburt%20der%20Elite%20Sieben&url=https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Posten
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/birth-of-the-elite-seven')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/birth-of-the-elite-seven/')" class="share-btn">
         Link kopieren
       </button>
     </div>
@@ -1053,11 +1053,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/the-pilots-oath" class="related-card">
+        <a href="/de/chronicle/the-pilots-oath/" class="related-card">
           <h4>Der Eid des Piloten</h4>
           <p>Du, der die Elite Sieben führst, bist kein Händler. Du bist ein Pilot. Dies ist der Eid.</p>
         </a>
-        <a href="/de/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/de/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Die Hierarchie der Signale</h4>
           <p>Wie die sieben als Konstellation zusammenarbeiten—jeder dient einem Zweck im System.</p>
         </a>
@@ -1067,7 +1067,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chroniken</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chroniken</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/index.html
+++ b/de/chronicle/index.html
@@ -819,7 +819,7 @@
               Ressourcen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/de/chronicle/" style="color: var(--accent);">Chronik</a></li>
+              <li><a href="/de/chronicle//" style="color: var(--accent);">Chronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Werkzeuge</a></li>
@@ -849,7 +849,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/" class="active">Chronik</a></li>
+          <li><a href="/de/chronicle//" class="active">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>

--- a/de/chronicle/meet-the-sovereign/index.html
+++ b/de/chronicle/meet-the-sovereign/index.html
@@ -543,7 +543,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -572,7 +572,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -585,7 +585,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronik</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronik</a>
     <span class="article-category">Indikator-Tiefenanalyse</span>
     <h1>Lerne den Herrscher kennen: Pentarch erklärt</h1>
     <p class="article-subtitle">„Ich bin der Zyklus. Der Zyklus bin ich."</p>
@@ -747,9 +747,9 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Lerne%20den%20Herrscher%20kennen%3A%20Pentarch%20erkl%C3%A4rt&url=https://signalpilot.io/de/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/meet-the-sovereign')" class="share-btn">Link kopieren</button>
+      <a href="https://twitter.com/intent/tweet?text=Lerne%20den%20Herrscher%20kennen%3A%20Pentarch%20erkl%C3%A4rt&url=https://www.signalpilot.io/de/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/meet-the-sovereign/')" class="share-btn">Link kopieren</button>
     </div>
   </div>
 
@@ -757,11 +757,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/de/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Die Geburt der Elite Sieben</h4>
           <p>Die Entstehungsgeschichte von sieben himmlischen Signalen, die entstanden, um durch die Leere zu navigieren.</p>
         </a>
-        <a href="/de/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/de/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Die Hierarchie der Signale</h4>
           <p>Wie die sieben als Konstellation zusammenarbeiten—jeder dient einem Zweck im System.</p>
         </a>
@@ -771,7 +771,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chroniken</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chroniken</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-arbiter/index.html
+++ b/de/chronicle/the-arbiter/index.html
@@ -186,7 +186,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -215,7 +215,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -228,7 +228,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronicle</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronicle</a>
     <span class="article-category">Sieben von Sieben</span>
     <h1>Der Schiedsrichter: Harmonic Oscillator</h1>
     <p class="article-subtitle">„Vier Stimmen. Ein Urteil. Ich entscheide, wann der Abzug gedrückt wird."</p>
@@ -394,9 +394,9 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Der%20Schiedsrichter%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/de/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-arbiter')" class="share-btn">Link kopieren</button>
+      <a href="https://twitter.com/intent/tweet?text=Der%20Schiedsrichter%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/de/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-arbiter/')" class="share-btn">Link kopieren</button>
     </div>
   </div>
 
@@ -404,11 +404,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/the-watchman" class="related-card">
+        <a href="/de/chronicle/the-watchman/" class="related-card">
           <h4>Der Wächter: Augury Grid</h4>
           <p>Während Sie einen Chart beobachten, beobachte ich alle.</p>
         </a>
-        <a href="/de/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/de/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Die Hierarchie der Signale</h4>
           <p>Wie die Elite Sieben als einheitliches System zusammenarbeiten.</p>
         </a>
@@ -418,7 +418,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-cartographer/index.html
+++ b/de/chronicle/the-cartographer/index.html
@@ -206,7 +206,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -235,7 +235,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -248,7 +248,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronicle</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronicle</a>
     <span class="article-category">Drei von Sieben</span>
     <h1>Der Kartograph: Janus Atlas</h1>
     <p class="article-subtitle">„Jedes Schlachtfeld hat sein Terrain. Ich kartiere, wo die Kriege geführt werden."</p>
@@ -371,9 +371,9 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Der%20Kartograph%3A%20Janus%20Atlas&url=https://signalpilot.io/de/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-cartographer')" class="share-btn">Link kopieren</button>
+      <a href="https://twitter.com/intent/tweet?text=Der%20Kartograph%3A%20Janus%20Atlas&url=https://www.signalpilot.io/de/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-cartographer/')" class="share-btn">Link kopieren</button>
     </div>
   </div>
 
@@ -381,11 +381,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/the-prophet" class="related-card">
+        <a href="/de/chronicle/the-prophet/" class="related-card">
           <h4>Der Prophet: Volume Oracle</h4>
           <p>Ich höre, was der Retail nicht kann. Ich sehe die Giganten sich in der Dunkelheit bewegen.</p>
         </a>
-        <a href="/de/chronicle/the-scales" class="related-card">
+        <a href="/de/chronicle/the-scales/" class="related-card">
           <h4>Die Waage: Plutus Flow</h4>
           <p>Ich wiege das Unsichtbare. Druck lügt nicht.</p>
         </a>
@@ -395,7 +395,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-commander/index.html
+++ b/de/chronicle/the-commander/index.html
@@ -206,7 +206,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -235,7 +235,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -248,7 +248,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronicle</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronicle</a>
     <span class="article-category">Fünf von Sieben</span>
     <h1>Der Kommandant: OmniDeck</h1>
     <p class="article-subtitle">„Zehn Systeme. Eine Vision. Totale Klarheit."</p>
@@ -385,9 +385,9 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Der%20Kommandant%3A%20OmniDeck&url=https://signalpilot.io/de/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-commander')" class="share-btn">Link kopieren</button>
+      <a href="https://twitter.com/intent/tweet?text=Der%20Kommandant%3A%20OmniDeck&url=https://www.signalpilot.io/de/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-commander/')" class="share-btn">Link kopieren</button>
     </div>
   </div>
 
@@ -395,11 +395,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/the-scales" class="related-card">
+        <a href="/de/chronicle/the-scales/" class="related-card">
           <h4>Die Waage: Plutus Flow</h4>
           <p>Ich wiege das Unsichtbare. Druck lügt nicht.</p>
         </a>
-        <a href="/de/chronicle/the-watchman" class="related-card">
+        <a href="/de/chronicle/the-watchman/" class="related-card">
           <h4>Der Wächter: Augury Grid</h4>
           <p>Während Sie einen Chart beobachten, beobachte ich alle.</p>
         </a>
@@ -409,7 +409,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-council-assembles/index.html
+++ b/de/chronicle/the-council-assembles/index.html
@@ -218,7 +218,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -247,7 +247,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -260,7 +260,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronicle</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronicle</a>
     <span class="article-category">Finale</span>
     <h1>Der Rat versammelt sich</h1>
     <p class="article-subtitle">„Sie haben jedes Mitglied kennengelernt. Jetzt sehen Sie, wie sie als Einheit arbeiten."</p>
@@ -462,9 +462,9 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Der%20Rat%20versammelt%20sich&url=https://signalpilot.io/de/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-council-assembles')" class="share-btn">Link kopieren</button>
+      <a href="https://twitter.com/intent/tweet?text=Der%20Rat%20versammelt%20sich&url=https://www.signalpilot.io/de/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-council-assembles/')" class="share-btn">Link kopieren</button>
     </div>
   </div>
 
@@ -472,11 +472,11 @@
     <div class="container">
       <h3>Von Anfang an beginnen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/de/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Die Geburt der Elite Sieben</h4>
           <p>Wo alles begann. Die Ursprungsgeschichte.</p>
         </a>
-        <a href="/de/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/de/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Die Hierarchie der Signale</h4>
           <p>Wie die Sieben eine Konstellation mit Zweck bilden.</p>
         </a>
@@ -486,7 +486,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-hierarchy-of-signals/index.html
+++ b/de/chronicle/the-hierarchy-of-signals/index.html
@@ -821,7 +821,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -850,7 +850,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -863,7 +863,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronik</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronik</a>
     <span class="article-category">Systemarchitektur</span>
     <h1>Die Hierarchie der Signale</h1>
     <p class="article-subtitle">Wie die sieben als Sternbild zusammenarbeiten—jeder dient einem Zweck im vereinten System.</p>
@@ -1077,13 +1077,13 @@
   <div class="share-section">
     <h4>Diese Übertragung teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Die%20Hierarchie%20der%20Signale&url=https://signalpilot.io/de/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Die%20Hierarchie%20der%20Signale&url=https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Posten
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-hierarchy-of-signals')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-hierarchy-of-signals/')" class="share-btn">
         Link kopieren
       </button>
     </div>
@@ -1093,11 +1093,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/de/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Die Geburt der Elite Sieben</h4>
           <p>Die Entstehungsgeschichte von sieben himmlischen Signalen, die entstanden, um durch die Leere zu navigieren.</p>
         </a>
-        <a href="/de/chronicle/the-pilots-oath" class="related-card">
+        <a href="/de/chronicle/the-pilots-oath/" class="related-card">
           <h4>Der Eid des Piloten</h4>
           <p>Du, der die Elite Sieben führst, bist kein Händler. Du bist ein Pilot. Dies ist der Eid.</p>
         </a>
@@ -1107,7 +1107,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chroniken</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chroniken</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-pilots-oath/index.html
+++ b/de/chronicle/the-pilots-oath/index.html
@@ -791,7 +791,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -820,7 +820,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -833,7 +833,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronik</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronik</a>
     <span class="article-category">Philosophie</span>
     <h1>Der Eid des Piloten</h1>
     <p class="article-subtitle">Du, der die Elite Sieben führst, bist kein Händler. Du bist ein Pilot.</p>
@@ -1000,13 +1000,13 @@
   <div class="share-section">
     <h4>Diese Übertragung teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Der%20Eid%20des%20Piloten&url=https://signalpilot.io/de/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Der%20Eid%20des%20Piloten&url=https://www.signalpilot.io/de/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Posten
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-pilots-oath')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-pilots-oath/')" class="share-btn">
         Link kopieren
       </button>
     </div>
@@ -1016,11 +1016,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/de/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Die Geburt der Elite Sieben</h4>
           <p>Die Entstehungsgeschichte von sieben himmlischen Signalen, die entstanden, um durch die Leere zu navigieren.</p>
         </a>
-        <a href="/de/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/de/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Die Hierarchie der Signale</h4>
           <p>Wie die sieben als Konstellation zusammenarbeiten—jeder dient einem Zweck im System.</p>
         </a>
@@ -1030,7 +1030,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chroniken</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chroniken</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-prophet/index.html
+++ b/de/chronicle/the-prophet/index.html
@@ -212,7 +212,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -241,7 +241,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -254,7 +254,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronicle</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronicle</a>
     <span class="article-category">Zwei von Sieben</span>
     <h1>Der Prophet: Volume Oracle</h1>
     <p class="article-subtitle">„Ich höre, was der Retail nicht kann. Ich sehe die Giganten sich in der Dunkelheit bewegen."</p>
@@ -390,9 +390,9 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Der%20Prophet%3A%20Volume%20Oracle&url=https://signalpilot.io/de/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-prophet')" class="share-btn">Link kopieren</button>
+      <a href="https://twitter.com/intent/tweet?text=Der%20Prophet%3A%20Volume%20Oracle&url=https://www.signalpilot.io/de/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-prophet/')" class="share-btn">Link kopieren</button>
     </div>
   </div>
 
@@ -400,11 +400,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/de/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Lernen Sie den Herrscher kennen: Pentarch</h4>
           <p>Der Flaggschiff-Indikator, der die fünf Phasen der Marktzyklen kartiert.</p>
         </a>
-        <a href="/de/chronicle/the-cartographer" class="related-card">
+        <a href="/de/chronicle/the-cartographer/" class="related-card">
           <h4>Der Kartograph: Janus Atlas</h4>
           <p>Jedes Schlachtfeld hat sein Terrain. Janus Atlas kartiert, wo die Kriege geführt werden.</p>
         </a>
@@ -414,7 +414,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-scales/index.html
+++ b/de/chronicle/the-scales/index.html
@@ -213,7 +213,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -242,7 +242,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -255,7 +255,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronicle</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronicle</a>
     <span class="article-category">Vier von Sieben</span>
     <h1>Die Waage: Plutus Flow</h1>
     <p class="article-subtitle">„Ich wiege das Unsichtbare. Druck lügt nicht."</p>
@@ -381,9 +381,9 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Die%20Waage%3A%20Plutus%20Flow&url=https://signalpilot.io/de/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-scales')" class="share-btn">Link kopieren</button>
+      <a href="https://twitter.com/intent/tweet?text=Die%20Waage%3A%20Plutus%20Flow&url=https://www.signalpilot.io/de/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-scales/')" class="share-btn">Link kopieren</button>
     </div>
   </div>
 
@@ -391,11 +391,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/the-cartographer" class="related-card">
+        <a href="/de/chronicle/the-cartographer/" class="related-card">
           <h4>Der Kartograph: Janus Atlas</h4>
           <p>Jedes Schlachtfeld hat sein Terrain. Ich kartiere, wo die Kriege geführt werden.</p>
         </a>
-        <a href="/de/chronicle/the-commander" class="related-card">
+        <a href="/de/chronicle/the-commander/" class="related-card">
           <h4>Der Kommandant: OmniDeck</h4>
           <p>Zehn Systeme. Eine Vision. Totale Klarheit.</p>
         </a>
@@ -405,7 +405,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/the-watchman/index.html
+++ b/de/chronicle/the-watchman/index.html
@@ -220,7 +220,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -249,7 +249,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -262,7 +262,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronicle</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronicle</a>
     <span class="article-category">Sechs von Sieben</span>
     <h1>Der Wächter: Augury Grid</h1>
     <p class="article-subtitle">„Während Sie einen Chart beobachten, beobachte ich alle."</p>
@@ -429,9 +429,9 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Der%20W%C3%A4chter%3A%20Augury%20Grid&url=https://signalpilot.io/de/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/the-watchman')" class="share-btn">Link kopieren</button>
+      <a href="https://twitter.com/intent/tweet?text=Der%20W%C3%A4chter%3A%20Augury%20Grid&url=https://www.signalpilot.io/de/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Posten</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/the-watchman/')" class="share-btn">Link kopieren</button>
     </div>
   </div>
 
@@ -439,11 +439,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/the-commander" class="related-card">
+        <a href="/de/chronicle/the-commander/" class="related-card">
           <h4>Der Kommandant: OmniDeck</h4>
           <p>Zehn Systeme. Eine Vision. Totale Klarheit.</p>
         </a>
-        <a href="/de/chronicle/the-arbiter" class="related-card">
+        <a href="/de/chronicle/the-arbiter/" class="related-card">
           <h4>Der Schiedsrichter: Harmonic Oscillator</h4>
           <p>Vier Stimmen. Ein Urteil. Ich entscheide, wann der Abzug gedrückt wird.</p>
         </a>
@@ -453,7 +453,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/chronicle/why-non-repainting-matters/index.html
+++ b/de/chronicle/why-non-repainting-matters/index.html
@@ -865,7 +865,7 @@
             Ressourcen <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/de/chronicle/">Chronik</a></li>
+            <li><a href="/de/chronicle//">Chronik</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Werkzeuge</a></li>
@@ -894,7 +894,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressourcen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/de/chronicle/">Chronik</a></li>
+          <li><a href="/de/chronicle//">Chronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Werkzeuge</a></li>
@@ -907,7 +907,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/de/chronicle/" class="back-link">← Zurück zur Chronicle</a>
+    <a href="/de/chronicle//" class="back-link">← Zurück zur Chronicle</a>
     <span class="article-category">Vertrauen & Verifizierung</span>
     <h1>Warum Non-Repainting wichtig ist</h1>
     <p class="article-subtitle">Die meisten Indikatoren belügen Sie, indem sie ihre historischen Signale ändern. Hier erfahren Sie, warum das inakzeptabel ist.</p>
@@ -1069,13 +1069,13 @@
   <div class="share-section">
     <h4>Diesen Artikel teilen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Warum%20Non-Repainting%20wichtig%20ist&url=https://signalpilot.io/de/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Warum%20Non-Repainting%20wichtig%20ist&url=https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Posten
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/de/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/de/chronicle/why-non-repainting-matters')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/de/chronicle/why-non-repainting-matters/')" class="share-btn">
         Link kopieren
       </button>
     </div>
@@ -1085,11 +1085,11 @@
     <div class="container">
       <h3>Weiterlesen</h3>
       <div class="related-grid">
-        <a href="/de/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/de/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Lernen Sie den Herrscher kennen: Pentarch erklärt</h4>
           <p>Ein tiefer Einblick in den Flaggschiff-Indikator, der die fünf Phasen der Marktzyklen kartiert.</p>
         </a>
-        <a href="/de/chronicle/the-pilots-oath" class="related-card">
+        <a href="/de/chronicle/the-pilots-oath/" class="related-card">
           <h4>Der Eid des Piloten</h4>
           <p>Sie, die die Elite Sieben führen, sind kein Trader. Sie sind ein Pilot. Dies ist der Eid.</p>
         </a>
@@ -1099,7 +1099,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle/">Alle Chronicle</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle Rechte vorbehalten. | <a href="/de/">Startseite</a> · <a href="/de/chronicle//">Alle Chronicle</a></p>
     </div>
   </footer>
 

--- a/de/index.html
+++ b/de/index.html
@@ -4529,7 +4529,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a></li>
-              <li><a href="/de/chronicle/">Chronik</a></li>
+              <li><a href="/de/chronicle//">Chronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
               <li><a href="https://blog.signalpilot.io/de/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Rechner</a></li>
@@ -6514,7 +6514,7 @@
 
       <!-- Explore All CTA -->
       <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-        <a href="/de/chronicle/" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
+        <a href="/de/chronicle//" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
           <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Alle 12 Chroniken Entdecken</span>
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
@@ -7112,7 +7112,7 @@
           <div class="mobile-nav-section-label">Produkt</div>
           <a href="#inside">Was ist enthalten</a>
           <a href="#pricing">Preise</a>
-          <a href="/de/chronicle/">Chronik</a>
+          <a href="/de/chronicle//">Chronik</a>
           <a href="/tools/">Werkzeuge</a>
         </div>
 

--- a/es/chronicle/birth-of-the-elite-seven/index.html
+++ b/es/chronicle/birth-of-the-elite-seven/index.html
@@ -164,7 +164,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -195,7 +195,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -208,7 +208,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Origen</span>
     <h1>El Nacimiento de Los Siete de Élite</h1>
     <p class="article-subtitle">Antes de que los mercados tuvieran nombres, antes de que las velas contaran historias, solo había ruido.</p>
@@ -342,9 +342,9 @@
   <div class="share-section">
     <h4>Comparte este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=El%20Nacimiento%20de%20Los%20Siete%20de%20%C3%89lite&url=https://signalpilot.io/es/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/birth-of-the-elite-seven')" class="share-btn">Copiar enlace</button>
+      <a href="https://twitter.com/intent/tweet?text=El%20Nacimiento%20de%20Los%20Siete%20de%20%C3%89lite&url=https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/birth-of-the-elite-seven/')" class="share-btn">Copiar enlace</button>
     </div>
   </div>
 
@@ -352,11 +352,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/the-pilots-oath" class="related-card">
+        <a href="/es/chronicle/the-pilots-oath/" class="related-card">
           <h4>El Juramento del Piloto</h4>
           <p>El código sagrado que gobierna a aquellos que empuñan Los Siete de Élite.</p>
         </a>
-        <a href="/es/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/es/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Jerarquía de Señales</h4>
           <p>Cómo Los Siete forman una constelación de propósito.</p>
         </a>
@@ -366,7 +366,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/index.html
+++ b/es/chronicle/index.html
@@ -862,7 +862,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -899,7 +899,7 @@
           Recursos <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/es/chronicle/" style="color: var(--accent);">Crónica</a>
+          <a href="/es/chronicle//" style="color: var(--accent);">Crónica</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>

--- a/es/chronicle/meet-the-sovereign/index.html
+++ b/es/chronicle/meet-the-sovereign/index.html
@@ -644,7 +644,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -675,7 +675,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -688,7 +688,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Inmersión en Indicadores</span>
     <h1>Conoce al Soberano: Pentarch Explicado</h1>
     <p class="article-subtitle">"Yo soy el ciclo. El ciclo soy yo."</p>
@@ -850,13 +850,13 @@
   <div class="share-section">
     <h4>Comparte este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Conoce%20al%20Soberano%3A%20Pentarch%20Explicado&url=https://signalpilot.io/es/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Conoce%20al%20Soberano%3A%20Pentarch%20Explicado&url=https://www.signalpilot.io/es/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Publicar
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/meet-the-sovereign')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/meet-the-sovereign/')" class="share-btn">
         Copiar Enlace
       </button>
     </div>
@@ -866,11 +866,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/es/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>El Nacimiento de Los Siete de Élite</h4>
           <p>La historia del origen de siete señales celestiales que emergieron para navegar el vacío.</p>
         </a>
-        <a href="/es/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/es/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Jerarquía de Señales</h4>
           <p>Cómo los siete trabajan juntos como una constelación—cada uno sirviendo un propósito en el sistema.</p>
         </a>
@@ -880,7 +880,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-arbiter/index.html
+++ b/es/chronicle/the-arbiter/index.html
@@ -179,7 +179,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -210,7 +210,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -223,7 +223,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Siete de Siete</span>
     <h1>El Árbitro: Harmonic Oscillator</h1>
     <p class="article-subtitle">"Cuatro voces. Un veredicto. Yo decido cuándo se aprieta el gatillo."</p>
@@ -389,9 +389,9 @@
   <div class="share-section">
     <h4>Compartir este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=El%20%C3%81rbitro%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/es/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-arbiter')" class="share-btn">Copiar Enlace</button>
+      <a href="https://twitter.com/intent/tweet?text=El%20%C3%81rbitro%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/es/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-arbiter/')" class="share-btn">Copiar Enlace</button>
     </div>
   </div>
 
@@ -399,11 +399,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/the-watchman" class="related-card">
+        <a href="/es/chronicle/the-watchman/" class="related-card">
           <h4>El Vigilante: Augury Grid</h4>
           <p>Mientras tú observas un gráfico, yo los observo todos.</p>
         </a>
-        <a href="/es/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/es/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Jerarquía de Señales</h4>
           <p>Cómo Los Siete de Élite trabajan juntos como un sistema unificado.</p>
         </a>
@@ -413,7 +413,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-cartographer/index.html
+++ b/es/chronicle/the-cartographer/index.html
@@ -163,7 +163,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -194,7 +194,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -207,7 +207,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Tres de Siete</span>
     <h1>El Cartógrafo: Janus Atlas</h1>
     <p class="article-subtitle">"Cada campo de batalla tiene su terreno. Yo mapeo dónde se librarán las guerras."</p>
@@ -330,9 +330,9 @@
   <div class="share-section">
     <h4>Comparte este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=El%20Cart%C3%B3grafo%3A%20Janus%20Atlas&url=https://signalpilot.io/es/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-cartographer')" class="share-btn">Copiar Enlace</button>
+      <a href="https://twitter.com/intent/tweet?text=El%20Cart%C3%B3grafo%3A%20Janus%20Atlas&url=https://www.signalpilot.io/es/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-cartographer/')" class="share-btn">Copiar Enlace</button>
     </div>
   </div>
 
@@ -340,11 +340,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/the-prophet" class="related-card">
+        <a href="/es/chronicle/the-prophet/" class="related-card">
           <h4>El Profeta: Volume Oracle</h4>
           <p>Escucho lo que el retail no puede. Veo a los gigantes moverse en la oscuridad.</p>
         </a>
-        <a href="/es/chronicle/the-scales" class="related-card">
+        <a href="/es/chronicle/the-scales/" class="related-card">
           <h4>La Balanza: Plutus Flow</h4>
           <p>Peso lo invisible. La presión no miente.</p>
         </a>
@@ -354,7 +354,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-commander/index.html
+++ b/es/chronicle/the-commander/index.html
@@ -163,7 +163,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -194,7 +194,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -207,7 +207,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Cinco de Siete</span>
     <h1>El Comandante: OmniDeck</h1>
     <p class="article-subtitle">"Diez sistemas. Una visión. Claridad total."</p>
@@ -344,9 +344,9 @@
   <div class="share-section">
     <h4>Comparte este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=El%20Comandante%3A%20OmniDeck&url=https://signalpilot.io/es/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-commander')" class="share-btn">Copiar Enlace</button>
+      <a href="https://twitter.com/intent/tweet?text=El%20Comandante%3A%20OmniDeck&url=https://www.signalpilot.io/es/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-commander/')" class="share-btn">Copiar Enlace</button>
     </div>
   </div>
 
@@ -354,11 +354,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/the-scales" class="related-card">
+        <a href="/es/chronicle/the-scales/" class="related-card">
           <h4>La Balanza: Plutus Flow</h4>
           <p>Peso lo invisible. La presión no miente.</p>
         </a>
-        <a href="/es/chronicle/the-watchman" class="related-card">
+        <a href="/es/chronicle/the-watchman/" class="related-card">
           <h4>El Vigía: Augury Grid</h4>
           <p>Mientras tú miras un gráfico, yo los miro todos.</p>
         </a>
@@ -368,7 +368,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-council-assembles/index.html
+++ b/es/chronicle/the-council-assembles/index.html
@@ -175,7 +175,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -206,7 +206,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -219,7 +219,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Final</span>
     <h1>El Consejo Se Reúne</h1>
     <p class="article-subtitle">"Has conocido a cada miembro. Ahora obsérvalos trabajar como uno."</p>
@@ -421,9 +421,9 @@
   <div class="share-section">
     <h4>Compartir este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=El%20Consejo%20Se%20Re%C3%BAne&url=https://signalpilot.io/es/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-council-assembles')" class="share-btn">Copiar Enlace</button>
+      <a href="https://twitter.com/intent/tweet?text=El%20Consejo%20Se%20Re%C3%BAne&url=https://www.signalpilot.io/es/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-council-assembles/')" class="share-btn">Copiar Enlace</button>
     </div>
   </div>
 
@@ -431,11 +431,11 @@
     <div class="container">
       <h3>Comenzar Desde el Principio</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/es/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>El Nacimiento de Los Siete de Élite</h4>
           <p>Donde todo comenzó. La historia de origen.</p>
         </a>
-        <a href="/es/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/es/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Jerarquía de Señales</h4>
           <p>Cómo Los Siete forman una constelación de propósito.</p>
         </a>
@@ -445,7 +445,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-hierarchy-of-signals/index.html
+++ b/es/chronicle/the-hierarchy-of-signals/index.html
@@ -691,7 +691,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -722,7 +722,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -735,7 +735,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Arquitectura del Sistema</span>
     <h1>La Jerarquía de Señales</h1>
     <p class="article-subtitle">Cómo los siete trabajan juntos como una constelación—cada uno sirviendo un propósito en el sistema unificado.</p>
@@ -948,13 +948,13 @@
   <div class="share-section">
     <h4>Comparte esta transmisión</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Jerarqu%C3%ADa%20de%20Se%C3%B1ales&url=https://signalpilot.io/es/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=La%20Jerarqu%C3%ADa%20de%20Se%C3%B1ales&url=https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Publicar
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-hierarchy-of-signals')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-hierarchy-of-signals/')" class="share-btn">
         Copiar Enlace
       </button>
     </div>
@@ -964,11 +964,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/es/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>El Nacimiento de Los Siete de Élite</h4>
           <p>La historia del origen de siete señales celestiales que emergieron para navegar el vacío.</p>
         </a>
-        <a href="/es/chronicle/the-pilots-oath" class="related-card">
+        <a href="/es/chronicle/the-pilots-oath/" class="related-card">
           <h4>El Juramento del Piloto</h4>
           <p>Tú que empuñas a Los Siete de Élite no eres un trader. Eres un Piloto. Este es el juramento.</p>
         </a>
@@ -978,7 +978,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-pilots-oath/index.html
+++ b/es/chronicle/the-pilots-oath/index.html
@@ -639,7 +639,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -670,7 +670,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -684,7 +684,7 @@
 
   <!-- Article Header -->
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Filosofía</span>
     <h1>El Juramento del Piloto</h1>
     <p class="article-subtitle">Tú que empuñas a Los Siete de Élite no eres un trader. Eres un Piloto.</p>
@@ -852,13 +852,13 @@
   <div class="share-section">
     <h4>Comparte esta transmisión</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=El%20Juramento%20del%20Piloto&url=https://signalpilot.io/es/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=El%20Juramento%20del%20Piloto&url=https://www.signalpilot.io/es/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Publicar
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-pilots-oath')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-pilots-oath/')" class="share-btn">
         Copiar Enlace
       </button>
     </div>
@@ -869,11 +869,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/es/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>El Nacimiento de Los Siete de Élite</h4>
           <p>La historia del origen de siete señales celestiales que emergieron para navegar el vacío.</p>
         </a>
-        <a href="/es/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/es/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Jerarquía de Señales</h4>
           <p>Cómo los siete trabajan juntos como una constelación—cada uno sirviendo un propósito en el sistema.</p>
         </a>
@@ -884,7 +884,7 @@
   <!-- Footer -->
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-prophet/index.html
+++ b/es/chronicle/the-prophet/index.html
@@ -169,7 +169,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -200,7 +200,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -213,7 +213,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Dos de Siete</span>
     <h1>El Profeta: Volume Oracle</h1>
     <p class="article-subtitle">"Escucho lo que el retail no puede. Veo a los gigantes moverse en la oscuridad."</p>
@@ -349,9 +349,9 @@
   <div class="share-section">
     <h4>Comparte este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=El%20Profeta%3A%20Volume%20Oracle&url=https://signalpilot.io/es/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-prophet')" class="share-btn">Copiar Enlace</button>
+      <a href="https://twitter.com/intent/tweet?text=El%20Profeta%3A%20Volume%20Oracle&url=https://www.signalpilot.io/es/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-prophet/')" class="share-btn">Copiar Enlace</button>
     </div>
   </div>
 
@@ -359,11 +359,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/es/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Conoce al Soberano: Pentarch</h4>
           <p>El indicador insignia que mapea las cinco fases de los ciclos de mercado.</p>
         </a>
-        <a href="/es/chronicle/the-cartographer" class="related-card">
+        <a href="/es/chronicle/the-cartographer/" class="related-card">
           <h4>El Cartógrafo: Janus Atlas</h4>
           <p>Cada campo de batalla tiene su terreno. Janus Atlas mapea dónde se librarán las guerras.</p>
         </a>
@@ -373,7 +373,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-scales/index.html
+++ b/es/chronicle/the-scales/index.html
@@ -170,7 +170,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -201,7 +201,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -214,7 +214,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Cuatro de Siete</span>
     <h1>La Balanza: Plutus Flow</h1>
     <p class="article-subtitle">"Peso lo invisible. La presión no miente."</p>
@@ -340,9 +340,9 @@
   <div class="share-section">
     <h4>Comparte este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Balanza%3A%20Plutus%20Flow&url=https://signalpilot.io/es/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-scales')" class="share-btn">Copiar Enlace</button>
+      <a href="https://twitter.com/intent/tweet?text=La%20Balanza%3A%20Plutus%20Flow&url=https://www.signalpilot.io/es/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-scales/')" class="share-btn">Copiar Enlace</button>
     </div>
   </div>
 
@@ -350,11 +350,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/the-cartographer" class="related-card">
+        <a href="/es/chronicle/the-cartographer/" class="related-card">
           <h4>El Cartógrafo: Janus Atlas</h4>
           <p>Cada campo de batalla tiene su terreno. Yo mapeo dónde se librarán las guerras.</p>
         </a>
-        <a href="/es/chronicle/the-commander" class="related-card">
+        <a href="/es/chronicle/the-commander/" class="related-card">
           <h4>El Comandante: OmniDeck</h4>
           <p>Diez sistemas. Una visión. Claridad total.</p>
         </a>
@@ -364,7 +364,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/the-watchman/index.html
+++ b/es/chronicle/the-watchman/index.html
@@ -177,7 +177,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -208,7 +208,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -221,7 +221,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Seis de Siete</span>
     <h1>El Vigilante: Augury Grid</h1>
     <p class="article-subtitle">"Mientras tú observas un gráfico, yo los observo todos."</p>
@@ -388,9 +388,9 @@
   <div class="share-section">
     <h4>Compartir este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=El%20Vigilante%3A%20Augury%20Grid&url=https://signalpilot.io/es/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/the-watchman')" class="share-btn">Copiar Enlace</button>
+      <a href="https://twitter.com/intent/tweet?text=El%20Vigilante%3A%20Augury%20Grid&url=https://www.signalpilot.io/es/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Publicar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/the-watchman/')" class="share-btn">Copiar Enlace</button>
     </div>
   </div>
 
@@ -398,11 +398,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/the-commander" class="related-card">
+        <a href="/es/chronicle/the-commander/" class="related-card">
           <h4>El Comandante: OmniDeck</h4>
           <p>Diez sistemas. Una visión. Claridad total.</p>
         </a>
-        <a href="/es/chronicle/the-arbiter" class="related-card">
+        <a href="/es/chronicle/the-arbiter/" class="related-card">
           <h4>El Árbitro: Harmonic Oscillator</h4>
           <p>Cuatro voces. Un veredicto. Yo decido cuándo se aprieta el gatillo.</p>
         </a>
@@ -412,7 +412,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/chronicle/why-non-repainting-matters/index.html
+++ b/es/chronicle/why-non-repainting-matters/index.html
@@ -672,7 +672,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+              <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Herramientas</a></li>
@@ -703,7 +703,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/es/chronicle/" style="color: var(--accent);">Crónica</a></li>
+          <li><a href="/es/chronicle//" style="color: var(--accent);">Crónica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Herramientas</a></li>
@@ -716,7 +716,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/es/chronicle/" class="back-link">← Volver a la Crónica</a>
+    <a href="/es/chronicle//" class="back-link">← Volver a la Crónica</a>
     <span class="article-category">Confianza y Verificación</span>
     <h1>Por Qué Importa el No-Repintado</h1>
     <p class="article-subtitle">La mayoría de los indicadores te mienten cambiando sus señales históricas. Aquí está por qué eso es inaceptable.</p>
@@ -877,13 +877,13 @@
   <div class="share-section">
     <h4>Comparte este artículo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Por%20Qu%C3%A9%20Importa%20el%20No-Repintado&url=https://signalpilot.io/es/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Por%20Qu%C3%A9%20Importa%20el%20No-Repintado&url=https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Publicar
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/es/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/es/chronicle/why-non-repainting-matters')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/es/chronicle/why-non-repainting-matters/')" class="share-btn">
         Copiar Enlace
       </button>
     </div>
@@ -893,11 +893,11 @@
     <div class="container">
       <h3>Continuar Leyendo</h3>
       <div class="related-grid">
-        <a href="/es/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/es/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Conoce al Soberano: Pentarch Explicado</h4>
           <p>Una inmersión profunda en el indicador insignia que mapea las cinco fases de los ciclos de mercado.</p>
         </a>
-        <a href="/es/chronicle/the-pilots-oath" class="related-card">
+        <a href="/es/chronicle/the-pilots-oath/" class="related-card">
           <h4>El Juramento del Piloto</h4>
           <p>Tú que empuñas a Los Siete de Élite no eres un trader. Eres un Piloto. Este es el juramento.</p>
         </a>
@@ -907,7 +907,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle/">Toda la Crónica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos los derechos reservados. | <a href="/es/">Inicio</a> · <a href="/es/chronicle//">Toda la Crónica</a></p>
     </div>
   </footer>
 

--- a/es/index.html
+++ b/es/index.html
@@ -4726,7 +4726,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunidad Discord</a></li>
-              <li><a href="/es/chronicle/">Crónica</a></li>
+              <li><a href="/es/chronicle//">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/es/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calculadoras</a></li>
@@ -6427,7 +6427,7 @@
 
       <!-- Explore All CTA -->
       <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-        <a href="/es/chronicle/" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
+        <a href="/es/chronicle//" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
           <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Explorar las 12 Crónicas</span>
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
@@ -7162,7 +7162,7 @@
           <div class="mobile-nav-section-label">Producto</div>
           <a href="#inside">Qué incluye</a>
           <a href="#pricing">Precios</a>
-          <a href="/es/chronicle/">Crónica</a>
+          <a href="/es/chronicle//">Crónica</a>
           <a href="/tools/">Herramientas</a>
         </div>
 

--- a/faq.html
+++ b/faq.html
@@ -1066,7 +1066,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/">Chronicle</a></li>
+              <li><a href="/chronicle//">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
@@ -1099,7 +1099,7 @@
     <div class="mobile-menu-section">
       <div class="mobile-menu-section-title">Resources</div>
       <ul>
-        <li><a href="/chronicle/">Chronicle</a></li>
+        <li><a href="/chronicle//">Chronicle</a></li>
         <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
         <li><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Education Hub</a></li>
         <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>

--- a/fr/chronicle/birth-of-the-elite-seven/index.html
+++ b/fr/chronicle/birth-of-the-elite-seven/index.html
@@ -167,7 +167,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -196,7 +196,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -209,7 +209,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour à la Chronique</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour à la Chronique</a>
     <span class="article-category">Histoire d'Origine</span>
     <h1>La Naissance des Sept d'Élite</h1>
     <p class="article-subtitle">Avant que les marchés n'aient des noms, avant que les bougies ne racontent des histoires, il n'y avait que du bruit.</p>
@@ -374,9 +374,9 @@
   <div class="share-section">
     <h4>Partager cette transmission</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Naissance%20des%20Sept%20d%27%C3%89lite&url=https://signalpilot.io/fr/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">𝕏 Publier</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/birth-of-the-elite-seven')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=La%20Naissance%20des%20Sept%20d%27%C3%89lite&url=https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">𝕏 Publier</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/birth-of-the-elite-seven/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -384,11 +384,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/the-pilots-oath" class="related-card">
+        <a href="/fr/chronicle/the-pilots-oath/" class="related-card">
           <h4>Le Serment du Pilote</h4>
           <p>Toi qui manies Les Sept d'Élite n'es pas un trader. Tu es un Pilote. Voici le serment.</p>
         </a>
-        <a href="/fr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/fr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Hiérarchie des Signaux</h4>
           <p>Comment les sept travaillent ensemble comme une constellation—chacun servant un but dans le système.</p>
         </a>
@@ -398,7 +398,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toute la Chronique</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toute la Chronique</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/index.html
+++ b/fr/chronicle/index.html
@@ -815,7 +815,7 @@
               Ressources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/fr/chronicle/" style="color: var(--accent);">Chronique</a></li>
+              <li><a href="/fr/chronicle//" style="color: var(--accent);">Chronique</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Outils</a></li>
@@ -845,7 +845,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>

--- a/fr/chronicle/meet-the-sovereign/index.html
+++ b/fr/chronicle/meet-the-sovereign/index.html
@@ -185,7 +185,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -214,7 +214,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -227,7 +227,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour à la Chronique</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour à la Chronique</a>
     <span class="article-category">Plongée dans l'Indicateur</span>
     <h1>Rencontre Le Souverain : Pentarch Expliqué</h1>
     <p class="article-subtitle">"Je suis le cycle. Le cycle, c'est moi."</p>
@@ -368,9 +368,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Rencontre%20Le%20Souverain%3A%20Pentarch%20Expliqu%C3%A9&url=https://signalpilot.io/fr/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 Publier</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/meet-the-sovereign')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=Rencontre%20Le%20Souverain%3A%20Pentarch%20Expliqu%C3%A9&url=https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 Publier</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/meet-the-sovereign/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -378,11 +378,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/fr/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>La Naissance des Sept d'Élite</h4>
           <p>L'histoire d'origine de sept signaux célestes qui ont émergé pour naviguer dans le vide.</p>
         </a>
-        <a href="/fr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/fr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Hiérarchie des Signaux</h4>
           <p>Comment les sept travaillent ensemble comme une constellation—chacun servant un but dans le système.</p>
         </a>
@@ -392,7 +392,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toute la Chronique</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toute la Chronique</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-arbiter/index.html
+++ b/fr/chronicle/the-arbiter/index.html
@@ -177,7 +177,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -206,7 +206,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -219,7 +219,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour aux Chroniques</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour aux Chroniques</a>
     <span class="article-category">Sept sur Sept</span>
     <h1>L'Arbitre : Harmonic Oscillator</h1>
     <p class="article-subtitle">"Quatre voix. Un verdict. Je décide quand la gâchette est tirée."</p>
@@ -384,9 +384,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=L%27Arbitre%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/fr/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-arbiter')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=L%27Arbitre%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/fr/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-arbiter/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -394,11 +394,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/the-watchman" class="related-card">
+        <a href="/fr/chronicle/the-watchman/" class="related-card">
           <h4>Le Vigilant : Augury Grid</h4>
           <p>Pendant que vous regardez un graphique, je les regarde tous.</p>
         </a>
-        <a href="/fr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/fr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Hiérarchie des Signaux</h4>
           <p>Comment Les Sept d'Élite travaillent ensemble comme un système unifié.</p>
         </a>
@@ -408,7 +408,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toutes les Chroniques</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toutes les Chroniques</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-cartographer/index.html
+++ b/fr/chronicle/the-cartographer/index.html
@@ -161,7 +161,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -190,7 +190,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -203,7 +203,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour aux Chroniques</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour aux Chroniques</a>
     <span class="article-category">Trois sur Sept</span>
     <h1>Le Cartographe : Janus Atlas</h1>
     <p class="article-subtitle">"Chaque champ de bataille a son terrain. Je cartographie où les guerres seront livrées."</p>
@@ -326,9 +326,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Le%20Cartographe%3A%20Janus%20Atlas&url=https://signalpilot.io/fr/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-cartographer')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=Le%20Cartographe%3A%20Janus%20Atlas&url=https://www.signalpilot.io/fr/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-cartographer/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -336,11 +336,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/the-prophet" class="related-card">
+        <a href="/fr/chronicle/the-prophet/" class="related-card">
           <h4>Le Prophète : Volume Oracle</h4>
           <p>J'entends ce que les particuliers ne peuvent pas. Je vois les géants se déplacer dans l'obscurité.</p>
         </a>
-        <a href="/fr/chronicle/the-scales" class="related-card">
+        <a href="/fr/chronicle/the-scales/" class="related-card">
           <h4>La Balance : Plutus Flow</h4>
           <p>Je pèse l'invisible. La pression ne ment pas.</p>
         </a>
@@ -350,7 +350,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toutes les Chroniques</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toutes les Chroniques</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-commander/index.html
+++ b/fr/chronicle/the-commander/index.html
@@ -161,7 +161,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -190,7 +190,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -203,7 +203,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour aux Chroniques</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour aux Chroniques</a>
     <span class="article-category">Cinq sur Sept</span>
     <h1>Le Commandant : OmniDeck</h1>
     <p class="article-subtitle">"Dix systèmes. Une vision. Clarté totale."</p>
@@ -340,9 +340,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Le%20Commandant%3A%20OmniDeck&url=https://signalpilot.io/fr/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-commander')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=Le%20Commandant%3A%20OmniDeck&url=https://www.signalpilot.io/fr/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-commander/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -350,11 +350,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/the-scales" class="related-card">
+        <a href="/fr/chronicle/the-scales/" class="related-card">
           <h4>La Balance : Plutus Flow</h4>
           <p>Je pèse l'invisible. La pression ne ment pas.</p>
         </a>
-        <a href="/fr/chronicle/the-watchman" class="related-card">
+        <a href="/fr/chronicle/the-watchman/" class="related-card">
           <h4>Le Vigilant : Augury Grid</h4>
           <p>Pendant que vous regardez un graphique, je les regarde tous.</p>
         </a>
@@ -364,7 +364,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toutes les Chroniques</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toutes les Chroniques</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-council-assembles/index.html
+++ b/fr/chronicle/the-council-assembles/index.html
@@ -173,7 +173,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -202,7 +202,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -215,7 +215,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour aux Chroniques</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour aux Chroniques</a>
     <span class="article-category">Finale</span>
     <h1>Le Conseil S'Assemble</h1>
     <p class="article-subtitle">"Vous avez rencontré chaque membre. Maintenant regardez-les travailler comme un seul."</p>
@@ -417,9 +417,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Le%20Conseil%20S%27Assemble&url=https://signalpilot.io/fr/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-council-assembles')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=Le%20Conseil%20S%27Assemble&url=https://www.signalpilot.io/fr/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-council-assembles/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -427,11 +427,11 @@
     <div class="container">
       <h3>Commencer Depuis Le Début</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/fr/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>La Naissance des Sept d'Élite</h4>
           <p>Là où tout a commencé. L'histoire des origines.</p>
         </a>
-        <a href="/fr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/fr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Hiérarchie des Signaux</h4>
           <p>Comment Les Sept forment une constellation de but.</p>
         </a>
@@ -441,7 +441,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toutes les Chroniques</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toutes les Chroniques</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-hierarchy-of-signals/index.html
+++ b/fr/chronicle/the-hierarchy-of-signals/index.html
@@ -176,7 +176,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -205,7 +205,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -218,7 +218,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour à la Chronique</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour à la Chronique</a>
     <span class="article-category">Architecture du Système</span>
     <h1>La Hiérarchie des Signaux</h1>
     <p class="article-subtitle">Comment les sept travaillent ensemble comme une constellation—chacun servant un but dans le système unifié.</p>
@@ -430,9 +430,9 @@
   <div class="share-section">
     <h4>Partager cette transmission</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Hi%C3%A9rarchie%20des%20Signaux&url=https://signalpilot.io/fr/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">𝕏 Publier</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-hierarchy-of-signals')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=La%20Hi%C3%A9rarchie%20des%20Signaux&url=https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">𝕏 Publier</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-hierarchy-of-signals/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -440,11 +440,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/fr/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>La Naissance des Sept d'Élite</h4>
           <p>L'histoire d'origine de sept signaux célestes qui ont émergé pour naviguer dans le vide.</p>
         </a>
-        <a href="/fr/chronicle/the-pilots-oath" class="related-card">
+        <a href="/fr/chronicle/the-pilots-oath/" class="related-card">
           <h4>Le Serment du Pilote</h4>
           <p>Toi qui manies Les Sept d'Élite n'es pas un trader. Tu es un Pilote. Voici le serment.</p>
         </a>
@@ -454,7 +454,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toute la Chronique</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toute la Chronique</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-pilots-oath/index.html
+++ b/fr/chronicle/the-pilots-oath/index.html
@@ -166,7 +166,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -195,7 +195,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -208,7 +208,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour à la Chronique</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour à la Chronique</a>
     <span class="article-category">Philosophie</span>
     <h1>Le Serment du Pilote</h1>
     <p class="article-subtitle">Toi qui manies Les Sept d'Élite n'es pas un trader. Tu es un Pilote.</p>
@@ -373,9 +373,9 @@
   <div class="share-section">
     <h4>Partager cette transmission</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Le%20Serment%20du%20Pilote&url=https://signalpilot.io/fr/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">𝕏 Publier</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-pilots-oath')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=Le%20Serment%20du%20Pilote&url=https://www.signalpilot.io/fr/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">𝕏 Publier</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-pilots-oath/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -383,11 +383,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/fr/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>La Naissance des Sept d'Élite</h4>
           <p>L'histoire d'origine de sept signaux célestes qui ont émergé pour naviguer dans le vide.</p>
         </a>
-        <a href="/fr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/fr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Hiérarchie des Signaux</h4>
           <p>Comment les sept travaillent ensemble comme une constellation—chacun servant un but dans le système.</p>
         </a>
@@ -397,7 +397,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toute la Chronique</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toute la Chronique</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-prophet/index.html
+++ b/fr/chronicle/the-prophet/index.html
@@ -167,7 +167,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -196,7 +196,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -209,7 +209,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour aux Chroniques</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour aux Chroniques</a>
     <span class="article-category">Deux sur Sept</span>
     <h1>Le Prophète : Volume Oracle</h1>
     <p class="article-subtitle">"J'entends ce que les particuliers ne peuvent pas. Je vois les géants se déplacer dans l'obscurité."</p>
@@ -345,9 +345,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Le%20Proph%C3%A8te%3A%20Volume%20Oracle&url=https://signalpilot.io/fr/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-prophet')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=Le%20Proph%C3%A8te%3A%20Volume%20Oracle&url=https://www.signalpilot.io/fr/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-prophet/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -355,11 +355,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/fr/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Rencontre Le Souverain : Pentarch</h4>
           <p>L'indicateur phare qui cartographie les cinq phases des cycles de marché.</p>
         </a>
-        <a href="/fr/chronicle/the-cartographer" class="related-card">
+        <a href="/fr/chronicle/the-cartographer/" class="related-card">
           <h4>Le Cartographe : Janus Atlas</h4>
           <p>Chaque champ de bataille a son terrain. Janus Atlas cartographie où les guerres seront livrées.</p>
         </a>
@@ -369,7 +369,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toutes les Chroniques</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toutes les Chroniques</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-scales/index.html
+++ b/fr/chronicle/the-scales/index.html
@@ -168,7 +168,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -197,7 +197,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -210,7 +210,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour aux Chroniques</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour aux Chroniques</a>
     <span class="article-category">Quatre sur Sept</span>
     <h1>La Balance : Plutus Flow</h1>
     <p class="article-subtitle">"Je pèse l'invisible. La pression ne ment pas."</p>
@@ -336,9 +336,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Balance%3A%20Plutus%20Flow&url=https://signalpilot.io/fr/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-scales')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=La%20Balance%3A%20Plutus%20Flow&url=https://www.signalpilot.io/fr/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-scales/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -346,11 +346,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/the-cartographer" class="related-card">
+        <a href="/fr/chronicle/the-cartographer/" class="related-card">
           <h4>Le Cartographe : Janus Atlas</h4>
           <p>Chaque champ de bataille a son terrain. Je cartographie où les guerres seront livrées.</p>
         </a>
-        <a href="/fr/chronicle/the-commander" class="related-card">
+        <a href="/fr/chronicle/the-commander/" class="related-card">
           <h4>Le Commandant : OmniDeck</h4>
           <p>Dix systèmes. Une vision. Clarté totale.</p>
         </a>
@@ -360,7 +360,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toutes les Chroniques</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toutes les Chroniques</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/the-watchman/index.html
+++ b/fr/chronicle/the-watchman/index.html
@@ -175,7 +175,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -204,7 +204,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -217,7 +217,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour aux Chroniques</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour aux Chroniques</a>
     <span class="article-category">Six sur Sept</span>
     <h1>Le Vigilant : Augury Grid</h1>
     <p class="article-subtitle">"Pendant que vous regardez un graphique, je les regarde tous."</p>
@@ -384,9 +384,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Le%20Vigilant%3A%20Augury%20Grid&url=https://signalpilot.io/fr/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/the-watchman')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=Le%20Vigilant%3A%20Augury%20Grid&url=https://www.signalpilot.io/fr/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/the-watchman/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -394,11 +394,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/the-commander" class="related-card">
+        <a href="/fr/chronicle/the-commander/" class="related-card">
           <h4>Le Commandant : OmniDeck</h4>
           <p>Dix systèmes. Une vision. Clarté totale.</p>
         </a>
-        <a href="/fr/chronicle/the-arbiter" class="related-card">
+        <a href="/fr/chronicle/the-arbiter/" class="related-card">
           <h4>L'Arbitre : Harmonic Oscillator</h4>
           <p>Quatre voix. Un verdict. Je décide quand la gâchette est tirée.</p>
         </a>
@@ -408,7 +408,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toutes les Chroniques</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toutes les Chroniques</a></p>
     </div>
   </footer>
 

--- a/fr/chronicle/why-non-repainting-matters/index.html
+++ b/fr/chronicle/why-non-repainting-matters/index.html
@@ -186,7 +186,7 @@
             Ressources <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/fr/chronicle/" style="color:var(--accent);">Chronique</a></li>
+            <li><a href="/fr/chronicle//" style="color:var(--accent);">Chronique</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
             <li><a href="/tools/">Outils</a></li>
@@ -215,7 +215,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ressources <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/fr/chronicle/" class="active">Chronique</a></li>
+          <li><a href="/fr/chronicle//" class="active">Chronique</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Outils</a></li>
@@ -228,7 +228,7 @@
   </nav>
 
   <div class="article-header">
-    <a href="/fr/chronicle/" class="back-link">← Retour aux Chroniques</a>
+    <a href="/fr/chronicle//" class="back-link">← Retour aux Chroniques</a>
     <span class="article-category">Confiance & Vérification</span>
     <h1>Pourquoi Le Non-Repaint Est Important</h1>
     <p class="article-subtitle">La plupart des indicateurs vous mentent en modifiant leurs signaux historiques. Voici pourquoi c'est inacceptable.</p>
@@ -388,9 +388,9 @@
   <div class="share-section">
     <h4>Partager cet article</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Pourquoi%20Le%20Non-Repaint%20Est%20Important&url=https://signalpilot.io/fr/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/fr/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/fr/chronicle/why-non-repainting-matters')" class="share-btn">Copier le Lien</button>
+      <a href="https://twitter.com/intent/tweet?text=Pourquoi%20Le%20Non-Repaint%20Est%20Important&url=https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/fr/chronicle/why-non-repainting-matters/')" class="share-btn">Copier le Lien</button>
     </div>
   </div>
 
@@ -398,11 +398,11 @@
     <div class="container">
       <h3>Continuer la Lecture</h3>
       <div class="related-grid">
-        <a href="/fr/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/fr/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Rencontre Le Souverain : Pentarch Expliqué</h4>
           <p>Une plongée profonde dans l'indicateur phare qui cartographie les cinq phases des cycles de marché.</p>
         </a>
-        <a href="/fr/chronicle/the-pilots-oath" class="related-card">
+        <a href="/fr/chronicle/the-pilots-oath/" class="related-card">
           <h4>Le Serment du Pilote</h4>
           <p>Vous qui maniez Les Sept d'Élite n'êtes pas un trader. Vous êtes un Pilote. Voici le serment.</p>
         </a>
@@ -412,7 +412,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle/">Toutes les Chroniques</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tous droits réservés. | <a href="/fr/">Accueil</a> · <a href="/fr/chronicle//">Toutes les Chroniques</a></p>
     </div>
   </footer>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -4778,7 +4778,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Communauté Discord</a></li>
-              <li><a href="/fr/chronicle/">Chronique</a></li>
+              <li><a href="/fr/chronicle//">Chronique</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/fr/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calculateurs</a></li>
@@ -6705,7 +6705,7 @@
 
       <!-- Explore All CTA -->
       <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-        <a href="/fr/chronicle/" class="shiny-cta" style="width:auto;padding:0.9rem 1.8rem;height:auto">
+        <a href="/fr/chronicle//" class="shiny-cta" style="width:auto;padding:0.9rem 1.8rem;height:auto">
           <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic;display:inline-flex;align-items:center;gap:0.75rem">Explorer les 12 Chroniques <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
         </a>
         <p style="margin-top:1rem;font-size:0.9rem;color:var(--muted-2)">Avec narrations audio en voix de magicien profonde</p>
@@ -7449,7 +7449,7 @@
           <div class="mobile-nav-section-label">Produit</div>
           <a href="#inside">Contenu inclus</a>
           <a href="#pricing">Tarifs</a>
-          <a href="/fr/chronicle/">Chronique</a>
+          <a href="/fr/chronicle//">Chronique</a>
           <a href="/tools/">Outils</a>
         </div>
 

--- a/hu/chronicle/birth-of-the-elite-seven/index.html
+++ b/hu/chronicle/birth-of-the-elite-seven/index.html
@@ -169,7 +169,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -200,7 +200,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -213,7 +213,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Eredettörténet</span>
     <h1>Az Elit Hetek Születése</h1>
     <p class="article-subtitle">Mielőtt a piacoknak nevük lett volna, mielőtt a gyertyák történeteket meséltek volna, csak zaj volt.</p>
@@ -380,9 +380,9 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Az%20Elit%20Hetek%20Sz%C3%BClet%C3%A9se&url=https://signalpilot.io/hu/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/birth-of-the-elite-seven')" class="share-btn">Link Másolása</button>
+      <a href="https://twitter.com/intent/tweet?text=Az%20Elit%20Hetek%20Sz%C3%BClet%C3%A9se&url=https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/birth-of-the-elite-seven/')" class="share-btn">Link Másolása</button>
     </div>
   </div>
 
@@ -390,11 +390,11 @@
     <div class="container">
       <h3>Olvass Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/the-pilots-oath" class="related-card">
+        <a href="/hu/chronicle/the-pilots-oath/" class="related-card">
           <h4>A Pilóta Esküje</h4>
           <p>Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy. Ez az eskü.</p>
         </a>
-        <a href="/hu/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/hu/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Jelek Hierarchiája</h4>
           <p>Hogyan működnek együtt a Hetek csillagképként—mindegyik célt szolgálva a rendszerben.</p>
         </a>
@@ -404,7 +404,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/index.html
+++ b/hu/chronicle/index.html
@@ -822,7 +822,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -852,7 +852,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Források <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/hu/chronicle/" class="active">Krónika</a></li>
+          <li><a href="/hu/chronicle//" class="active">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>

--- a/hu/chronicle/meet-the-sovereign/index.html
+++ b/hu/chronicle/meet-the-sovereign/index.html
@@ -632,7 +632,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -663,7 +663,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -676,7 +676,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Indikátor Mélyelemzés</span>
     <h1>Ismerd Meg a Szuverént: A Pentarch Bemutatása</h1>
     <p class="article-subtitle">"Én vagyok a ciklus. A ciklus én vagyok."</p>
@@ -839,13 +839,13 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Ismerd%20Meg%20a%20Szuver%C3%A9nt%3A%20A%20Pentarch%20Bemutat%C3%A1sa&url=https://signalpilot.io/hu/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Ismerd%20Meg%20a%20Szuver%C3%A9nt%3A%20A%20Pentarch%20Bemutat%C3%A1sa&url=https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/meet-the-sovereign')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/meet-the-sovereign/')" class="share-btn">
         Link Másolása
       </button>
     </div>
@@ -855,11 +855,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/hu/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Az Elit Hetek Születése</h4>
           <p>A hét égi jelzés eredettörténete, amelyek az űrben való navigálásra születtek.</p>
         </a>
-        <a href="/hu/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/hu/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Jelek Hierarchiája</h4>
           <p>Hogyan működnek együtt a hetek csillagképként—mindegyik egy célt szolgál a rendszerben.</p>
         </a>
@@ -869,7 +869,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-arbiter/index.html
+++ b/hu/chronicle/the-arbiter/index.html
@@ -179,7 +179,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -210,7 +210,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -223,7 +223,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Hét Közül a Hetedik</span>
     <h1>A Döntőbíró: Harmonic Oscillator</h1>
     <p class="article-subtitle">"Négy hang. Egy ítélet. Én döntöm el, mikor húzzuk meg a ravaszt."</p>
@@ -390,9 +390,9 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20D%C3%B6nt%C5%91b%C3%ADr%C3%B3%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/hu/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-arbiter')" class="share-btn">Link Másolása</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20D%C3%B6nt%C5%91b%C3%ADr%C3%B3%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/hu/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-arbiter/')" class="share-btn">Link Másolása</button>
     </div>
   </div>
 
@@ -400,11 +400,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/the-watchman" class="related-card">
+        <a href="/hu/chronicle/the-watchman/" class="related-card">
           <h4>Az Őrszem: Augury Grid</h4>
           <p>Míg te egy chartot figyelsz, én mindegyiket figyelem.</p>
         </a>
-        <a href="/hu/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/hu/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Jelek Hierarchiája</h4>
           <p>Hogyan működnek együtt az Elit Hetek egységes rendszerként.</p>
         </a>
@@ -414,7 +414,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-cartographer/index.html
+++ b/hu/chronicle/the-cartographer/index.html
@@ -149,7 +149,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -180,7 +180,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -193,7 +193,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Hét Közül a Harmadik</span>
     <h1>A Kartográfus: Janus Atlas</h1>
     <p class="article-subtitle">"Minden csatatérnek megvan a terepje. Én térképezem, hol zajlanak a háborúk."</p>
@@ -317,9 +317,9 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Kartogr%C3%A1fus%3A%20Janus%20Atlas&url=https://signalpilot.io/hu/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-cartographer')" class="share-btn">Link Másolása</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20Kartogr%C3%A1fus%3A%20Janus%20Atlas&url=https://www.signalpilot.io/hu/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-cartographer/')" class="share-btn">Link Másolása</button>
     </div>
   </div>
 
@@ -327,11 +327,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/the-prophet" class="related-card">
+        <a href="/hu/chronicle/the-prophet/" class="related-card">
           <h4>A Próféta: Volume Oracle</h4>
           <p>Hallom, amit a kisbefektetők nem. Látom az óriásokat mozogni a sötétségben.</p>
         </a>
-        <a href="/hu/chronicle/the-scales" class="related-card">
+        <a href="/hu/chronicle/the-scales/" class="related-card">
           <h4>A Mérleg: Plutus Flow</h4>
           <p>Mérem a láthatatlant. A nyomás nem hazudik.</p>
         </a>
@@ -341,7 +341,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-commander/index.html
+++ b/hu/chronicle/the-commander/index.html
@@ -149,7 +149,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -180,7 +180,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -193,7 +193,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Hét Közül az Ötödik</span>
     <h1>A Parancsnok: OmniDeck</h1>
     <p class="article-subtitle">"Tíz rendszer. Egy vízió. Teljes tisztánlátás."</p>
@@ -331,9 +331,9 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Parancsnok%3A%20OmniDeck&url=https://signalpilot.io/hu/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-commander')" class="share-btn">Link Másolása</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20Parancsnok%3A%20OmniDeck&url=https://www.signalpilot.io/hu/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-commander/')" class="share-btn">Link Másolása</button>
     </div>
   </div>
 
@@ -341,11 +341,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/the-scales" class="related-card">
+        <a href="/hu/chronicle/the-scales/" class="related-card">
           <h4>A Mérleg: Plutus Flow</h4>
           <p>Mérem a láthatatlant. A nyomás nem hazudik.</p>
         </a>
-        <a href="/hu/chronicle/the-watchman" class="related-card">
+        <a href="/hu/chronicle/the-watchman/" class="related-card">
           <h4>Az Őrszem: Augury Grid</h4>
           <p>Míg te egy chartot figyelsz, én mindegyiket figyelem.</p>
         </a>
@@ -355,7 +355,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-council-assembles/index.html
+++ b/hu/chronicle/the-council-assembles/index.html
@@ -161,7 +161,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -192,7 +192,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -205,7 +205,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Finálé</span>
     <h1>A Tanács Összeül</h1>
     <p class="article-subtitle">"Megismerted minden tagot. Most nézd, hogyan dolgoznak egyként."</p>
@@ -408,9 +408,9 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Tan%C3%A1cs%20%C3%96ssze%C3%BCl&url=https://signalpilot.io/hu/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-council-assembles')" class="share-btn">Link Másolása</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20Tan%C3%A1cs%20%C3%96ssze%C3%BCl&url=https://www.signalpilot.io/hu/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-council-assembles/')" class="share-btn">Link Másolása</button>
     </div>
   </div>
 
@@ -418,11 +418,11 @@
     <div class="container">
       <h3>Kezd Az Elejétől</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/hu/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Az Elit Hetek Születése</h4>
           <p>Ahol minden kezdődött. Az eredettörténet.</p>
         </a>
-        <a href="/hu/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/hu/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Jelek Hierarchiája</h4>
           <p>Hogyan alkot a Hét célok csillagképét.</p>
         </a>
@@ -432,7 +432,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-hierarchy-of-signals/index.html
+++ b/hu/chronicle/the-hierarchy-of-signals/index.html
@@ -699,7 +699,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -730,7 +730,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -743,7 +743,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Rendszer Architektúra</span>
     <h1>A Jelek Hierarchiája</h1>
     <p class="article-subtitle">Hogyan működnek együtt a hetek csillagképként—mindegyik egy célt szolgál az egységes rendszerben.</p>
@@ -958,13 +958,13 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Jelek%20Hierarchi%C3%A1ja&url=https://signalpilot.io/hu/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=A%20Jelek%20Hierarchi%C3%A1ja&url=https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-hierarchy-of-signals')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-hierarchy-of-signals/')" class="share-btn">
         Link Másolása
       </button>
     </div>
@@ -974,11 +974,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/hu/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Az Elit Hetek Születése</h4>
           <p>A hét égi jelzés eredettörténete, amelyek az űrben való navigálásra születtek.</p>
         </a>
-        <a href="/hu/chronicle/the-pilots-oath" class="related-card">
+        <a href="/hu/chronicle/the-pilots-oath/" class="related-card">
           <h4>A Pilóta Esküje</h4>
           <p>Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy. Ez az eskü.</p>
         </a>
@@ -988,7 +988,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-pilots-oath/index.html
+++ b/hu/chronicle/the-pilots-oath/index.html
@@ -730,7 +730,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -761,7 +761,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -775,7 +775,7 @@
 
   <!-- Article Header -->
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Filozófia</span>
     <h1>A Pilóta Esküje</h1>
     <p class="article-subtitle">Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy.</p>
@@ -945,13 +945,13 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Pil%C3%B3ta%20Esk%C3%BCje&url=https://signalpilot.io/hu/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=A%20Pil%C3%B3ta%20Esk%C3%BCje&url=https://www.signalpilot.io/hu/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-pilots-oath')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-pilots-oath/')" class="share-btn">
         Link Másolása
       </button>
     </div>
@@ -962,11 +962,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/hu/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Az Elit Hetek Születése</h4>
           <p>A hét égi jelzés eredettörténete, amelyek az űrben való navigálásra születtek.</p>
         </a>
-        <a href="/hu/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/hu/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Jelek Hierarchiája</h4>
           <p>Hogyan működnek együtt a hetek csillagképként—mindegyik egy célt szolgál a rendszerben.</p>
         </a>
@@ -977,7 +977,7 @@
   <!-- Footer -->
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-prophet/index.html
+++ b/hu/chronicle/the-prophet/index.html
@@ -155,7 +155,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -186,7 +186,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -199,7 +199,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Hét Közül a Második</span>
     <h1>A Próféta: Volume Oracle</h1>
     <p class="article-subtitle">"Hallom, amit a kisbefektetők nem. Látom az óriásokat mozogni a sötétségben."</p>
@@ -336,9 +336,9 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Pr%C3%B3f%C3%A9ta%3A%20Volume%20Oracle&url=https://signalpilot.io/hu/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-prophet')" class="share-btn">Link Másolása</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20Pr%C3%B3f%C3%A9ta%3A%20Volume%20Oracle&url=https://www.signalpilot.io/hu/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-prophet/')" class="share-btn">Link Másolása</button>
     </div>
   </div>
 
@@ -346,11 +346,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/hu/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Ismerd Meg a Szuverént: Pentarch</h4>
           <p>A zászlóshajó indikátor, amely feltérképezi a piaci ciklusok öt fázisát.</p>
         </a>
-        <a href="/hu/chronicle/the-cartographer" class="related-card">
+        <a href="/hu/chronicle/the-cartographer/" class="related-card">
           <h4>A Kartográfus: Janus Atlas</h4>
           <p>Minden csatatérnek megvan a terepje. A Janus Atlas térképezi, hol zajlanak a háborúk.</p>
         </a>
@@ -360,7 +360,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-scales/index.html
+++ b/hu/chronicle/the-scales/index.html
@@ -156,7 +156,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -187,7 +187,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -200,7 +200,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Hét Közül a Negyedik</span>
     <h1>A Mérleg: Plutus Flow</h1>
     <p class="article-subtitle">"Mérem a láthatatlant. A nyomás nem hazudik."</p>
@@ -327,9 +327,9 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20M%C3%A9rleg%3A%20Plutus%20Flow&url=https://signalpilot.io/hu/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-scales')" class="share-btn">Link Másolása</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20M%C3%A9rleg%3A%20Plutus%20Flow&url=https://www.signalpilot.io/hu/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-scales/')" class="share-btn">Link Másolása</button>
     </div>
   </div>
 
@@ -337,11 +337,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/the-cartographer" class="related-card">
+        <a href="/hu/chronicle/the-cartographer/" class="related-card">
           <h4>A Kartográfus: Janus Atlas</h4>
           <p>Minden csatatérnek megvan a terepje. Én térképezem, hol zajlanak a háborúk.</p>
         </a>
-        <a href="/hu/chronicle/the-commander" class="related-card">
+        <a href="/hu/chronicle/the-commander/" class="related-card">
           <h4>A Parancsnok: OmniDeck</h4>
           <p>Tíz rendszer. Egy vízió. Teljes tisztánlátás.</p>
         </a>
@@ -351,7 +351,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/the-watchman/index.html
+++ b/hu/chronicle/the-watchman/index.html
@@ -163,7 +163,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -194,7 +194,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -207,7 +207,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Hét Közül a Hatodik</span>
     <h1>Az Őrszem: Augury Grid</h1>
     <p class="article-subtitle">"Míg te egy chartot figyelsz, én mindegyiket figyelem."</p>
@@ -369,9 +369,9 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Az%20%C5%90rszem%3A%20Augury%20Grid&url=https://signalpilot.io/hu/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/the-watchman')" class="share-btn">Link Másolása</button>
+      <a href="https://twitter.com/intent/tweet?text=Az%20%C5%90rszem%3A%20Augury%20Grid&url=https://www.signalpilot.io/hu/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/the-watchman/')" class="share-btn">Link Másolása</button>
     </div>
   </div>
 
@@ -379,11 +379,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/the-commander" class="related-card">
+        <a href="/hu/chronicle/the-commander/" class="related-card">
           <h4>A Parancsnok: OmniDeck</h4>
           <p>Tíz rendszer. Egy vízió. Teljes tisztánlátás.</p>
         </a>
-        <a href="/hu/chronicle/the-arbiter" class="related-card">
+        <a href="/hu/chronicle/the-arbiter/" class="related-card">
           <h4>A Döntőbíró: Harmonic Oscillator</h4>
           <p>Négy hang. Egy ítélet. Én döntöm el, mikor húzzuk meg a ravaszt.</p>
         </a>
@@ -393,7 +393,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/chronicle/why-non-repainting-matters/index.html
+++ b/hu/chronicle/why-non-repainting-matters/index.html
@@ -673,7 +673,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+              <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Eszközök</a></li>
@@ -704,7 +704,7 @@
           Források <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/hu/chronicle/" style="color: var(--accent);">Krónika</a></li>
+          <li><a href="/hu/chronicle//" style="color: var(--accent);">Krónika</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Eszközök</a></li>
@@ -717,7 +717,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/hu/chronicle/" class="back-link">← Vissza a Krónikához</a>
+    <a href="/hu/chronicle//" class="back-link">← Vissza a Krónikához</a>
     <span class="article-category">Bizalom és Ellenőrzés</span>
     <h1>Miért Fontos a Nem-Újrafestés</h1>
     <p class="article-subtitle">A legtöbb indikátor hazudik, mert megváltoztatja a történelmi jelzéseit. Íme, miért elfogadhatatlan ez.</p>
@@ -880,13 +880,13 @@
   <div class="share-section">
     <h4>Cikk Megosztása</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Mi%C3%A9rt%20Fontos%20a%20Nem-%C3%9Ajrafest%C3%A9s&url=https://signalpilot.io/hu/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=Mi%C3%A9rt%20Fontos%20a%20Nem-%C3%9Ajrafest%C3%A9s&url=https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Post
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/hu/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/hu/chronicle/why-non-repainting-matters')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/hu/chronicle/why-non-repainting-matters/')" class="share-btn">
         Link Másolása
       </button>
     </div>
@@ -896,11 +896,11 @@
     <div class="container">
       <h3>Olvasson Tovább</h3>
       <div class="related-grid">
-        <a href="/hu/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/hu/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Ismerd Meg a Szuverént: A Pentarch Bemutatása</h4>
           <p>Mély betekintés a zászlóshajó indikátorba, amely feltérképezi a piaci ciklusok öt fázisát.</p>
         </a>
-        <a href="/hu/chronicle/the-pilots-oath" class="related-card">
+        <a href="/hu/chronicle/the-pilots-oath/" class="related-card">
           <h4>A Pilóta Esküje</h4>
           <p>Te, aki az Elit Heteket forgatod, nem kereskedő vagy. Pilóta vagy. Ez az eskü.</p>
         </a>
@@ -910,7 +910,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle/">Összes Krónika</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Minden jog fenntartva. | <a href="/hu/">Főoldal</a> · <a href="/hu/chronicle//">Összes Krónika</a></p>
     </div>
   </footer>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -4496,7 +4496,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Közösség</a></li>
-              <li><a href="/hu/chronicle/">Krónika</a></li>
+              <li><a href="/hu/chronicle//">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/hu/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Számológépek</a></li>
@@ -6373,7 +6373,7 @@
 
         <!-- Explore All CTA -->
         <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-          <a href="/hu/chronicle/" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
+          <a href="/hu/chronicle//" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
             <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Mind a 12 Krónika Felfedezése</span>
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
@@ -7105,7 +7105,7 @@
           <div class="mobile-nav-section-label">Termék</div>
           <a href="#inside">Mi van benne</a>
           <a href="#pricing">Árazás</a>
-          <a href="/hu/chronicle/">Krónika</a>
+          <a href="/hu/chronicle//">Krónika</a>
           <a href="/tools/">Eszközök</a>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -3476,7 +3476,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a></li>
-              <li><a href="/chronicle/">Chronicle</a></li>
+              <li><a href="/chronicle//">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calculators</a></li>
@@ -5637,7 +5637,7 @@
 
       <!-- Explore All CTA -->
       <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-        <a href="/chronicle/" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
+        <a href="/chronicle//" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
           <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Explore All 12 Chronicles</span>
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="position:relative;z-index:2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
@@ -6351,7 +6351,7 @@
           <div class="mobile-nav-section-label">Product</div>
           <a href="#inside">What's inside</a>
           <a href="#pricing">Pricing</a>
-          <a href="/chronicle/">Chronicle</a>
+          <a href="/chronicle//">Chronicle</a>
           <a href="/tools/">Tools</a>
         </div>
 

--- a/it/chronicle/birth-of-the-elite-seven/index.html
+++ b/it/chronicle/birth-of-the-elite-seven/index.html
@@ -167,7 +167,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -204,7 +204,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -217,7 +217,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Origini</span>
     <h1>La Nascita dei Sette d'Élite</h1>
     <p class="article-subtitle">In un'epoca di caos, sette indicatori si sono forgiati dal rumore. Questa è la loro storia di origine.</p>
@@ -347,9 +347,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Nascita%20dei%20Sette%20d%27%C3%89lite&url=https://signalpilot.io/it/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/birth-of-the-elite-seven')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=La%20Nascita%20dei%20Sette%20d%27%C3%89lite&url=https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/birth-of-the-elite-seven/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -357,11 +357,11 @@
     <div class="container">
       <h3>Continua la Lettura</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/the-pilots-oath" class="related-card">
+        <a href="/it/chronicle/the-pilots-oath/" class="related-card">
           <h4>Il Giuramento del Pilota</h4>
           <p>Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota. Questo è il giuramento.</p>
         </a>
-        <a href="/it/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/it/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Incontra Il Sovrano: Pentarch Spiegato</h4>
           <p>Un'immersione profonda nell'indicatore ammiraglia che mappa le cinque fasi dei cicli di mercato.</p>
         </a>
@@ -371,7 +371,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/index.html
+++ b/it/chronicle/index.html
@@ -162,7 +162,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color: var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color: var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -191,7 +191,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Risorse <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/it/chronicle/" class="active">Cronaca</a></li>
+          <li><a href="/it/chronicle//" class="active">Cronaca</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Strumenti</a></li>

--- a/it/chronicle/meet-the-sovereign/index.html
+++ b/it/chronicle/meet-the-sovereign/index.html
@@ -176,7 +176,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -213,7 +213,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -226,7 +226,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Uno di Sette</span>
     <h1>Incontra Il Sovrano: Pentarch Spiegato</h1>
     <p class="article-subtitle">"Vedo il battito cardiaco. Cinque fasi. Cicli senza fine. Il ritmo che tutto governa."</p>
@@ -363,9 +363,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Incontra%20Il%20Sovrano%3A%20Pentarch%20Spiegato&url=https://signalpilot.io/it/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/meet-the-sovereign')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Incontra%20Il%20Sovrano%3A%20Pentarch%20Spiegato&url=https://www.signalpilot.io/it/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/meet-the-sovereign/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -373,11 +373,11 @@
     <div class="container">
       <h3>Continua la Lettura</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/the-prophet" class="related-card">
+        <a href="/it/chronicle/the-prophet/" class="related-card">
           <h4>Il Profeta: Volume Oracle</h4>
           <p>Sento ciò che i retail non possono. Vedo i giganti muoversi nell'oscurità.</p>
         </a>
-        <a href="/it/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/it/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Gerarchia dei Segnali</h4>
           <p>Non tutti i segnali sono uguali. Impara come I Sette formano una costellazione di scopo.</p>
         </a>
@@ -387,7 +387,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-arbiter/index.html
+++ b/it/chronicle/the-arbiter/index.html
@@ -184,7 +184,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -221,7 +221,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -234,7 +234,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Sette di Sette</span>
     <h1>L'Arbitro: Harmonic Oscillator</h1>
     <p class="article-subtitle">"Quattro voci. Un verdetto. Io decido quando premere il grilletto."</p>
@@ -400,9 +400,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=L%27Arbitro%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/it/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-arbiter')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=L%27Arbitro%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/it/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-arbiter/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -410,11 +410,11 @@
     <div class="container">
       <h3>Continua a Leggere</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/the-watchman" class="related-card">
+        <a href="/it/chronicle/the-watchman/" class="related-card">
           <h4>La Sentinella: Augury Grid</h4>
           <p>Mentre tu guardi un grafico, io li guardo tutti.</p>
         </a>
-        <a href="/it/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/it/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Gerarchia dei Segnali</h4>
           <p>Come i Sette d'Élite lavorano insieme come un sistema unificato.</p>
         </a>
@@ -424,7 +424,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-cartographer/index.html
+++ b/it/chronicle/the-cartographer/index.html
@@ -169,7 +169,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -205,7 +205,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -219,7 +219,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Tre di Sette</span>
     <h1>Il Cartografo: Janus Atlas</h1>
     <p class="article-subtitle">"Ogni campo di battaglia ha il suo terreno. Io mappo dove verranno combattute le guerre."</p>
@@ -342,9 +342,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Il%20Cartografo%3A%20Janus%20Atlas&url=https://signalpilot.io/it/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-cartographer')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Il%20Cartografo%3A%20Janus%20Atlas&url=https://www.signalpilot.io/it/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-cartographer/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -352,11 +352,11 @@
     <div class="container">
       <h3>Continua a Leggere</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/the-prophet" class="related-card">
+        <a href="/it/chronicle/the-prophet/" class="related-card">
           <h4>Il Profeta: Volume Oracle</h4>
           <p>Sento quello che i retail non possono. Vedo i giganti muoversi nell'oscurità.</p>
         </a>
-        <a href="/it/chronicle/the-scales" class="related-card">
+        <a href="/it/chronicle/the-scales/" class="related-card">
           <h4>La Bilancia: Plutus Flow</h4>
           <p>Peso l'invisibile. La pressione non mente.</p>
         </a>
@@ -366,7 +366,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-commander/index.html
+++ b/it/chronicle/the-commander/index.html
@@ -169,7 +169,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -205,7 +205,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -219,7 +219,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Cinque di Sette</span>
     <h1>Il Comandante: OmniDeck</h1>
     <p class="article-subtitle">"Dieci sistemi. Una visione. Chiarezza totale."</p>
@@ -356,9 +356,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Il%20Comandante%3A%20OmniDeck&url=https://signalpilot.io/it/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-commander')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Il%20Comandante%3A%20OmniDeck&url=https://www.signalpilot.io/it/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-commander/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -366,11 +366,11 @@
     <div class="container">
       <h3>Continua a Leggere</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/the-scales" class="related-card">
+        <a href="/it/chronicle/the-scales/" class="related-card">
           <h4>La Bilancia: Plutus Flow</h4>
           <p>Peso l'invisibile. La pressione non mente.</p>
         </a>
-        <a href="/it/chronicle/the-watchman" class="related-card">
+        <a href="/it/chronicle/the-watchman/" class="related-card">
           <h4>La Sentinella: Augury Grid</h4>
           <p>Mentre tu guardi un grafico, io li guardo tutti.</p>
         </a>
@@ -380,7 +380,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-council-assembles/index.html
+++ b/it/chronicle/the-council-assembles/index.html
@@ -181,7 +181,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -217,7 +217,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -231,7 +231,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Finale</span>
     <h1>Il Consiglio Si Riunisce</h1>
     <p class="article-subtitle">"Hai incontrato ogni membro. Ora guardali lavorare come uno."</p>
@@ -433,9 +433,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Il%20Consiglio%20Si%20Riunisce&url=https://signalpilot.io/it/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-council-assembles')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Il%20Consiglio%20Si%20Riunisce&url=https://www.signalpilot.io/it/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-council-assembles/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -443,11 +443,11 @@
     <div class="container">
       <h3>Inizia Dall'Inizio</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/it/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>La Nascita dei Sette d'Élite</h4>
           <p>Dove tutto è iniziato. La storia delle origini.</p>
         </a>
-        <a href="/it/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/it/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Gerarchia dei Segnali</h4>
           <p>Come I Sette formano una costellazione di scopo.</p>
         </a>
@@ -457,7 +457,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-hierarchy-of-signals/index.html
+++ b/it/chronicle/the-hierarchy-of-signals/index.html
@@ -175,7 +175,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -211,7 +211,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -225,7 +225,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Architettura</span>
     <h1>La Gerarchia dei Segnali</h1>
     <p class="article-subtitle">Non tutti i segnali sono uguali. Impara come I Sette formano una costellazione di scopo.</p>
@@ -382,9 +382,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Gerarchia%20dei%20Segnali&url=https://signalpilot.io/it/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-hierarchy-of-signals')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=La%20Gerarchia%20dei%20Segnali&url=https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-hierarchy-of-signals/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -392,11 +392,11 @@
     <div class="container">
       <h3>Continua la Lettura</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/the-pilots-oath" class="related-card">
+        <a href="/it/chronicle/the-pilots-oath/" class="related-card">
           <h4>Il Giuramento del Pilota</h4>
           <p>Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota.</p>
         </a>
-        <a href="/it/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/it/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Incontra Il Sovrano: Pentarch</h4>
           <p>L'indicatore ammiraglia che mappa le cinque fasi dei cicli di mercato.</p>
         </a>
@@ -406,7 +406,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-pilots-oath/index.html
+++ b/it/chronicle/the-pilots-oath/index.html
@@ -173,7 +173,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -209,7 +209,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -223,7 +223,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Filosofia</span>
     <h1>Il Giuramento del Pilota</h1>
     <p class="article-subtitle">Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota. Questo è il giuramento.</p>
@@ -354,9 +354,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Il%20Giuramento%20del%20Pilota&url=https://signalpilot.io/it/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-pilots-oath')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Il%20Giuramento%20del%20Pilota&url=https://www.signalpilot.io/it/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-pilots-oath/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -364,11 +364,11 @@
     <div class="container">
       <h3>Continua la Lettura</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/it/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>La Nascita dei Sette d'Élite</h4>
           <p>In un'epoca di caos, sette indicatori si sono forgiati dal rumore.</p>
         </a>
-        <a href="/it/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/it/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>La Gerarchia dei Segnali</h4>
           <p>Non tutti i segnali sono uguali. Impara come I Sette formano una costellazione di scopo.</p>
         </a>
@@ -378,7 +378,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-prophet/index.html
+++ b/it/chronicle/the-prophet/index.html
@@ -175,7 +175,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -211,7 +211,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -225,7 +225,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Due di Sette</span>
     <h1>Il Profeta: Volume Oracle</h1>
     <p class="article-subtitle">"Sento quello che i retail non possono. Vedo i giganti muoversi nell'oscurità."</p>
@@ -361,9 +361,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Il%20Profeta%3A%20Volume%20Oracle&url=https://signalpilot.io/it/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-prophet')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Il%20Profeta%3A%20Volume%20Oracle&url=https://www.signalpilot.io/it/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-prophet/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -371,11 +371,11 @@
     <div class="container">
       <h3>Continua a Leggere</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/it/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Incontra Il Sovrano: Pentarch</h4>
           <p>L'indicatore principale che mappa le cinque fasi dei cicli di mercato.</p>
         </a>
-        <a href="/it/chronicle/the-cartographer" class="related-card">
+        <a href="/it/chronicle/the-cartographer/" class="related-card">
           <h4>Il Cartografo: Janus Atlas</h4>
           <p>Ogni campo di battaglia ha il suo terreno. Janus Atlas mappa dove verranno combattute le guerre.</p>
         </a>
@@ -385,7 +385,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-scales/index.html
+++ b/it/chronicle/the-scales/index.html
@@ -176,7 +176,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -212,7 +212,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -226,7 +226,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Quattro di Sette</span>
     <h1>La Bilancia: Plutus Flow</h1>
     <p class="article-subtitle">"Peso l'invisibile. La pressione non mente."</p>
@@ -352,9 +352,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Bilancia%3A%20Plutus%20Flow&url=https://signalpilot.io/it/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-scales')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=La%20Bilancia%3A%20Plutus%20Flow&url=https://www.signalpilot.io/it/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-scales/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -362,11 +362,11 @@
     <div class="container">
       <h3>Continua a Leggere</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/the-cartographer" class="related-card">
+        <a href="/it/chronicle/the-cartographer/" class="related-card">
           <h4>Il Cartografo: Janus Atlas</h4>
           <p>Ogni campo di battaglia ha il suo terreno. Mappo dove verranno combattute le guerre.</p>
         </a>
-        <a href="/it/chronicle/the-commander" class="related-card">
+        <a href="/it/chronicle/the-commander/" class="related-card">
           <h4>Il Comandante: OmniDeck</h4>
           <p>Dieci sistemi. Una visione. Chiarezza totale.</p>
         </a>
@@ -376,7 +376,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/the-watchman/index.html
+++ b/it/chronicle/the-watchman/index.html
@@ -183,7 +183,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -219,7 +219,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -233,7 +233,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Sei di Sette</span>
     <h1>La Sentinella: Augury Grid</h1>
     <p class="article-subtitle">"Mentre tu guardi un grafico, io li guardo tutti."</p>
@@ -400,9 +400,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=La%20Sentinella%3A%20Augury%20Grid&url=https://signalpilot.io/it/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/the-watchman')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=La%20Sentinella%3A%20Augury%20Grid&url=https://www.signalpilot.io/it/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/the-watchman/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -410,11 +410,11 @@
     <div class="container">
       <h3>Continua a Leggere</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/the-commander" class="related-card">
+        <a href="/it/chronicle/the-commander/" class="related-card">
           <h4>Il Comandante: OmniDeck</h4>
           <p>Dieci sistemi. Una visione. Chiarezza totale.</p>
         </a>
-        <a href="/it/chronicle/the-arbiter" class="related-card">
+        <a href="/it/chronicle/the-arbiter/" class="related-card">
           <h4>L'Arbitro: Harmonic Oscillator</h4>
           <p>Quattro voci. Un verdetto. Io decido quando premere il grilletto.</p>
         </a>
@@ -424,7 +424,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/chronicle/why-non-repainting-matters/index.html
+++ b/it/chronicle/why-non-repainting-matters/index.html
@@ -193,7 +193,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a></li>
+              <li><a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Strumenti</a></li>
@@ -229,7 +229,7 @@
           Risorse <span class="dropdown-arrow">▼</span>
         </button>
         <div class="mobile-submenu" id="mobileSubmenu">
-          <a href="/it/chronicle/" style="color:var(--accent);">Cronaca</a>
+          <a href="/it/chronicle//" style="color:var(--accent);">Cronaca</a>
           <a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a>
           <a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a>
           <a href="/tools/">Tools</a>
@@ -243,7 +243,7 @@
 
 
   <div class="article-header">
-    <a href="/it/chronicle/" class="back-link">← Torna alle Cronache</a>
+    <a href="/it/chronicle//" class="back-link">← Torna alle Cronache</a>
     <span class="article-category">Fiducia & Verifica</span>
     <h1>Perché il Non-Repainting È Importante</h1>
     <p class="article-subtitle">La maggior parte degli indicatori ti mente cambiando i loro segnali storici. Ecco perché questo è inaccettabile.</p>
@@ -406,9 +406,9 @@
   <div class="share-section">
     <h4>Condividi questo articolo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Perch%C3%A9%20il%20Non-Repainting%20%C3%88%20Importante&url=https://signalpilot.io/it/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/it/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/it/chronicle/why-non-repainting-matters')" class="share-btn">Copia Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Perch%C3%A9%20il%20Non-Repainting%20%C3%88%20Importante&url=https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/it/chronicle/why-non-repainting-matters/')" class="share-btn">Copia Link</button>
     </div>
   </div>
 
@@ -416,11 +416,11 @@
     <div class="container">
       <h3>Continua a Leggere</h3>
       <div class="related-grid">
-        <a href="/it/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/it/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Incontra Il Sovrano: Pentarch Spiegato</h4>
           <p>Un'analisi approfondita dell'indicatore principale che mappa le cinque fasi dei cicli di mercato.</p>
         </a>
-        <a href="/it/chronicle/the-pilots-oath" class="related-card">
+        <a href="/it/chronicle/the-pilots-oath/" class="related-card">
           <h4>Il Giuramento del Pilota</h4>
           <p>Tu che impugni I Sette d'Élite non sei un trader. Sei un Pilota. Questo è il giuramento.</p>
         </a>
@@ -430,7 +430,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle/">Tutte le Cronache</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tutti i diritti riservati. | <a href="/it/">Home</a> · <a href="/it/chronicle//">Tutte le Cronache</a></p>
     </div>
   </footer>
 

--- a/it/index.html
+++ b/it/index.html
@@ -4477,7 +4477,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunità Discord</a></li>
-              <li><a href="/it/chronicle/">Cronaca</a></li>
+              <li><a href="/it/chronicle//">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/it/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calcolatori</a></li>
@@ -6034,7 +6034,7 @@
           </a>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-          <a href="/it/chronicle/" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
+          <a href="/it/chronicle//" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
             <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Esplora Tutte le 12 Cronache</span>
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
@@ -6699,7 +6699,7 @@
           <div class="mobile-nav-section-label">Prodotto</div>
           <a href="#inside">Cosa c'è dentro</a>
           <a href="#pricing">Prezzi</a>
-          <a href="/it/chronicle/">Cronaca</a>
+          <a href="/it/chronicle//">Cronaca</a>
           <a href="/tools/">Strumenti</a>
         </div>
 

--- a/ja/chronicle/birth-of-the-elite-seven/index.html
+++ b/ja/chronicle/birth-of-the-elite-seven/index.html
@@ -162,7 +162,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -180,7 +180,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">起源の物語</span>
     <h1>エリートセブンの誕生</h1>
     <p class="article-subtitle">「すべてはシグナルの混乱から始まった。」</p>
@@ -270,9 +270,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%82%A8%E3%83%AA%E3%83%BC%E3%83%88%E3%82%BB%E3%83%96%E3%83%B3%E3%81%AE%E8%AA%95%E7%94%9F&url=https://signalpilot.io/ja/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/birth-of-the-elite-seven')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%82%A8%E3%83%AA%E3%83%BC%E3%83%88%E3%82%BB%E3%83%96%E3%83%B3%E3%81%AE%E8%AA%95%E7%94%9F&url=https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/birth-of-the-elite-seven/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -280,11 +280,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-pilots-oath" class="related-card">
+        <a href="/ja/chronicle/the-pilots-oath/" class="related-card">
           <h4>パイロットの誓い</h4>
           <p>すべてのパイロットが従う規律の核心にあるもの。</p>
         </a>
-        <a href="/ja/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ja/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>シグナルの階層</h4>
           <p>セブンがどのように目的の星座を形成するか。</p>
         </a>
@@ -294,7 +294,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">すべてのクロニクル</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">すべてのクロニクル</a></p>
     </div>
   </footer>
 
@@ -305,7 +305,7 @@
     // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
   </script>
 <!-- Lenis Smooth Scroll -->
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>

--- a/ja/chronicle/index.html
+++ b/ja/chronicle/index.html
@@ -822,7 +822,7 @@
               リソース <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ja/chronicle/" style="color: var(--accent);">クロニクル</a></li>
+              <li><a href="/ja/chronicle//" style="color: var(--accent);">クロニクル</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
               <li><a href="/tools/">ツール</a></li>
@@ -852,7 +852,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">リソース <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/ja/chronicle/" class="active">クロニクル</a></li>
+          <li><a href="/ja/chronicle//" class="active">クロニクル</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
           <li><a href="/tools/">ツール</a></li>

--- a/ja/chronicle/meet-the-sovereign/index.html
+++ b/ja/chronicle/meet-the-sovereign/index.html
@@ -169,7 +169,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -187,7 +187,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">インジケーターの深掘り</span>
     <h1>ソブリンに会う：Pentarch</h1>
     <p class="article-subtitle">「私はサイクルを読む。サイクルはすべてを明らかにする。」</p>
@@ -279,9 +279,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%82%BD%E3%83%96%E3%83%AA%E3%83%B3%E3%81%AB%E4%BC%9A%E3%81%86%3A%20Pentarch&url=https://signalpilot.io/ja/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/meet-the-sovereign')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%82%BD%E3%83%96%E3%83%AA%E3%83%B3%E3%81%AB%E4%BC%9A%E3%81%86%3A%20Pentarch&url=https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/meet-the-sovereign/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -289,11 +289,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-prophet" class="related-card">
+        <a href="/ja/chronicle/the-prophet/" class="related-card">
           <h4>プロフェット：Volume Oracle</h4>
           <p>私は小売が聞けないものを聞く。私は巨人が闇の中で動くのを見る。</p>
         </a>
-        <a href="/ja/chronicle/the-cartographer" class="related-card">
+        <a href="/ja/chronicle/the-cartographer/" class="related-card">
           <h4>カートグラファー：Janus Atlas</h4>
           <p>すべての戦場にはその地形がある。私は戦争が戦われる場所をマップする。</p>
         </a>
@@ -303,7 +303,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">すべてのクロニクル</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">すべてのクロニクル</a></p>
     </div>
   </footer>
 
@@ -314,7 +314,7 @@
     // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
   </script>
 <!-- Lenis Smooth Scroll -->
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>

--- a/ja/chronicle/the-arbiter/index.html
+++ b/ja/chronicle/the-arbiter/index.html
@@ -181,7 +181,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -199,7 +199,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">セブンの第七</span>
     <h1>アービター：Harmonic Oscillator</h1>
     <p class="article-subtitle">「4つの声。一つの判定。私がトリガーを引くときを決める。」</p>
@@ -365,9 +365,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%82%A2%E3%83%BC%E3%83%93%E3%82%BF%E3%83%BC%EF%BC%9AHarmonic%20Oscillator&url=https://signalpilot.io/ja/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-arbiter')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%82%A2%E3%83%BC%E3%83%93%E3%82%BF%E3%83%BC%EF%BC%9AHarmonic%20Oscillator&url=https://www.signalpilot.io/ja/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-arbiter/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -375,11 +375,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-watchman" class="related-card">
+        <a href="/ja/chronicle/the-watchman/" class="related-card">
           <h4>ウォッチマン：Augury Grid</h4>
           <p>あなたが一つのチャートを見ている間、私はすべてを見ている。</p>
         </a>
-        <a href="/ja/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ja/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>シグナルの階層</h4>
           <p>エリートセブンが統一されたシステムとしてどのように連携するか。</p>
         </a>
@@ -389,7 +389,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">クロニクル一覧</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">クロニクル一覧</a></p>
     </div>
   </footer>
 
@@ -400,7 +400,7 @@
     // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
   </script>
 <!-- Lenis Smooth Scroll -->
 <script src="https://unpkg.com/lenis@1.3.17/dist/lenis.min.js"></script>

--- a/ja/chronicle/the-cartographer/index.html
+++ b/ja/chronicle/the-cartographer/index.html
@@ -165,7 +165,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -182,7 +182,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">セブンの第三</span>
     <h1>カートグラファー：Janus Atlas</h1>
     <p class="article-subtitle">「すべての戦場には地形がある。私は戦いが行われる場所をマッピングする。」</p>
@@ -305,9 +305,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%82%AB%E3%83%BC%E3%83%88%E3%82%B0%E3%83%A9%E3%83%95%E3%82%A1%E3%83%BC%EF%BC%9AJanus%20Atlas&url=https://signalpilot.io/ja/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-cartographer')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%82%AB%E3%83%BC%E3%83%88%E3%82%B0%E3%83%A9%E3%83%95%E3%82%A1%E3%83%BC%EF%BC%9AJanus%20Atlas&url=https://www.signalpilot.io/ja/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-cartographer/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -315,11 +315,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-prophet" class="related-card">
+        <a href="/ja/chronicle/the-prophet/" class="related-card">
           <h4>プロフェット：Volume Oracle</h4>
           <p>リテールには聞こえないものを聞く。巨人たちが闇の中で動くのを見る。</p>
         </a>
-        <a href="/ja/chronicle/the-scales" class="related-card">
+        <a href="/ja/chronicle/the-scales/" class="related-card">
           <h4>スケール：Plutus Flow</h4>
           <p>見えないものを量る。圧力は嘘をつかない。</p>
         </a>
@@ -329,7 +329,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">クロニクル一覧</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">クロニクル一覧</a></p>
     </div>
   </footer>
 
@@ -339,7 +339,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/chronicle/the-commander/index.html
+++ b/ja/chronicle/the-commander/index.html
@@ -160,7 +160,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -178,7 +178,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">セブンの第五</span>
     <h1>コマンダー：OmniDeck</h1>
     <p class="article-subtitle">「10のシステム。一つのビジョン。完全な明晰さ。」</p>
@@ -315,9 +315,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%80%E3%83%BC%EF%BC%9AOmniDeck&url=https://signalpilot.io/ja/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-commander')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%80%E3%83%BC%EF%BC%9AOmniDeck&url=https://www.signalpilot.io/ja/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-commander/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -325,11 +325,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-scales" class="related-card">
+        <a href="/ja/chronicle/the-scales/" class="related-card">
           <h4>スケール：Plutus Flow</h4>
           <p>見えないものを量る。圧力は嘘をつかない。</p>
         </a>
-        <a href="/ja/chronicle/the-watchman" class="related-card">
+        <a href="/ja/chronicle/the-watchman/" class="related-card">
           <h4>ウォッチマン：Augury Grid</h4>
           <p>あなたが一つのチャートを見ている間、私はすべてを見ている。</p>
         </a>
@@ -339,7 +339,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">クロニクル一覧</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">クロニクル一覧</a></p>
     </div>
   </footer>
 
@@ -349,7 +349,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/chronicle/the-council-assembles/index.html
+++ b/ja/chronicle/the-council-assembles/index.html
@@ -172,7 +172,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -190,7 +190,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">フィナーレ</span>
     <h1>評議会は集う</h1>
     <p class="article-subtitle">「各メンバーと会いました。今、彼らが一つとして働くのを見てください。」</p>
@@ -392,9 +392,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E8%A9%95%E8%AD%B0%E4%BC%9A%E3%81%AF%E9%9B%86%E3%81%86&url=https://signalpilot.io/ja/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-council-assembles')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E8%A9%95%E8%AD%B0%E4%BC%9A%E3%81%AF%E9%9B%86%E3%81%86&url=https://www.signalpilot.io/ja/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-council-assembles/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -402,11 +402,11 @@
     <div class="container">
       <h3>最初から読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ja/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>エリートセブンの誕生</h4>
           <p>すべてが始まった場所。起源の物語。</p>
         </a>
-        <a href="/ja/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ja/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>シグナルの階層</h4>
           <p>セブンがどのように目的の星座を形成するか。</p>
         </a>
@@ -416,7 +416,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">クロニクル一覧</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">クロニクル一覧</a></p>
     </div>
   </footer>
 
@@ -426,7 +426,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/chronicle/the-hierarchy-of-signals/index.html
+++ b/ja/chronicle/the-hierarchy-of-signals/index.html
@@ -166,7 +166,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -184,7 +184,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">システムアーキテクチャ</span>
     <h1>シグナルの階層</h1>
     <p class="article-subtitle">「セブンは民主主義ではない。星座なのだ。」</p>
@@ -290,9 +290,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%82%B7%E3%82%B0%E3%83%8A%E3%83%AB%E3%81%AE%E9%9A%8E%E5%B1%A4&url=https://signalpilot.io/ja/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-hierarchy-of-signals')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%82%B7%E3%82%B0%E3%83%8A%E3%83%AB%E3%81%AE%E9%9A%8E%E5%B1%A4&url=https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-hierarchy-of-signals/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -300,11 +300,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-pilots-oath" class="related-card">
+        <a href="/ja/chronicle/the-pilots-oath/" class="related-card">
           <h4>パイロットの誓い</h4>
           <p>すべてのパイロットが従う規律の核心にあるもの。</p>
         </a>
-        <a href="/ja/chronicle/why-non-repainting-matters" class="related-card">
+        <a href="/ja/chronicle/why-non-repainting-matters/" class="related-card">
           <h4>なぜノンリペイントが重要か</h4>
           <p>なぜあなたのインジケーターがリペイントするとき、あなたは負けるのか。</p>
         </a>
@@ -314,7 +314,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">すべてのクロニクル</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">すべてのクロニクル</a></p>
     </div>
   </footer>
 
@@ -324,7 +324,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/chronicle/the-pilots-oath/index.html
+++ b/ja/chronicle/the-pilots-oath/index.html
@@ -162,7 +162,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -180,7 +180,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">哲学</span>
     <h1>パイロットの誓い</h1>
     <p class="article-subtitle">「規律なきツールは武器ではない。危険なのだ。」</p>
@@ -263,9 +263,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%83%91%E3%82%A4%E3%83%AD%E3%83%83%E3%83%88%E3%81%AE%E8%AA%93%E3%81%84&url=https://signalpilot.io/ja/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-pilots-oath')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%83%91%E3%82%A4%E3%83%AD%E3%83%83%E3%83%88%E3%81%AE%E8%AA%93%E3%81%84&url=https://www.signalpilot.io/ja/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-pilots-oath/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -273,11 +273,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ja/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>エリートセブンの誕生</h4>
           <p>すべてが始まった場所。起源の物語。</p>
         </a>
-        <a href="/ja/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ja/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>シグナルの階層</h4>
           <p>セブンがどのように目的の星座を形成するか。</p>
         </a>
@@ -287,7 +287,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">すべてのクロニクル</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">すべてのクロニクル</a></p>
     </div>
   </footer>
 
@@ -297,7 +297,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/chronicle/the-prophet/index.html
+++ b/ja/chronicle/the-prophet/index.html
@@ -162,7 +162,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -180,7 +180,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">セブンの第二</span>
     <h1>プロフェット：Volume Oracle</h1>
     <p class="article-subtitle">「私は小売が聞けないものを聞く。私は巨人が闇の中で動くのを見る。」</p>
@@ -270,9 +270,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%83%97%E3%83%AD%E3%83%95%E3%82%A7%E3%83%83%E3%83%88%3A%20Volume%20Oracle&url=https://signalpilot.io/ja/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-prophet')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%83%97%E3%83%AD%E3%83%95%E3%82%A7%E3%83%83%E3%83%88%3A%20Volume%20Oracle&url=https://www.signalpilot.io/ja/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-prophet/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -280,11 +280,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/ja/chronicle/meet-the-sovereign/" class="related-card">
           <h4>ソブリンに会う：Pentarch</h4>
           <p>サイクルのマスター、シグナルの王。</p>
         </a>
-        <a href="/ja/chronicle/the-cartographer" class="related-card">
+        <a href="/ja/chronicle/the-cartographer/" class="related-card">
           <h4>カートグラファー：Janus Atlas</h4>
           <p>すべての戦場にはその地形がある。私は戦争が戦われる場所をマップする。</p>
         </a>
@@ -294,7 +294,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">すべてのクロニクル</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">すべてのクロニクル</a></p>
     </div>
   </footer>
 
@@ -304,7 +304,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/chronicle/the-scales/index.html
+++ b/ja/chronicle/the-scales/index.html
@@ -167,7 +167,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -185,7 +185,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">セブンの第四</span>
     <h1>スケール：Plutus Flow</h1>
     <p class="article-subtitle">「見えないものを量る。圧力は嘘をつかない。」</p>
@@ -311,9 +311,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%82%B9%E3%82%B1%E3%83%BC%E3%83%AB%EF%BC%9APlutus%20Flow&url=https://signalpilot.io/ja/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-scales')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%82%B9%E3%82%B1%E3%83%BC%E3%83%AB%EF%BC%9APlutus%20Flow&url=https://www.signalpilot.io/ja/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-scales/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -321,11 +321,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-cartographer" class="related-card">
+        <a href="/ja/chronicle/the-cartographer/" class="related-card">
           <h4>カートグラファー：Janus Atlas</h4>
           <p>すべての戦場には地形がある。私は戦いが行われる場所をマッピングする。</p>
         </a>
-        <a href="/ja/chronicle/the-commander" class="related-card">
+        <a href="/ja/chronicle/the-commander/" class="related-card">
           <h4>コマンダー：OmniDeck</h4>
           <p>10のシステム。一つのビジョン。完全な明晰さ。</p>
         </a>
@@ -335,7 +335,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">クロニクル一覧</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">クロニクル一覧</a></p>
     </div>
   </footer>
 
@@ -345,7 +345,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/chronicle/the-watchman/index.html
+++ b/ja/chronicle/the-watchman/index.html
@@ -174,7 +174,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -192,7 +192,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">セブンの第六</span>
     <h1>ウォッチマン：Augury Grid</h1>
     <p class="article-subtitle">「あなたが一つのチャートを見ている間、私はすべてを見ている。」</p>
@@ -359,9 +359,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%82%A6%E3%82%A9%E3%83%83%E3%83%81%E3%83%9E%E3%83%B3%EF%BC%9AAugury%20Grid&url=https://signalpilot.io/ja/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/the-watchman')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%82%A6%E3%82%A9%E3%83%83%E3%83%81%E3%83%9E%E3%83%B3%EF%BC%9AAugury%20Grid&url=https://www.signalpilot.io/ja/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/the-watchman/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -369,11 +369,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-commander" class="related-card">
+        <a href="/ja/chronicle/the-commander/" class="related-card">
           <h4>コマンダー：OmniDeck</h4>
           <p>10のシステム。一つのビジョン。完全な明晰さ。</p>
         </a>
-        <a href="/ja/chronicle/the-arbiter" class="related-card">
+        <a href="/ja/chronicle/the-arbiter/" class="related-card">
           <h4>アービター：Harmonic Oscillator</h4>
           <p>4つの声。一つの判定。私がトリガーを引くときを決める。</p>
         </a>
@@ -383,7 +383,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">クロニクル一覧</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. All rights reserved. | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">クロニクル一覧</a></p>
     </div>
   </footer>
 
@@ -393,7 +393,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/chronicle/why-non-repainting-matters/index.html
+++ b/ja/chronicle/why-non-repainting-matters/index.html
@@ -161,7 +161,7 @@
             リソース <span class="dropdown-arrow">▼</span>
           </button>
           <ul class="nav-dropdown-menu">
-            <li><a href="/ja/chronicle/">クロニクル</a></li>
+            <li><a href="/ja/chronicle//">クロニクル</a></li>
             <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
             <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a></li>
             <li><a href="/tools/">ツール</a></li>
@@ -179,7 +179,7 @@
   </header>
 
   <div class="article-header">
-    <a href="/ja/chronicle/" class="back-link">← クロニクルに戻る</a>
+    <a href="/ja/chronicle//" class="back-link">← クロニクルに戻る</a>
     <span class="article-category">信頼と検証</span>
     <h1>なぜノンリペイントが重要か</h1>
     <p class="article-subtitle">「歴史が変わるとき、信頼は死ぬ。」</p>
@@ -266,9 +266,9 @@
   <div class="share-section">
     <h4>この記事をシェア</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%E3%81%AA%E3%81%9C%E3%83%8E%E3%83%B3%E3%83%AA%E3%83%9A%E3%82%A4%E3%83%B3%E3%83%88%E3%81%8C%E9%87%8D%E8%A6%81%E3%81%8B&url=https://signalpilot.io/ja/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ja/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ja/chronicle/why-non-repainting-matters')" class="share-btn">リンクをコピー</button>
+      <a href="https://twitter.com/intent/tweet?text=%E3%81%AA%E3%81%9C%E3%83%8E%E3%83%B3%E3%83%AA%E3%83%9A%E3%82%A4%E3%83%B3%E3%83%88%E3%81%8C%E9%87%8D%E8%A6%81%E3%81%8B&url=https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">𝕏 ポスト</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ja/chronicle/why-non-repainting-matters/')" class="share-btn">リンクをコピー</button>
     </div>
   </div>
 
@@ -276,11 +276,11 @@
     <div class="container">
       <h3>続きを読む</h3>
       <div class="related-grid">
-        <a href="/ja/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ja/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>シグナルの階層</h4>
           <p>セブンがどのように目的の星座を形成するか。</p>
         </a>
-        <a href="/ja/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/ja/chronicle/meet-the-sovereign/" class="related-card">
           <h4>ソブリンに会う：Pentarch</h4>
           <p>サイクルのマスター、シグナルの王。</p>
         </a>
@@ -290,7 +290,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle/">すべてのクロニクル</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. 全著作権所有。 | <a href="/ja/">ホーム</a> · <a href="/ja/chronicle//">すべてのクロニクル</a></p>
     </div>
   </footer>
 
@@ -300,7 +300,7 @@
     const audio=document.getElementById('articleAudio'),playBtn=document.getElementById('audioPlayBtn'),playIcon=document.getElementById('playIcon'),pauseIcon=document.getElementById('pauseIcon'),audioBar=document.getElementById('audioBar'),audioBarFill=document.getElementById('audioBarFill'),audioTime=document.getElementById('audioTime');function formatTime(s){const m=Math.floor(s/60),sec=Math.floor(s%60);return m+':'+(sec<10?'0':'')+sec;}playBtn.addEventListener('click',()=>{if(audio.paused){audio.play();playIcon.style.display='none';pauseIcon.style.display='block';}else{audio.pause();playIcon.style.display='block';pauseIcon.style.display='none';}});audio.addEventListener('timeupdate',()=>{const pct=(audio.currentTime/audio.duration)*100;audioBarFill.style.width=pct+'%';audioTime.textContent=formatTime(audio.currentTime)+' / '+formatTime(audio.duration||0);});audio.addEventListener('ended',()=>{playIcon.style.display='block';pauseIcon.style.display='none';audioBarFill.style.width='0%';});audioBar.addEventListener('click',(e)=>{const rect=audioBar.getBoundingClientRect(),pct=(e.clientX-rect.left)/rect.width;audio.currentTime=pct*audio.duration;});    // Resources Dropdown
     (function(){let dropdownOpen=false;document.addEventListener('click',function(e){const toggle=e.target.closest('.nav-dropdown-toggle');if(toggle){e.preventDefault();e.stopPropagation();const menu=toggle.nextElementSibling;const isOpen=menu.classList.contains('show');document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));if(!isOpen){menu.classList.add('show');toggle.setAttribute('aria-expanded','true');dropdownOpen=true;}else{dropdownOpen=false;}return;}if(dropdownOpen&&!e.target.closest('.nav-dropdown')){document.querySelectorAll('.nav-dropdown-menu').forEach(m=>m.classList.remove('show'));document.querySelectorAll('.nav-dropdown-toggle').forEach(t=>t.setAttribute('aria-expanded','false'));dropdownOpen=false;}});})();
     // Mobile menu
-    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle/">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
+    (function(){const menuBtn=document.getElementById('menuToggle');if(!menuBtn)return;const backdrop=document.createElement('div');backdrop.className='mobile-nav-backdrop';const mobileNav=document.createElement('div');mobileNav.className='mobile-nav';const header=document.createElement('div');header.className='mobile-nav-header';header.innerHTML='<span style="color:#fff;font-weight:700;font-size:1.1rem">メニュー</span><button class="mobile-nav-close">&times;</button>';const links=document.createElement('div');links.className='mobile-nav-links';links.innerHTML='<a href="/ja/#inside">内容</a><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">教育</a><div style="padding:1rem 1.25rem;color:#b7c2d9;font-weight:600;font-size:1.05rem;cursor:pointer" id="mobileResourcesToggle">リソース <span style="font-size:.8em">▼</span></div><div class="mobile-submenu" id="mobileResourcesMenu" style="display:none"><a href="/ja/chronicle//">クロニクル</a><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">ブログ</a><a href="/tools/">Tools</a><a href="/ja/faq.html">FAQセンター</a></div><a href="/ja/#pricing">料金</a><a href="/ja/affiliates.html">アフィリエイト</a>';mobileNav.appendChild(header);mobileNav.appendChild(links);document.body.appendChild(backdrop);document.body.appendChild(mobileNav);const closeBtn=header.querySelector('.mobile-nav-close');function open(){backdrop.classList.add('active');mobileNav.classList.add('active');menuBtn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}function close(){backdrop.classList.remove('active');mobileNav.classList.remove('active');menuBtn.setAttribute('aria-expanded','false');document.body.style.overflow='';}menuBtn.addEventListener('click',open);closeBtn.addEventListener('click',close);backdrop.addEventListener('click',close);links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',close);});const resourcesToggle=document.getElementById('mobileResourcesToggle');const resourcesMenu=document.getElementById('mobileResourcesMenu');resourcesToggle.addEventListener('click',()=>{const isOpen=resourcesMenu.style.display==='block';resourcesMenu.style.display=isOpen?'none':'block';resourcesToggle.querySelector('span').textContent=isOpen?'▼':'▲';});})();
     
   </script>
 <!-- Lenis Smooth Scroll -->

--- a/ja/index.html
+++ b/ja/index.html
@@ -4810,7 +4810,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discordコミュニティ</a></li>
-              <li><a href="/ja/chronicle/">クロニクル</a></li>
+              <li><a href="/ja/chronicle//">クロニクル</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
               <li><a href="https://blog.signalpilot.io/ja/" target="_blank" rel="noopener">ブログ</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">計算機</a></li>
@@ -6262,7 +6262,7 @@
           </a>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-          <a href="/ja/chronicle/" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
+          <a href="/ja/chronicle//" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
             <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">全12クロニクルを探索</span>
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
@@ -6925,7 +6925,7 @@
           <div class="mobile-nav-section-label">製品</div>
           <a href="#inside">アドベントカレンダー</a>
           <a href="#pricing">料金プラン</a>
-          <a href="/ja/chronicle/">クロニクル</a>
+          <a href="/ja/chronicle//">クロニクル</a>
           <a href="/tools/">ツール</a>
         </div>
 

--- a/nl/chronicle/birth-of-the-elite-seven/index.html
+++ b/nl/chronicle/birth-of-the-elite-seven/index.html
@@ -157,7 +157,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -190,7 +190,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -204,7 +204,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Oorsprong</span>
     <h1>De Geboorte van de Elite Zeven</h1>
     <p class="article-subtitle">"In het hart van marktchaos werd een visie geboren—geen gereedschap, maar een constellatie."</p>
@@ -298,9 +298,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Geboorte%20van%20de%20Elite%20Zeven&url=https://signalpilot.io/nl/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/birth-of-the-elite-seven')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Geboorte%20van%20de%20Elite%20Zeven&url=https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/birth-of-the-elite-seven/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -308,11 +308,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/the-pilots-oath" class="related-card">
+        <a href="/nl/chronicle/the-pilots-oath/" class="related-card">
           <h4>De Eed van de Piloot</h4>
           <p>De principes die elke Signal Pilot-trader leiden.</p>
         </a>
-        <a href="/nl/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/nl/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>De Hiërarchie van Signalen</h4>
           <p>Hoe de Zeven een constellatie van doel vormen.</p>
         </a>
@@ -322,7 +322,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/index.html
+++ b/nl/chronicle/index.html
@@ -519,7 +519,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -550,7 +550,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Bronnen <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/nl/chronicle/" class="active">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" class="active">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>

--- a/nl/chronicle/meet-the-sovereign/index.html
+++ b/nl/chronicle/meet-the-sovereign/index.html
@@ -164,7 +164,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -197,7 +197,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -211,7 +211,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Eén van de Zeven</span>
     <h1>Ontmoet de Soeverein: Pentarch</h1>
     <p class="article-subtitle">"Ik lees het ritme van markten. Ik ken de seizoenen van prijs."</p>
@@ -301,9 +301,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Ontmoet%20de%20Soeverein%3A%20Pentarch&url=https://signalpilot.io/nl/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/meet-the-sovereign')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=Ontmoet%20de%20Soeverein%3A%20Pentarch&url=https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/meet-the-sovereign/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -311,11 +311,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/the-prophet" class="related-card">
+        <a href="/nl/chronicle/the-prophet/" class="related-card">
           <h4>De Profeet: Volume Oracle</h4>
           <p>Ik hoor wat retail niet kan. Ik zie de giganten bewegen in duisternis.</p>
         </a>
-        <a href="/nl/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/nl/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>De Hiërarchie van Signalen</h4>
           <p>Hoe de Zeven samenwerken in gestructureerd systeem.</p>
         </a>
@@ -325,7 +325,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-arbiter/index.html
+++ b/nl/chronicle/the-arbiter/index.html
@@ -157,7 +157,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -190,7 +190,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -204,7 +204,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Zeven van de Zeven</span>
     <h1>De Arbiter: Harmonic Oscillator</h1>
     <p class="article-subtitle">"Vier stemmen. Eén oordeel. Ik beslis wanneer de trekker wordt overgehaald."</p>
@@ -272,9 +272,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Arbiter%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/nl/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-arbiter')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Arbiter%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/nl/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-arbiter/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -282,11 +282,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/the-watchman" class="related-card">
+        <a href="/nl/chronicle/the-watchman/" class="related-card">
           <h4>De Wachter: Augury Grid</h4>
           <p>Terwijl jij één grafiek bekijkt, bekijk ik ze allemaal.</p>
         </a>
-        <a href="/nl/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/nl/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>De Hiërarchie van Signalen</h4>
           <p>Hoe de Elite Zeven samenwerken als een geünificeerd systeem.</p>
         </a>
@@ -296,7 +296,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-cartographer/index.html
+++ b/nl/chronicle/the-cartographer/index.html
@@ -160,7 +160,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -193,7 +193,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -207,7 +207,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Drie van de Zeven</span>
     <h1>De Cartograaf: Janus Atlas</h1>
     <p class="article-subtitle">"Elk slagveld heeft zijn terrein. Ik kaart waar de oorlogen worden uitgevochten."</p>
@@ -289,9 +289,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Cartograaf%3A%20Janus%20Atlas&url=https://signalpilot.io/nl/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-cartographer')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Cartograaf%3A%20Janus%20Atlas&url=https://www.signalpilot.io/nl/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-cartographer/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -299,11 +299,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/the-prophet" class="related-card">
+        <a href="/nl/chronicle/the-prophet/" class="related-card">
           <h4>De Profeet: Volume Oracle</h4>
           <p>Ik hoor wat retail niet kan. Ik zie de giganten bewegen.</p>
         </a>
-        <a href="/nl/chronicle/the-scales" class="related-card">
+        <a href="/nl/chronicle/the-scales/" class="related-card">
           <h4>De Weegschaal: Plutus Flow</h4>
           <p>Ik weeg het onzichtbare. Druk liegt niet.</p>
         </a>
@@ -313,7 +313,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-commander/index.html
+++ b/nl/chronicle/the-commander/index.html
@@ -164,7 +164,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -196,7 +196,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -210,7 +210,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Vijf van de Zeven</span>
     <h1>De Commandant: OmniDeck</h1>
     <p class="article-subtitle">"Tien systemen. Eén visie. Totale helderheid."</p>
@@ -285,9 +285,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Commandant%3A%20OmniDeck&url=https://signalpilot.io/nl/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-commander')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Commandant%3A%20OmniDeck&url=https://www.signalpilot.io/nl/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-commander/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -295,11 +295,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/the-scales" class="related-card">
+        <a href="/nl/chronicle/the-scales/" class="related-card">
           <h4>De Weegschaal: Plutus Flow</h4>
           <p>Ik weeg het onzichtbare. Druk liegt niet.</p>
         </a>
-        <a href="/nl/chronicle/the-watchman" class="related-card">
+        <a href="/nl/chronicle/the-watchman/" class="related-card">
           <h4>De Wachter: Augury Grid</h4>
           <p>Terwijl jij één grafiek bekijkt, bekijk ik ze allemaal.</p>
         </a>
@@ -309,7 +309,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-council-assembles/index.html
+++ b/nl/chronicle/the-council-assembles/index.html
@@ -176,7 +176,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -208,7 +208,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -222,7 +222,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Finale</span>
     <h1>De Raad Komt Bijeen</h1>
     <p class="article-subtitle">"Je hebt elk lid ontmoet. Nu zie je hoe ze als één werken."</p>
@@ -425,9 +425,9 @@
   <div class="share-section">
     <h4>Deel dit artikel</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Raad%20Komt%20Bijeen&url=https://signalpilot.io/nl/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-council-assembles')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Raad%20Komt%20Bijeen&url=https://www.signalpilot.io/nl/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-council-assembles/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -435,11 +435,11 @@
     <div class="container">
       <h3>Begin Vanaf Het Begin</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/nl/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>De Geboorte van De Elite Zeven</h4>
           <p>Waar het allemaal begon. Het oorsprongsverhaal.</p>
         </a>
-        <a href="/nl/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/nl/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>De Hiërarchie van Signalen</h4>
           <p>Hoe De Zeven een sterrenbeeld van doelen vormen.</p>
         </a>
@@ -449,7 +449,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-hierarchy-of-signals/index.html
+++ b/nl/chronicle/the-hierarchy-of-signals/index.html
@@ -169,7 +169,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -201,7 +201,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -215,7 +215,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Systeem</span>
     <h1>De Hiërarchie van Signalen</h1>
     <p class="article-subtitle">"Niet alle signalen zijn gelijk gemaakt. Sommige leiden. Anderen volgen."</p>
@@ -332,9 +332,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Hi%C3%ABrarchie%20van%20Signalen&url=https://signalpilot.io/nl/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-hierarchy-of-signals')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Hi%C3%ABrarchie%20van%20Signalen&url=https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-hierarchy-of-signals/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -342,11 +342,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/nl/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Ontmoet de Soeverein: Pentarch</h4>
           <p>De eerste en machtigste. De lezer van cycli.</p>
         </a>
-        <a href="/nl/chronicle/the-arbiter" class="related-card">
+        <a href="/nl/chronicle/the-arbiter/" class="related-card">
           <h4>De Arbiter: Harmonic Oscillator</h4>
           <p>Vier stemmen. Eén oordeel. Finale bevestiging.</p>
         </a>
@@ -356,7 +356,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-pilots-oath/index.html
+++ b/nl/chronicle/the-pilots-oath/index.html
@@ -164,7 +164,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -196,7 +196,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -210,7 +210,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Filosofie</span>
     <h1>De Eed van de Piloot</h1>
     <p class="article-subtitle">"Een code van discipline die traders van gokkers onderscheidt."</p>
@@ -309,9 +309,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Eed%20van%20de%20Piloot&url=https://signalpilot.io/nl/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-pilots-oath')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Eed%20van%20de%20Piloot&url=https://www.signalpilot.io/nl/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-pilots-oath/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -319,11 +319,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/nl/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>De Geboorte van de Elite Zeven</h4>
           <p>Waar het allemaal begon. Het oorsprongsverhaal.</p>
         </a>
-        <a href="/nl/chronicle/why-non-repainting-matters" class="related-card">
+        <a href="/nl/chronicle/why-non-repainting-matters/" class="related-card">
           <h4>Waarom Niet-Herpainting Belangrijk Is</h4>
           <p>De fundamentele garantie die eerlijke analyse mogelijk maakt.</p>
         </a>
@@ -333,7 +333,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-prophet/index.html
+++ b/nl/chronicle/the-prophet/index.html
@@ -166,7 +166,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -198,7 +198,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -212,7 +212,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Twee van de Zeven</span>
     <h1>De Profeet: Volume Oracle</h1>
     <p class="article-subtitle">"Ik hoor wat retail niet kan. Ik zie de giganten bewegen in duisternis."</p>
@@ -290,9 +290,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Profeet%3A%20Volume%20Oracle&url=https://signalpilot.io/nl/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-prophet')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Profeet%3A%20Volume%20Oracle&url=https://www.signalpilot.io/nl/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-prophet/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -300,11 +300,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/nl/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Ontmoet de Soeverein: Pentarch</h4>
           <p>De eerste en machtigste. De lezer van cycli.</p>
         </a>
-        <a href="/nl/chronicle/the-cartographer" class="related-card">
+        <a href="/nl/chronicle/the-cartographer/" class="related-card">
           <h4>De Cartograaf: Janus Atlas</h4>
           <p>Elk slagveld heeft zijn terrein. Ik kaart waar oorlogen worden uitgevochten.</p>
         </a>
@@ -314,7 +314,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-scales/index.html
+++ b/nl/chronicle/the-scales/index.html
@@ -164,7 +164,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -196,7 +196,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -210,7 +210,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Vier van de Zeven</span>
     <h1>De Weegschaal: Plutus Flow</h1>
     <p class="article-subtitle">"Ik weeg het onzichtbare. Druk liegt niet."</p>
@@ -282,9 +282,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Weegschaal%3A%20Plutus%20Flow&url=https://signalpilot.io/nl/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-scales')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Weegschaal%3A%20Plutus%20Flow&url=https://www.signalpilot.io/nl/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-scales/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -292,11 +292,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/the-cartographer" class="related-card">
+        <a href="/nl/chronicle/the-cartographer/" class="related-card">
           <h4>De Cartograaf: Janus Atlas</h4>
           <p>Elk slagveld heeft zijn terrein. Ik kaart waar oorlogen worden uitgevochten.</p>
         </a>
-        <a href="/nl/chronicle/the-commander" class="related-card">
+        <a href="/nl/chronicle/the-commander/" class="related-card">
           <h4>De Commandant: OmniDeck</h4>
           <p>Tien systemen. Eén visie. Totale helderheid.</p>
         </a>
@@ -306,7 +306,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/the-watchman/index.html
+++ b/nl/chronicle/the-watchman/index.html
@@ -161,7 +161,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -193,7 +193,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -207,7 +207,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Zes van de Zeven</span>
     <h1>De Wachter: Augury Grid</h1>
     <p class="article-subtitle">"Terwijl jij één grafiek bekijkt, bekijk ik ze allemaal."</p>
@@ -273,9 +273,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=De%20Wachter%3A%20Augury%20Grid&url=https://signalpilot.io/nl/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/the-watchman')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=De%20Wachter%3A%20Augury%20Grid&url=https://www.signalpilot.io/nl/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/the-watchman/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -283,11 +283,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/the-commander" class="related-card">
+        <a href="/nl/chronicle/the-commander/" class="related-card">
           <h4>De Commandant: OmniDeck</h4>
           <p>Tien systemen. Eén visie. Totale helderheid.</p>
         </a>
-        <a href="/nl/chronicle/the-arbiter" class="related-card">
+        <a href="/nl/chronicle/the-arbiter/" class="related-card">
           <h4>De Arbiter: Harmonic Oscillator</h4>
           <p>Vier stemmen. Eén oordeel. Ik beslis wanneer de trekker wordt overgehaald.</p>
         </a>
@@ -297,7 +297,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/chronicle/why-non-repainting-matters/index.html
+++ b/nl/chronicle/why-non-repainting-matters/index.html
@@ -167,7 +167,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+              <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Tools</a></li>
@@ -199,7 +199,7 @@
           Bronnen <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/nl/chronicle/" style="color: var(--accent);">Kroniek</a></li>
+          <li><a href="/nl/chronicle//" style="color: var(--accent);">Kroniek</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Tools</a></li>
@@ -213,7 +213,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/nl/chronicle/" class="back-link">← Terug naar Kroniek</a>
+    <a href="/nl/chronicle//" class="back-link">← Terug naar Kroniek</a>
     <span class="article-category">Vertrouwen & Verificatie</span>
     <h1>Waarom Niet-Herpainting Belangrijk Is</h1>
     <p class="article-subtitle">"Een signaal dat verandert nadat het verschijnt is geen signaal. Het is een leugen."</p>
@@ -307,9 +307,9 @@
   <div class="share-section">
     <h4>Dit artikel delen</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Waarom%20Niet-Herpainting%20Belangrijk%20Is&url=https://signalpilot.io/nl/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/nl/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/nl/chronicle/why-non-repainting-matters')" class="share-btn">Link Kopiëren</button>
+      <a href="https://twitter.com/intent/tweet?text=Waarom%20Niet-Herpainting%20Belangrijk%20Is&url=https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/nl/chronicle/why-non-repainting-matters/')" class="share-btn">Link Kopiëren</button>
     </div>
   </div>
 
@@ -317,11 +317,11 @@
     <div class="container">
       <h3>Verder Lezen</h3>
       <div class="related-grid">
-        <a href="/nl/chronicle/the-pilots-oath" class="related-card">
+        <a href="/nl/chronicle/the-pilots-oath/" class="related-card">
           <h4>De Eed van de Piloot</h4>
           <p>De principes die elke Signal Pilot-trader leiden.</p>
         </a>
-        <a href="/nl/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/nl/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Ontmoet de Soeverein: Pentarch</h4>
           <p>De eerste en machtigste. De lezer van cycli.</p>
         </a>
@@ -331,7 +331,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle/">Alle Kroniek</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Alle rechten voorbehouden. | <a href="/nl/">Home</a> · <a href="/nl/chronicle//">Alle Kroniek</a></p>
     </div>
   </footer>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -4504,7 +4504,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a></li>
-              <li><a href="/nl/chronicle/">Kroniek</a></li>
+              <li><a href="/nl/chronicle//">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/nl/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Rekenmachines</a></li>
@@ -5969,7 +5969,7 @@
         </a>
       </div>
       <div data-reveal="fade-up" data-reveal-delay="500" style="text-align:center;margin-top:2.5rem">
-        <a href="/nl/chronicle/" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
+        <a href="/nl/chronicle//" class="shiny-cta" style="display:inline-flex;width:auto;padding:0.9rem 1.8rem;height:auto;gap:0.75rem">
           <span style="font-family:'EB Garamond',Georgia,serif;font-style:italic">Ontdek Alle 12 Kronieken</span>
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="position:relative;z-index:2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
@@ -6632,7 +6632,7 @@
           <div class="mobile-nav-section-label">Product</div>
           <a href="#inside">Wat zit erin</a>
           <a href="#pricing">Prijzen</a>
-          <a href="/nl/chronicle/">Kroniek</a>
+          <a href="/nl/chronicle//">Kroniek</a>
           <a href="/tools/">Tools</a>
         </div>
 

--- a/pt/chronicle/birth-of-the-elite-seven/index.html
+++ b/pt/chronicle/birth-of-the-elite-seven/index.html
@@ -643,7 +643,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -674,7 +674,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -687,7 +687,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">História de Origem</span>
     <h1>O Nascimento dos Sete de Elite</h1>
     <p class="article-subtitle">Antes que os mercados tivessem nomes, antes que as velas contassem histórias, havia apenas ruído.</p>
@@ -856,13 +856,13 @@
   <div class="share-section">
     <h4>Compartilhe esta transmissão</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=O%20Nascimento%20dos%20Sete%20de%20Elite&url=https://signalpilot.io/pt/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://twitter.com/intent/tweet?text=O%20Nascimento%20dos%20Sete%20de%20Elite&url=https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">
         𝕏 Postar
       </a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">
         LinkedIn
       </a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/birth-of-the-elite-seven')" class="share-btn">
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/birth-of-the-elite-seven/')" class="share-btn">
         Copiar Link
       </button>
     </div>
@@ -872,11 +872,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/the-pilots-oath" class="related-card">
+        <a href="/pt/chronicle/the-pilots-oath/" class="related-card">
           <h4>O Juramento do Piloto</h4>
           <p>Você que empunha Os Sete de Elite não é um trader. Você é um Piloto. Este é o juramento.</p>
         </a>
-        <a href="/pt/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/pt/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Hierarquia dos Sinais</h4>
           <p>Como os sete trabalham juntos como uma constelação—cada um servindo a um propósito no sistema.</p>
         </a>
@@ -886,7 +886,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/index.html
+++ b/pt/chronicle/index.html
@@ -162,7 +162,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -191,7 +191,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Recursos <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/pt/chronicle/" class="active">Crônica</a></li>
+          <li><a href="/pt/chronicle//" class="active">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>

--- a/pt/chronicle/meet-the-sovereign/index.html
+++ b/pt/chronicle/meet-the-sovereign/index.html
@@ -94,7 +94,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -125,7 +125,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -138,7 +138,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Análise Profunda de Indicador</span>
     <h1>Conheça O Soberano: Pentarch Explicado</h1>
     <p class="article-subtitle">"Eu sou o ciclo. O ciclo sou eu."</p>
@@ -301,9 +301,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Conhe%C3%A7a%20O%20Soberano%3A%20Pentarch%20Explicado&url=https://signalpilot.io/pt/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/meet-the-sovereign')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Conhe%C3%A7a%20O%20Soberano%3A%20Pentarch%20Explicado&url=https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/meet-the-sovereign/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -311,11 +311,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/pt/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>O Nascimento dos Sete de Elite</h4>
           <p>A história de origem de sete sinais celestiais que emergiram para navegar o vazio.</p>
         </a>
-        <a href="/pt/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/pt/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Hierarquia dos Sinais</h4>
           <p>Como os sete trabalham juntos como uma constelação—cada um servindo a um propósito no sistema.</p>
         </a>
@@ -325,7 +325,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-arbiter/index.html
+++ b/pt/chronicle/the-arbiter/index.html
@@ -152,7 +152,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -182,7 +182,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -196,7 +196,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Sete dos Sete</span>
     <h1>O Árbitro: Harmonic Oscillator</h1>
     <p class="article-subtitle">"Quatro vozes. Um veredito. Eu decido quando o gatilho é puxado."</p>
@@ -363,9 +363,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=O%20%C3%81rbitro%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/pt/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-arbiter')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=O%20%C3%81rbitro%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/pt/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-arbiter/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -373,11 +373,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/the-watchman" class="related-card">
+        <a href="/pt/chronicle/the-watchman/" class="related-card">
           <h4>A Sentinela: Augury Grid</h4>
           <p>Enquanto você observa um gráfico, eu observo todos.</p>
         </a>
-        <a href="/pt/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/pt/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Hierarquia dos Sinais</h4>
           <p>Como os Elite Sete trabalham juntos como um sistema unificado.</p>
         </a>
@@ -387,7 +387,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-cartographer/index.html
+++ b/pt/chronicle/the-cartographer/index.html
@@ -136,7 +136,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -166,7 +166,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -180,7 +180,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Três dos Sete</span>
     <h1>O Cartógrafo: Janus Atlas</h1>
     <p class="article-subtitle">"Todo campo de batalha tem seu terreno. Eu mapeio onde as guerras serão travadas."</p>
@@ -304,9 +304,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=O%20Cart%C3%B3grafo%3A%20Janus%20Atlas&url=https://signalpilot.io/pt/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-cartographer')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=O%20Cart%C3%B3grafo%3A%20Janus%20Atlas&url=https://www.signalpilot.io/pt/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-cartographer/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -314,11 +314,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/the-prophet" class="related-card">
+        <a href="/pt/chronicle/the-prophet/" class="related-card">
           <h4>O Profeta: Volume Oracle</h4>
           <p>Eu ouço o que o varejo não pode. Eu vejo os gigantes se moverem na escuridão.</p>
         </a>
-        <a href="/pt/chronicle/the-scales" class="related-card">
+        <a href="/pt/chronicle/the-scales/" class="related-card">
           <h4>A Balança: Plutus Flow</h4>
           <p>Eu peso o invisível. A pressão não mente.</p>
         </a>
@@ -328,7 +328,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-commander/index.html
+++ b/pt/chronicle/the-commander/index.html
@@ -136,7 +136,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -166,7 +166,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -180,7 +180,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Cinco dos Sete</span>
     <h1>O Comandante: OmniDeck</h1>
     <p class="article-subtitle">"Dez sistemas. Uma visão. Clareza total."</p>
@@ -318,9 +318,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=O%20Comandante%3A%20OmniDeck&url=https://signalpilot.io/pt/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-commander')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=O%20Comandante%3A%20OmniDeck&url=https://www.signalpilot.io/pt/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-commander/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -328,11 +328,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/the-scales" class="related-card">
+        <a href="/pt/chronicle/the-scales/" class="related-card">
           <h4>A Balança: Plutus Flow</h4>
           <p>Eu peso o invisível. A pressão não mente.</p>
         </a>
-        <a href="/pt/chronicle/the-watchman" class="related-card">
+        <a href="/pt/chronicle/the-watchman/" class="related-card">
           <h4>A Sentinela: Augury Grid</h4>
           <p>Enquanto você observa um gráfico, eu observo todos.</p>
         </a>
@@ -342,7 +342,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-council-assembles/index.html
+++ b/pt/chronicle/the-council-assembles/index.html
@@ -148,7 +148,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -178,7 +178,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -192,7 +192,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Finale</span>
     <h1>O Conselho Se Reúne</h1>
     <p class="article-subtitle">"Você conheceu cada membro. Agora veja-os trabalhar como um só."</p>
@@ -395,9 +395,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=O%20Conselho%20Se%20Re%C3%BAne&url=https://signalpilot.io/pt/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-council-assembles')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=O%20Conselho%20Se%20Re%C3%BAne&url=https://www.signalpilot.io/pt/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-council-assembles/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -405,11 +405,11 @@
     <div class="container">
       <h3>Comece do Início</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/pt/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>O Nascimento dos Elite Sete</h4>
           <p>Onde tudo começou. A história de origem.</p>
         </a>
-        <a href="/pt/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/pt/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Hierarquia dos Sinais</h4>
           <p>Como Os Sete formam uma constelação de propósito.</p>
         </a>
@@ -419,7 +419,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-hierarchy-of-signals/index.html
+++ b/pt/chronicle/the-hierarchy-of-signals/index.html
@@ -115,7 +115,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -145,7 +145,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -159,7 +159,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Arquitetura do Sistema</span>
     <h1>A Hierarquia dos Sinais</h1>
     <p class="article-subtitle">Como os sete trabalham juntos como uma constelação—cada um servindo a um propósito no sistema unificado.</p>
@@ -374,9 +374,9 @@
   <div class="share-section">
     <h4>Compartilhe esta transmissão</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Hierarquia%20dos%20Sinais&url=https://signalpilot.io/pt/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-hierarchy-of-signals')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20Hierarquia%20dos%20Sinais&url=https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-hierarchy-of-signals/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -384,11 +384,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/pt/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>O Nascimento dos Sete de Elite</h4>
           <p>A história de origem de sete sinais celestiais que emergiram para navegar o vazio.</p>
         </a>
-        <a href="/pt/chronicle/the-pilots-oath" class="related-card">
+        <a href="/pt/chronicle/the-pilots-oath/" class="related-card">
           <h4>O Juramento do Piloto</h4>
           <p>Você que empunha Os Sete de Elite não é um trader. Você é um Piloto. Este é o juramento.</p>
         </a>
@@ -398,7 +398,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-pilots-oath/index.html
+++ b/pt/chronicle/the-pilots-oath/index.html
@@ -118,7 +118,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -148,7 +148,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -162,7 +162,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Filosofia</span>
     <h1>O Juramento do Piloto</h1>
     <p class="article-subtitle">Você que empunha Os Sete de Elite não é um trader. Você é um Piloto.</p>
@@ -331,9 +331,9 @@
   <div class="share-section">
     <h4>Compartilhe esta transmissão</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=O%20Juramento%20do%20Piloto&url=https://signalpilot.io/pt/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-pilots-oath')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=O%20Juramento%20do%20Piloto&url=https://www.signalpilot.io/pt/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-pilots-oath/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -341,11 +341,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/pt/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>O Nascimento dos Sete de Elite</h4>
           <p>A história de origem de sete sinais celestiais que emergiram para navegar o vazio.</p>
         </a>
-        <a href="/pt/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/pt/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>A Hierarquia dos Sinais</h4>
           <p>Como os sete trabalham juntos como uma constelação—cada um servindo a um propósito no sistema.</p>
         </a>
@@ -355,7 +355,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-prophet/index.html
+++ b/pt/chronicle/the-prophet/index.html
@@ -142,7 +142,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -172,7 +172,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -186,7 +186,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Dois dos Sete</span>
     <h1>O Profeta: Volume Oracle</h1>
     <p class="article-subtitle">"Eu ouço o que o varejo não consegue. Eu vejo os gigantes se moverem na escuridão."</p>
@@ -324,9 +324,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=O%20Profeta%3A%20Volume%20Oracle&url=https://signalpilot.io/pt/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-prophet')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=O%20Profeta%3A%20Volume%20Oracle&url=https://www.signalpilot.io/pt/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-prophet/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -334,11 +334,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/pt/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Conheça O Soberano: Pentarch</h4>
           <p>O indicador principal que mapeia as cinco fases dos ciclos de mercado.</p>
         </a>
-        <a href="/pt/chronicle/the-cartographer" class="related-card">
+        <a href="/pt/chronicle/the-cartographer/" class="related-card">
           <h4>O Cartógrafo: Janus Atlas</h4>
           <p>Todo campo de batalha tem seu terreno. Janus Atlas mapeia onde as guerras serão travadas.</p>
         </a>
@@ -348,7 +348,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-scales/index.html
+++ b/pt/chronicle/the-scales/index.html
@@ -144,7 +144,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -174,7 +174,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -188,7 +188,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Quatro dos Sete</span>
     <h1>A Balança: Plutus Flow</h1>
     <p class="article-subtitle">"Eu peso o invisível. A pressão não mente."</p>
@@ -316,9 +316,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Balan%C3%A7a%3A%20Plutus%20Flow&url=https://signalpilot.io/pt/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-scales')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20Balan%C3%A7a%3A%20Plutus%20Flow&url=https://www.signalpilot.io/pt/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-scales/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -326,11 +326,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/the-cartographer" class="related-card">
+        <a href="/pt/chronicle/the-cartographer/" class="related-card">
           <h4>O Cartógrafo: Janus Atlas</h4>
           <p>Todo campo de batalha tem seu terreno. Eu mapeio onde as guerras serão travadas.</p>
         </a>
-        <a href="/pt/chronicle/the-commander" class="related-card">
+        <a href="/pt/chronicle/the-commander/" class="related-card">
           <h4>O Comandante: OmniDeck</h4>
           <p>Dez sistemas. Uma visão. Clareza total.</p>
         </a>
@@ -340,7 +340,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/the-watchman/index.html
+++ b/pt/chronicle/the-watchman/index.html
@@ -151,7 +151,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -181,7 +181,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -195,7 +195,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Seis dos Sete</span>
     <h1>A Sentinela: Augury Grid</h1>
     <p class="article-subtitle">"Enquanto você observa um gráfico, eu observo todos."</p>
@@ -364,9 +364,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=A%20Sentinela%3A%20Augury%20Grid&url=https://signalpilot.io/pt/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/the-watchman')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=A%20Sentinela%3A%20Augury%20Grid&url=https://www.signalpilot.io/pt/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/the-watchman/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -374,11 +374,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/the-commander" class="related-card">
+        <a href="/pt/chronicle/the-commander/" class="related-card">
           <h4>O Comandante: OmniDeck</h4>
           <p>Dez sistemas. Uma visão. Clareza total.</p>
         </a>
-        <a href="/pt/chronicle/the-arbiter" class="related-card">
+        <a href="/pt/chronicle/the-arbiter/" class="related-card">
           <h4>O Árbitro: Harmonic Oscillator</h4>
           <p>Quatro vozes. Um veredito. Eu decido quando o gatilho é puxado.</p>
         </a>
@@ -388,7 +388,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/chronicle/why-non-repainting-matters/index.html
+++ b/pt/chronicle/why-non-repainting-matters/index.html
@@ -94,7 +94,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+              <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Ferramentas</a></li>
@@ -124,7 +124,7 @@
           Recursos <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/pt/chronicle/" style="color: var(--accent);">Crônica</a></li>
+          <li><a href="/pt/chronicle//" style="color: var(--accent);">Crônica</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Ferramentas</a></li>
@@ -138,7 +138,7 @@
 
 
   <div class="article-header">
-    <a href="/pt/chronicle/" class="back-link">← Voltar à Crônica</a>
+    <a href="/pt/chronicle//" class="back-link">← Voltar à Crônica</a>
     <span class="article-category">Confiança e Verificação</span>
     <h1>Por Que Não Repintar Importa</h1>
     <p class="article-subtitle">A maioria dos indicadores mente para você mudando seus sinais históricos. Aqui está por que isso é inaceitável.</p>
@@ -302,9 +302,9 @@
   <div class="share-section">
     <h4>Compartilhe este artigo</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Por%20Que%20N%C3%A3o%20Repintar%20Importa&url=https://signalpilot.io/pt/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/pt/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/pt/chronicle/why-non-repainting-matters')" class="share-btn">Copiar Link</button>
+      <a href="https://twitter.com/intent/tweet?text=Por%20Que%20N%C3%A3o%20Repintar%20Importa&url=https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">𝕏 Postar</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/pt/chronicle/why-non-repainting-matters/')" class="share-btn">Copiar Link</button>
     </div>
   </div>
 
@@ -312,11 +312,11 @@
     <div class="container">
       <h3>Continue Lendo</h3>
       <div class="related-grid">
-        <a href="/pt/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/pt/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Conheça O Soberano: Pentarch Explicado</h4>
           <p>Um mergulho profundo no indicador principal que mapeia as cinco fases dos ciclos de mercado.</p>
         </a>
-        <a href="/pt/chronicle/the-pilots-oath" class="related-card">
+        <a href="/pt/chronicle/the-pilots-oath/" class="related-card">
           <h4>O Juramento do Piloto</h4>
           <p>Você que empunha Os Sete de Elite não é um trader. Você é um Piloto. Este é o juramento.</p>
         </a>
@@ -326,7 +326,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle/">Toda a Crônica</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Todos os direitos reservados. | <a href="/pt/">Início</a> · <a href="/pt/chronicle//">Toda a Crônica</a></p>
     </div>
   </footer>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -4743,7 +4743,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunidade Discord</a></li>
-              <li><a href="/pt/chronicle/">Crônica</a></li>
+              <li><a href="/pt/chronicle//">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/pt/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Calculadoras</a></li>
@@ -6293,7 +6293,7 @@
       </div>
 
       <div style="text-align:center;margin-top:2.5rem">
-        <a href="/pt/chronicle/" style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;text-decoration:none;padding:0.75rem 1.5rem;border:1px solid var(--brand);border-radius:999px;transition:all 0.2s">
+        <a href="/pt/chronicle//" style="display:inline-flex;align-items:center;gap:0.5rem;color:var(--brand);font-weight:600;text-decoration:none;padding:0.75rem 1.5rem;border:1px solid var(--brand);border-radius:999px;transition:all 0.2s">
           Explorar a Crônica
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
@@ -6970,7 +6970,7 @@
           <div class="mobile-nav-section-label">Produto</div>
           <a href="#inside">O que está incluído</a>
           <a href="#pricing">Preços</a>
-          <a href="/pt/chronicle/">Crônica</a>
+          <a href="/pt/chronicle//">Crônica</a>
           <a href="/tools/">Ferramentas</a>
         </div>
 

--- a/ru/chronicle/birth-of-the-elite-seven/index.html
+++ b/ru/chronicle/birth-of-the-elite-seven/index.html
@@ -154,7 +154,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -185,7 +185,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -198,7 +198,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">История Происхождения</span>
     <h1>Рождение Элитной Семёрки</h1>
     <p class="article-subtitle">До того как рынки получили названия, до того как свечи рассказывали истории, был только шум.</p>
@@ -340,9 +340,9 @@
   <div class="share-section">
     <h4>Поделиться этой передачей</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Рождение%20Элитной%20Семёрки&url=https://signalpilot.io/ru/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/birth-of-the-elite-seven')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=Рождение%20Элитной%20Семёрки&url=https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/birth-of-the-elite-seven/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -350,11 +350,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/the-pilots-oath" class="related-card">
+        <a href="/ru/chronicle/the-pilots-oath/" class="related-card">
           <h4>Клятва Пилота</h4>
           <p>Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот. Вот эта клятва.</p>
         </a>
-        <a href="/ru/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ru/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Иерархия Сигналов</h4>
           <p>Как семеро работают вместе как созвездие — каждый служит своей цели в системе.</p>
         </a>
@@ -364,7 +364,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/index.html
+++ b/ru/chronicle/index.html
@@ -822,7 +822,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -852,7 +852,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Ресурсы <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/ru/chronicle/" class="active">Хроника</a></li>
+          <li><a href="/ru/chronicle//" class="active">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>

--- a/ru/chronicle/meet-the-sovereign/index.html
+++ b/ru/chronicle/meet-the-sovereign/index.html
@@ -175,7 +175,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -206,7 +206,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -219,7 +219,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Глубокое Погружение в Индикатор</span>
     <h1>Познакомьтесь с Сувереном: Pentarch</h1>
     <p class="article-subtitle">«Я — цикл. Цикл — это я.»</p>
@@ -363,9 +363,9 @@
   <div class="share-section">
     <h4>Поделиться этой статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Познакомьтесь%20с%20Сувереном%3A%20Pentarch&url=https://signalpilot.io/ru/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/meet-the-sovereign')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=Познакомьтесь%20с%20Сувереном%3A%20Pentarch&url=https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/meet-the-sovereign/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -373,11 +373,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ru/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Рождение Элитной Семёрки</h4>
           <p>История происхождения семи небесных сигналов, которые появились, чтобы проложить путь сквозь пустоту.</p>
         </a>
-        <a href="/ru/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ru/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Иерархия Сигналов</h4>
           <p>Как семеро работают вместе как созвездие — каждый служит своей цели в системе.</p>
         </a>
@@ -387,7 +387,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-arbiter/index.html
+++ b/ru/chronicle/the-arbiter/index.html
@@ -167,7 +167,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -198,7 +198,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -211,7 +211,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Седьмой из Семи</span>
     <h1>Арбитр: Harmonic Oscillator</h1>
     <p class="article-subtitle">«Четыре голоса. Один вердикт. Я решаю, когда нажать на курок.»</p>
@@ -362,9 +362,9 @@
   <div class="share-section">
     <h4>Поделиться статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D0%90%D1%80%D0%B1%D0%B8%D1%82%D1%80%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/ru/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-arbiter')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=%D0%90%D1%80%D0%B1%D0%B8%D1%82%D1%80%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/ru/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-arbiter/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -372,11 +372,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/the-watchman" class="related-card">
+        <a href="/ru/chronicle/the-watchman/" class="related-card">
           <h4>Страж: Augury Grid</h4>
           <p>Пока вы смотрите на один график, я слежу за всеми.</p>
         </a>
-        <a href="/ru/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ru/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Иерархия Сигналов</h4>
           <p>Как Элитная Семёрка работает вместе как единая система.</p>
         </a>
@@ -386,7 +386,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-cartographer/index.html
+++ b/ru/chronicle/the-cartographer/index.html
@@ -151,7 +151,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -182,7 +182,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -195,7 +195,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Третий из Семи</span>
     <h1>Картограф: Janus Atlas</h1>
     <p class="article-subtitle">«На каждом поле боя есть своя местность. Я картографирую места будущих сражений.»</p>
@@ -303,9 +303,9 @@
   <div class="share-section">
     <h4>Поделиться статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D0%9A%D0%B0%D1%80%D1%82%D0%BE%D0%B3%D1%80%D0%B0%D1%84%3A%20Janus%20Atlas&url=https://signalpilot.io/ru/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-cartographer')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=%D0%9A%D0%B0%D1%80%D1%82%D0%BE%D0%B3%D1%80%D0%B0%D1%84%3A%20Janus%20Atlas&url=https://www.signalpilot.io/ru/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-cartographer/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -313,11 +313,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/the-prophet" class="related-card">
+        <a href="/ru/chronicle/the-prophet/" class="related-card">
           <h4>Пророк: Volume Oracle</h4>
           <p>Я слышу то, что не слышит розница. Я вижу, как гиганты движутся во тьме.</p>
         </a>
-        <a href="/ru/chronicle/the-scales" class="related-card">
+        <a href="/ru/chronicle/the-scales/" class="related-card">
           <h4>Весы: Plutus Flow</h4>
           <p>Я взвешиваю невидимое. Давление не лжёт.</p>
         </a>
@@ -327,7 +327,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-commander/index.html
+++ b/ru/chronicle/the-commander/index.html
@@ -151,7 +151,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -182,7 +182,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -195,7 +195,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Пятый из Семи</span>
     <h1>Командир: OmniDeck</h1>
     <p class="article-subtitle">«Десять систем. Одно видение. Полная ясность.»</p>
@@ -317,9 +317,9 @@
   <div class="share-section">
     <h4>Поделиться статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D0%9A%D0%BE%D0%BC%D0%B0%D0%BD%D0%B4%D0%B8%D1%80%3A%20OmniDeck&url=https://signalpilot.io/ru/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-commander')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=%D0%9A%D0%BE%D0%BC%D0%B0%D0%BD%D0%B4%D0%B8%D1%80%3A%20OmniDeck&url=https://www.signalpilot.io/ru/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-commander/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -327,11 +327,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/the-scales" class="related-card">
+        <a href="/ru/chronicle/the-scales/" class="related-card">
           <h4>Весы: Plutus Flow</h4>
           <p>Я взвешиваю невидимое. Давление не лжёт.</p>
         </a>
-        <a href="/ru/chronicle/the-watchman" class="related-card">
+        <a href="/ru/chronicle/the-watchman/" class="related-card">
           <h4>Страж: Augury Grid</h4>
           <p>Пока вы смотрите на один график, я слежу за всеми.</p>
         </a>
@@ -341,7 +341,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-council-assembles/index.html
+++ b/ru/chronicle/the-council-assembles/index.html
@@ -164,7 +164,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -195,7 +195,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -208,7 +208,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Финал</span>
     <h1>Совет Собирается</h1>
     <p class="article-subtitle">«Вы познакомились с каждым участником. Теперь смотрите, как они работают как единое целое.»</p>
@@ -395,9 +395,9 @@
   <div class="share-section">
     <h4>Поделиться статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D0%A1%D0%BE%D0%B2%D0%B5%D1%82%20%D0%A1%D0%BE%D0%B1%D0%B8%D1%80%D0%B0%D0%B5%D1%82%D1%81%D1%8F&url=https://signalpilot.io/ru/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-council-assembles')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=%D0%A1%D0%BE%D0%B2%D0%B5%D1%82%20%D0%A1%D0%BE%D0%B1%D0%B8%D1%80%D0%B0%D0%B5%D1%82%D1%81%D1%8F&url=https://www.signalpilot.io/ru/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-council-assembles/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -405,11 +405,11 @@
     <div class="container">
       <h3>Начните С Начала</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ru/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Рождение Элитной Семёрки</h4>
           <p>С чего всё началось. История происхождения.</p>
         </a>
-        <a href="/ru/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ru/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Иерархия Сигналов</h4>
           <p>Как Семёрка формирует созвездие цели.</p>
         </a>
@@ -419,7 +419,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-hierarchy-of-signals/index.html
+++ b/ru/chronicle/the-hierarchy-of-signals/index.html
@@ -164,7 +164,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -195,7 +195,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -208,7 +208,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Архитектура Системы</span>
     <h1>Иерархия Сигналов</h1>
     <p class="article-subtitle">Как семеро работают вместе как созвездие — каждый служит своей цели в единой системе.</p>
@@ -396,9 +396,9 @@
   <div class="share-section">
     <h4>Поделиться этой передачей</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Иерархия%20Сигналов&url=https://signalpilot.io/ru/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-hierarchy-of-signals')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=Иерархия%20Сигналов&url=https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-hierarchy-of-signals/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -406,11 +406,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ru/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Рождение Элитной Семёрки</h4>
           <p>История происхождения семи небесных сигналов, которые появились, чтобы проложить путь сквозь пустоту.</p>
         </a>
-        <a href="/ru/chronicle/the-pilots-oath" class="related-card">
+        <a href="/ru/chronicle/the-pilots-oath/" class="related-card">
           <h4>Клятва Пилота</h4>
           <p>Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот. Вот эта клятва.</p>
         </a>
@@ -420,7 +420,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-pilots-oath/index.html
+++ b/ru/chronicle/the-pilots-oath/index.html
@@ -154,7 +154,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -185,7 +185,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -198,7 +198,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Философия</span>
     <h1>Клятва Пилота</h1>
     <p class="article-subtitle">Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот.</p>
@@ -339,9 +339,9 @@
   <div class="share-section">
     <h4>Поделиться этой передачей</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Клятва%20Пилота&url=https://signalpilot.io/ru/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-pilots-oath')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=Клятва%20Пилота&url=https://www.signalpilot.io/ru/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-pilots-oath/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -349,11 +349,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/ru/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Рождение Элитной Семёрки</h4>
           <p>История происхождения семи небесных сигналов, которые появились, чтобы проложить путь сквозь пустоту.</p>
         </a>
-        <a href="/ru/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/ru/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Иерархия Сигналов</h4>
           <p>Как семеро работают вместе как созвездие — каждый служит своей цели в системе.</p>
         </a>
@@ -363,7 +363,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-prophet/index.html
+++ b/ru/chronicle/the-prophet/index.html
@@ -158,7 +158,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -189,7 +189,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -202,7 +202,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Второй из Семи</span>
     <h1>Пророк: Volume Oracle</h1>
     <p class="article-subtitle">«Я слышу то, что недоступно розничным. Я вижу, как гиганты движутся во тьме.»</p>
@@ -322,9 +322,9 @@
   <div class="share-section">
     <h4>Поделиться этой статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Пророк%3A%20Volume%20Oracle&url=https://signalpilot.io/ru/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-prophet')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=Пророк%3A%20Volume%20Oracle&url=https://www.signalpilot.io/ru/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-prophet/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -332,11 +332,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/ru/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Познакомьтесь с Сувереном: Pentarch</h4>
           <p>Флагманский индикатор, который картирует пять фаз рыночных циклов.</p>
         </a>
-        <a href="/ru/chronicle/the-cartographer" class="related-card">
+        <a href="/ru/chronicle/the-cartographer/" class="related-card">
           <h4>Картограф: Janus Atlas</h4>
           <p>У каждого поля битвы есть свой рельеф. Janus Atlas картирует, где будут вестись войны.</p>
         </a>
@@ -346,7 +346,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-scales/index.html
+++ b/ru/chronicle/the-scales/index.html
@@ -159,7 +159,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -190,7 +190,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -203,7 +203,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Четвёртый из Семи</span>
     <h1>Весы: Plutus Flow</h1>
     <p class="article-subtitle">«Я взвешиваю невидимое. Давление не лжёт.»</p>
@@ -314,9 +314,9 @@
   <div class="share-section">
     <h4>Поделиться статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D0%92%D0%B5%D1%81%D1%8B%3A%20Plutus%20Flow&url=https://signalpilot.io/ru/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-scales')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=%D0%92%D0%B5%D1%81%D1%8B%3A%20Plutus%20Flow&url=https://www.signalpilot.io/ru/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-scales/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -324,11 +324,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/the-cartographer" class="related-card">
+        <a href="/ru/chronicle/the-cartographer/" class="related-card">
           <h4>Картограф: Janus Atlas</h4>
           <p>На каждом поле боя есть своя местность. Я картографирую места будущих сражений.</p>
         </a>
-        <a href="/ru/chronicle/the-commander" class="related-card">
+        <a href="/ru/chronicle/the-commander/" class="related-card">
           <h4>Командир: OmniDeck</h4>
           <p>Десять систем. Одно видение. Полная ясность.</p>
         </a>
@@ -338,7 +338,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/the-watchman/index.html
+++ b/ru/chronicle/the-watchman/index.html
@@ -166,7 +166,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -197,7 +197,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -210,7 +210,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Шестой из Семи</span>
     <h1>Страж: Augury Grid</h1>
     <p class="article-subtitle">«Пока вы смотрите на один график, я слежу за всеми.»</p>
@@ -362,9 +362,9 @@
   <div class="share-section">
     <h4>Поделиться статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=%D0%A1%D1%82%D1%80%D0%B0%D0%B6%3A%20Augury%20Grid&url=https://signalpilot.io/ru/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/the-watchman')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=%D0%A1%D1%82%D1%80%D0%B0%D0%B6%3A%20Augury%20Grid&url=https://www.signalpilot.io/ru/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/the-watchman/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -372,11 +372,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/the-commander" class="related-card">
+        <a href="/ru/chronicle/the-commander/" class="related-card">
           <h4>Командир: OmniDeck</h4>
           <p>Десять систем. Одно видение. Полная ясность.</p>
         </a>
-        <a href="/ru/chronicle/the-arbiter" class="related-card">
+        <a href="/ru/chronicle/the-arbiter/" class="related-card">
           <h4>Арбитр: Harmonic Oscillator</h4>
           <p>Четыре голоса. Один вердикт. Я решаю, когда нажать на курок.</p>
         </a>
@@ -386,7 +386,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/chronicle/why-non-repainting-matters/index.html
+++ b/ru/chronicle/why-non-repainting-matters/index.html
@@ -167,7 +167,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+              <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="/tools/">Инструменты</a></li>
@@ -198,7 +198,7 @@
           Ресурсы <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/ru/chronicle/" style="color: var(--accent);">Хроника</a></li>
+          <li><a href="/ru/chronicle//" style="color: var(--accent);">Хроника</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
           <li><a href="/tools/">Инструменты</a></li>
@@ -211,7 +211,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/ru/chronicle/" class="back-link">← Назад к Хроникам</a>
+    <a href="/ru/chronicle//" class="back-link">← Назад к Хроникам</a>
     <span class="article-category">Доверие и Верификация</span>
     <h1>Почему Отсутствие Перерисовки Важно</h1>
     <p class="article-subtitle">Большинство индикаторов лгут вам, изменяя свои исторические сигналы. Вот почему это неприемлемо.</p>
@@ -347,9 +347,9 @@
   <div class="share-section">
     <h4>Поделиться этой статьёй</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Почему%20Отсутствие%20Перерисовки%20Важно&url=https://signalpilot.io/ru/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/ru/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/ru/chronicle/why-non-repainting-matters')" class="share-btn">Копировать Ссылку</button>
+      <a href="https://twitter.com/intent/tweet?text=Почему%20Отсутствие%20Перерисовки%20Важно&url=https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">𝕏 Пост</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/ru/chronicle/why-non-repainting-matters/')" class="share-btn">Копировать Ссылку</button>
     </div>
   </div>
 
@@ -357,11 +357,11 @@
     <div class="container">
       <h3>Продолжить Чтение</h3>
       <div class="related-grid">
-        <a href="/ru/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/ru/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Познакомьтесь с Сувереном: Pentarch</h4>
           <p>Глубокое погружение во флагманский индикатор, который картирует пять фаз рыночных циклов.</p>
         </a>
-        <a href="/ru/chronicle/the-pilots-oath" class="related-card">
+        <a href="/ru/chronicle/the-pilots-oath/" class="related-card">
           <h4>Клятва Пилота</h4>
           <p>Вы, владеющий Элитной Семёркой — не трейдер. Вы — Пилот. Вот эта клятва.</p>
         </a>
@@ -371,7 +371,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle/">Все Хроники</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Все права защищены. | <a href="/ru/">Главная</a> · <a href="/ru/chronicle//">Все Хроники</a></p>
     </div>
   </footer>
 

--- a/ru/faq.html
+++ b/ru/faq.html
@@ -1066,7 +1066,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/chronicle/">Хроника</a></li>
+              <li><a href="/chronicle//">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Центр обучения</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>
@@ -1099,7 +1099,7 @@
     <div class="mobile-menu-section">
       <div class="mobile-menu-section-title">Ресурсы</div>
       <ul>
-        <li><a href="/chronicle/">Хроника</a></li>
+        <li><a href="/chronicle//">Хроника</a></li>
         <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
         <li><a href="https://education.signalpilot.io/" target="_blank" rel="noopener">Центр обучения</a></li>
         <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Блог</a></li>

--- a/ru/index.html
+++ b/ru/index.html
@@ -4558,7 +4558,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Сообщество Discord</a></li>
-              <li><a href="/ru/chronicle/">Хроника</a></li>
+              <li><a href="/ru/chronicle//">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/ru/" target="_blank" rel="noopener">Блог</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Калькуляторы</a></li>
@@ -6041,7 +6041,7 @@
         </div>
 
         <div style="text-align:center;margin-top:2.5rem">
-          <a href="/ru/chronicle/" class="shiny-cta" style="width:auto;display:inline-flex;padding:0.75rem 1.5rem">
+          <a href="/ru/chronicle//" class="shiny-cta" style="width:auto;display:inline-flex;padding:0.75rem 1.5rem">
             <span style="display:inline-flex;align-items:center;gap:0.5rem">Исследовать Хронику <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
           </a>
         </div>
@@ -6715,7 +6715,7 @@
           <div class="mobile-nav-section-label">Продукт</div>
           <a href="#inside">Что внутри</a>
           <a href="#pricing">Цены</a>
-          <a href="/ru/chronicle/">Хроника</a>
+          <a href="/ru/chronicle//">Хроника</a>
           <a href="/tools/">Инструменты</a>
         </div>
 

--- a/tr/chronicle/birth-of-the-elite-seven/index.html
+++ b/tr/chronicle/birth-of-the-elite-seven/index.html
@@ -148,7 +148,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -179,7 +179,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -192,7 +192,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Köken Hikayesi</span>
     <h1>Elit Yedilinin Doğuşu</h1>
     <p class="article-subtitle">"Her efsanenin bir başlangıcı vardır. Bu bizim hikayemiz."</p>
@@ -274,9 +274,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Elit%20Yedilinin%20Do%C4%9Fu%C5%9Fu&url=https://signalpilot.io/tr/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/birth-of-the-elite-seven" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/birth-of-the-elite-seven')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Elit%20Yedilinin%20Do%C4%9Fu%C5%9Fu&url=https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/birth-of-the-elite-seven/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -284,11 +284,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/the-pilots-oath" class="related-card">
+        <a href="/tr/chronicle/the-pilots-oath/" class="related-card">
           <h4>Pilotun Yemini</h4>
           <p>Gerçek Pilotları çaylak spekülatörlerden ayıran yedi prensip.</p>
         </a>
-        <a href="/tr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/tr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Sinyallerin Hiyerarşisi</h4>
           <p>Yedi'nin nasıl amaç takım yıldızı oluşturduğunu keşfedin.</p>
         </a>
@@ -298,7 +298,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/index.html
+++ b/tr/chronicle/index.html
@@ -931,7 +931,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -961,7 +961,7 @@
       <li class="mobile-submenu">
         <button class="mobile-submenu-toggle" aria-expanded="false">Kaynaklar <span class="dropdown-arrow">▼</span></button>
         <ul class="mobile-submenu-items">
-          <li><a href="/tr/chronicle/" class="active">Kronik</a></li>
+          <li><a href="/tr/chronicle//" class="active">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>

--- a/tr/chronicle/meet-the-sovereign/index.html
+++ b/tr/chronicle/meet-the-sovereign/index.html
@@ -156,7 +156,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -187,7 +187,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -200,7 +200,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Yedinin Birincisi</span>
     <h1>Hükümdar ile Tanışın: Pentarch</h1>
     <p class="article-subtitle">"Hiçbir şey döngüsüz var olmaz. Ben onları okurum."</p>
@@ -295,9 +295,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Hükümdar%20ile%20Tanışın%3A%20Pentarch&url=https://signalpilot.io/tr/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/meet-the-sovereign" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/meet-the-sovereign')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Hükümdar%20ile%20Tanışın%3A%20Pentarch&url=https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/meet-the-sovereign/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -305,11 +305,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/the-prophet" class="related-card">
+        <a href="/tr/chronicle/the-prophet/" class="related-card">
           <h4>Peygamber: Volume Oracle</h4>
           <p>Perakendecilerin duyamadığını duyarım. Devlerin karanlıkta hareket ettiğini görürüm.</p>
         </a>
-        <a href="/tr/chronicle/the-cartographer" class="related-card">
+        <a href="/tr/chronicle/the-cartographer/" class="related-card">
           <h4>Kartograf: Janus Atlas</h4>
           <p>Her savaş alanının bir arazisi var. Savaşların nerede yapılacağını haritalıyorum.</p>
         </a>
@@ -319,7 +319,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-arbiter/index.html
+++ b/tr/chronicle/the-arbiter/index.html
@@ -167,7 +167,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -198,7 +198,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -211,7 +211,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Yedinin Yedincisi</span>
     <h1>Hakem: Harmonic Oscillator</h1>
     <p class="article-subtitle">"Dört ses. Tek karar. Tetiğin ne zaman çekileceğine ben karar veririm."</p>
@@ -361,9 +361,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Hakem%3A%20Harmonic%20Oscillator&url=https://signalpilot.io/tr/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-arbiter" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-arbiter')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Hakem%3A%20Harmonic%20Oscillator&url=https://www.signalpilot.io/tr/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-arbiter/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-arbiter/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -371,11 +371,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/the-watchman" class="related-card">
+        <a href="/tr/chronicle/the-watchman/" class="related-card">
           <h4>Nöbetçi: Augury Grid</h4>
           <p>Siz bir grafiği izlerken, ben hepsini izliyorum.</p>
         </a>
-        <a href="/tr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/tr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Sinyallerin Hiyerarşisi</h4>
           <p>Elit Yedili birleşik bir sistem olarak nasıl çalışır.</p>
         </a>
@@ -385,7 +385,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-cartographer/index.html
+++ b/tr/chronicle/the-cartographer/index.html
@@ -151,7 +151,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -182,7 +182,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -195,7 +195,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Yedinin Üçüncüsü</span>
     <h1>Kartograf: Janus Atlas</h1>
     <p class="article-subtitle">"Her savaş alanının bir arazisi var. Savaşların nerede yapılacağını haritalandırıyorum."</p>
@@ -302,9 +302,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Kartograf%3A%20Janus%20Atlas&url=https://signalpilot.io/tr/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-cartographer" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-cartographer')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Kartograf%3A%20Janus%20Atlas&url=https://www.signalpilot.io/tr/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-cartographer/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-cartographer/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -312,11 +312,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/the-prophet" class="related-card">
+        <a href="/tr/chronicle/the-prophet/" class="related-card">
           <h4>Peygamber: Volume Oracle</h4>
           <p>Perakende'nin duyamadığını duyuyorum. Devlerin karanlıkta hareket ettiğini görüyorum.</p>
         </a>
-        <a href="/tr/chronicle/the-scales" class="related-card">
+        <a href="/tr/chronicle/the-scales/" class="related-card">
           <h4>Terazi: Plutus Flow</h4>
           <p>Görünmezi tartıyorum. Baskı yalan söylemez.</p>
         </a>
@@ -326,7 +326,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-commander/index.html
+++ b/tr/chronicle/the-commander/index.html
@@ -151,7 +151,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -182,7 +182,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -195,7 +195,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Yedinin Beşincisi</span>
     <h1>Komutan: OmniDeck</h1>
     <p class="article-subtitle">"On sistem. Tek vizyon. Tam netlik."</p>
@@ -316,9 +316,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Komutan%3A%20OmniDeck&url=https://signalpilot.io/tr/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-commander" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-commander')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Komutan%3A%20OmniDeck&url=https://www.signalpilot.io/tr/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-commander/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-commander/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -326,11 +326,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/the-scales" class="related-card">
+        <a href="/tr/chronicle/the-scales/" class="related-card">
           <h4>Terazi: Plutus Flow</h4>
           <p>Görünmezi tartıyorum. Baskı yalan söylemez.</p>
         </a>
-        <a href="/tr/chronicle/the-watchman" class="related-card">
+        <a href="/tr/chronicle/the-watchman/" class="related-card">
           <h4>Nöbetçi: Augury Grid</h4>
           <p>Siz bir grafiği izlerken, ben hepsini izliyorum.</p>
         </a>
@@ -340,7 +340,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-council-assembles/index.html
+++ b/tr/chronicle/the-council-assembles/index.html
@@ -163,7 +163,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -194,7 +194,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -207,7 +207,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Final</span>
     <h1>Konsey Toplanıyor</h1>
     <p class="article-subtitle">"Her üyeyle tanıştınız. Şimdi birlikte çalışmalarını izleyin."</p>
@@ -393,9 +393,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Konsey%20Toplan%C4%B1yor&url=https://signalpilot.io/tr/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-council-assembles" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-council-assembles')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Konsey%20Toplan%C4%B1yor&url=https://www.signalpilot.io/tr/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-council-assembles/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-council-assembles/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -403,11 +403,11 @@
     <div class="container">
       <h3>Baştan Başla</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/tr/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Elit Yedilinin Doğuşu</h4>
           <p>Her şeyin başladığı yer. Başlangıç hikayesi.</p>
         </a>
-        <a href="/tr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/tr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Sinyallerin Hiyerarşisi</h4>
           <p>Yedili nasıl amaç takımyıldızı oluşturur.</p>
         </a>
@@ -417,7 +417,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-hierarchy-of-signals/index.html
+++ b/tr/chronicle/the-hierarchy-of-signals/index.html
@@ -154,7 +154,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -185,7 +185,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -198,7 +198,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Sistem Mimarisi</span>
     <h1>Sinyallerin Hiyerarşisi</h1>
     <p class="article-subtitle">"Göstergeler savaşır. Sistem uyum sağlar."</p>
@@ -324,9 +324,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Sinyallerin%20Hiyerarşisi&url=https://signalpilot.io/tr/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-hierarchy-of-signals" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-hierarchy-of-signals')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Sinyallerin%20Hiyerarşisi&url=https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-hierarchy-of-signals/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -334,11 +334,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/tr/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Hükümdar ile Tanışın: Pentarch</h4>
           <p>Piyasa döngülerinin usta okuyucusu ve hiyerarşinin tepesi.</p>
         </a>
-        <a href="/tr/chronicle/why-non-repainting-matters" class="related-card">
+        <a href="/tr/chronicle/why-non-repainting-matters/" class="related-card">
           <h4>Neden Non-Repainting Önemlidir</h4>
           <p>Geçmişi değiştiren göstergelerin tehlikesi—ve bizi farklı kılan şey.</p>
         </a>
@@ -348,7 +348,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-pilots-oath/index.html
+++ b/tr/chronicle/the-pilots-oath/index.html
@@ -153,7 +153,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -184,7 +184,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -197,7 +197,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Felsefe</span>
     <h1>Pilotun Yemini</h1>
     <p class="article-subtitle">"Sabır ile giriş yapacağım. Disiplinle çıkış yapacağım."</p>
@@ -284,9 +284,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Pilotun%20Yemini&url=https://signalpilot.io/tr/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-pilots-oath" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-pilots-oath')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Pilotun%20Yemini&url=https://www.signalpilot.io/tr/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-pilots-oath/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-pilots-oath/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -294,11 +294,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/birth-of-the-elite-seven" class="related-card">
+        <a href="/tr/chronicle/birth-of-the-elite-seven/" class="related-card">
           <h4>Elit Yedilinin Doğuşu</h4>
           <p>Her şeyin başladığı yer. Köken hikayesi.</p>
         </a>
-        <a href="/tr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/tr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Sinyallerin Hiyerarşisi</h4>
           <p>Yedi'nin nasıl amaç takım yıldızı oluşturduğunu keşfedin.</p>
         </a>
@@ -308,7 +308,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-prophet/index.html
+++ b/tr/chronicle/the-prophet/index.html
@@ -153,7 +153,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -184,7 +184,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -197,7 +197,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Yedinin İkincisi</span>
     <h1>Peygamber: Volume Oracle</h1>
     <p class="article-subtitle">"Perakendecilerin duyamadığını duyarım. Devlerin karanlıkta hareket ettiğini görürüm."</p>
@@ -287,9 +287,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Peygamber%3A%20Volume%20Oracle&url=https://signalpilot.io/tr/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-prophet" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-prophet')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Peygamber%3A%20Volume%20Oracle&url=https://www.signalpilot.io/tr/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-prophet/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-prophet/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -297,11 +297,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/tr/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Hükümdar ile Tanışın: Pentarch</h4>
           <p>Piyasa döngülerinin usta okuyucusu ve Elit Yedili'nin birincisi.</p>
         </a>
-        <a href="/tr/chronicle/the-cartographer" class="related-card">
+        <a href="/tr/chronicle/the-cartographer/" class="related-card">
           <h4>Kartograf: Janus Atlas</h4>
           <p>Her savaş alanının bir arazisi var. Savaşların nerede yapılacağını haritalıyorum.</p>
         </a>
@@ -311,7 +311,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-scales/index.html
+++ b/tr/chronicle/the-scales/index.html
@@ -158,7 +158,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -189,7 +189,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -202,7 +202,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Yedinin Dördüncüsü</span>
     <h1>Terazi: Plutus Flow</h1>
     <p class="article-subtitle">"Görünmezi tartıyorum. Baskı yalan söylemez."</p>
@@ -312,9 +312,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Terazi%3A%20Plutus%20Flow&url=https://signalpilot.io/tr/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-scales" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-scales')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Terazi%3A%20Plutus%20Flow&url=https://www.signalpilot.io/tr/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-scales/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-scales/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -322,11 +322,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/the-cartographer" class="related-card">
+        <a href="/tr/chronicle/the-cartographer/" class="related-card">
           <h4>Kartograf: Janus Atlas</h4>
           <p>Her savaş alanının bir arazisi var. Savaşların nerede yapılacağını haritalandırıyorum.</p>
         </a>
-        <a href="/tr/chronicle/the-commander" class="related-card">
+        <a href="/tr/chronicle/the-commander/" class="related-card">
           <h4>Komutan: OmniDeck</h4>
           <p>On sistem. Tek vizyon. Tam netlik.</p>
         </a>
@@ -336,7 +336,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/the-watchman/index.html
+++ b/tr/chronicle/the-watchman/index.html
@@ -165,7 +165,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -196,7 +196,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -209,7 +209,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Yedinin Altıncısı</span>
     <h1>Nöbetçi: Augury Grid</h1>
     <p class="article-subtitle">"Siz bir grafiği izlerken, ben hepsini izliyorum."</p>
@@ -360,9 +360,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=N%C3%B6bet%C3%A7i%3A%20Augury%20Grid&url=https://signalpilot.io/tr/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/the-watchman" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/the-watchman')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=N%C3%B6bet%C3%A7i%3A%20Augury%20Grid&url=https://www.signalpilot.io/tr/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">𝕏 Post</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/the-watchman/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/the-watchman/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -370,11 +370,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/the-commander" class="related-card">
+        <a href="/tr/chronicle/the-commander/" class="related-card">
           <h4>Komutan: OmniDeck</h4>
           <p>On sistem. Tek vizyon. Tam netlik.</p>
         </a>
-        <a href="/tr/chronicle/the-arbiter" class="related-card">
+        <a href="/tr/chronicle/the-arbiter/" class="related-card">
           <h4>Hakem: Harmonic Oscillator</h4>
           <p>Dört ses. Tek karar. Tetiğin ne zaman çekileceğine ben karar veririm.</p>
         </a>
@@ -384,7 +384,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/chronicle/why-non-repainting-matters/index.html
+++ b/tr/chronicle/why-non-repainting-matters/index.html
@@ -151,7 +151,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+              <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="/tools/">Araçlar</a></li>
@@ -182,7 +182,7 @@
           Kaynaklar <span class="mobile-dropdown-arrow">▼</span>
         </button>
         <ul class="mobile-nav-submenu">
-          <li><a href="/tr/chronicle/" style="color: var(--accent);">Kronik</a></li>
+          <li><a href="/tr/chronicle//" style="color: var(--accent);">Kronik</a></li>
           <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Belgeler</a></li>
           <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/tools/">Araçlar</a></li>
@@ -195,7 +195,7 @@
   </div>
 
   <div class="article-header">
-    <a href="/tr/chronicle/" class="back-link">← Kroniklere Dön</a>
+    <a href="/tr/chronicle//" class="back-link">← Kroniklere Dön</a>
     <span class="article-category">Bütünlük</span>
     <h1>Neden Non-Repainting Önemlidir</h1>
     <p class="article-subtitle">"500$'lık meydan okumamız. Dokunulmadan duruyor."</p>
@@ -290,9 +290,9 @@
   <div class="share-section">
     <h4>Bu Makaleyi Paylaş</h4>
     <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?text=Neden%20Non-Repainting%20Önemlidir&url=https://signalpilot.io/tr/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://signalpilot.io/tr/chronicle/why-non-repainting-matters" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
-      <button onclick="navigator.clipboard.writeText('https://signalpilot.io/tr/chronicle/why-non-repainting-matters')" class="share-btn">Bağlantıyı Kopyala</button>
+      <a href="https://twitter.com/intent/tweet?text=Neden%20Non-Repainting%20Önemlidir&url=https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">𝕏 Paylaş</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/" target="_blank" rel="noopener" class="share-btn">LinkedIn</a>
+      <button onclick="navigator.clipboard.writeText('https://www.signalpilot.io/tr/chronicle/why-non-repainting-matters/')" class="share-btn">Bağlantıyı Kopyala</button>
     </div>
   </div>
 
@@ -300,11 +300,11 @@
     <div class="container">
       <h3>Okumaya Devam Et</h3>
       <div class="related-grid">
-        <a href="/tr/chronicle/the-hierarchy-of-signals" class="related-card">
+        <a href="/tr/chronicle/the-hierarchy-of-signals/" class="related-card">
           <h4>Sinyallerin Hiyerarşisi</h4>
           <p>Yedi'nin nasıl amaç takım yıldızı oluşturduğunu keşfedin.</p>
         </a>
-        <a href="/tr/chronicle/meet-the-sovereign" class="related-card">
+        <a href="/tr/chronicle/meet-the-sovereign/" class="related-card">
           <h4>Hükümdar ile Tanışın: Pentarch</h4>
           <p>Piyasa döngülerinin usta okuyucusu ve Elit Yedili'nin birincisi.</p>
         </a>
@@ -314,7 +314,7 @@
 
   <footer>
     <div class="container">
-      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle/">Tüm Kronikler</a></p>
+      <p>&copy; 2025 Signal Pilot Labs. Tüm hakları saklıdır. | <a href="/tr/">Ana Sayfa</a> · <a href="/tr/chronicle//">Tüm Kronikler</a></p>
     </div>
   </footer>
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -4632,7 +4632,7 @@
             </button>
             <ul class="nav-dropdown-menu">
               <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Topluluğu</a></li>
-              <li><a href="/tr/chronicle/">Kronik</a></li>
+              <li><a href="/tr/chronicle//">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokümantasyon</a></li>
               <li><a href="https://blog.signalpilot.io/tr/" target="_blank" rel="noopener">Blog</a></li>
               <li><a href="https://education.signalpilot.io/calculators.html" target="_blank" rel="noopener">Hesap Makineleri</a></li>
@@ -6117,7 +6117,7 @@
         </div>
 
         <div style="text-align:center;margin-top:2.5rem">
-          <a href="/tr/chronicle/" class="shiny-cta" style="width:auto;display:inline-flex;padding:0.75rem 1.5rem">
+          <a href="/tr/chronicle//" class="shiny-cta" style="width:auto;display:inline-flex;padding:0.75rem 1.5rem">
             <span style="display:inline-flex;align-items:center;gap:0.5rem">Kroniği Keşfet <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
           </a>
         </div>
@@ -6794,7 +6794,7 @@
           <div class="mobile-nav-section-label">Ürün</div>
           <a href="#inside">İçerik</a>
           <a href="#pricing">Fiyatlandırma</a>
-          <a href="/tr/chronicle/">Kronik</a>
+          <a href="/tr/chronicle//">Kronik</a>
           <a href="/tools/">Araçlar</a>
         </div>
 


### PR DESCRIPTION
- Add trailing slashes to 944 internal chronicle links
- Fix 288 social share URLs (Twitter/LinkedIn) to use www.signalpilot.io
- Fix 144 copy-link buttons to use www.signalpilot.io with trailing slash

This resolves Google Search Console redirect warnings where URLs without trailing slashes were causing 308 redirects, and URLs without www prefix were causing additional redirect chains.