### PR TITLE
Add redirect from free subdirectory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,11 @@
       "source": "/index.html",
       "destination": "/",
       "permanent": true
+    },
+    {
+      "source": "/free",
+      "destination": "https://education.signalpilot.io/free",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
Redirect www.signalpilot.io/free to education.signalpilot.io/free where the free resources landing page will be hosted.