### PR TITLE
Add Gumroad conversion tracking for Google Ads

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
@@ -7375,6 +7394,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/de/index.html
+++ b/de/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
@@ -7810,6 +7829,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/es/index.html
+++ b/es/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
@@ -7843,6 +7862,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
@@ -8107,6 +8126,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
@@ -7669,6 +7688,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
@@ -7167,6 +7186,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/it/index.html
+++ b/it/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
@@ -7253,6 +7272,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
@@ -7496,6 +7515,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
@@ -7183,6 +7202,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
@@ -7541,6 +7560,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
@@ -7295,6 +7314,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -11,6 +11,25 @@
     gtag('config', 'AW-17835897996');
   </script>
 
+  <!-- Event snippet for Gumroad Purchase conversion tracking -->
+  <script>
+  function gtag_report_conversion(url) {
+    var callback = function () {
+      if (typeof(url) != 'undefined') {
+        window.location = url;
+      }
+    };
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/eDa_CMPAjuYbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD',
+        'transaction_id': '',
+        'event_callback': callback
+    });
+    return false;
+  }
+  </script>
+
   <meta charset="utf-8" />
   <!-- Cache bust v2 - force reload after mobile fixes -->
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
@@ -7376,6 +7395,10 @@ if ('serviceWorker' in navigator) {
           plan_name: this.textContent.trim(),
           payment_method: 'gumroad'
         });
+        // Report Google Ads conversion on Gumroad button click
+        if (typeof gtag_report_conversion === 'function') {
+          gtag_report_conversion();
+        }
       });
     });
 


### PR DESCRIPTION
Add gtag_report_conversion function to track Gumroad button clicks as Google Ads conversions. Applied to all 12 language variant index pages (en, ar, de, es, fr, hu, it, ja, nl, pt, ru, tr).