### PR TITLE
Add TradingView preview section and pricing card links

### DIFF
--- a/index.html
+++ b/index.html
@@ -5117,7 +5117,7 @@
                   <div class="mt-6 h-px bg-white/10"></div>
 
                   <!-- Preview Link -->
-                  <a href="#preview" class="preview-indicators-link">
+                  <a href="#preview" class="preview-indicators-link" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Preview all 7 indicators on TradingView
                   </a>
@@ -5182,7 +5182,7 @@
                   <div class="mt-6 h-px bg-white/10"></div>
 
                   <!-- Preview Link -->
-                  <a href="#preview" class="preview-indicators-link">
+                  <a href="#preview" class="preview-indicators-link" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Preview all 7 indicators on TradingView
                   </a>
@@ -5270,7 +5270,7 @@
                   <div class="mt-6 h-px bg-white/10"></div>
 
                   <!-- Preview Link -->
-                  <a href="#preview" class="preview-indicators-link">
+                  <a href="#preview" class="preview-indicators-link" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Preview all 7 indicators on TradingView
                   </a>

--- a/index.html
+++ b/index.html
@@ -4482,6 +4482,116 @@
 
     </section>
 
+    <!-- PREVIEW ON TRADINGVIEW SECTION -->
+    <section id="preview" class="section" style="padding:4rem 0;background:linear-gradient(180deg,transparent 0%,rgba(41,98,255,.03) 50%,transparent 100%)">
+      <div class="container" style="max-width:900px">
+        <div data-reveal="fade-up" style="text-align:center;margin-bottom:2rem">
+          <div style="display:inline-flex;align-items:center;gap:0.5rem;padding:0.4rem 1rem;background:rgba(41,98,255,0.1);border:1px solid rgba(41,98,255,0.3);border-radius:999px;margin-bottom:1.25rem">
+            <svg width="18" height="18" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="#2962FF"/></svg>
+            <span style="font-size:0.85rem;font-weight:600;color:#2962FF">TradingView</span>
+          </div>
+          <h2 class="headline lg" style="margin-bottom:0.75rem">
+            <span style="color:var(--text)">Preview Before You Buy</span>
+          </h2>
+          <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">
+            See exactly what you're getting. Full indicator pages with features, screenshots, and documentation.
+          </p>
+        </div>
+
+        <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
+          <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured">
+            <span class="tv-preview-star">★</span> Pentarch
+          </a>
+          <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">
+            OmniDeck
+          </a>
+          <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">
+            Janus Atlas
+          </a>
+          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">
+            Augury Grid
+          </a>
+          <a href="https://www.tradingview.com/script/5k54Nwwf-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">
+            Plutus Flow
+          </a>
+          <a href="https://www.tradingview.com/script/sALNHXWz-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">
+            Harmonic Oscillator
+          </a>
+          <a href="https://www.tradingview.com/script/VuCqquQC-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">
+            Volume Oracle
+          </a>
+        </div>
+
+        <p data-reveal="fade-up" data-reveal-delay="200" style="text-align:center;color:var(--muted);font-size:0.9rem">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:inline;vertical-align:middle;margin-right:0.3rem;opacity:0.7"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Invite-only access granted instantly after purchase
+        </p>
+      </div>
+
+      <style>
+        .tv-preview-btn {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.4rem;
+          padding: 0.65rem 1.25rem;
+          font-size: 0.9rem;
+          font-weight: 600;
+          color: #2962FF;
+          background: rgba(41,98,255,0.08);
+          border: 1px solid rgba(41,98,255,0.25);
+          border-radius: 8px;
+          text-decoration: none;
+          transition: all 0.2s ease;
+        }
+        .tv-preview-btn:hover {
+          background: rgba(41,98,255,0.15);
+          border-color: rgba(41,98,255,0.5);
+          transform: translateY(-2px);
+          box-shadow: 0 4px 12px rgba(41,98,255,0.2);
+        }
+        .tv-preview-btn.featured {
+          background: linear-gradient(135deg, rgba(41,98,255,0.15), rgba(91,138,255,0.1));
+          border-color: rgba(41,98,255,0.4);
+        }
+        .tv-preview-btn.featured:hover {
+          background: linear-gradient(135deg, rgba(41,98,255,0.25), rgba(91,138,255,0.15));
+          border-color: #2962FF;
+        }
+        .tv-preview-star {
+          color: #fbbf24;
+          font-size: 0.8rem;
+        }
+        @media (max-width: 640px) {
+          .tv-preview-btn {
+            padding: 0.55rem 1rem;
+            font-size: 0.8rem;
+          }
+        }
+        /* Preview link in pricing cards */
+        .preview-indicators-link {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 0.5rem;
+          margin-top: 1rem;
+          padding: 0.6rem 1rem;
+          font-size: 0.8rem;
+          font-weight: 500;
+          color: #2962FF;
+          background: rgba(41,98,255,0.08);
+          border: 1px solid rgba(41,98,255,0.2);
+          border-radius: 8px;
+          text-decoration: none;
+          transition: all 0.2s ease;
+        }
+        .preview-indicators-link:hover {
+          background: rgba(41,98,255,0.15);
+          border-color: rgba(41,98,255,0.4);
+          color: #4d82ff;
+        }
+      </style>
+    </section>
+
     <!-- TESTIMONIALS - MOVED UP FOR TRUST BEFORE ASK -->
 
     <section id="testimonials" class="section" style="padding:4rem 0;overflow:hidden">
@@ -5006,6 +5116,12 @@
 
                   <div class="mt-6 h-px bg-white/10"></div>
 
+                  <!-- Preview Link -->
+                  <a href="#preview" class="preview-indicators-link">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Preview all 7 indicators on TradingView
+                  </a>
+
                   <!-- TradingView Username -->
                   <div class="mt-6">
                     <label class="text-xs font-medium text-white/70 mb-2 block">TradingView Username</label>
@@ -5064,6 +5180,12 @@
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
+
+                  <!-- Preview Link -->
+                  <a href="#preview" class="preview-indicators-link">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Preview all 7 indicators on TradingView
+                  </a>
 
                   <!-- TradingView Username -->
                   <div class="mt-6">
@@ -5146,6 +5268,12 @@
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
+
+                  <!-- Preview Link -->
+                  <a href="#preview" class="preview-indicators-link">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Preview all 7 indicators on TradingView
+                  </a>
 
                   <!-- TradingView Username -->
                   <div class="mt-6">


### PR DESCRIPTION
Option 2: Dedicated "Preview Before You Buy" section
- Placed after product cards, before testimonials
- 7 indicator buttons linking to TradingView script pages
- TradingView-branded styling with blue theme
- Responsive design for mobile

Option 4: Preview links in pricing cards
- Added to all 3 pricing tiers (monthly, yearly, lifetime)
- Links scroll to preview section
- Consistent TradingView blue styling