### PR TITLE
Fix mobile CTA button language redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A fast, static marketing website for Signal Pilot — 7 non-repainting TradingVi
 
 ### Hero Section
 - **Headline:** "The edge isn't seeing more. It's seeing what matters."
-- **Trust badges:** 100% Non-Repainting (Audited) | 14-Day Money-Back Guarantee
+- **Trust badges:** 100% Non-Repainting (Audited) | 7-Day Money-Back Guarantee
 - **Hero video:** Live chart demo showcasing Pentarch cycle detection
 - **CTA:** Get Started button linking to pricing
 
@@ -83,7 +83,7 @@ A fast, static marketing website for Signal Pilot — 7 non-repainting TradingVi
 - TradingView invite process
 - Access delivery speed (1-8 hours)
 - Support response times
-- Refund policy (14-day money-back)
+- Refund policy (7-day money-back)
 
 ### Footer
 - **Product:** Indicators, Pricing, Documentation, FAQ

--- a/ar/index.html
+++ b/ar/index.html
@@ -4597,7 +4597,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">جرب مجاناً</span>
         <span class="cta-short">جرب</span>
       </a>

--- a/de/index.html
+++ b/de/index.html
@@ -4595,7 +4595,7 @@
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Kostenlos Testen</span>
         <span class="cta-short">Test</span>
       </a>

--- a/es/index.html
+++ b/es/index.html
@@ -4809,7 +4809,7 @@
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Prueba Gratis</span>
         <span class="cta-short">Prueba</span>
       </a>

--- a/fr/index.html
+++ b/fr/index.html
@@ -4875,7 +4875,7 @@
       <div class="nav-spacer"></div>
 
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Essai Gratuit</span>
         <span class="cta-short">Essai</span>
       </a>

--- a/hu/index.html
+++ b/hu/index.html
@@ -4542,7 +4542,7 @@
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Próbáld Ki</span>
         <span class="cta-short">Próba</span>
       </a>

--- a/it/index.html
+++ b/it/index.html
@@ -4507,7 +4507,7 @@
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Prova Gratis</span>
         <span class="cta-short">Prova</span>
       </a>

--- a/ja/index.html
+++ b/ja/index.html
@@ -4856,7 +4856,7 @@
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">無料お試し</span>
         <span class="cta-short">試す</span>
       </a>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4534,7 +4534,7 @@
       <div class="nav-spacer"></div>
 
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Gratis Proberen</span>
         <span class="cta-short">Probeer</span>
       </a>

--- a/pt/index.html
+++ b/pt/index.html
@@ -4789,7 +4789,7 @@
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Teste Grátis</span>
         <span class="cta-short">Teste</span>
       </a>

--- a/ru/index.html
+++ b/ru/index.html
@@ -4619,7 +4619,7 @@
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Попробовать</span>
         <span class="cta-short">Тест</span>
       </a>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4694,7 +4694,7 @@
 
       <div class="nav-spacer"></div>
 
-      <a href="#pricing" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+      <a href="#trial" class="shiny-cta cta-header" style="display:inline-flex;width:auto;height:auto;margin-left:.75rem;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Ücretsiz Dene</span>
         <span class="cta-short">Dene</span>
       </a>


### PR DESCRIPTION
- Change header CTA button link from #pricing to #trial in all 11 language files (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr)
- Fix README.md: change "14-Day Money-Back Guarantee" to "7-Day" in 2 places to match actual website content