### PR TITLE
Update Discord invite link to non-expiring

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4533,7 +4533,7 @@ html[lang="ar"] [style*="text-align:center"] {
               الموارد <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">مجتمع Discord</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">مجتمع Discord</a></li>
               <li><a href="/ar/chronicle/">السجل</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">الوثائق</a></li>
               <li><a href="https://blog.signalpilot.io/ar/" target="_blank" rel="noopener">المدونة</a></li>
@@ -6562,7 +6562,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="البريد الإلكتروني" onmouseover="this.style.color='#fff';this.style.background='rgba(91,138,255,.15)';this.style.borderColor='rgba(91,138,255,.3)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="مجتمع Discord" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="مجتمع Discord" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -6858,7 +6858,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">المجتمع</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">مجتمع Discord</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">مجتمع Discord</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/de/index.html
+++ b/de/index.html
@@ -4494,7 +4494,7 @@
               Ressourcen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Community</a></li>
               <li><a href="/de/chronicle/">Chronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentation</a></li>
               <li><a href="https://blog.signalpilot.io/de/" target="_blank" rel="noopener">Blog</a></li>
@@ -6909,7 +6909,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="E-Mail" onmouseover="this.style.color='#fff';this.style.background='rgba(91,138,255,.15)';this.style.borderColor='rgba(91,138,255,.3)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Discord Community" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Discord Community" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -7206,7 +7206,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Community</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Community</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/es/index.html
+++ b/es/index.html
@@ -4708,7 +4708,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunidad Discord</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Comunidad Discord</a></li>
               <li><a href="/es/chronicle/">Crónica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentación</a></li>
               <li><a href="https://blog.signalpilot.io/es/" target="_blank" rel="noopener">Blog</a></li>
@@ -6943,7 +6943,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Correo" onmouseover="this.style.color='#fff';this.style.background='rgba(91,138,255,.15)';this.style.borderColor='rgba(91,138,255,.3)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Comunidad Discord" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Comunidad Discord" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -7240,7 +7240,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Comunidad</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunidad Discord</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Comunidad Discord</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/fr/index.html
+++ b/fr/index.html
@@ -4769,7 +4769,7 @@
               Ressources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Communauté Discord</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Communauté Discord</a></li>
               <li><a href="/fr/chronicle/">Chronique</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/fr/" target="_blank" rel="noopener">Blog</a></li>
@@ -7204,7 +7204,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Email" onmouseover="this.style.color='#fff';this.style.background='rgba(91,138,255,.15)';this.style.borderColor='rgba(91,138,255,.3)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Communauté Discord" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Communauté Discord" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -7504,7 +7504,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Communauté</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Communauté Discord</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Communauté Discord</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/hu/index.html
+++ b/hu/index.html
@@ -4478,7 +4478,7 @@
               Források <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Közösség</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Közösség</a></li>
               <li><a href="/hu/chronicle/">Krónika</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokumentáció</a></li>
               <li><a href="https://blog.signalpilot.io/hu/" target="_blank" rel="noopener">Blog</a></li>
@@ -6812,7 +6812,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="E-mail" onmouseover="this.style.color='#fff';this.style.background='rgba(91,138,255,.15)';this.style.borderColor='rgba(91,138,255,.3)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Discord Közösség" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Discord Közösség" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -7108,7 +7108,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Közösség</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Közösség</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Közösség</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/index.html
+++ b/index.html
@@ -3453,7 +3453,7 @@
               Resources <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Community</a></li>
               <li><a href="/chronicle/">Chronicle</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentation</a></li>
               <li><a href="https://blog.signalpilot.io/" target="_blank" rel="noopener">Blog</a></li>
@@ -6206,7 +6206,7 @@
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;margin-top:1.25rem">
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Discord Community" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="Discord Community" onmouseover="this.style.color='#fff';this.style.background='rgba(88,101,242,.25)';this.style.borderColor='rgba(88,101,242,.5)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
               <a href="https://github.com/Signalpilot/signalpilot.io" target="_blank" rel="noopener" style="color:var(--muted);transition:all .2s;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)" title="GitHub" onmouseover="this.style.color='#fff';this.style.background='rgba(91,138,255,.15)';this.style.borderColor='rgba(91,138,255,.3)'" onmouseout="this.style.color='var(--muted)';this.style.background='rgba(255,255,255,.03)';this.style.borderColor='rgba(255,255,255,.06)'">
@@ -6514,7 +6514,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Community</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Community</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/it/index.html
+++ b/it/index.html
@@ -4442,7 +4442,7 @@
               Risorse <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunità Discord</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Comunità Discord</a></li>
               <li><a href="/it/chronicle/">Cronaca</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentazione</a></li>
               <li><a href="https://blog.signalpilot.io/it/" target="_blank" rel="noopener">Blog</a></li>
@@ -6397,7 +6397,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:color .2s,transform .2s" title="Email" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Comunità Discord" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Comunità Discord" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -6689,7 +6689,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Comunità</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunità Discord</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Comunità Discord</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/ja/index.html
+++ b/ja/index.html
@@ -4792,7 +4792,7 @@
               リソース <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discordコミュニティ</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discordコミュニティ</a></li>
               <li><a href="/ja/chronicle/">クロニクル</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">ドキュメント</a></li>
               <li><a href="https://blog.signalpilot.io/ja/" target="_blank" rel="noopener">ブログ</a></li>
@@ -6635,7 +6635,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:color .2s,transform .2s" title="メール" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Discordコミュニティ" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Discordコミュニティ" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -6928,7 +6928,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">コミュニティ</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discordコミュニティ</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discordコミュニティ</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/nl/index.html
+++ b/nl/index.html
@@ -4469,7 +4469,7 @@
               Bronnen <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Community</a></li>
               <li><a href="/nl/chronicle/">Kroniek</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentatie</a></li>
               <li><a href="https://blog.signalpilot.io/nl/" target="_blank" rel="noopener">Blog</a></li>
@@ -6330,7 +6330,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:color .2s,transform .2s" title="E-mail" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Discord Community" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Discord Community" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -6622,7 +6622,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Community</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Community</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Community</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/pt/index.html
+++ b/pt/index.html
@@ -4725,7 +4725,7 @@
               Recursos <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunidade Discord</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Comunidade Discord</a></li>
               <li><a href="/pt/chronicle/">Crônica</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Documentação</a></li>
               <li><a href="https://blog.signalpilot.io/pt/" target="_blank" rel="noopener">Blog</a></li>
@@ -6691,7 +6691,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:color .2s,transform .2s" title="E-mail" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Comunidade Discord" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Comunidade Discord" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -6983,7 +6983,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Comunidade</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Comunidade Discord</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Comunidade Discord</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/ru/index.html
+++ b/ru/index.html
@@ -4551,7 +4551,7 @@
               Ресурсы <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Сообщество Discord</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Сообщество Discord</a></li>
               <li><a href="/ru/chronicle/">Хроника</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Документация</a></li>
               <li><a href="https://blog.signalpilot.io/ru/" target="_blank" rel="noopener">Блог</a></li>
@@ -6442,7 +6442,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:color .2s,transform .2s" title="Эл. почта" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Сообщество Discord" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Сообщество Discord" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -6733,7 +6733,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Сообщество</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Сообщество Discord</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Сообщество Discord</a>
         </div>
 
         <div class="mobile-nav-section">

--- a/tr/index.html
+++ b/tr/index.html
@@ -4626,7 +4626,7 @@
               Kaynaklar <span class="dropdown-arrow">▼</span>
             </button>
             <ul class="nav-dropdown-menu">
-              <li><a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Topluluğu</a></li>
+              <li><a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Topluluğu</a></li>
               <li><a href="/tr/chronicle/">Kronik</a></li>
               <li><a href="https://docs.signalpilot.io/" target="_blank" rel="noopener">Dokümantasyon</a></li>
               <li><a href="https://blog.signalpilot.io/tr/" target="_blank" rel="noopener">Blog</a></li>
@@ -6519,7 +6519,7 @@
               <a href="mailto:support@signalpilot.io" style="color:var(--muted);transition:color .2s,transform .2s" title="E-posta" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
               </a>
-              <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Discord Topluluğu" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
+              <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener" style="color:var(--muted);transition:color .2s,transform .2s" title="Discord Topluluğu" onmouseover="this.style.color='var(--brand)';this.style.transform='translateY(-2px)'" onmouseout="this.style.color='var(--muted)';this.style.transform='translateY(0)'">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               </a>
             </div>
@@ -6813,7 +6813,7 @@
 
         <div class="mobile-nav-section">
           <div class="mobile-nav-section-label">Topluluk</div>
-          <a href="https://discord.gg/K6BgD8wN" target="_blank" rel="noopener">Discord Topluluğu</a>
+          <a href="https://discord.gg/5guVbGEyj8" target="_blank" rel="noopener">Discord Topluluğu</a>
         </div>
 
         <div class="mobile-nav-section">


### PR DESCRIPTION
Replace old Discord link (K6BgD8wN) with new permanent invite link (5guVbGEyj8) across all 12 language versions of the site.