### PR TITLE
Review TradingView indicator scripts

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4699,13 +4699,6 @@ html[lang="ar"] [style*="text-align:center"] {
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4954,6 +4947,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -4964,6 +4958,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -4974,6 +4969,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -4984,6 +4980,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5000,6 +4997,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -5010,6 +5008,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -5020,6 +5019,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5045,6 +5045,10 @@ html[lang="ar"] [style*="text-align:center"] {
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -5071,6 +5075,14 @@ html[lang="ar"] [style*="text-align:center"] {
             border: none;
             color: var(--brand);
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.2rem;
+            padding: 0;
+            font-size: 0.6rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-chart-card .elite-card-badge { font-size: 0.55rem !important; padding: 0.15rem 0.4rem; }
           /* Panel cards (horizontal 2:1) - TOP LEFT corner, smaller text */
           .elite-panel-card .elite-card-content {
@@ -5092,6 +5104,14 @@ html[lang="ar"] [style*="text-align:center"] {
             border: none;
             color: var(--brand);
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.45rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-panel-card .elite-card-badge { font-size: 0.4rem !important; padding: 0.1rem 0.3rem; }
         }
         @media (max-width: 480px) {
@@ -5104,6 +5124,7 @@ html[lang="ar"] [style*="text-align:center"] {
           .elite-chart-card .elite-card-title { font-size: 1rem !important; }
           .elite-chart-card .elite-card-subtitle { font-size: 0.7rem !important; }
           .elite-chart-card .elite-card-link { font-size: 0.5rem !important; }
+          .elite-chart-card .elite-card-link-tv { font-size: 0.5rem !important; }
           .elite-chart-card .elite-card-badge { font-size: 0.45rem !important; padding: 0.1rem 0.3rem; }
           /* Panel cards - TOP LEFT, even smaller */
           .elite-panel-card .elite-card-content {
@@ -5114,6 +5135,7 @@ html[lang="ar"] [style*="text-align:center"] {
           .elite-panel-card .elite-card-title { font-size: 0.9rem !important; }
           .elite-panel-card .elite-card-subtitle { font-size: 0.65rem !important; }
           .elite-panel-card .elite-card-link { font-size: 0.4rem !important; }
+          .elite-panel-card .elite-card-link-tv { font-size: 0.4rem !important; }
           .elite-panel-card .elite-card-badge { font-size: 0.35rem !important; padding: 0.1rem 0.25rem; }
         }
       </style>

--- a/de/index.html
+++ b/de/index.html
@@ -4660,13 +4660,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4821,6 +4814,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -4831,6 +4825,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -4841,6 +4836,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -4851,6 +4847,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4871,6 +4868,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -4881,6 +4879,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -4891,6 +4890,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5041,6 +5041,43 @@
           font-weight: 500;
           text-shadow: 0 1px 8px rgba(0,0,0,0.5);
         }
+        .elite-card-link {
+          display: inline-block;
+          margin-top: 0.5rem;
+          padding: 0.35rem 0.75rem;
+          font-size: 0.7rem;
+          font-weight: 600;
+          color: var(--brand);
+          background: rgba(91,138,255,0.1);
+          border: 1px solid rgba(91,138,255,0.3);
+          border-radius: 6px;
+          text-decoration: none;
+          transition: all 0.2s ease;
+        }
+        .elite-card-link:hover {
+          background: rgba(91,138,255,0.2);
+          border-color: var(--brand);
+          color: #fff;
+        }
+        .elite-card-link-tv {
+          display: inline-block;
+          margin-top: 0.5rem;
+          margin-left: 0.4rem;
+          padding: 0.35rem 0.75rem;
+          font-size: 0.7rem;
+          font-weight: 600;
+          color: #2962FF;
+          background: rgba(41,98,255,0.1);
+          border: 1px solid rgba(41,98,255,0.3);
+          border-radius: 6px;
+          text-decoration: none;
+          transition: all 0.2s ease;
+        }
+        .elite-card-link-tv:hover {
+          background: rgba(41,98,255,0.2);
+          border-color: #2962FF;
+          color: #fff;
+        }
 
         /* Panel card - position content at bottom */
         .elite-panel-card .elite-card-content {
@@ -5085,6 +5122,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.15rem !important;
+            padding: 0 !important;
+            font-size: 0.6rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.55rem !important;
             padding: 0.12rem 0.35rem !important;
@@ -5111,6 +5156,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.1rem !important;
+            padding: 0 !important;
+            font-size: 0.45rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-panel-card .elite-card-badge {
             font-size: 0.4rem !important;
             padding: 0.08rem 0.2rem !important;
@@ -5136,6 +5189,9 @@
           .elite-chart-card .elite-card-link {
             font-size: 0.55rem !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            font-size: 0.55rem !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.5rem !important;
             padding: 0.08rem 0.25rem !important;
@@ -5153,6 +5209,9 @@
             font-size: 0.65rem !important;
           }
           .elite-panel-card .elite-card-link {
+            font-size: 0.4rem !important;
+          }
+          .elite-panel-card .elite-card-link-tv {
             font-size: 0.4rem !important;
           }
           .elite-panel-card .elite-card-badge {

--- a/es/index.html
+++ b/es/index.html
@@ -4857,13 +4857,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -5007,6 +5000,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5017,6 +5011,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -5027,6 +5022,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -5037,6 +5033,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5055,6 +5052,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -5065,6 +5063,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -5075,6 +5074,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5102,6 +5102,10 @@
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -5133,6 +5137,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.15rem !important;
+            padding: 0 !important;
+            font-size: 0.6rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.55rem !important;
             padding: 0.12rem 0.35rem !important;
@@ -5158,6 +5170,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.1rem !important;
+            padding: 0 !important;
+            font-size: 0.45rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-panel-card .elite-card-badge {
             font-size: 0.4rem !important;
             padding: 0.08rem 0.2rem !important;
@@ -5182,6 +5202,9 @@
           .elite-chart-card .elite-card-link {
             font-size: 0.55rem !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            font-size: 0.55rem !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.5rem !important;
             padding: 0.08rem 0.25rem !important;
@@ -5198,6 +5221,9 @@
             font-size: 0.65rem !important;
           }
           .elite-panel-card .elite-card-link {
+            font-size: 0.4rem !important;
+          }
+          .elite-panel-card .elite-card-link-tv {
             font-size: 0.4rem !important;
           }
           .elite-panel-card .elite-card-badge {

--- a/fr/index.html
+++ b/fr/index.html
@@ -4910,13 +4910,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -5131,6 +5124,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5141,6 +5135,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -5151,6 +5146,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -5161,6 +5157,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5181,6 +5178,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -5191,6 +5189,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -5201,6 +5200,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5345,6 +5345,43 @@
           font-weight: 500;
           text-shadow: 0 1px 8px rgba(0,0,0,0.5);
         }
+        .elite-card-link {
+          display: inline-block;
+          margin-top: 0.5rem;
+          padding: 0.35rem 0.75rem;
+          font-size: 0.7rem;
+          font-weight: 600;
+          color: var(--brand);
+          background: rgba(91,138,255,0.1);
+          border: 1px solid rgba(91,138,255,0.3);
+          border-radius: 6px;
+          text-decoration: none;
+          transition: all 0.2s ease;
+        }
+        .elite-card-link:hover {
+          background: rgba(91,138,255,0.2);
+          border-color: var(--brand);
+          color: #fff;
+        }
+        .elite-card-link-tv {
+          display: inline-block;
+          margin-top: 0.5rem;
+          margin-left: 0.4rem;
+          padding: 0.35rem 0.75rem;
+          font-size: 0.7rem;
+          font-weight: 600;
+          color: #2962FF;
+          background: rgba(41,98,255,0.1);
+          border: 1px solid rgba(41,98,255,0.3);
+          border-radius: 6px;
+          text-decoration: none;
+          transition: all 0.2s ease;
+        }
+        .elite-card-link-tv:hover {
+          background: rgba(41,98,255,0.2);
+          border-color: #2962FF;
+          color: #fff;
+        }
         .elite-panel-card .elite-card-content {
           bottom: 1rem;
           transform: none;
@@ -5386,6 +5423,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.15rem !important;
+            padding: 0 !important;
+            font-size: 0.6rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.55rem !important;
             padding: 0.12rem 0.35rem !important;
@@ -5412,6 +5457,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.1rem !important;
+            padding: 0 !important;
+            font-size: 0.45rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-panel-card .elite-card-badge {
             font-size: 0.4rem !important;
             padding: 0.08rem 0.2rem !important;
@@ -5437,6 +5490,9 @@
           .elite-chart-card .elite-card-link {
             font-size: 0.55rem !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            font-size: 0.55rem !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.5rem !important;
             padding: 0.08rem 0.25rem !important;
@@ -5454,6 +5510,9 @@
             font-size: 0.65rem !important;
           }
           .elite-panel-card .elite-card-link {
+            font-size: 0.4rem !important;
+          }
+          .elite-panel-card .elite-card-link-tv {
             font-size: 0.4rem !important;
           }
           .elite-panel-card .elite-card-badge {

--- a/hu/index.html
+++ b/hu/index.html
@@ -4627,13 +4627,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4840,6 +4833,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -4850,6 +4844,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -4860,6 +4855,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -4870,6 +4866,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4886,6 +4883,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -4896,6 +4894,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -4906,6 +4905,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4931,6 +4931,10 @@
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -4957,6 +4961,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.2rem;
+            padding: 0;
+            font-size: 0.6rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-chart-card .elite-card-badge { font-size: 0.55rem !important; padding: 0.15rem 0.4rem; }
           /* Panel cards (horizontal 2:1) - TOP LEFT corner, smaller text */
           .elite-panel-card .elite-card-content {
@@ -4978,6 +4990,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.45rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-panel-card .elite-card-badge { font-size: 0.4rem !important; padding: 0.1rem 0.3rem; }
         }
         @media (max-width: 480px) {
@@ -4990,6 +5010,7 @@
           .elite-chart-card .elite-card-title { font-size: 1rem !important; }
           .elite-chart-card .elite-card-subtitle { font-size: 0.7rem !important; }
           .elite-chart-card .elite-card-link { font-size: 0.5rem !important; }
+          .elite-chart-card .elite-card-link-tv { font-size: 0.5rem !important; }
           .elite-chart-card .elite-card-badge { font-size: 0.45rem !important; padding: 0.1rem 0.3rem; }
           /* Panel cards - TOP LEFT, even smaller */
           .elite-panel-card .elite-card-content {
@@ -5000,6 +5021,7 @@
           .elite-panel-card .elite-card-title { font-size: 0.9rem !important; }
           .elite-panel-card .elite-card-subtitle { font-size: 0.65rem !important; }
           .elite-panel-card .elite-card-link { font-size: 0.4rem !important; }
+          .elite-panel-card .elite-card-link-tv { font-size: 0.4rem !important; }
           .elite-panel-card .elite-card-badge { font-size: 0.35rem !important; padding: 0.1rem 0.25rem; }
         }
       </style>

--- a/index.html
+++ b/index.html
@@ -3599,13 +3599,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4014,6 +4007,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -4024,6 +4018,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -4034,6 +4029,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -4044,6 +4040,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4064,6 +4061,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -4074,6 +4072,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -4084,6 +4083,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4121,6 +4121,25 @@
         .elite-card-link:hover {
           background: rgba(91,138,255,0.2);
           border-color: var(--brand);
+          color: #fff;
+        }
+        .elite-card-link-tv {
+          display: inline-block;
+          margin-top: 0.5rem;
+          margin-left: 0.4rem;
+          padding: 0.35rem 0.75rem;
+          font-size: 0.7rem;
+          font-weight: 600;
+          color: #2962FF;
+          background: rgba(41,98,255,0.1);
+          border: 1px solid rgba(41,98,255,0.3);
+          border-radius: 6px;
+          text-decoration: none;
+          transition: all 0.2s ease;
+        }
+        .elite-card-link-tv:hover {
+          background: rgba(41,98,255,0.2);
+          border-color: #2962FF;
           color: #fff;
         }
         /* Gradient border effect */
@@ -4308,6 +4327,15 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.15rem !important;
+            margin-left: 0.3rem !important;
+            padding: 0 !important;
+            font-size: 0.6rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.55rem !important;
             padding: 0.12rem 0.35rem !important;
@@ -4334,6 +4362,15 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.1rem !important;
+            margin-left: 0.3rem !important;
+            padding: 0 !important;
+            font-size: 0.45rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-panel-card .elite-card-badge {
             font-size: 0.4rem !important;
             padding: 0.08rem 0.2rem !important;
@@ -4359,6 +4396,9 @@
           .elite-chart-card .elite-card-link {
             font-size: 0.55rem !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            font-size: 0.55rem !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.5rem !important;
             padding: 0.08rem 0.25rem !important;
@@ -4376,6 +4416,9 @@
             font-size: 0.65rem !important;
           }
           .elite-panel-card .elite-card-link {
+            font-size: 0.4rem !important;
+          }
+          .elite-panel-card .elite-card-link-tv {
             font-size: 0.4rem !important;
           }
           .elite-panel-card .elite-card-badge {

--- a/it/index.html
+++ b/it/index.html
@@ -4608,13 +4608,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4821,6 +4814,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -4831,6 +4825,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -4841,6 +4836,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -4851,6 +4847,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4867,6 +4864,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -4877,6 +4875,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -4887,6 +4886,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4912,6 +4912,10 @@
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -4943,6 +4947,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.15rem !important;
+            padding: 0 !important;
+            font-size: 0.6rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.55rem !important;
             padding: 0.12rem 0.35rem !important;
@@ -4968,6 +4980,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.1rem !important;
+            padding: 0 !important;
+            font-size: 0.45rem !important;
+            background: transparent !important;
+            border: none !important;
+            color: #2962FF !important;
+          }
           .elite-panel-card .elite-card-badge {
             font-size: 0.4rem !important;
             padding: 0.08rem 0.2rem !important;
@@ -4992,6 +5012,9 @@
           .elite-chart-card .elite-card-link {
             font-size: 0.55rem !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            font-size: 0.55rem !important;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.5rem !important;
             padding: 0.08rem 0.25rem !important;
@@ -5008,6 +5031,9 @@
             font-size: 0.65rem !important;
           }
           .elite-panel-card .elite-card-link {
+            font-size: 0.4rem !important;
+          }
+          .elite-panel-card .elite-card-link-tv {
             font-size: 0.4rem !important;
           }
           .elite-panel-card .elite-card-badge {

--- a/ja/index.html
+++ b/ja/index.html
@@ -4941,13 +4941,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -5154,6 +5147,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5164,6 +5158,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -5174,6 +5169,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -5184,6 +5180,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5200,6 +5197,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -5210,6 +5208,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -5220,6 +5219,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5245,6 +5245,10 @@
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -5271,6 +5275,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.2rem;
+            padding: 0;
+            font-size: 0.6rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-chart-card .elite-card-badge { font-size: 0.55rem !important; padding: 0.15rem 0.4rem; }
           /* Panel cards (horizontal 2:1) - TOP LEFT corner, smaller text */
           .elite-panel-card .elite-card-content {
@@ -5292,6 +5304,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.45rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-panel-card .elite-card-badge { font-size: 0.4rem !important; padding: 0.1rem 0.3rem; }
         }
         @media (max-width: 480px) {
@@ -5304,6 +5324,7 @@
           .elite-chart-card .elite-card-title { font-size: 1rem !important; }
           .elite-chart-card .elite-card-subtitle { font-size: 0.7rem !important; }
           .elite-chart-card .elite-card-link { font-size: 0.5rem !important; }
+          .elite-chart-card .elite-card-link-tv { font-size: 0.5rem !important; }
           .elite-chart-card .elite-card-badge { font-size: 0.45rem !important; padding: 0.1rem 0.3rem; }
           /* Panel cards - TOP LEFT, even smaller */
           .elite-panel-card .elite-card-content {
@@ -5314,6 +5335,7 @@
           .elite-panel-card .elite-card-title { font-size: 0.9rem !important; }
           .elite-panel-card .elite-card-subtitle { font-size: 0.65rem !important; }
           .elite-panel-card .elite-card-link { font-size: 0.4rem !important; }
+          .elite-panel-card .elite-card-link-tv { font-size: 0.4rem !important; }
           .elite-panel-card .elite-card-badge { font-size: 0.35rem !important; padding: 0.1rem 0.25rem; }
         }
       </style>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4636,13 +4636,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4849,6 +4842,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -4859,6 +4853,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -4869,6 +4864,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -4879,6 +4875,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4895,6 +4892,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -4905,6 +4903,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -4915,6 +4914,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4940,6 +4940,10 @@
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -4966,6 +4970,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.2rem;
+            padding: 0;
+            font-size: 0.6rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-chart-card .elite-card-badge { font-size: 0.55rem !important; padding: 0.15rem 0.4rem; }
           /* Panel cards (horizontal 2:1) - TOP LEFT corner, smaller text */
           .elite-panel-card .elite-card-content {
@@ -4987,6 +4999,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.45rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-panel-card .elite-card-badge { font-size: 0.4rem !important; padding: 0.1rem 0.3rem; }
         }
         @media (max-width: 480px) {
@@ -4999,6 +5019,7 @@
           .elite-chart-card .elite-card-title { font-size: 1rem !important; }
           .elite-chart-card .elite-card-subtitle { font-size: 0.7rem !important; }
           .elite-chart-card .elite-card-link { font-size: 0.5rem !important; }
+          .elite-chart-card .elite-card-link-tv { font-size: 0.5rem !important; margin-left: 0.2rem; }
           .elite-chart-card .elite-card-badge { font-size: 0.45rem !important; padding: 0.1rem 0.3rem; }
           /* Panel cards - TOP LEFT, even smaller */
           .elite-panel-card .elite-card-content {
@@ -5009,6 +5030,7 @@
           .elite-panel-card .elite-card-title { font-size: 0.9rem !important; }
           .elite-panel-card .elite-card-subtitle { font-size: 0.65rem !important; }
           .elite-panel-card .elite-card-link { font-size: 0.4rem !important; }
+          .elite-panel-card .elite-card-link-tv { font-size: 0.4rem !important; margin-left: 0.2rem; }
           .elite-panel-card .elite-card-badge { font-size: 0.35rem !important; padding: 0.1rem 0.25rem; }
         }
       </style>

--- a/pt/index.html
+++ b/pt/index.html
@@ -4874,13 +4874,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4993,6 +4986,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5003,6 +4997,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -5013,6 +5008,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -5023,6 +5019,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5039,6 +5036,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -5049,6 +5047,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -5059,6 +5058,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5084,6 +5084,10 @@
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -5115,6 +5119,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.6rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.55rem !important;
             padding: 0.12rem 0.35rem !important;
@@ -5140,6 +5152,14 @@
             border: none !important;
             color: var(--brand) !important;
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.45rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-panel-card .elite-card-badge {
             font-size: 0.4rem !important;
             padding: 0.08rem 0.2rem !important;
@@ -5164,6 +5184,10 @@
           .elite-chart-card .elite-card-link {
             font-size: 0.55rem !important;
           }
+          .elite-chart-card .elite-card-link-tv {
+            font-size: 0.5rem !important;
+            margin-left: 0.2rem;
+          }
           .elite-chart-card .elite-card-badge {
             font-size: 0.5rem !important;
             padding: 0.08rem 0.25rem !important;
@@ -5181,6 +5205,10 @@
           }
           .elite-panel-card .elite-card-link {
             font-size: 0.4rem !important;
+          }
+          .elite-panel-card .elite-card-link-tv {
+            font-size: 0.4rem !important;
+            margin-left: 0.2rem;
           }
           .elite-panel-card .elite-card-badge {
             font-size: 0.35rem !important;

--- a/ru/index.html
+++ b/ru/index.html
@@ -4689,13 +4689,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4808,6 +4801,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -4818,6 +4812,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -4828,6 +4823,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -4838,6 +4834,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4854,6 +4851,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -4864,6 +4862,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -4874,6 +4873,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4899,6 +4899,10 @@
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -4925,6 +4929,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.6rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-chart-card .elite-card-badge { font-size: 0.55rem !important; padding: 0.15rem 0.4rem; }
           /* Panel cards (horizontal 2:1) - TOP LEFT corner, smaller text */
           .elite-panel-card .elite-card-content {
@@ -4946,6 +4958,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.45rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-panel-card .elite-card-badge { font-size: 0.4rem !important; padding: 0.1rem 0.3rem; }
         }
         @media (max-width: 480px) {
@@ -4958,6 +4978,7 @@
           .elite-chart-card .elite-card-title { font-size: 1rem !important; }
           .elite-chart-card .elite-card-subtitle { font-size: 0.7rem !important; }
           .elite-chart-card .elite-card-link { font-size: 0.5rem !important; }
+          .elite-chart-card .elite-card-link-tv { font-size: 0.5rem !important; margin-left: 0.2rem; }
           .elite-chart-card .elite-card-badge { font-size: 0.45rem !important; padding: 0.1rem 0.3rem; }
           /* Panel cards - TOP LEFT, even smaller */
           .elite-panel-card .elite-card-content {
@@ -4968,6 +4989,7 @@
           .elite-panel-card .elite-card-title { font-size: 0.9rem !important; }
           .elite-panel-card .elite-card-subtitle { font-size: 0.65rem !important; }
           .elite-panel-card .elite-card-link { font-size: 0.4rem !important; }
+          .elite-panel-card .elite-card-link-tv { font-size: 0.4rem !important; margin-left: 0.2rem; }
           .elite-panel-card .elite-card-badge { font-size: 0.35rem !important; padding: 0.1rem 0.25rem; }
         }
       </style>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4763,13 +4763,6 @@
             </a>
           </div>
 
-          <!-- TradingView Badge -->
-          <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:0.6rem;margin-top:1.5rem;padding:0.6rem 1.2rem;background:linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05));border:1px solid rgba(41,98,255,0.4);border-radius:8px;text-decoration:none;transition:all 0.2s ease" onmouseover="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.25),rgba(41,98,255,0.1))';this.style.borderColor='rgba(41,98,255,0.6)';this.style.transform='translateY(-2px)'" onmouseout="this.style.background='linear-gradient(135deg,rgba(41,98,255,0.15),rgba(41,98,255,0.05))';this.style.borderColor='rgba(41,98,255,0.4)';this.style.transform='translateY(0)'">
-            <svg width="24" height="24" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
-            <span style="font-size:0.95rem;color:var(--text)">View Indicators on <strong style="color:#2962FF">TradingView</strong></span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2962FF" stroke-width="2.5" style="margin-left:0.25rem"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
-          </a>
-
         </div>
 
         <!-- HERO COMPARISON SLIDER -->
@@ -4882,6 +4875,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
+              <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -4892,6 +4886,7 @@
               <p class="elite-card-title">OmniDeck</p>
               <p class="elite-card-subtitle">Unified Chart Overlay</p>
               <a href="https://docs.signalpilot.io/omnideck-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
+              <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/janus-atlas-v10/">
@@ -4902,6 +4897,7 @@
               <p class="elite-card-title">Janus Atlas</p>
               <p class="elite-card-subtitle">Multi-Timeframe Auto-Levels</p>
               <a href="https://docs.signalpilot.io/janus-atlas-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
+              <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/augury-grid-v10/">
@@ -4912,6 +4908,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
+              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4928,6 +4925,7 @@
               <p class="elite-card-title">Plutus Flow</p>
               <p class="elite-card-subtitle">Statistical OBV Analysis</p>
               <a href="https://docs.signalpilot.io/plutus-flow-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
+              <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/harmonic-oscillator-v10/">
@@ -4938,6 +4936,7 @@
               <p class="elite-card-title">Harmonic Oscillator</p>
               <p class="elite-card-subtitle">Multi-Component Momentum</p>
               <a href="https://docs.signalpilot.io/harmonic-oscillator-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
+              <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-panel-card" data-docs="https://docs.signalpilot.io/volume-oracle-v10/">
@@ -4948,6 +4947,7 @@
               <p class="elite-card-title">Volume Oracle</p>
               <p class="elite-card-subtitle">Regime Detection</p>
               <a href="https://docs.signalpilot.io/volume-oracle-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
+              <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4973,6 +4973,10 @@
         .elite-card-content{position:absolute;bottom:1rem;left:1.25rem}
         .elite-card-title{color:#fff;font-size:1.35rem;font-weight:700;margin:0 0 .35rem 0;text-shadow:0 2px 12px rgba(0,0,0,0.7),0 0 20px rgba(91,138,255,0.3);letter-spacing:0.02em}
         .elite-card-subtitle{color:rgba(255,255,255,0.85);font-size:.85rem;margin:0;font-weight:500;text-shadow:0 1px 8px rgba(0,0,0,0.5)}
+        .elite-card-link{display:inline-block;margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:var(--brand);background:rgba(91,138,255,0.1);border:1px solid rgba(91,138,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link:hover{background:rgba(91,138,255,0.2);border-color:var(--brand);color:#fff}
+        .elite-card-link-tv{display:inline-block;margin-top:0.5rem;margin-left:0.4rem;padding:0.35rem 0.75rem;font-size:0.7rem;font-weight:600;color:#2962FF;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:6px;text-decoration:none;transition:all 0.2s ease}
+        .elite-card-link-tv:hover{background:rgba(41,98,255,0.2);border-color:#2962FF;color:#fff}
         .elite-panel-card .elite-card-content{bottom:1rem;transform:none}
         .elite-panel-card .elite-card-title{font-size:1.3rem}
         .elite-panel-card .elite-card-badge{top:auto;bottom:.75rem;right:.75rem}
@@ -4999,6 +5003,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-chart-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.6rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-chart-card .elite-card-badge { font-size: 0.55rem !important; padding: 0.15rem 0.4rem; }
           /* Panel cards (horizontal 2:1) - TOP LEFT corner, smaller text */
           .elite-panel-card .elite-card-content {
@@ -5020,6 +5032,14 @@
             border: none;
             color: var(--brand);
           }
+          .elite-panel-card .elite-card-link-tv {
+            margin-top: 0.15rem;
+            padding: 0;
+            font-size: 0.45rem !important;
+            background: transparent;
+            border: none;
+            color: #2962FF;
+          }
           .elite-panel-card .elite-card-badge { font-size: 0.4rem !important; padding: 0.1rem 0.3rem; }
         }
         @media (max-width: 480px) {
@@ -5032,6 +5052,7 @@
           .elite-chart-card .elite-card-title { font-size: 1rem !important; }
           .elite-chart-card .elite-card-subtitle { font-size: 0.7rem !important; }
           .elite-chart-card .elite-card-link { font-size: 0.5rem !important; }
+          .elite-chart-card .elite-card-link-tv { font-size: 0.5rem !important; margin-left: 0.2rem; }
           .elite-chart-card .elite-card-badge { font-size: 0.45rem !important; padding: 0.1rem 0.3rem; }
           /* Panel cards - TOP LEFT, even smaller */
           .elite-panel-card .elite-card-content {
@@ -5042,6 +5063,7 @@
           .elite-panel-card .elite-card-title { font-size: 0.9rem !important; }
           .elite-panel-card .elite-card-subtitle { font-size: 0.65rem !important; }
           .elite-panel-card .elite-card-link { font-size: 0.4rem !important; }
+          .elite-panel-card .elite-card-link-tv { font-size: 0.4rem !important; margin-left: 0.2rem; }
           .elite-panel-card .elite-card-badge { font-size: 0.35rem !important; padding: 0.1rem 0.25rem; }
         }
       </style>


### PR DESCRIPTION
- Remove "View Indicators on TradingView" button from hero section (scripts are private/invite-only)
- Add direct TradingView script links to each of the 7 indicator product cards
- Add .elite-card-link-tv CSS styling with TradingView blue color (#2962FF)
- Add responsive mobile styles for the new links