### PR TITLE
Fix mobile blog carousel touch scrolling for real devices

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4146,13 +4146,17 @@ html[lang="ar"] [style*="text-align:center"] {
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -6005,14 +6009,14 @@ html[lang="ar"] [style*="text-align:center"] {
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">أحدث المقالات</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">رؤى التداول والاستراتيجيات وتحليل السوق</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/de/index.html
+++ b/de/index.html
@@ -4083,13 +4083,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -6488,14 +6492,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Neueste Blog-Artikel</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Trading-Einblicke, Strategien und Marktanalysen</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/es/index.html
+++ b/es/index.html
@@ -4297,13 +4297,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -6385,14 +6389,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Últimos Artículos</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Perspectivas de trading, estrategias y análisis de mercado</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/fr/index.html
+++ b/fr/index.html
@@ -4344,13 +4344,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -6640,14 +6644,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Derniers Articles</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Analyses de trading, stratégies et études de marché</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/hu/index.html
+++ b/hu/index.html
@@ -4091,13 +4091,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -6256,14 +6260,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Legújabb Cikkek</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Kereskedési betekintések, stratégiák és piacelemzés</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/index.html
+++ b/index.html
@@ -3349,13 +3349,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
   </style>
@@ -5681,14 +5685,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Latest from the Blog</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Trading insights, strategies, and market analysis</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
           <div style="width:80px;height:20px;background:var(--border);border-radius:4px;margin-bottom:.75rem;animation:pulse 1.5s infinite"></div>

--- a/it/index.html
+++ b/it/index.html
@@ -4064,13 +4064,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -5922,14 +5926,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Ultimi Articoli</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Approfondimenti sul trading, strategie e analisi di mercato</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/ja/index.html
+++ b/ja/index.html
@@ -4405,13 +4405,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -6163,14 +6167,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">最新の記事</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">トレーディングの洞察、戦略、市場分析</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/nl/index.html
+++ b/nl/index.html
@@ -4082,13 +4082,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -5857,14 +5861,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Laatste Artikelen</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Handelsinzichten, strategieën en marktanalyse</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/pt/index.html
+++ b/pt/index.html
@@ -4337,13 +4337,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -6199,14 +6203,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Últimos Artigos</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Insights de trading, estratégias e análise de mercado</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/ru/index.html
+++ b/ru/index.html
@@ -4164,13 +4164,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -5952,14 +5956,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Последние Статьи</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Торговые инсайты, стратегии и анализ рынка</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">

--- a/tr/index.html
+++ b/tr/index.html
@@ -4254,13 +4254,17 @@
 
     /* Mobile: Allow articles carousel to scroll horizontally */
     @media (max-width: 768px) {
-      .container:has(> .articles-carousel) {
+      #blog-section .container {
+        overflow: visible !important;
         overflow-x: visible !important;
         overflow-y: visible !important;
       }
+      #blog-carousel,
       .articles-carousel {
-        touch-action: pan-x !important;
+        overflow-x: auto !important;
         -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x pan-y !important;
+        scroll-snap-type: x mandatory;
       }
     }
 
@@ -6029,14 +6033,14 @@
 
 
   <!-- LATEST ARTICLES CAROUSEL -->
-  <section style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
-    <div class="container">
+  <section id="blog-section" style="padding:4rem 0;background:var(--bg-elev);border-top:1px solid var(--border)">
+    <div class="container" style="overflow:visible !important">
       <div style="text-align:center;margin-bottom:2rem">
         <h2 style="font-size:2rem;font-weight:700;margin:0 0 .5rem 0">Son Makaleler</h2>
         <p style="color:var(--muted);font-size:1rem;margin:0">Ticaret içgörüleri, stratejiler ve piyasa analizi</p>
       </div>
 
-      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin">
+      <div id="blog-carousel" class="articles-carousel" style="display:flex;gap:1.5rem;overflow-x:auto;scroll-snap-type:x mandatory;padding:1rem 0;-webkit-overflow-scrolling:touch;scrollbar-width:thin;touch-action:pan-x pan-y;-webkit-touch-callout:none">
 
         <!-- Loading skeleton -->
         <div class="article-card article-skeleton" style="flex:0 0 300px;scroll-snap-align:start;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">


### PR DESCRIPTION
The :has() CSS selector wasn't working on all mobile browsers. This update uses a more robust approach:

- Added id="blog-section" to blog section for direct targeting
- Added inline overflow:visible on container
- Added inline touch-action:pan-x pan-y on carousel element
- Updated CSS to use direct ID selectors instead of :has()
- Added -webkit-touch-callout:none to prevent long-press issues

This ensures horizontal touch scrolling works on actual mobile devices (iOS Safari, Android Chrome) not just browser DevTools.