### PR TITLE
Reduce text clutter on website

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5533,7 +5533,7 @@ html[lang="ar"] [style*="text-align:center"] {
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/سنة</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">وفر $489/سنة. أفضل قيمة للمتداولين الملتزمين.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">أفضل قيمة للمتداولين الملتزمين.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5542,7 +5542,7 @@ html[lang="ar"] [style*="text-align:center"] {
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      وفر $489 مقابل الشهري
+                      جميع التحديثات المستقبلية مشمولة
                     </li>
                   </ul>
 
@@ -6544,7 +6544,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.12em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.9rem;line-height:1.7;margin:0 0 1.25rem 0;max-width:280px">
-              مصمم لـ <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">المتداولين</span> الذين يطالبون بالدقة. 82 درساً مجانياً + 7 مؤشرات TradingView متميزة.
+              مصمم لـ <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">المتداولين</span> الذين يطالبون بالدقة. 7 مؤشرات TradingView متميزة.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;margin-top:1.25rem">

--- a/de/index.html
+++ b/de/index.html
@@ -6039,7 +6039,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/Jahr</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Spare $489/Jahr. Bester Wert für engagierte Trader.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Bester Wert für engagierte Trader.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -6048,7 +6048,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Spare $489 vs monatliche Abrechnung
+                      Alle zukünftigen Updates inklusive
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6979,7 +6979,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.12em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.9rem;line-height:1.7;margin:0 0 1.25rem 0;max-width:280px">
-              Entwickelt für <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">Trader</span>, die Präzision fordern. 82 kostenlose Lektionen + 7 Premium TradingView-Indikatoren.
+              Entwickelt für <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">Trader</span>, die Präzision fordern. 7 Premium TradingView-Indikatoren.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;margin-top:1.25rem">

--- a/es/index.html
+++ b/es/index.html
@@ -5927,7 +5927,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/año</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Ahorra $489/año. Mejor valor para traders comprometidos.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Mejor valor para traders comprometidos.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5936,7 +5936,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Ahorra $489 vs mensual
+                      Todas las actualizaciones futuras incluidas
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -7008,7 +7008,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.12em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.9rem;line-height:1.7;margin:0 0 1.25rem 0;max-width:280px">
-              Construido para <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">traders</span> que exigen precisión. 82 lecciones gratuitas + 7 indicadores premium de TradingView.
+              Construido para <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">traders</span> que exigen precisión. 7 indicadores premium de TradingView.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;margin-top:1.25rem">

--- a/fr/index.html
+++ b/fr/index.html
@@ -6188,7 +6188,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/an</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Économisez $489/an. Meilleure valeur pour les traders engagés.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Meilleure valeur pour les traders engagés.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -6197,7 +6197,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Économisez $489 vs mensuel
+                      Toutes les mises à jour futures incluses
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -7273,7 +7273,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.12em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.9rem;line-height:1.7;margin:0 0 1.25rem 0;max-width:280px">
-              Conçu pour <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">traders</span> qui exigent la précision. 82 leçons gratuites + 7 indicateurs TradingView premium.
+              Conçu pour <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">traders</span> qui exigent la précision. 7 indicateurs TradingView premium.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;margin-top:1.25rem">

--- a/hu/index.html
+++ b/hu/index.html
@@ -5826,7 +5826,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/év</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Spórolj $489/év. Legjobb érték az elkötelezett kereskedőknek.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Legjobb érték az elkötelezett kereskedőknek.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5835,7 +5835,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Spórolj $489 a havihoz képest
+                      Minden jövőbeli frissítés beleértve
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6840,7 +6840,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.12em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.9rem;line-height:1.7;margin:0 0 1.25rem 0;max-width:280px">
-              Készült <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">kereskedőknek</span>, akik precizitást követelnek. 82 ingyenes lecke + 7 prémium TradingView indikátor.
+              Készült <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">kereskedőknek</span>, akik precizitást követelnek. 7 prémium TradingView indikátor.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;margin-top:1.25rem">

--- a/index.html
+++ b/index.html
@@ -5162,7 +5162,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/year</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Save $489/year. Best value for committed traders.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Best value for committed traders.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5171,7 +5171,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Save $489 vs monthly billing
+                      All future updates included
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6224,7 +6224,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.12em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.9rem;line-height:1.7;margin:0 0 1.25rem 0;max-width:280px">
-              Built for <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">traders</span> who demand precision. 82 free lessons + 7 premium TradingView indicators.
+              Built for <span id="footer-decode" class="signal-decode" style="color:var(--brand);font-weight:600">traders</span> who demand precision. 7 premium TradingView indicators.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;margin-top:1.25rem">

--- a/it/index.html
+++ b/it/index.html
@@ -5430,7 +5430,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/anno</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Risparmia $489/anno. Miglior valore per trader impegnati.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Miglior valore per trader impegnati.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5439,7 +5439,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Risparmia $489 vs mensile
+                      Tutti gli aggiornamenti futuri inclusi
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6428,7 +6428,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.85rem;line-height:1.7;margin:0 0 1.25rem 0">
-              82 lezioni gratuite + 7 indicatori TradingView premium. Costruito per <span style="color:var(--brand);font-weight:600">trader</span> seri.
+              7 indicatori TradingView premium. Costruito per <span style="color:var(--brand);font-weight:600">trader</span> seri.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;align-items:center">

--- a/ja/index.html
+++ b/ja/index.html
@@ -5735,7 +5735,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/年</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">年間$489節約。本格的なトレーダーに最適な価値。</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">本格的なトレーダーに最適な価値。</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5744,7 +5744,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      月額と比較して$489節約
+                      今後のすべてのアップデートを含む
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6665,7 +6665,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.85rem;line-height:1.7;margin:0 0 1.25rem 0">
-              82の無料レッスン + 7つのプレミアムTradingViewインジケーター。本格的な<span style="color:var(--brand);font-weight:600">トレーダー</span>のために構築。
+              7つのプレミアムTradingViewインジケーター。本格的な<span style="color:var(--brand);font-weight:600">トレーダー</span>のために構築。
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;align-items:center">

--- a/nl/index.html
+++ b/nl/index.html
@@ -5423,7 +5423,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/jaar</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Bespaar $489/jaar. Beste waarde voor toegewijde traders.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Beste waarde voor toegewijde traders.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5432,7 +5432,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Bespaar $489 vs maandelijks
+                      Alle toekomstige updates inbegrepen
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6355,7 +6355,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.85rem;line-height:1.7;margin:0 0 1.25rem 0">
-              82 gratis lessen + 7 premium TradingView indicatoren. Gebouwd voor serieuze <span style="color:var(--brand);font-weight:600">traders</span>.
+              7 premium TradingView indicatoren. Gebouwd voor serieuze <span style="color:var(--brand);font-weight:600">traders</span>.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;align-items:center">

--- a/pt/index.html
+++ b/pt/index.html
@@ -5699,7 +5699,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/ano</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Economize $489/ano. Melhor valor para traders comprometidos.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Melhor valor para traders comprometidos.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5708,7 +5708,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Economize $489 vs mensal
+                      Todas as atualizações futuras incluídas
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6712,7 +6712,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.85rem;line-height:1.7;margin:0 0 1.25rem 0">
-              82 aulas gratuitas + 7 indicadores premium do TradingView. Construído para <span style="color:var(--brand);font-weight:600">traders</span> sérios.
+              7 indicadores premium do TradingView. Construído para <span style="color:var(--brand);font-weight:600">traders</span> sérios.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;align-items:center">

--- a/ru/index.html
+++ b/ru/index.html
@@ -5515,7 +5515,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/год</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Экономия $489/год. Лучшая цена для преданных трейдеров.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Лучшая цена для преданных трейдеров.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5524,7 +5524,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Экономия $489 по сравнению с ежемесячной подпиской
+                      Все будущие обновления включены
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6467,7 +6467,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.85rem;line-height:1.7;margin:0 0 1.25rem 0">
-              82 бесплатных урока + 7 премиум индикаторов TradingView. Создано для серьёзных <span style="color:var(--brand);font-weight:600">трейдеров</span>.
+              7 премиум индикаторов TradingView. Создано для серьёзных <span style="color:var(--brand);font-weight:600">трейдеров</span>.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;align-items:center">

--- a/tr/index.html
+++ b/tr/index.html
@@ -5590,7 +5590,7 @@
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/yıl</span>
                   </div>
 
-                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">$489/yıl tasarruf edin. Kararlı yatırımcılar için en iyi değer.</p>
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Kararlı yatırımcılar için en iyi değer.</p>
 
                   <ul class="mt-6 space-y-2 text-sm text-neutral-300">
                     <li class="flex items-start gap-3">
@@ -5599,7 +5599,7 @@
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Aylığa göre $489 tasarruf edin
+                      Tüm gelecek güncellemeler dahil
                     </li>
                     <li class="flex items-start gap-3">
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
@@ -6544,7 +6544,7 @@
               <span style="font-family:'Gugi',system-ui,-apple-system,sans-serif;text-transform:uppercase;letter-spacing:.1em;background:linear-gradient(135deg,#5b8aff,#764ba2);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">Signal Pilot</span>
             </h4>
             <p style="color:var(--muted);font-size:.85rem;line-height:1.7;margin:0 0 1.25rem 0">
-              82 ücretsiz ders + 7 premium TradingView göstergesi. Ciddi <span style="color:var(--brand);font-weight:600">trader'lar</span> için inşa edildi.
+              7 premium TradingView göstergesi. Ciddi <span style="color:var(--brand);font-weight:600">trader'lar</span> için inşa edildi.
             </p>
             <!-- Social Icons -->
             <div style="display:flex;gap:1rem;align-items:center">


### PR DESCRIPTION
- Remove duplicate "Save $489/year" from yearly pricing card description
- Replace "$489 savings" bullet with "All future updates included"
- Remove "82 free lessons" from footer (already shown in hero)

Applied to all 12 language versions (en, ar, de, es, fr, hu, it, ja, nl, pt, ru, tr)