### PR TITLE
Implement responsive CTA button with shortened text for smaller screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -3553,7 +3553,7 @@
 
       <a class="shiny-cta cta-header" href="#trial" style="display:inline-flex;width:auto;height:auto;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Try Free →</span>
-        <span class="cta-short">Try</span>
+        <span class="cta-short">Try Free</span>
       </a>
 
 

--- a/index.html
+++ b/index.html
@@ -2362,6 +2362,11 @@
     .cta-header:hover{
       box-shadow:0 0 20px rgba(91,138,255,0.5), 0 0 40px rgba(91,138,255,0.3);
     }
+    .cta-header .cta-short{display:none}
+    @media (max-width:1350px){
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
+    }
 
     /* Adjust for 1920px monitors */
     @media (max-width:1950px){
@@ -2388,9 +2393,15 @@
       nav ul{gap:.5rem}
     }
 
-    /* Hide CTA on smaller tablets/phones - will show in mobile menu instead */
+    /* Compact CTA on smaller tablets/phones - show "Try" button alongside flag */
     @media (max-width:1100px){
-      .cta-header{display:none !important}
+      .cta-header{
+        padding:.4rem .7rem !important;
+        font-size:.8rem !important;
+        margin-left:.35rem;
+      }
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
     }
 
     /* More compact for medium screens */
@@ -2611,8 +2622,15 @@
         border-left: none;
       }
 
-      /* Hide desktop CTA on mobile */
-      .cta-header{display:none}
+      /* Show compact CTA on mobile - "Try" button next to flag */
+      .cta-header{
+        display:inline-flex !important;
+        padding:.4rem .75rem !important;
+        font-size:.82rem !important;
+        margin-left:.35rem;
+      }
+      .cta-header .cta-full{display:none}
+      .cta-header .cta-short{display:inline}
 
     }
 
@@ -3533,7 +3551,10 @@
         </button>
       </div>
 
-      <a class="shiny-cta cta-header" href="#trial" style="display:inline-flex;width:auto;padding:0.75rem 1.5rem;height:auto;white-space:nowrap"><span>Try Free →</span></a>
+      <a class="shiny-cta cta-header" href="#trial" style="display:inline-flex;width:auto;height:auto;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
+        <span class="cta-full">Try Free →</span>
+        <span class="cta-short">Try</span>
+      </a>
 
 
       <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="mainnav">Menu ☰</button>


### PR DESCRIPTION
## Summary
This PR improves the Call-to-Action (CTA) button responsiveness by introducing a shortened "Try" variant that displays on smaller screens instead of completely hiding the button. This ensures better visibility and accessibility of the trial signup action across all device sizes.

## Key Changes
- **Added dual CTA text variants**: Introduced `.cta-full` ("Try Free →") and `.cta-short` ("Try") spans within the CTA button to support responsive text switching
- **Responsive breakpoints**: 
  - At 1350px and below: Switch from full to short text
  - At 1100px and below: Apply compact styling (reduced padding and font size) while keeping short text visible
  - On mobile: Display compact CTA inline with adjusted spacing instead of hiding completely
- **Updated styling**: Modified CTA button padding and font size for smaller viewports to maintain visual balance
- **Removed display:none**: Replaced the previous approach of hiding the CTA entirely on smaller screens with a more user-friendly compact variant

## Implementation Details
- The CTA button now uses `display:inline-flex` consistently across all breakpoints
- Short text is hidden by default (`.cta-short{display:none}`) and shown only on smaller screens via media queries
- Padding and font-size adjustments ensure the compact button doesn't overwhelm the header on mobile devices
- The change maintains the existing hover effects and styling while improving mobile/tablet UX