### PR TITLE
Update education URL from subdirectory to subdomain

### DIFF
--- a/content-plan/CONTENT_PLAN_PART1.md
+++ b/content-plan/CONTENT_PLAN_PART1.md
@@ -321,7 +321,7 @@ This one lesson changes everything.
 
 Full breakdown: Why support fails, how stops get hunted, how to trade with institutional flow.
 
-Free at signalpilot.io/education
+Free at education.signalpilot.io
 
 #trading #liquidity #smartmoney
 ```
@@ -793,7 +793,7 @@ The candle tells you WHERE. Delta tells you WHO.
 
 Including delta analysis, absorption patterns, and why most volume analysis is incomplete.
 
-Free at signalpilot.io/education
+Free at education.signalpilot.io
 
 #trading #volume #orderflow
 ```
@@ -2056,7 +2056,7 @@ Sellers quietly filling while price ticks up.
 ```
 The candle lies. Delta tells the truth.
 
-Full lesson: signalpilot.io/education
+Full lesson: education.signalpilot.io
 
 #delta #orderflow #trading
 ```
@@ -17192,7 +17192,7 @@ Start learning in bio 🔗
    - Advanced: Purple border (#8b5cf6), "27 LESSONS"
    - Professional: Gold border (#c9a962), "8 LESSONS"
 6. **Topics List:** Small text below in Inter, 18pt, #a0a0a0
-7. **Bottom CTA:** "signalpilot.io/education" in Inter, 24pt, #4a90d9
+7. **Bottom CTA:** "education.signalpilot.io" in Inter, 24pt, #4a90d9
 8. **Export:** PNG, high quality
 
 ### Carousel Slides


### PR DESCRIPTION
## Summary
Updated all references to the education content URL from the subdirectory format (`signalpilot.io/education`) to the subdomain format (`education.signalpilot.io`) throughout the content plan documentation.

## Changes Made
- Updated 4 instances of the education URL across the content plan:
  - 2 instances in social media post content (trading/liquidity and volume/orderflow posts)
  - 1 instance in delta analysis post content
  - 1 instance in carousel slide design specifications

## Details
This change reflects a migration of the education content to a dedicated subdomain, which likely improves:
- URL structure and SEO
- Content organization and scalability
- User experience with a dedicated education platform

All references have been consistently updated to use the new `education.signalpilot.io` domain.