### PR TITLE
Fix mobile blog carousel horizontal scroll for all non-English languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4429,6 +4429,31 @@ html[lang="ar"] [style*="text-align:center"] {
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/de/index.html
+++ b/de/index.html
@@ -4427,6 +4427,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/es/index.html
+++ b/es/index.html
@@ -4641,6 +4641,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -4702,6 +4702,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -4374,6 +4374,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/it/index.html
+++ b/it/index.html
@@ -4338,6 +4338,31 @@
       }
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -4688,6 +4688,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -4365,6 +4365,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -4620,6 +4620,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 
 </head>

--- a/ru/index.html
+++ b/ru/index.html
@@ -4447,6 +4447,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -4522,6 +4522,31 @@
 
     }
 
+    /* FINAL MOBILE BLOG CAROUSEL OVERRIDE - fixes horizontal touch scroll */
+    @media (max-width: 768px) {
+      section#blog-section,
+      section#blog-section > .container {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+      }
+      #blog-carousel.articles-carousel,
+      div#blog-carousel {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        overflow-x: scroll !important;
+        overflow-y: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+        touch-action: pan-x !important;
+        scroll-snap-type: none !important;
+        overscroll-behavior-x: contain !important;
+      }
+      #blog-carousel .article-card {
+        flex: 0 0 280px !important;
+        min-width: 280px !important;
+      }
+    }
+
   </style>
 </head>
 


### PR DESCRIPTION
Added final CSS override at end of head styles to ensure blog carousel can scroll horizontally on mobile. The fix uses high-specificity selectors targeting #blog-section and #blog-carousel to override any conflicting overflow: hidden rules that exist in the duplicate CSS blocks.