### PR TITLE
Remove additional redundant text across website

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4747,10 +4747,6 @@ html[lang="ar"] [style*="text-align:center"] {
 
             </div>
 
-            <!-- Risk Disclosure -->
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">
-              ⚠️ أدوات تعليمية فقط. ليست نصيحة مالية. التداول ينطوي على مخاطر خسارة كبيرة.
-            </p>
         </div>
 
         <!-- Hero Comparison Slider Script - GPU Optimized -->
@@ -5626,10 +5622,6 @@ html[lang="ar"] [style*="text-align:center"] {
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       لا تدفع مرة أخرى أبداً
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      جميع التحديثات المستقبلية مشمولة
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5703,8 +5695,7 @@ html[lang="ar"] [style*="text-align:center"] {
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            شاهد كشف دورة Pentarch عملياً. قم بإعداد تنبيهاتك.
-            اختبر استراتيجياتك. <strong style="color:var(--brand)">بدون مخاطر، بدون التزام.</strong>
+            شاهد كشف دورة Pentarch عملياً. قم بإعداد تنبيهاتك. اختبر استراتيجياتك.
           </p>
         </div>
 

--- a/de/index.html
+++ b/de/index.html
@@ -4737,7 +4737,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Nur Bildungswerkzeuge. Keine Finanzberatung. Der Handel birgt ein erhebliches Verlustrisiko.</p>
         </div>
 
         <script>
@@ -6136,10 +6135,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Nie wieder bezahlen
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Alle zukünftigen Updates inklusive
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -6209,8 +6204,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Sehen Sie Pentarchs Zyklus-Erkennung in Aktion. Richten Sie Ihre Alarme ein.
-            Testen Sie Ihre Strategien. <strong style="color:var(--brand)">Geld-zurück-Garantie. Keine Verpflichtung.</strong>
+            Sehen Sie Pentarchs Zyklus-Erkennung in Aktion. Richten Sie Ihre Alarme ein. Testen Sie Ihre Strategien.
           </p>
         </div>
 

--- a/es/index.html
+++ b/es/index.html
@@ -4947,7 +4947,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Solo herramientas educativas. No es asesoramiento financiero. El trading implica riesgo de pérdida.</p>
         </div>
         <script>
         (function() {
@@ -6024,10 +6023,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Nunca más pagues
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Todas las actualizaciones futuras incluidas
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -6101,8 +6096,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Observa la detección de ciclos Pentarch en acción. Configura tus alertas.
-            Prueba tus estrategias. <strong style="color:var(--brand)">Garantía de devolución. Sin compromiso.</strong>
+            Observa la detección de ciclos Pentarch en acción. Configura tus alertas. Prueba tus estrategias.
           </p>
         </div>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -5016,7 +5016,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Outils éducatifs uniquement. Le trading comporte un risque de perte.</p>
         </div>
         <script>
         (function() {
@@ -6285,10 +6284,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Ne payez plus jamais, jamais
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Toutes les futures mises à jour incluses
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -6363,8 +6358,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Voyez la détection de cycle Pentarch en action. Configurez vos alertes.
-            Testez vos stratégies. <strong style="color:var(--brand)">Satisfait ou remboursé. Sans engagement.</strong>
+            Voyez la détection de cycle Pentarch en action. Configurez vos alertes. Testez vos stratégies.
           </p>
         </div>
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -4683,7 +4683,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Csak oktatási célú eszközök. A kereskedés veszteséggel járhat.</p>
         </div>
         <script>
         (function() {
@@ -5923,10 +5922,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Soha többé ne fizess
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Minden jövőbeli frissítés benne van
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5999,8 +5994,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Lásd a Pentarch ciklusdetektálást működés közben. Állítsd be a riasztásaidat.
-            Teszteld a stratégiáidat. <strong style="color:var(--brand)">Pénzvisszafizetési garancia. Kötelezettség nélkül.</strong>
+            Lásd a Pentarch ciklusdetektálást működés közben. Állítsd be a riasztásaidat. Teszteld a stratégiáidat.
           </p>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -3689,10 +3689,6 @@
 
             </div>
 
-            <!-- Risk Disclosure -->
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">
-              ⚠️ Educational tools only. Not financial advice. Trading involves substantial risk of loss.
-            </p>
         </div>
 
         <!-- Hero Comparison Slider Script - GPU Optimized -->
@@ -5261,10 +5257,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Never pay again, ever
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      All future updates included
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5335,8 +5327,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            See Pentarch cycle detection in action. Set up your alerts.
-            Test your strategies. <strong style="color:var(--brand)">Money-back guarantee. No commitment.</strong>
+            See Pentarch cycle detection in action. Set up your alerts. Test your strategies.
           </p>
         </div>
 

--- a/it/index.html
+++ b/it/index.html
@@ -4648,7 +4648,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Solo strumenti educativi. Il trading comporta rischio di perdita.</p>
         </div>
         <script>
         (function() {
@@ -5527,10 +5526,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Non pagare mai più
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Tutti gli aggiornamenti futuri inclusi
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5604,8 +5599,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Vedi il rilevamento del ciclo Pentarch in azione. Configura i tuoi avvisi.
-            Testa le tue strategie. <strong style="color:var(--brand)">Garanzia di rimborso. Senza impegno.</strong>
+            Vedi il rilevamento del ciclo Pentarch in azione. Configura i tuoi avvisi. Testa le tue strategie.
           </p>
         </div>
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -4997,7 +4997,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ 教育ツールのみ。取引には損失リスクが伴います。</p>
         </div>
         <script>
         (function() {
@@ -5832,10 +5831,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       二度と支払い不要
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      将来のすべてのアップデート込み
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5908,8 +5903,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Pentarchサイクル検出の実際をご覧ください。アラートを設定し、
-            戦略をテストしてください。 <strong style="color:var(--brand)">返金保証付き。契約不要。</strong>
+            Pentarchサイクル検出の実際をご覧ください。アラートを設定し、戦略をテストしてください。
           </p>
         </div>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -4675,7 +4675,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Alleen educatieve hulpmiddelen. Handelen brengt verliesrisico met zich mee.</p>
         </div>
         <script>
         (function() {
@@ -5520,10 +5519,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Nooit meer betalen, ooit
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Alle toekomstige updates inbegrepen
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5597,8 +5592,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Zie Pentarch cyclusdetectie in actie. Stel je waarschuwingen in.
-            Test je strategieën. <strong style="color:var(--brand)">Geld-terug-garantie. Geen verplichting.</strong>
+            Zie Pentarch cyclusdetectie in actie. Stel je waarschuwingen in. Test je strategieën.
           </p>
         </div>
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -4931,7 +4931,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Apenas ferramentas educacionais. Não é aconselhamento financeiro. O trading envolve risco substancial de perda.</p>
         </div>
 
         <script>
@@ -5796,10 +5795,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Nunca mais pague
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Todas as atualizações futuras incluídas
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5873,8 +5868,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Veja a detecção de ciclos Pentarch em ação. Configure seus alertas.
-            Teste suas estratégias. <strong style="color:var(--brand)">Garantia de reembolso. Sem compromisso.</strong>
+            Veja a detecção de ciclos Pentarch em ação. Configure seus alertas. Teste suas estratégias.
           </p>
         </div>
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -4761,7 +4761,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Только образовательные инструменты. Не финансовые советы. Торговля связана со значительным риском убытков.</p>
         </div>
 
         <script>
@@ -5612,10 +5611,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Больше никогда не платите
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Все будущие обновления включены
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5688,8 +5683,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Посмотрите определение циклов Pentarch в действии. Настройте свои алерты.
-            Протестируйте свои стратегии. <strong style="color:var(--brand)">Гарантия возврата денег. Без обязательств.</strong>
+            Посмотрите определение циклов Pentarch в действии. Настройте свои алерты. Протестируйте свои стратегии.
           </p>
         </div>
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -4836,7 +4836,6 @@
                 </div>
               </div>
             </div>
-            <p style="margin-top:1rem;font-size:0.75rem;color:var(--muted);opacity:0.7;text-align:center">⚠️ Sadece eğitim araçları. Finansal tavsiye değildir. Ticaret önemli kayıp riski içerir.</p>
         </div>
 
         <script>
@@ -5687,10 +5686,6 @@
                       <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
                       Bir daha asla ödemeyin
                     </li>
-                    <li class="flex items-start gap-3">
-                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-white/30"></span>
-                      Tüm gelecek güncellemeler dahil
-                    </li>
                   </ul>
 
                   <div class="mt-6 h-px bg-white/10"></div>
@@ -5763,8 +5758,7 @@
           </h2>
 
           <p style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:600px;margin:0 auto">
-            Pentarch döngü tespitini uygulamada görün. Alarmlarınızı kurun.
-            Stratejilerinizi test edin. <strong style="color:var(--brand)">Para iade garantisi. Taahhüt yok.</strong>
+            Pentarch döngü tespitini uygulamada görün. Alarmlarınızı kurun. Stratejilerinizi test edin.
           </p>
         </div>
 


### PR DESCRIPTION
- Remove hero risk disclosure (covered by educational disclaimer section)
- Remove "Money-back guarantee" from trial CTA (already in hero + pricing)
- Remove "All future updates included" bullet from Lifetime card (already in description)

Applied to all 12 language versions (en, ar, de, es, fr, hu, it, ja, nl, pt, ru, tr)