### PR TITLE
Restyle hero slider controls: text buttons for Before/After

### DIFF
--- a/index.html
+++ b/index.html
@@ -1701,6 +1701,10 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Hero slider text buttons */
+    #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
+    #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
+
     /* Founding Member Badge - Shiny Gold Border (like CTA buttons) */
     .founding-badge {
       --gradient-angle:0deg;
@@ -3636,14 +3640,14 @@
         <div style="margin-bottom:3rem;max-width:1100px;margin-left:auto;margin-right:auto">
 
             <!-- Slider Controls -->
-            <div style="display:flex;justify-content:center;gap:0.5rem;margin-bottom:1.25rem;flex-wrap:nowrap;align-items:center">
-              <button id="hero-btn-before" class="btn btn-secondary" style="width:90px;height:38px;font-size:0.85rem;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center;padding:0">
+            <div style="display:flex;justify-content:center;gap:1.5rem;margin-bottom:1.25rem;flex-wrap:nowrap;align-items:center">
+              <button id="hero-btn-before" style="background:none;border:none;cursor:pointer;font-size:0.9rem;font-weight:500;color:var(--muted);padding:0.5rem 0;transition:all 0.2s ease;text-shadow:0 0 20px transparent">
                 ← Before
               </button>
-              <button id="hero-btn-autoplay" class="shiny-cta" style="width:90px;height:38px;font-size:0.85rem;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center;padding:0">
+              <button id="hero-btn-autoplay" class="shiny-cta" style="width:100px;height:38px;font-size:0.85rem;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center;padding:0">
                 <span>▶ Auto</span>
               </button>
-              <button id="hero-btn-after" class="btn btn-secondary" style="width:90px;height:38px;font-size:0.85rem;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center;padding:0">
+              <button id="hero-btn-after" style="background:none;border:none;cursor:pointer;font-size:0.9rem;font-weight:500;color:var(--muted);padding:0.5rem 0;transition:all 0.2s ease;text-shadow:0 0 20px transparent">
                 After →
               </button>
             </div>


### PR DESCRIPTION
- Remove boxed btn-secondary style from Before/After buttons
- Convert to clean text buttons with hover glow effect
- Keep shiny Pause/Auto button as the prominent center control
- Add hover states with blue text-shadow and active scale effect