### PR TITLE
Add Pentarch Solo plan tier to pricing section

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -148,14 +148,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -216,14 +216,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -289,7 +289,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -2581,6 +2581,24 @@
     .shiny-cta::after{content:'';pointer-events:none;position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1;width:100%;aspect-ratio:1;background:linear-gradient(-50deg,transparent,#1e3a8a,transparent);mask-image:radial-gradient(circle at bottom,transparent 40%,black);opacity:0.6;animation:shiny-shimmer 4s linear infinite}
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
+
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     @media (max-width: 768px){.shiny-cta{animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;-webkit-animation:shiny-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,linear-gradient(135deg,#1e3a8a 0%,#3b82f6 50%,#1e3a8a 100%) border-box}.shiny-cta::before,.shiny-cta::after{display:none}@-webkit-keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}@keyframes shiny-pulse{0%,100%{box-shadow:0 0 12px rgba(59,130,246,0.25)}50%{box-shadow:0 0 25px rgba(59,130,246,0.4)}}}
     @media (prefers-reduced-motion: reduce){.shiny-cta,.shiny-cta::before,.shiny-cta::after{animation:none}}
 
@@ -3831,7 +3849,7 @@ html[lang="ar"] [style*="text-align:center"] {
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3844,7 +3862,7 @@ html[lang="ar"] [style*="text-align:center"] {
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3857,7 +3875,7 @@ html[lang="ar"] [style*="text-align:center"] {
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4011,7 +4029,7 @@ html[lang="ar"] [style*="text-align:center"] {
           {
             "@type": "Offer",
             "name": "الخطة الشهرية",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4021,7 +4039,7 @@ html[lang="ar"] [style*="text-align:center"] {
           {
             "@type": "Offer",
             "name": "الخطة السنوية",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4031,7 +4049,7 @@ html[lang="ar"] [style*="text-align:center"] {
           {
             "@type": "Offer",
             "name": "الوصول مدى الحياة",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5441,7 +5459,69 @@ html[lang="ar"] [style*="text-align:center"] {
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-cyan-950/50 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(34,211,238,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+
+                <div class="relative">
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-cyan-400/70 mb-1">/شهر</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">مؤشر Pentarch فقط. أداة واحدة، تركيز واحد.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-neutral-300">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      كشف مرحلة دورة Pentarch
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      تنبيهات في الوقت الفعلي
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      إلغاء في أي وقت
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-cyan-500/20"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    معاينة Pentarch على TradingView
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-cyan-300/70 mb-2 block">اسم مستخدم TradingView</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@اسم_المستخدم.tradingview" required class="w-full px-3 py-2.5 bg-cyan-950/30 border border-cyan-500/20 rounded-lg text-white text-sm placeholder-cyan-300/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">اسم مستخدم TradingView مطلوب</div>
+                  </div>
+
+                  <!-- Consent -->
+                  <label class="consent flex items-start gap-2 mt-4 text-xs text-cyan-300/50 cursor-pointer">
+                    <input class="tick mt-0.5" type="checkbox" id="consent-pentarch">
+                    <span>أفهم أن <span class="font-medium text-cyan-300/70">Signal Pilot</span> تعليمي. لا نصائح مالية.</span>
+                  </label>
+                  <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">الموافقة مطلوبة</div>
+
+                  <div class="mt-6">
+                    <button class="shiny-cta shiny-cta-cyan w-full" onclick="handlePlanPurchase('pentarch')" style="font-size:0.95rem">
+                      <span>احصل على Pentarch - $29/شهر</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5449,7 +5529,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/شهر</span>
                   </div>
 
@@ -5495,7 +5575,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>اشترك - $99/شهر</span>
+                      <span>اشترك - $69/شهر</span>
                     </a>
                   </div>
                 </div>
@@ -5510,7 +5590,7 @@ html[lang="ar"] [style*="text-align:center"] {
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">الأكثر شعبية</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/سنة</span>
                   </div>
 
@@ -5552,7 +5632,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>اشترك - $699/سنة</span>
+                      <span>اشترك - $399/سنة</span>
                     </a>
                   </div>
                 </div>
@@ -5580,7 +5660,7 @@ html[lang="ar"] [style*="text-align:center"] {
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">لمرة واحدة</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -5634,7 +5714,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>شراء مدى الحياة - $1,799</span>
+                      <span>شراء مدى الحياة - $999</span>
                     </a>
                   </div>
 
@@ -5778,7 +5858,7 @@ html[lang="ar"] [style*="text-align:center"] {
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            بعد 7 أيام: اشترك للمتابعة ($99/شهرياً) أو تنتهي الفترة التجريبية
+            بعد 7 أيام: اشترك للمتابعة ($69/شهرياً) أو تنتهي الفترة التجريبية
           </p>
         </div>
 
@@ -7514,7 +7594,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }

--- a/de/index.html
+++ b/de/index.html
@@ -147,14 +147,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -205,7 +205,7 @@
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Jährliches Abonnement (Bester Wert)",
-        "description": "Professionelle TradingView-Indikatoren mit Pentarch™-Zykluserkennung. Sparen Sie $489/Jahr. Alle 7 Elite-Indikatoren plus zukünftige Updates. 100% nicht-repaintierend, geprüft. Prioritätssupport und fortgeschrittenes Training inklusive.",
+        "description": "Professionelle TradingView-Indikatoren mit Pentarch™-Zykluserkennung. Sparen Sie $429/Jahr. Alle 7 Elite-Indikatoren plus zukünftige Updates. 100% nicht-repaintierend, geprüft. Prioritätssupport und fortgeschrittenes Training inklusive.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -215,14 +215,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -270,7 +270,7 @@
           {
             "@type": "PropertyValue",
             "name": "Jährliche Ersparnis",
-            "value": "$489"
+            "value": "$429"
           }
         ]
       },
@@ -288,7 +288,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -2533,6 +2533,23 @@
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
     .shiny-cta>span{position:relative;z-index:1}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -3768,7 +3785,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3781,7 +3798,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3794,7 +3811,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3948,7 +3965,7 @@
           {
             "@type": "Offer",
             "name": "Monatsabo",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -3958,17 +3975,17 @@
           {
             "@type": "Offer",
             "name": "Jahresabo",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Jährliche Abrechnung - sparen Sie $489 gegenüber monatlich (41% Rabatt)"
+            "description": "Jährliche Abrechnung - sparen Sie $429 gegenüber monatlich (52% Rabatt)"
           },
           {
             "@type": "Offer",
             "name": "Lebenslanger Zugang",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5887,10 +5904,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5899,6 +5917,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -5913,14 +5932,24 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-neutral-900/60 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                </div>
+                <div>
+                  <p class="text-white text-base font-medium tracking-tight">Pentarch Solo</p>
+                  <p class="text-neutral-400 text-sm">Nur Flaggschiff-Indikator</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Monatlich</p>
-                  <p class="text-neutral-400 text-sm">Flexibel, jederzeit kündbar</p>
+                  <p class="text-neutral-400 text-sm">Alle 7, jederzeit kündbar</p>
                 </div>
               </div>
 
@@ -5930,7 +5959,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Jährlich</p>
-                  <p class="text-neutral-400 text-sm">Bester Wert - spare $489</p>
+                  <p class="text-neutral-400 text-sm">Bester Wert - spare $429</p>
                 </div>
               </div>
 
@@ -5946,7 +5975,72 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(255,255,255,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+                <div class="pointer-events-none absolute inset-0" style="background: radial-gradient(ellipse at 50% 30%, rgba(34,211,238,0.1) 0%, transparent 60%);"></div>
+
+                <div class="relative">
+                  <p class="text-xs uppercase tracking-wide text-cyan-400 mb-2">Hier starten</p>
+
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/Monat</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Unser Flaggschiff-Indikator für Zykluserkennung. Perfekter Einstiegspunkt.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-neutral-300">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Pentarch Zykluserkennung
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Echtzeit-Alarme &amp; Signale
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Jederzeit upgraden, Guthaben wird angerechnet
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-white/10"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Pentarch auf TradingView ansehen
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-white/70 mb-2 block">TradingView Benutzername</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@dein.tradingview" required class="w-full px-3 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white text-sm placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">TradingView Benutzername erforderlich</div>
+                  </div>
+
+                  <!-- Consent -->
+                  <label class="consent flex items-start gap-2 mt-4 text-xs text-white/50 cursor-pointer">
+                    <input class="tick mt-0.5" type="checkbox" id="consent-pentarch">
+                    <span>Ich verstehe, dass <span class="font-medium text-white/70">Signal Pilot</span> nur zu Bildungszwecken dient. Keine Finanzberatung.</span>
+                  </label>
+                  <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Zustimmung erforderlich</div>
+
+                  <div class="mt-6">
+                    <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta shiny-cta-cyan w-full justify-center">
+                      <span>Pentarch holen - 29$/Monat</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5954,7 +6048,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/Monat</span>
                   </div>
 
@@ -6004,7 +6098,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Abonnieren - 99$/Monat</span>
+                      <span>Abonnieren - 69$/Monat</span>
                     </a>
                   </div>
                 </div>
@@ -6019,7 +6113,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Am beliebtesten</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/Jahr</span>
                   </div>
 
@@ -6061,7 +6155,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Abonnieren - 699$/Jahr</span>
+                      <span>Abonnieren - 399$/Jahr</span>
                     </a>
                   </div>
                 </div>
@@ -6089,7 +6183,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">einmalig</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -6143,7 +6237,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Lifetime kaufen - 1.799$</span>
+                      <span>Lifetime kaufen - 999$</span>
                     </a>
                   </div>
                 </div>
@@ -6283,7 +6377,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            Nach 7 Tagen: Abonnieren Sie für $99/Monat oder die Testversion läuft ab
+            Nach 7 Tagen: Abonnieren Sie für $69/Monat oder die Testversion läuft ab
           </p>
         </div>
 
@@ -7949,7 +8043,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }

--- a/es/index.html
+++ b/es/index.html
@@ -149,14 +149,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -207,7 +207,7 @@
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Suscripción Anual (Mejor Valor)",
-        "description": "Indicadores profesionales para TradingView con detección de ciclos Pentarch™. Ahorra $489/año. Los 7 indicadores élite más actualizaciones futuras. 100% sin repintado, auditado. Soporte prioritario y formación avanzada incluidos.",
+        "description": "Indicadores profesionales para TradingView con detección de ciclos Pentarch™. Ahorra $429/año. Los 7 indicadores élite más actualizaciones futuras. 100% sin repintado, auditado. Soporte prioritario y formación avanzada incluidos.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -217,14 +217,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -272,7 +272,7 @@
           {
             "@type": "PropertyValue",
             "name": "Ahorro Anual",
-            "value": "$489"
+            "value": "$429"
           }
         ]
       },
@@ -290,7 +290,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -2764,6 +2764,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -3982,7 +3999,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3995,7 +4012,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4008,7 +4025,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4162,7 +4179,7 @@
           {
             "@type": "Offer",
             "name": "Plan Mensual",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4172,17 +4189,17 @@
           {
             "@type": "Offer",
             "name": "Plan Anual",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Facturación anual - ahorra $489 vs mensual (41% de descuento)"
+            "description": "Facturación anual - ahorra $429 vs mensual (52% de descuento)"
           },
           {
             "@type": "Offer",
             "name": "Acceso de Por Vida",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5775,10 +5792,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5787,6 +5805,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -5801,14 +5820,24 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-neutral-900/60 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                </div>
+                <div>
+                  <p class="text-white text-base font-medium tracking-tight">Pentarch Solo</p>
+                  <p class="text-neutral-400 text-sm">Solo indicador principal</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Mensual</p>
-                  <p class="text-neutral-400 text-sm">Flexible, cancela cuando quieras</p>
+                  <p class="text-neutral-400 text-sm">Los 7, cancela cuando quieras</p>
                 </div>
               </div>
 
@@ -5818,7 +5847,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Anual</p>
-                  <p class="text-neutral-400 text-sm">Mejor valor - ahorra $489</p>
+                  <p class="text-neutral-400 text-sm">Mejor valor - ahorra $429</p>
                 </div>
               </div>
 
@@ -5834,7 +5863,72 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(255,255,255,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+                <div class="pointer-events-none absolute inset-0" style="background: radial-gradient(ellipse at 50% 30%, rgba(34,211,238,0.1) 0%, transparent 60%);"></div>
+
+                <div class="relative">
+                  <p class="text-xs uppercase tracking-wide text-cyan-400 mb-2">Empieza aquí</p>
+
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/mes</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Nuestro indicador principal de detección de ciclos. Punto de entrada perfecto.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-neutral-300">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Detección de ciclos Pentarch
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Alertas y señales en tiempo real
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Actualiza cuando quieras, te acreditamos
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-white/10"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Vista previa de Pentarch en TradingView
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-white/70 mb-2 block">Nombre de usuario TradingView</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@tu.tradingview" required class="w-full px-3 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white text-sm placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Nombre de usuario TradingView requerido</div>
+                  </div>
+
+                  <!-- Consent -->
+                  <label class="consent flex items-start gap-2 mt-4 text-xs text-white/50 cursor-pointer">
+                    <input class="tick mt-0.5" type="checkbox" id="consent-pentarch">
+                    <span>Entiendo que <span class="font-medium text-white/70">Signal Pilot</span> es educativo. Sin asesoramiento financiero.</span>
+                  </label>
+                  <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Consentimiento requerido</div>
+
+                  <div class="mt-6">
+                    <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta shiny-cta-cyan w-full justify-center">
+                      <span>Obtener Pentarch - $29/mes</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5842,7 +5936,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/mes</span>
                   </div>
 
@@ -5892,7 +5986,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Suscribirse - $99/mes</span>
+                      <span>Suscribirse - $69/mes</span>
                     </a>
                   </div>
                 </div>
@@ -5907,7 +6001,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Más Popular</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/año</span>
                   </div>
 
@@ -5949,7 +6043,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Suscribirse - $699/año</span>
+                      <span>Suscribirse - $399/año</span>
                     </a>
                   </div>
                 </div>
@@ -5977,7 +6071,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">único</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -6031,7 +6125,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Comprar de por Vida - $1,799</span>
+                      <span>Comprar de por Vida - $999</span>
                     </a>
                   </div>
 
@@ -6175,7 +6269,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            Después de 7 Días: Suscríbete para continuar ($99/mes) o la prueba expira
+            Después de 7 Días: Suscríbete para continuar ($69/mes) o la prueba expira
           </p>
         </div>
 
@@ -7982,7 +8076,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }

--- a/fr/index.html
+++ b/fr/index.html
@@ -148,14 +148,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -206,7 +206,7 @@
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Abonnement Annuel (Meilleure Offre)",
-        "description": "Indicateurs professionnels pour TradingView avec détection de cycles Pentarch™. Économisez $489/an. Tous les 7 indicateurs élite plus les mises à jour futures. 100% sans repeinture, audité. Support prioritaire et formation avancée inclus.",
+        "description": "Indicateurs professionnels pour TradingView avec détection de cycles Pentarch™. Économisez $429/an. Tous les 7 indicateurs élite plus les mises à jour futures. 100% sans repeinture, audité. Support prioritaire et formation avancée inclus.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -216,14 +216,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -271,7 +271,7 @@
           {
             "@type": "PropertyValue",
             "name": "Économies Annuelles",
-            "value": "$489"
+            "value": "$429"
           }
         ]
       },
@@ -289,7 +289,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -1144,6 +1144,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -1977,6 +1994,23 @@
     }
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
+
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
 
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
@@ -4033,7 +4067,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4046,7 +4080,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4059,7 +4093,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4213,7 +4247,7 @@
           {
             "@type": "Offer",
             "name": "Abonnement Mensuel",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4223,17 +4257,17 @@
           {
             "@type": "Offer",
             "name": "Abonnement Annuel",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Facturation annuelle - économisez 489$ vs mensuel (41% de réduction)"
+            "description": "Facturation annuelle - économisez 489$ vs mensuel (52% de réduction)"
           },
           {
             "@type": "Offer",
             "name": "Accès à Vie",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -6036,10 +6070,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -6048,6 +6083,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -6062,14 +6098,24 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-neutral-900/60 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                </div>
+                <div>
+                  <p class="text-white text-base font-medium tracking-tight">Pentarch Solo</p>
+                  <p class="text-neutral-400 text-sm">Indicateur phare uniquement</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Mensuel</p>
-                  <p class="text-neutral-400 text-sm">Flexible, annulez quand vous voulez</p>
+                  <p class="text-neutral-400 text-sm">Les 7, annulez quand vous voulez</p>
                 </div>
               </div>
 
@@ -6079,7 +6125,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Annuel</p>
-                  <p class="text-neutral-400 text-sm">Meilleure valeur - économisez $489</p>
+                  <p class="text-neutral-400 text-sm">Meilleure valeur - économisez $429</p>
                 </div>
               </div>
 
@@ -6095,7 +6141,72 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(255,255,255,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+                <div class="pointer-events-none absolute inset-0" style="background: radial-gradient(ellipse at 50% 30%, rgba(34,211,238,0.1) 0%, transparent 60%);"></div>
+
+                <div class="relative">
+                  <p class="text-xs uppercase tracking-wide text-cyan-400 mb-2">Commencez ici</p>
+
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/mois</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Notre indicateur phare de détection de cycles. Point d'entrée parfait.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-neutral-300">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Détection de cycles Pentarch
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Alertes et signaux en temps réel
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Mise à niveau à tout moment, nous vous créditons
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-white/10"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Aperçu de Pentarch sur TradingView
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-white/70 mb-2 block">Nom d'utilisateur TradingView</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@votre.tradingview" required class="w-full px-3 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white text-sm placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Nom d'utilisateur TradingView requis</div>
+                  </div>
+
+                  <!-- Consent -->
+                  <label class="consent flex items-start gap-2 mt-4 text-xs text-white/50 cursor-pointer">
+                    <input class="tick mt-0.5" type="checkbox" id="consent-pentarch">
+                    <span>Je comprends que <span class="font-medium text-white/70">Signal Pilot</span> est éducatif. Pas de conseil financier.</span>
+                  </label>
+                  <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Consentement requis</div>
+
+                  <div class="mt-6">
+                    <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta shiny-cta-cyan w-full justify-center">
+                      <span>Obtenir Pentarch - 29$/mois</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -6103,7 +6214,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/mois</span>
                   </div>
 
@@ -6153,7 +6264,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>S'abonner - $99/mois</span>
+                      <span>S'abonner - $69/mois</span>
                     </a>
                   </div>
                 </div>
@@ -6168,7 +6279,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Le Plus Populaire</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/an</span>
                   </div>
 
@@ -6210,7 +6321,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>S'abonner - $699/an</span>
+                      <span>S'abonner - $399/an</span>
                     </a>
                   </div>
                 </div>
@@ -6238,7 +6349,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">unique</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -6292,7 +6403,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Acheter à Vie - $1,799</span>
+                      <span>Acheter à Vie - $999</span>
                     </a>
                   </div>
 
@@ -6435,7 +6546,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            Après 7 jours : Abonnez-vous pour continuer (99$/mois) ou l'essai expire
+            Après 7 jours : Abonnez-vous pour continuer (69$/mois) ou l'essai expire
           </p>
         </div>
 
@@ -8246,7 +8357,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }

--- a/hu/index.html
+++ b/hu/index.html
@@ -147,14 +147,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -215,14 +215,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -288,7 +288,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -2615,6 +2615,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -3776,7 +3793,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3789,7 +3806,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3802,7 +3819,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3956,7 +3973,7 @@
           {
             "@type": "Offer",
             "name": "Havi Csomag",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -3966,17 +3983,17 @@
           {
             "@type": "Offer",
             "name": "Éves Csomag",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Éves számlázás - spórolj $489-et a havihoz képest (41% kedvezmény)"
+            "description": "Éves számlázás - spórolj $429-et a havihoz képest (52% kedvezmény)"
           },
           {
             "@type": "Offer",
             "name": "Élethosszig Tartó Csomag",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5678,6 +5695,7 @@
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5686,6 +5704,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -5700,7 +5719,17 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-cyan-950/40 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                </div>
+                <div>
+                  <p class="text-cyan-100 text-base font-medium tracking-tight">Kezd itt</p>
+                  <p class="text-cyan-400/70 text-sm">Csak a zászlóshajó indikátor</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -5717,7 +5746,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Éves</p>
-                  <p class="text-neutral-400 text-sm">Legjobb érték - spórolj $489-t</p>
+                  <p class="text-neutral-400 text-sm">Legjobb érték - spórolj $429-t</p>
                 </div>
               </div>
 
@@ -5733,7 +5762,62 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-cyan-950/50 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(34,211,238,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+
+                <div class="relative">
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-cyan-400/70 mb-1">/hó</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-cyan-100/80 max-w-[40ch]">Tökéletes kezdés. Zászlóshajó indikátorunk.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-cyan-100/70">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Pentarch™ ciklus indikátor
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Valós idejű riasztások
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Bármikor lemondható
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-cyan-500/20"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Pentarch előnézete a TradingView-on
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-cyan-200/70 mb-2 block">TradingView felhasználónév</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@te.tradingview" required class="w-full px-3 py-2.5 bg-cyan-950/30 border border-cyan-500/20 rounded-lg text-white text-sm placeholder-cyan-300/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">TradingView felhasználónév szükséges</div>
+                  </div>
+
+                  <div class="mt-6">
+                    <button class="shiny-cta shiny-cta-cyan w-full" onclick="handlePlanPurchase('pentarch')" style="font-size:0.95rem">
+                      <span>Pentarch megrendelése - $29/hó</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5741,7 +5825,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/hó</span>
                   </div>
 
@@ -5791,7 +5875,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Feliratkozás - $99/hó</span>
+                      <span>Feliratkozás - $69/hó</span>
                     </a>
                   </div>
                 </div>
@@ -5806,7 +5890,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Legnépszerűbb</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/év</span>
                   </div>
 
@@ -5848,7 +5932,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Feliratkozás - $699/év</span>
+                      <span>Feliratkozás - $399/év</span>
                     </a>
                   </div>
                 </div>
@@ -5876,7 +5960,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">egyszeri</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -5930,7 +6014,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Élethosszig Vásárlás - $1,799</span>
+                      <span>Élethosszig Vásárlás - $999</span>
                     </a>
                   </div>
 
@@ -6073,7 +6157,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            7 nap után: Előfizetés a folytatáshoz ($99/hó) vagy a próbaidő lejár
+            7 nap után: Előfizetés a folytatáshoz ($69/hó) vagy a próbaidő lejár
           </p>
         </div>
 
@@ -7808,7 +7892,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }

--- a/index.html
+++ b/index.html
@@ -5048,7 +5048,7 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
+            <div class="grid grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
@@ -5091,7 +5091,7 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
 
               <!-- PENTARCH SOLO -->
               <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">

--- a/index.html
+++ b/index.html
@@ -4982,15 +4982,15 @@
           </div>
         </div>
 
-        <!-- What's Included - ALL Plans Identical -->
+        <!-- What's Included -->
         <div style="text-align:center;max-width:900px;margin:1.5rem auto;padding:1.75rem 2rem;background:linear-gradient(135deg,rgba(91,138,255,.1),rgba(91,138,255,.05));border:2px solid rgba(91,138,255,.25);border-radius:12px" data-reveal="scale" data-reveal-delay="200">
           <p style="font-size:1.05rem;color:var(--text);margin:0 0 1rem 0;font-weight:700">
-            ✨ Every plan includes the exact same features:
+            ✨ All plans include:
           </p>
           <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:0.75rem;text-align:left;max-width:800px;margin:0 auto">
             <div style="display:flex;align-items:center;gap:.5rem">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
-              <span style="font-size:.9rem;color:var(--muted)">All 7 elite indicators</span>
+              <span style="font-size:.9rem;color:var(--muted)">Real-time alerts</span>
             </div>
             <div style="display:flex;align-items:center;gap:.5rem">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
@@ -5006,7 +5006,7 @@
             </div>
           </div>
           <p style="font-size:.85rem;color:var(--muted-2);margin:1rem 0 0 0;font-style:italic">
-            Only difference between plans: how you pay (monthly, yearly, or once)
+            Pentarch Solo = 1 indicator • Monthly/Yearly/Lifetime = All 7 indicators
           </p>
         </div>
 
@@ -5020,10 +5020,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5032,6 +5033,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -5046,14 +5048,24 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-neutral-900/60 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                </div>
+                <div>
+                  <p class="text-white text-base font-medium tracking-tight">Pentarch Solo</p>
+                  <p class="text-neutral-400 text-sm">Flagship indicator only</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Monthly</p>
-                  <p class="text-neutral-400 text-sm">Flexible, cancel anytime</p>
+                  <p class="text-neutral-400 text-sm">All 7, cancel anytime</p>
                 </div>
               </div>
 
@@ -5079,7 +5091,72 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(255,255,255,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+                <div class="pointer-events-none absolute inset-0" style="background: radial-gradient(ellipse at 50% 30%, rgba(34,211,238,0.1) 0%, transparent 60%);"></div>
+
+                <div class="relative">
+                  <p class="text-xs uppercase tracking-wide text-cyan-400 mb-2">Start Here</p>
+
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$49</p>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/month</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Our flagship cycle detection indicator. Perfect entry point.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-neutral-300">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Pentarch cycle detection
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Real-time alerts &amp; signals
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50 bg-cyan-400/20"></span>
+                      Upgrade anytime, we'll credit you
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-white/10"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/c8FDqXfN-Pentarch-Cycle-Phase-Detection-Signal-Pilot/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Preview Pentarch on TradingView
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-white/70 mb-2 block">TradingView Username</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@your.tradingview" required class="w-full px-3 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white text-sm placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#3ed598" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">TradingView username required</div>
+                  </div>
+
+                  <!-- Consent -->
+                  <label class="consent flex items-start gap-2 mt-4 text-xs text-white/50 cursor-pointer">
+                    <input class="tick mt-0.5" type="checkbox" id="consent-pentarch">
+                    <span>I understand <span class="font-medium text-white/70">Signal Pilot</span> is educational. No financial advice.</span>
+                  </label>
+                  <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Consent required</div>
+
+                  <div class="mt-6">
+                    <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center" style="background: linear-gradient(135deg, rgba(34,211,238,0.2), rgba(34,211,238,0.1)); border-color: rgba(34,211,238,0.3);">
+                      <span>Get Pentarch - $49/mo</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">

--- a/index.html
+++ b/index.html
@@ -5151,7 +5151,7 @@
                   <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Consent required</div>
 
                   <div class="mt-6">
-                    <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center" style="background: linear-gradient(135deg, rgba(34,211,238,0.2), rgba(34,211,238,0.1)); border-color: rgba(34,211,238,0.3);">
+                    <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center" style="--gradient-shine:#22d3ee;">
                       <span>Get Pentarch - $29/mo</span>
                     </a>
                   </div>

--- a/index.html
+++ b/index.html
@@ -171,14 +171,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -222,7 +222,7 @@
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Yearly Subscription (Best Value)",
-        "description": "Professional TradingView indicators with Pentarch™ cycle detection. Save $489/year. All 7 elite indicators plus future updates. 100% non-repainting, audited. Priority support and advanced training included.",
+        "description": "Professional TradingView indicators with Pentarch™ cycle detection. Save $429/year. All 7 elite indicators plus future updates. 100% non-repainting, audited. Priority support and advanced training included.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -232,14 +232,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -280,7 +280,7 @@
           {
             "@type": "PropertyValue",
             "name": "Annual Savings",
-            "value": "$489"
+            "value": "$429"
           }
         ]
       },
@@ -298,7 +298,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -3047,7 +3047,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3209,7 +3209,7 @@
           {
             "@type": "Offer",
             "name": "Monthly Plan",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -3219,17 +3219,17 @@
           {
             "@type": "Offer",
             "name": "Yearly Plan",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Annual billing - save $489 vs monthly (41% off)"
+            "description": "Annual billing - save $429 vs monthly (52% off)"
           },
           {
             "@type": "Offer",
             "name": "Lifetime Plan",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5075,7 +5075,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Yearly</p>
-                  <p class="text-neutral-400 text-sm">Best value - save $489</p>
+                  <p class="text-neutral-400 text-sm">Best value - save $429</p>
                 </div>
               </div>
 
@@ -5102,7 +5102,7 @@
                   <p class="text-xs uppercase tracking-wide text-cyan-400 mb-2">Start Here</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-pentarch-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$49</p>
+                    <p id="plan-pentarch-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/month</span>
                   </div>
 
@@ -5152,7 +5152,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center" style="background: linear-gradient(135deg, rgba(34,211,238,0.2), rgba(34,211,238,0.1)); border-color: rgba(34,211,238,0.3);">
-                      <span>Get Pentarch - $49/mo</span>
+                      <span>Get Pentarch - $29/mo</span>
                     </a>
                   </div>
                 </div>
@@ -5164,7 +5164,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/month</span>
                   </div>
 
@@ -5214,7 +5214,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Subscribe - $99/mo</span>
+                      <span>Subscribe - $69/mo</span>
                     </a>
                   </div>
                 </div>
@@ -5229,7 +5229,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Most Popular</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/year</span>
                   </div>
 
@@ -5275,7 +5275,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Subscribe - $699/yr</span>
+                      <span>Subscribe - $399/yr</span>
                     </a>
                   </div>
                 </div>
@@ -5304,7 +5304,7 @@
                   </div>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">once</span>
                   </div>
 
@@ -5359,7 +5359,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Buy Lifetime - $1,799</span>
+                      <span>Buy Lifetime - $999</span>
                     </a>
                   </div>
                 </div>
@@ -5500,7 +5500,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            After 7 Days: Subscribe to continue ($99/month) or trial expires
+            After 7 Days: Subscribe to continue ($69/month) or trial expires
           </p>
         </div>
 
@@ -7386,7 +7386,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: 100 Founding Member slots at fixed price
   const TOTAL_SLOTS = 100;
-  const PRICE = 1799;
+  const PRICE = 999;
 
   // Manual update: Change this number when you make a sale
   // Current: 1 sold (99 remaining per Gumroad)

--- a/index.html
+++ b/index.html
@@ -5041,6 +5041,13 @@
             flex-direction: column;
             flex: 1;
           }
+          /* Consistent feature list height */
+          #plan-pentarch > .relative > ul,
+          #plan-monthly > .relative > ul,
+          #plan-yearly > .relative > ul,
+          #plan-lifetime > .relative > ul {
+            min-height: 96px;
+          }
           /* Push button container to bottom */
           #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
@@ -5135,7 +5142,7 @@
                   <div class="mt-6 h-px bg-white/10"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/c8FDqXfN-Pentarch-Cycle-Phase-Detection-Signal-Pilot/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Preview Pentarch on TradingView
                   </a>

--- a/index.html
+++ b/index.html
@@ -1708,6 +1708,15 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -5151,7 +5160,7 @@
                   <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Consent required</div>
 
                   <div class="mt-6">
-                    <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center" style="--gradient-shine:#22d3ee;">
+                    <a href="https://signalpilot.gumroad.com/l/pentarch-solo" data-gumroad-overlay-checkout="true" class="shiny-cta shiny-cta-cyan w-full justify-center">
                       <span>Get Pentarch - $29/mo</span>
                     </a>
                   </div>

--- a/index.html
+++ b/index.html
@@ -5102,7 +5102,7 @@
                   <p class="text-xs uppercase tracking-wide text-cyan-400 mb-2">Start Here</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-pentarch-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/month</span>
                   </div>
 
@@ -5164,7 +5164,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/month</span>
                   </div>
 
@@ -5229,7 +5229,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Most Popular</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
+                    <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/year</span>
                   </div>
 
@@ -5304,7 +5304,7 @@
                   </div>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">once</span>
                   </div>
 

--- a/it/index.html
+++ b/it/index.html
@@ -147,14 +147,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -205,7 +205,7 @@
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Abbonamento Annuale (Miglior Valore)",
-        "description": "Indicatori TradingView professionali con rilevamento ciclo Pentarch™. Risparmia $489/anno. Tutti i 7 indicatori elite più aggiornamenti futuri. 100% senza ridipintura, verificato. Supporto prioritario e formazione avanzata inclusi.",
+        "description": "Indicatori TradingView professionali con rilevamento ciclo Pentarch™. Risparmia $429/anno. Tutti i 7 indicatori elite più aggiornamenti futuri. 100% senza ridipintura, verificato. Supporto prioritario e formazione avanzata inclusi.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -215,14 +215,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -270,7 +270,7 @@
           {
             "@type": "PropertyValue",
             "name": "Risparmio Annuale",
-            "value": "$489"
+            "value": "$429"
           }
         ]
       },
@@ -288,7 +288,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -2539,6 +2539,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span,.shiny-cta>span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -3750,7 +3767,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3763,7 +3780,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3776,7 +3793,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3930,7 +3947,7 @@
           {
             "@type": "Offer",
             "name": "Piano Mensile",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -3940,17 +3957,17 @@
           {
             "@type": "Offer",
             "name": "Piano Annuale",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Fatturazione annuale - risparmia $489 rispetto al mensile (41% di sconto)"
+            "description": "Fatturazione annuale - risparmia $429 rispetto al mensile (52% di sconto)"
           },
           {
             "@type": "Offer",
             "name": "Piano a Vita",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5278,10 +5295,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5290,6 +5308,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -5304,7 +5323,17 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-cyan-950/40 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                </div>
+                <div>
+                  <p class="text-cyan-100 text-base font-medium tracking-tight">Inizia qui</p>
+                  <p class="text-cyan-400/70 text-sm">Solo indicatore principale</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -5321,7 +5350,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Annuale</p>
-                  <p class="text-neutral-400 text-sm">Miglior valore - risparmia $489</p>
+                  <p class="text-neutral-400 text-sm">Miglior valore - risparmia $429</p>
                 </div>
               </div>
 
@@ -5337,7 +5366,62 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-cyan-950/50 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(34,211,238,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+
+                <div class="relative">
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-cyan-400/70 mb-1">/mese</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-cyan-100/80 max-w-[40ch]">Inizio perfetto. Il nostro indicatore principale.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-cyan-100/70">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Indicatore cicli Pentarch™
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Avvisi in tempo reale
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Annulla quando vuoi
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-cyan-500/20"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Anteprima Pentarch su TradingView
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-cyan-200/70 mb-2 block">Nome utente TradingView</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@tuo.tradingview" required class="w-full px-3 py-2.5 bg-cyan-950/30 border border-cyan-500/20 rounded-lg text-white text-sm placeholder-cyan-300/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Nome utente TradingView richiesto</div>
+                  </div>
+
+                  <div class="mt-6">
+                    <button class="shiny-cta shiny-cta-cyan w-full" onclick="handlePlanPurchase('pentarch')" style="font-size:0.95rem">
+                      <span>Ottieni Pentarch - $29/mese</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5345,7 +5429,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/mese</span>
                   </div>
 
@@ -5395,7 +5479,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Abbonati - $99/mese</span>
+                      <span>Abbonati - $69/mese</span>
                     </a>
                   </div>
                 </div>
@@ -5410,7 +5494,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Più Popolare</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/anno</span>
                   </div>
 
@@ -5452,7 +5536,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Abbonati - $699/anno</span>
+                      <span>Abbonati - $399/anno</span>
                     </a>
                   </div>
                 </div>
@@ -5480,7 +5564,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">unico</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -5534,7 +5618,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Acquista a Vita - $1,799</span>
+                      <span>Acquista a Vita - $999</span>
                     </a>
                   </div>
 
@@ -5678,7 +5762,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            Dopo 7 Giorni: Abbonati per continuare ($99/mese) oppure la prova scade
+            Dopo 7 Giorni: Abbonati per continuare ($69/mese) oppure la prova scade
           </p>
         </div>
 
@@ -7392,7 +7476,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }
@@ -8546,7 +8630,7 @@ if ('serviceWorker' in navigator) {
       const numbersToAnimate = [
         { text: '82', selector: 'contains "82"' },
         { text: '7', selector: 'contains " 7 "' },
-        { text: '489', selector: 'contains "489"' },
+        { text: '429', selector: 'contains "429"' },
         { text: '350', selector: 'contains "350"' },
         { text: '10', selector: 'contains " 10 "' },
         { text: '4', selector: 'contains " 4 "' }

--- a/ja/index.html
+++ b/ja/index.html
@@ -145,14 +145,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -203,7 +203,7 @@
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - 年間プラン（最もお得）",
-        "description": "Pentarch™サイクル検出機能を備えたTradingView向けプロフェッショナル・インジケーター。年間$489の節約。エリート7種類のインジケーターと今後のアップデートすべてを含む。100%ノンリペイント、監査済み。優先サポートと上級トレーニングを含む。",
+        "description": "Pentarch™サイクル検出機能を備えたTradingView向けプロフェッショナル・インジケーター。年間$429の節約。エリート7種類のインジケーターと今後のアップデートすべてを含む。100%ノンリペイント、監査済み。優先サポートと上級トレーニングを含む。",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -213,14 +213,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -268,7 +268,7 @@
           {
             "@type": "PropertyValue",
             "name": "年間節約額",
-            "value": "$489"
+            "value": "$429"
           }
         ]
       },
@@ -286,7 +286,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -2818,6 +2818,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -4090,7 +4107,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4103,7 +4120,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4116,7 +4133,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4270,7 +4287,7 @@
           {
             "@type": "Offer",
             "name": "月額プラン",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4280,17 +4297,17 @@
           {
             "@type": "Offer",
             "name": "年間プラン",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "年間課金 - 月額より489ドルお得（41%オフ）"
+            "description": "年間課金 - 月額より429ドルお得（52%オフ）"
           },
           {
             "@type": "Offer",
             "name": "永久ライセンス",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5583,10 +5600,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5595,6 +5613,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -5609,7 +5628,17 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-cyan-950/40 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                </div>
+                <div>
+                  <p class="text-cyan-100 text-base font-medium tracking-tight">ここから始める</p>
+                  <p class="text-cyan-400/70 text-sm">フラッグシップ指標のみ</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -5626,7 +5655,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">年額</p>
-                  <p class="text-neutral-400 text-sm">ベスト価値 - $489節約</p>
+                  <p class="text-neutral-400 text-sm">ベスト価値 - $429節約</p>
                 </div>
               </div>
 
@@ -5642,7 +5671,62 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-cyan-950/50 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(34,211,238,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+
+                <div class="relative">
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-cyan-400/70 mb-1">/月</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-cyan-100/80 max-w-[40ch]">完璧なスタート。フラッグシップ指標。</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-cyan-100/70">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Pentarch™サイクル指標
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      リアルタイムアラート
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      いつでも解約可能
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-cyan-500/20"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    TradingViewでPentarchをプレビュー
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-cyan-200/70 mb-2 block">TradingViewユーザー名</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@あなたのTradingView" required class="w-full px-3 py-2.5 bg-cyan-950/30 border border-cyan-500/20 rounded-lg text-white text-sm placeholder-cyan-300/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">TradingViewユーザー名が必要です</div>
+                  </div>
+
+                  <div class="mt-6">
+                    <button class="shiny-cta shiny-cta-cyan w-full" onclick="handlePlanPurchase('pentarch')" style="font-size:0.95rem">
+                      <span>Pentarchを取得 - $29/月</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5650,7 +5734,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/月</span>
                   </div>
 
@@ -5700,7 +5784,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>購読 - $99/月</span>
+                      <span>購読 - $69/月</span>
                     </a>
                   </div>
                 </div>
@@ -5715,7 +5799,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">最も人気</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/年</span>
                   </div>
 
@@ -5757,7 +5841,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>購読 - $699/年</span>
+                      <span>購読 - $399/年</span>
                     </a>
                   </div>
                 </div>
@@ -5785,7 +5869,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">一度きり</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -5839,7 +5923,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>ライフタイム購入 - $1,799</span>
+                      <span>ライフタイム購入 - $999</span>
                     </a>
                   </div>
 
@@ -5982,7 +6066,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            7日後：継続する場合は登録（月額$99）、またはトライアルは期限切れとなります
+            7日後：継続する場合は登録（月額$69）、またはトライアルは期限切れとなります
           </p>
         </div>
 
@@ -7635,7 +7719,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }
@@ -8694,7 +8778,7 @@ if ('serviceWorker' in navigator) {
       const numbersToAnimate = [
         { text: '82', selector: 'contains "82"' },
         { text: '7', selector: 'contains " 7 "' },
-        { text: '489', selector: 'contains "489"' },
+        { text: '429', selector: 'contains "429"' },
         { text: '350', selector: 'contains "350"' },
         { text: '10', selector: 'contains " 10 "' },
         { text: '4', selector: 'contains " 4 "' }

--- a/nl/index.html
+++ b/nl/index.html
@@ -144,14 +144,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -202,7 +202,7 @@
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Jaarlijks Abonnement (Beste Waarde)",
-        "description": "Professionele TradingView indicatoren met Pentarch™ cyclusdetectie. Bespaar $489/jaar. Alle 7 elite indicatoren plus toekomstige updates. 100% niet-herschilderend, geauditeerd. Prioriteitsondersteuning en geavanceerde training inbegrepen.",
+        "description": "Professionele TradingView indicatoren met Pentarch™ cyclusdetectie. Bespaar $429/jaar. Alle 7 elite indicatoren plus toekomstige updates. 100% niet-herschilderend, geauditeerd. Prioriteitsondersteuning en geavanceerde training inbegrepen.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -212,14 +212,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -267,7 +267,7 @@
           {
             "@type": "PropertyValue",
             "name": "Jaarlijkse Besparing",
-            "value": "$489"
+            "value": "$429"
           }
         ]
       },
@@ -285,7 +285,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -2598,6 +2598,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -3768,7 +3785,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3781,7 +3798,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3794,7 +3811,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3948,7 +3965,7 @@
           {
             "@type": "Offer",
             "name": "Maandabonnement",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -3958,17 +3975,17 @@
           {
             "@type": "Offer",
             "name": "Jaarabonnement",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Jaarlijkse facturering - bespaar $489 t.o.v. maandelijks (41% korting)"
+            "description": "Jaarlijkse facturering - bespaar $429 t.o.v. maandelijks (52% korting)"
           },
           {
             "@type": "Offer",
             "name": "Levenslange Toegang",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5271,10 +5288,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5283,6 +5301,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -5297,7 +5316,17 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-cyan-950/40 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                </div>
+                <div>
+                  <p class="text-cyan-100 text-base font-medium tracking-tight">Begin hier</p>
+                  <p class="text-cyan-400/70 text-sm">Alleen vlaggenschip indicator</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -5314,7 +5343,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Jaarlijks</p>
-                  <p class="text-neutral-400 text-sm">Beste waarde - bespaar $489</p>
+                  <p class="text-neutral-400 text-sm">Beste waarde - bespaar $429</p>
                 </div>
               </div>
 
@@ -5330,7 +5359,62 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-cyan-950/50 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(34,211,238,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+
+                <div class="relative">
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-cyan-400/70 mb-1">/maand</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-cyan-100/80 max-w-[40ch]">Perfecte start. Onze vlaggenschip indicator.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-cyan-100/70">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Pentarch™ cyclus indicator
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Real-time alerts
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Stop wanneer je wilt
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-cyan-500/20"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Bekijk Pentarch op TradingView
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-cyan-200/70 mb-2 block">TradingView Gebruikersnaam</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@jouw.tradingview" required class="w-full px-3 py-2.5 bg-cyan-950/30 border border-cyan-500/20 rounded-lg text-white text-sm placeholder-cyan-300/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">TradingView gebruikersnaam vereist</div>
+                  </div>
+
+                  <div class="mt-6">
+                    <button class="shiny-cta shiny-cta-cyan w-full" onclick="handlePlanPurchase('pentarch')" style="font-size:0.95rem">
+                      <span>Krijg Pentarch - $29/maand</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5338,7 +5422,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/maand</span>
                   </div>
 
@@ -5388,7 +5472,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Abonneren - $99/maand</span>
+                      <span>Abonneren - $69/maand</span>
                     </a>
                   </div>
                 </div>
@@ -5403,7 +5487,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Meest Populair</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/jaar</span>
                   </div>
 
@@ -5445,7 +5529,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Abonneren - $699/jaar</span>
+                      <span>Abonneren - $399/jaar</span>
                     </a>
                   </div>
                 </div>
@@ -5473,7 +5557,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">eenmalig</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -5527,7 +5611,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Koop Levenslang - $1,799</span>
+                      <span>Koop Levenslang - $999</span>
                     </a>
                   </div>
 
@@ -5671,7 +5755,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            Na 7 Dagen: Abonneer om door te gaan ($99/maand) of proefperiode verloopt
+            Na 7 Dagen: Abonneer om door te gaan ($69/maand) of proefperiode verloopt
           </p>
         </div>
 
@@ -7322,7 +7406,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }
@@ -8382,7 +8466,7 @@ if ('serviceWorker' in navigator) {
       const numbersToAnimate = [
         { text: '82', selector: 'contains "82"' },
         { text: '7', selector: 'contains " 7 "' },
-        { text: '489', selector: 'contains "489"' },
+        { text: '429', selector: 'contains "429"' },
         { text: '350', selector: 'contains "350"' },
         { text: '10', selector: 'contains " 10 "' },
         { text: '4', selector: 'contains " 4 "' }

--- a/pt/index.html
+++ b/pt/index.html
@@ -146,14 +146,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -197,7 +197,7 @@
         "@type": "Product",
         "@id": "https://www.signalpilot.io/#yearly-plan",
         "name": "Signal Pilot Elite Seven - Assinatura Anual (Melhor Valor)",
-        "description": "Indicadores profissionais para TradingView com detecção de ciclos Pentarch™. Economize $489/ano. Todos os 7 indicadores elite mais atualizações futuras. 100% sem repintura, auditado. Suporte prioritário e treinamento avançado incluídos.",
+        "description": "Indicadores profissionais para TradingView com detecção de ciclos Pentarch™. Economize $429/ano. Todos os 7 indicadores elite mais atualizações futuras. 100% sem repintura, auditado. Suporte prioritário e treinamento avançado incluídos.",
         "brand": {
           "@type": "Brand",
           "name": "Signal Pilot Labs"
@@ -207,14 +207,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -255,7 +255,7 @@
           {
             "@type": "PropertyValue",
             "name": "Economia Anual",
-            "value": "$489"
+            "value": "$429"
           }
         ]
       },
@@ -273,7 +273,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -2662,6 +2662,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -4022,7 +4039,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4035,7 +4052,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4048,7 +4065,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4202,7 +4219,7 @@
           {
             "@type": "Offer",
             "name": "Plano Mensal",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4212,17 +4229,17 @@
           {
             "@type": "Offer",
             "name": "Plano Anual",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
             "url": "https://www.signalpilot.io/#pricing",
-            "description": "Faturamento anual - economize $489 vs mensal (41% de desconto)"
+            "description": "Faturamento anual - economize $429 vs mensal (52% de desconto)"
           },
           {
             "@type": "Offer",
             "name": "Plano Vitalício",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5547,10 +5564,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5559,6 +5577,7 @@
             flex: 1;
           }
           /* Push button container to bottom */
+          #plan-pentarch > .relative > div.mt-6:last-of-type,
           #plan-monthly > .relative > div.mt-6:last-of-type,
           #plan-yearly > .relative > div.mt-6:last-of-type,
           #plan-lifetime > .relative > div.mt-6:last-of-type {
@@ -5573,7 +5592,17 @@
 
           <div class="p-6 sm:p-10">
             <!-- Small headers -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-4">
+              <div class="flex items-center gap-4 rounded-2xl ring-1 ring-cyan-500/30 bg-cyan-950/40 px-4 py-3">
+                <div class="w-10 h-10 rounded-xl bg-cyan-500/10 ring-1 ring-cyan-500/30 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-cyan-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                </div>
+                <div>
+                  <p class="text-cyan-100 text-base font-medium tracking-tight">Comece aqui</p>
+                  <p class="text-cyan-400/70 text-sm">Apenas indicador principal</p>
+                </div>
+              </div>
+
               <div class="flex items-center gap-4 rounded-2xl ring-1 ring-white/10 bg-neutral-900/60 px-4 py-3">
                 <div class="w-10 h-10 rounded-xl bg-white/5 ring-1 ring-white/10 flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -5590,7 +5619,7 @@
                 </div>
                 <div>
                   <p class="text-white text-base font-medium tracking-tight">Anual</p>
-                  <p class="text-neutral-400 text-sm">Melhor valor - economize $489</p>
+                  <p class="text-neutral-400 text-sm">Melhor valor - economize $429</p>
                 </div>
               </div>
 
@@ -5606,7 +5635,62 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-cyan-950/50 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(34,211,238,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+
+                <div class="relative">
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-cyan-400/70 mb-1">/mês</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-cyan-100/80 max-w-[40ch]">Início perfeito. Nosso indicador principal.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-cyan-100/70">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Indicador de ciclo Pentarch™
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Alertas em tempo real
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-500/50 bg-cyan-500/30"></span>
+                      Cancele quando quiser
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-cyan-500/20"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Visualize Pentarch no TradingView
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-cyan-200/70 mb-2 block">Nome de usuário TradingView</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@seu.tradingview" required class="w-full px-3 py-2.5 bg-cyan-950/30 border border-cyan-500/20 rounded-lg text-white text-sm placeholder-cyan-300/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Nome de usuário TradingView obrigatório</div>
+                  </div>
+
+                  <div class="mt-6">
+                    <button class="shiny-cta shiny-cta-cyan w-full" onclick="handlePlanPurchase('pentarch')" style="font-size:0.95rem">
+                      <span>Obter Pentarch - $29/mês</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5614,7 +5698,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/mês</span>
                   </div>
 
@@ -5664,7 +5748,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Assinar - $99/mês</span>
+                      <span>Assinar - $69/mês</span>
                     </a>
                   </div>
                 </div>
@@ -5679,7 +5763,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Mais Popular</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/ano</span>
                   </div>
 
@@ -5721,7 +5805,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Assinar - $699/ano</span>
+                      <span>Assinar - $399/ano</span>
                     </a>
                   </div>
                 </div>
@@ -5749,7 +5833,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">único</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -5803,7 +5887,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Comprar Vitalício - $1,799</span>
+                      <span>Comprar Vitalício - $999</span>
                     </a>
                   </div>
 
@@ -5947,7 +6031,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            Após 7 Dias: Assine para continuar ($99/mês) ou o teste expira
+            Após 7 Dias: Assine para continuar ($69/mês) ou o teste expira
           </p>
         </div>
 
@@ -7680,7 +7764,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }
@@ -8739,7 +8823,7 @@ if ('serviceWorker' in navigator) {
       const numbersToAnimate = [
         { text: '82', selector: 'contains "82"' },
         { text: '7', selector: 'contains " 7 "' },
-        { text: '489', selector: 'contains "489"' },
+        { text: '429', selector: 'contains "429"' },
         { text: '350', selector: 'contains "350"' },
         { text: '10', selector: 'contains " 10 "' },
         { text: '4', selector: 'contains " 4 "' }

--- a/ru/index.html
+++ b/ru/index.html
@@ -144,14 +144,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -212,14 +212,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -285,7 +285,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -1104,6 +1104,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -1911,6 +1928,23 @@
     }
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
+
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
 
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
@@ -3853,7 +3887,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3866,7 +3900,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3879,7 +3913,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4033,7 +4067,7 @@
           {
             "@type": "Offer",
             "name": "Ежемесячный план",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4043,7 +4077,7 @@
           {
             "@type": "Offer",
             "name": "Годовой план",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4053,7 +4087,7 @@
           {
             "@type": "Offer",
             "name": "Пожизненный доступ",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5422,7 +5456,69 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-cyan-950/50 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(34,211,238,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+
+                <div class="relative">
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-cyan-400/70 mb-1">/мес</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Только индикатор Pentarch. Один инструмент, одна цель.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-neutral-300">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      Определение фаз цикла Pentarch
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      Алерты в реальном времени
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      Отмена в любое время
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-cyan-500/20"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    Посмотреть Pentarch на TradingView
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-cyan-300/70 mb-2 block">Имя пользователя TradingView</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@ваш.tradingview" required class="w-full px-3 py-2.5 bg-cyan-950/30 border border-cyan-500/20 rounded-lg text-white text-sm placeholder-cyan-300/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Требуется имя пользователя TradingView</div>
+                  </div>
+
+                  <!-- Consent -->
+                  <label class="consent flex items-start gap-2 mt-4 text-xs text-cyan-300/50 cursor-pointer">
+                    <input class="tick mt-0.5" type="checkbox" id="consent-pentarch">
+                    <span>Я понимаю, что <span class="font-medium text-cyan-300/70">Signal Pilot</span> носит образовательный характер. Никаких финансовых советов.</span>
+                  </label>
+                  <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Требуется согласие</div>
+
+                  <div class="mt-6">
+                    <button class="shiny-cta shiny-cta-cyan w-full" onclick="handlePlanPurchase('pentarch')" style="font-size:0.95rem">
+                      <span>Получить Pentarch - $29/мес</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5430,7 +5526,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/мес</span>
                   </div>
 
@@ -5480,7 +5576,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Подписаться - $99/мес</span>
+                      <span>Подписаться - $69/мес</span>
                     </a>
                   </div>
                 </div>
@@ -5495,7 +5591,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">Самый популярный</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/год</span>
                   </div>
 
@@ -5537,7 +5633,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Подписаться - $699/год</span>
+                      <span>Подписаться - $399/год</span>
                     </a>
                   </div>
                 </div>
@@ -5565,7 +5661,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">разово</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -5619,7 +5715,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Купить Навсегда - $1,799</span>
+                      <span>Купить Навсегда - $999</span>
                     </a>
                   </div>
 
@@ -5766,7 +5862,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            После 7 дней: Подпишитесь для продолжения ($99/месяц) или пробный период истекает
+            После 7 дней: Подпишитесь для продолжения ($69/месяц) или пробный период истекает
           </p>
         </div>
 
@@ -7434,7 +7530,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }

--- a/tr/index.html
+++ b/tr/index.html
@@ -145,14 +145,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "99.00",
+          "price": "69.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "billingDuration": "P1M",
             "billingIncrement": "1"
@@ -213,14 +213,14 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "699.00",
+          "price": "399.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/InStock",
           "url": "https://www.signalpilot.io/#pricing",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "billingDuration": "P1Y",
             "billingIncrement": "1"
@@ -286,7 +286,7 @@
         "url": "https://www.signalpilot.io/#pricing",
         "offers": {
           "@type": "Offer",
-          "price": "1799.00",
+          "price": "999.00",
           "priceCurrency": "USD",
           "priceValidUntil": "2026-12-31",
           "availability": "https://schema.org/LimitedAvailability",
@@ -1150,6 +1150,23 @@
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
 
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
+
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
     #hero-btn-before:active,#hero-btn-after:active{transform:scale(0.95)}
@@ -2002,6 +2019,23 @@
     }
     @keyframes shiny-shimmer{to{transform:translate(-50%,-50%) rotate(360deg)}}
     .shiny-cta span{position:relative;z-index:2;display:inline-block}
+
+    /* Cyan variant for Pentarch Solo */
+    .shiny-cta-cyan{
+      --gradient-shine:#22d3ee;
+      background:linear-gradient(#0a0a0f,#0a0a0f) padding-box,conic-gradient(from calc(var(--gradient-angle) - var(--gradient-angle-offset)),transparent 0%,#164e63 5%,var(--gradient-shine) 15%,#164e63 30%,transparent 40%,transparent 100%) border-box;
+    }
+    .shiny-cta-cyan::after{
+      background:linear-gradient(-50deg,transparent,#164e63,transparent);
+    }
+
+    /* Consistent feature list height */
+    #plan-pentarch > .relative > ul,
+    #plan-monthly > .relative > ul,
+    #plan-yearly > .relative > ul,
+    #plan-lifetime > .relative > ul {
+      min-height: 96px;
+    }
 
     /* Hero slider text buttons */
     #hero-btn-before:hover,#hero-btn-after:hover{color:#fff;text-shadow:0 0 20px rgba(91,138,255,0.6)}
@@ -3943,7 +3977,7 @@
     "offers": [
       {
         "@type": "Offer",
-        "price": "99",
+        "price": "69",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3956,7 +3990,7 @@
       },
       {
         "@type": "Offer",
-        "price": "699",
+        "price": "399",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -3969,7 +4003,7 @@
       },
       {
         "@type": "Offer",
-        "price": "1799",
+        "price": "999",
         "priceCurrency": "USD",
         "priceValidUntil": "2026-12-31",
         "availability": "https://schema.org/InStock",
@@ -4123,7 +4157,7 @@
           {
             "@type": "Offer",
             "name": "Aylık Plan",
-            "price": "99.00",
+            "price": "69.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4133,7 +4167,7 @@
           {
             "@type": "Offer",
             "name": "Yıllık Plan",
-            "price": "699.00",
+            "price": "399.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/InStock",
@@ -4143,7 +4177,7 @@
           {
             "@type": "Offer",
             "name": "Ömür Boyu Erişim",
-            "price": "1799.00",
+            "price": "999.00",
             "priceCurrency": "USD",
             "priceValidUntil": "2026-12-31",
             "availability": "https://schema.org/LimitedAvailability",
@@ -5497,7 +5531,69 @@
             </div>
 
             <!-- Pricing cards -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+
+              <!-- PENTARCH SOLO -->
+              <div class="relative rounded-2xl ring-1 ring-cyan-500/30 bg-gradient-to-b from-cyan-950/50 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-pentarch" data-plan="pentarch">
+                <div class="pointer-events-none absolute inset-0 opacity-[0.18]" style="background-image: radial-gradient(rgba(34,211,238,0.25) 1px, transparent 1px); background-size: 18px 18px;"></div>
+
+                <div class="relative">
+                  <div class="flex items-end gap-3">
+                    <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
+                    <span class="text-[11px] uppercase text-cyan-400/70 mb-1">/ay</span>
+                  </div>
+
+                  <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Sadece Pentarch göstergesi. Tek araç, tek odak.</p>
+
+                  <ul class="mt-6 space-y-2 text-sm text-neutral-300">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      Pentarch Döngü Fazı Tespiti
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      Gerçek zamanlı uyarılar
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 w-2 h-2 rounded-full ring-1 ring-cyan-400/50"></span>
+                      İstediğiniz zaman iptal
+                    </li>
+                  </ul>
+
+                  <div class="mt-6 h-px bg-cyan-500/20"></div>
+
+                  <!-- Preview Link -->
+                  <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                    <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
+                    TradingView'da Pentarch'ı Önizle
+                  </a>
+
+                  <!-- TradingView Username -->
+                  <div class="mt-6">
+                    <label class="text-xs font-medium text-cyan-300/70 mb-2 block">TradingView Kullanıcı Adı</label>
+                    <div class="input-wrapper relative">
+                      <input id="tv-pentarch" placeholder="@kullanici.adi" required class="w-full px-3 py-2.5 bg-cyan-950/30 border border-cyan-500/20 rounded-lg text-white text-sm placeholder-cyan-300/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/50" style="padding-right:2.5rem">
+                      <div class="checkmark absolute right-2.5 top-1/2 -translate-y-1/2">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                      </div>
+                    </div>
+                    <div id="error-tv-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">TradingView kullanıcı adı gerekli</div>
+                  </div>
+
+                  <!-- Consent -->
+                  <label class="consent flex items-start gap-2 mt-4 text-xs text-cyan-300/50 cursor-pointer">
+                    <input class="tick mt-0.5" type="checkbox" id="consent-pentarch">
+                    <span><span class="font-medium text-cyan-300/70">Signal Pilot</span>'un eğitim amaçlı olduğunu anlıyorum. Finansal tavsiye değildir.</span>
+                  </label>
+                  <div id="error-consent-pentarch" style="display:none" class="text-red-400 text-xs mt-1.5">Onay gerekli</div>
+
+                  <div class="mt-6">
+                    <button class="shiny-cta shiny-cta-cyan w-full" onclick="handlePlanPurchase('pentarch')" style="font-size:0.95rem">
+                      <span>Pentarch Al - $29/ay</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
 
               <!-- MONTHLY -->
               <div class="relative rounded-2xl ring-1 ring-white/10 bg-gradient-to-b from-zinc-900/70 to-zinc-950 px-5 py-6 sm:px-8 sm:py-8 overflow-hidden" id="plan-monthly" data-plan="monthly">
@@ -5505,7 +5601,7 @@
 
                 <div class="relative">
                   <div class="flex items-end gap-3">
-                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$99</p>
+                    <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/ay</span>
                   </div>
 
@@ -5555,7 +5651,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/qrwlsu" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Abone Ol - $99/ay</span>
+                      <span>Abone Ol - $69/ay</span>
                     </a>
                   </div>
                 </div>
@@ -5570,7 +5666,7 @@
                   <p class="text-xs uppercase tracking-wide text-neutral-400 mb-2">En Popüler</p>
 
                   <div class="flex items-end gap-3">
-                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$699</p>
+                    <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">/yıl</span>
                   </div>
 
@@ -5612,7 +5708,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/xdjobx" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Abone Ol - $699/yıl</span>
+                      <span>Abone Ol - $399/yıl</span>
                     </a>
                   </div>
                 </div>
@@ -5640,7 +5736,7 @@
                     </svg>
                   </div>
                   <div class="flex items-end gap-3">
-                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$1,799</span></p>
+                    <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
                     <span class="text-[11px] uppercase text-neutral-400 mb-1">tek seferlik</span>
                   </div>
                   <!-- Remaining Counter -->
@@ -5694,7 +5790,7 @@
 
                   <div class="mt-6">
                     <a href="https://signalpilot.gumroad.com/l/vwesbz" data-gumroad-overlay-checkout="true" class="shiny-cta w-full justify-center">
-                      <span>Ömür Boyu Satın Al - $1,799</span>
+                      <span>Ömür Boyu Satın Al - $999</span>
                     </a>
                   </div>
 
@@ -5841,7 +5937,7 @@
         <!-- Social Proof -->
         <div style="text-align:center;margin-top:2rem">
           <p style="font-size:0.9rem;color:var(--muted-2)">
-            7 Gün Sonra: Devam etmek için abone olun ($99/ay) veya deneme süresi sona erer
+            7 Gün Sonra: Devam etmek için abone olun ($69/ay) veya deneme süresi sona erer
           </p>
         </div>
 
@@ -7515,7 +7611,7 @@ if ('serviceWorker' in navigator) {
 
   // Configuration: Define pricing tiers
   const PRICING_TIERS = [
-    { min: 0, max: 50, price: 1799, name: 'Tier 1' },
+    { min: 0, max: 50, price: 999, name: 'Tier 1' },
     { min: 51, max: 150, price: 2499, name: 'Tier 2' },
     { min: 151, max: 350, price: 3499, name: 'Tier 3' },
     { min: 351, max: Infinity, price: null, name: 'Removed' }


### PR DESCRIPTION
## Summary
Introduced a new "Pentarch Solo" entry-level pricing tier ($49/month) featuring only the flagship Pentarch cycle detection indicator, positioned alongside the existing Monthly/Yearly/Lifetime plans that include all 7 indicators.

## Key Changes
- **New pricing tier**: Added Pentarch Solo card with cyan branding to differentiate from other plans
- **Updated grid layout**: Changed pricing grid from 3 columns to 4 columns to accommodate the new plan
- **Clarified messaging**: 
  - Updated "What's Included" section header from "Every plan includes the exact same features" to "All plans include"
  - Changed feature list to highlight "Real-time alerts" instead of "All 7 elite indicators"
  - Updated footer note to clarify: "Pentarch Solo = 1 indicator • Monthly/Yearly/Lifetime = All 7 indicators"
- **Added form fields**: Included TradingView username input and consent checkbox for Pentarch Solo signup
- **Updated styling**: 
  - Added CSS selectors for `#plan-pentarch` to match layout behavior of other plan cards
  - Applied cyan accent color scheme to distinguish Solo tier visually
- **Added preview link**: Direct link to preview Pentarch indicator on TradingView

## Implementation Details
- Pentarch Solo uses cyan-500 color scheme (`ring-cyan-500/30`, `bg-cyan-500/10`) for visual distinction
- Includes "Start Here" label to position it as entry-level option
- Features upgrade path messaging: "Upgrade anytime, we'll credit you"
- Maintains consistent card structure and validation patterns with existing plans
- Grid layout responsive: 1 column on mobile, 4 columns on medium+ screens