### PR TITLE
Update mobile CTA button text from "Try" to "Try Free"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3553,7 +3553,7 @@
 
       <a class="shiny-cta cta-header" href="#trial" style="display:inline-flex;width:auto;height:auto;padding:.55rem 1.1rem;font-size:.9rem;white-space:nowrap">
         <span class="cta-full">Try Free →</span>
-        <span class="cta-short">Try</span>
+        <span class="cta-short">Try Free</span>
       </a>
 
 


### PR DESCRIPTION
## Summary
Updated the short-form call-to-action (CTA) button text on mobile devices to be more descriptive and consistent with the full-form text.

## Changes
- Modified the mobile CTA button text from "Try" to "Try Free" to better communicate the value proposition and match the intent of the full-form CTA button
- This change improves clarity for mobile users while maintaining the compact button size

## Details
The CTA button displays different text based on screen size:
- Full form (desktop): "Try Free →"
- Short form (mobile): Changed from "Try" → "Try Free"

This ensures mobile users see the same messaging about the free trial offer, improving consistency across all device sizes.