### PR TITLE
Fix mobile blog carousel horizontal scrolling across all languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4144,6 +4144,18 @@ html[lang="ar"] [style*="text-align:center"] {
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/de/index.html
+++ b/de/index.html
@@ -4081,6 +4081,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/es/index.html
+++ b/es/index.html
@@ -4295,6 +4295,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/fr/index.html
+++ b/fr/index.html
@@ -4342,6 +4342,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/hu/index.html
+++ b/hu/index.html
@@ -4089,6 +4089,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/index.html
+++ b/index.html
@@ -3346,6 +3346,18 @@
     .articles-carousel::-webkit-scrollbar-thumb:hover {
       background: var(--muted);
     }
+
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
   </style>
 
 </head>

--- a/it/index.html
+++ b/it/index.html
@@ -4062,6 +4062,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/ja/index.html
+++ b/ja/index.html
@@ -4403,6 +4403,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/nl/index.html
+++ b/nl/index.html
@@ -4080,6 +4080,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/pt/index.html
+++ b/pt/index.html
@@ -4335,6 +4335,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/ru/index.html
+++ b/ru/index.html
@@ -4162,6 +4162,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */

--- a/tr/index.html
+++ b/tr/index.html
@@ -4252,6 +4252,18 @@
       background: var(--muted);
     }
 
+    /* Mobile: Allow articles carousel to scroll horizontally */
+    @media (max-width: 768px) {
+      .container:has(> .articles-carousel) {
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      .articles-carousel {
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+      }
+    }
+
     /* MOBILE: Simple, clean mobile setup */
     @media (max-width: 768px) {
       /* NUCLEAR: Remove ALL transforms from containers - they break position:fixed */


### PR DESCRIPTION
Added CSS rules to enable horizontal touch scrolling for the articles carousel on mobile devices. The fix includes:
- Override container overflow to allow visible content
- Add touch-action: pan-x for explicit horizontal touch panning
- Add -webkit-overflow-scrolling: touch for iOS momentum scrolling

This resolves the issue where the blog carousel could not be scrolled horizontally on mobile devices in non-English language pages.