### PR TITLE
Add #indicators anchor ID to all language landing pages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4872,7 +4872,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
       <div style="max-width:56rem;margin:0 auto;text-align:center">
         <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">مجموعة المؤشرات</span>
         <h2 class="headline lg" style="margin-top:1.5rem;letter-spacing:-0.03em">

--- a/de/index.html
+++ b/de/index.html
@@ -4822,7 +4822,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
 
       <!-- Header -->
       <div style="max-width:56rem;margin:0 auto;text-align:center">

--- a/es/index.html
+++ b/es/index.html
@@ -5022,7 +5022,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
 
       <!-- Header -->
       <div style="max-width:56rem;margin:0 auto;text-align:center">

--- a/fr/index.html
+++ b/fr/index.html
@@ -5091,7 +5091,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
 
       <!-- Header -->
       <div style="max-width:56rem;margin:0 auto;text-align:center">

--- a/hu/index.html
+++ b/hu/index.html
@@ -4758,7 +4758,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
       <div style="max-width:56rem;margin:0 auto;text-align:center">
         <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Indikátor Készlet</span>
         <h2 class="headline lg" style="margin-top:1.5rem;letter-spacing:-0.03em">

--- a/index.html
+++ b/index.html
@@ -3964,7 +3964,7 @@
 
     <!-- WHAT'S INSIDE: THE ELITE 7 -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
 
       <!-- Header -->
       <div style="max-width:56rem;margin:0 auto;text-align:center">

--- a/it/index.html
+++ b/it/index.html
@@ -4725,7 +4725,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
       <div style="max-width:56rem;margin:0 auto;text-align:center">
         <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Suite di Indicatori</span>
         <h2 class="headline lg" style="margin-top:1.5rem;letter-spacing:-0.03em">

--- a/ja/index.html
+++ b/ja/index.html
@@ -5074,7 +5074,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
       <div style="max-width:56rem;margin:0 auto;text-align:center">
         <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">インジケーター・スイート</span>
         <h2 class="headline lg" style="margin-top:1.5rem;letter-spacing:-0.03em">

--- a/nl/index.html
+++ b/nl/index.html
@@ -4752,7 +4752,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
       <div style="max-width:56rem;margin:0 auto;text-align:center">
         <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Indicator Suite</span>
         <h2 class="headline lg" style="margin-top:1.5rem;letter-spacing:-0.03em">

--- a/pt/index.html
+++ b/pt/index.html
@@ -5009,7 +5009,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
       <div style="max-width:56rem;margin:0 auto;text-align:center">
         <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Suite de Indicadores</span>
         <h2 class="headline lg" style="margin-top:1.5rem;letter-spacing:-0.03em">

--- a/ru/index.html
+++ b/ru/index.html
@@ -4839,7 +4839,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
       <div style="max-width:56rem;margin:0 auto;text-align:center">
         <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Набор Индикаторов</span>
         <h2 class="headline lg" style="margin-top:1.5rem;letter-spacing:-0.03em">

--- a/tr/index.html
+++ b/tr/index.html
@@ -4914,7 +4914,7 @@
 
     <!-- WHAT'S INSIDE -->
 
-    <section id="inside" class="section" style="padding:4rem 1rem 5rem">
+    <section id="indicators" class="section" style="padding:4rem 1rem 5rem">
       <div style="max-width:56rem;margin:0 auto;text-align:center">
         <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Gösterge Paketi</span>
         <h2 class="headline lg" style="margin-top:1.5rem;letter-spacing:-0.03em">


### PR DESCRIPTION
Changed id="inside" to id="indicators" for the Elite Seven section across all 12 languages to enable direct linking from Google Ads sitelinks.