### PR TITLE
Fix pricing card alignment and text wrapping

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5400,10 +5400,11 @@ html[lang="ar"] [style*="text-align:center"] {
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5411,12 +5412,13 @@ html[lang="ar"] [style*="text-align:center"] {
             flex-direction: column;
             flex: 1;
           }
-          /* Push button container to bottom */
-          #plan-monthly > .relative > div.mt-6:last-of-type,
-          #plan-yearly > .relative > div.mt-6:last-of-type,
-          #plan-lifetime > .relative > div.mt-6:last-of-type {
-            margin-top: auto !important;
-            padding-top: 1.5rem;
+          /* Feature list grows to push everything below it into alignment */
+          #plan-pentarch > .relative > ul,
+          #plan-monthly > .relative > ul,
+          #plan-yearly > .relative > ul,
+          #plan-lifetime > .relative > ul {
+            flex-grow: 1;
+            min-height: 80px;
           }
         </style>
 
@@ -5530,7 +5532,7 @@ html[lang="ar"] [style*="text-align:center"] {
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/شهر</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/شهر</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">ادفع كما تذهب. إلغاء في أي وقت</p>
@@ -5591,7 +5593,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/سنة</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/سنة</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">أفضل قيمة للمتداولين الملتزمين.</p>
@@ -5661,7 +5663,7 @@ html[lang="ar"] [style*="text-align:center"] {
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">لمرة واحدة</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">لمرة واحدة</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/de/index.html
+++ b/de/index.html
@@ -5987,7 +5987,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/Monat</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/Monat</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Unser Flaggschiff-Indikator für Zykluserkennung. Perfekter Einstiegspunkt.</p>
@@ -6049,7 +6049,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/Monat</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/Monat</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Zahle nach Verbrauch. Jederzeit kündbar, keine Verpflichtung.</p>
@@ -6114,7 +6114,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/Jahr</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/Jahr</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Bester Wert für engagierte Trader.</p>
@@ -6184,7 +6184,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">einmalig</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">einmalig</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/es/index.html
+++ b/es/index.html
@@ -5875,7 +5875,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/mes</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/mes</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Nuestro indicador principal de detección de ciclos. Punto de entrada perfecto.</p>
@@ -5937,7 +5937,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/mes</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/mes</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Paga sobre la marcha. Cancela cuando quieras, sin compromiso.</p>
@@ -6002,7 +6002,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/año</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/año</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Mejor valor para traders comprometidos.</p>
@@ -6072,7 +6072,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">único</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">único</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/fr/index.html
+++ b/fr/index.html
@@ -6153,7 +6153,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/mois</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/mois</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Notre indicateur phare de détection de cycles. Point d'entrée parfait.</p>
@@ -6215,7 +6215,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/mois</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/mois</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Payez mensuellement. Annulez quand vous voulez, sans engagement.</p>
@@ -6280,7 +6280,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/an</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/an</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Meilleure valeur pour les traders engagés.</p>
@@ -6350,7 +6350,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">unique</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">unique</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/hu/index.html
+++ b/hu/index.html
@@ -5826,7 +5826,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/hó</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/hó</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Fizess menet közben. Bármikor lemondható.</p>
@@ -5891,7 +5891,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/év</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/év</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Legjobb érték az elkötelezett kereskedőknek.</p>
@@ -5961,7 +5961,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">egyszeri</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">egyszeri</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/index.html
+++ b/index.html
@@ -5041,20 +5041,13 @@
             flex-direction: column;
             flex: 1;
           }
-          /* Consistent feature list height */
+          /* Feature list grows to push everything below it into alignment */
           #plan-pentarch > .relative > ul,
           #plan-monthly > .relative > ul,
           #plan-yearly > .relative > ul,
           #plan-lifetime > .relative > ul {
-            min-height: 96px;
-          }
-          /* Push button container to bottom */
-          #plan-pentarch > .relative > div.mt-6:last-of-type,
-          #plan-monthly > .relative > div.mt-6:last-of-type,
-          #plan-yearly > .relative > div.mt-6:last-of-type,
-          #plan-lifetime > .relative > div.mt-6:last-of-type {
-            margin-top: auto !important;
-            padding-top: 1.5rem;
+            flex-grow: 1;
+            min-height: 80px;
           }
         </style>
 
@@ -5119,7 +5112,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-pentarch-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-cyan-400 via-cyan-300 to-cyan-500 bg-clip-text text-transparent">$29</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/month</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/month</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Our flagship cycle detection indicator. Perfect entry point.</p>
@@ -5181,7 +5174,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/month</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/month</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Pay as you go. Cancel anytime, no commitment.</p>
@@ -5246,7 +5239,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/year</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/year</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Best value for committed traders.</p>
@@ -5321,7 +5314,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">once</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">once</span>
                   </div>
 
                   <!-- Remaining Counter -->

--- a/it/index.html
+++ b/it/index.html
@@ -5430,7 +5430,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/mese</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/mese</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Paga man mano. Annulla quando vuoi.</p>
@@ -5495,7 +5495,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/anno</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/anno</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Miglior valore per trader impegnati.</p>
@@ -5565,7 +5565,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">unico</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">unico</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/ja/index.html
+++ b/ja/index.html
@@ -5735,7 +5735,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/月</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/月</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">使った分だけ支払い。いつでも解約可能。</p>
@@ -5800,7 +5800,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/年</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/年</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">本格的なトレーダーに最適な価値。</p>
@@ -5870,7 +5870,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">一度きり</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">一度きり</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/nl/index.html
+++ b/nl/index.html
@@ -5423,7 +5423,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/maand</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/maand</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Betaal per maand. Stop wanneer je wilt, geen verplichtingen.</p>
@@ -5488,7 +5488,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/jaar</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/jaar</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Beste waarde voor toegewijde traders.</p>
@@ -5558,7 +5558,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">eenmalig</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">eenmalig</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/pt/index.html
+++ b/pt/index.html
@@ -5699,7 +5699,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/mês</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/mês</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Pague conforme usa. Cancele quando quiser.</p>
@@ -5764,7 +5764,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/ano</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/ano</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Melhor valor para traders comprometidos.</p>
@@ -5834,7 +5834,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-4xl lg:text-5xl xl:text-6xl font-semibold tracking-tight whitespace-nowrap bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">único</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">único</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/ru/index.html
+++ b/ru/index.html
@@ -5397,10 +5397,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5408,12 +5409,13 @@
             flex-direction: column;
             flex: 1;
           }
-          /* Push button container to bottom */
-          #plan-monthly > .relative > div.mt-6:last-of-type,
-          #plan-yearly > .relative > div.mt-6:last-of-type,
-          #plan-lifetime > .relative > div.mt-6:last-of-type {
-            margin-top: auto !important;
-            padding-top: 1.5rem;
+          /* Feature list grows to push everything below it into alignment */
+          #plan-pentarch > .relative > ul,
+          #plan-monthly > .relative > ul,
+          #plan-yearly > .relative > ul,
+          #plan-lifetime > .relative > ul {
+            flex-grow: 1;
+            min-height: 80px;
           }
         </style>
 
@@ -5527,7 +5529,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/мес</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/мес</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Платите по мере использования. Отмена в любое время.</p>
@@ -5592,7 +5594,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/год</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/год</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Лучшая цена для преданных трейдеров.</p>
@@ -5662,7 +5664,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">разово</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">разово</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">

--- a/tr/index.html
+++ b/tr/index.html
@@ -5472,10 +5472,11 @@
 
         <!-- Pricing card alignment fix -->
         <style>
-          #plan-monthly, #plan-yearly, #plan-lifetime {
+          #plan-pentarch, #plan-monthly, #plan-yearly, #plan-lifetime {
             display: flex;
             flex-direction: column;
           }
+          #plan-pentarch > .relative,
           #plan-monthly > .relative,
           #plan-yearly > .relative,
           #plan-lifetime > .relative {
@@ -5483,12 +5484,13 @@
             flex-direction: column;
             flex: 1;
           }
-          /* Push button container to bottom */
-          #plan-monthly > .relative > div.mt-6:last-of-type,
-          #plan-yearly > .relative > div.mt-6:last-of-type,
-          #plan-lifetime > .relative > div.mt-6:last-of-type {
-            margin-top: auto !important;
-            padding-top: 1.5rem;
+          /* Feature list grows to push everything below it into alignment */
+          #plan-pentarch > .relative > ul,
+          #plan-monthly > .relative > ul,
+          #plan-yearly > .relative > ul,
+          #plan-lifetime > .relative > ul {
+            flex-grow: 1;
+            min-height: 80px;
           }
         </style>
 
@@ -5602,7 +5604,7 @@
                 <div class="relative">
                   <div class="flex items-end gap-3">
                     <p id="plan-monthly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$69</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/ay</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/ay</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[40ch]">Kullandıkça ödeyin. İstediğiniz zaman iptal edin.</p>
@@ -5667,7 +5669,7 @@
 
                   <div class="flex items-end gap-3">
                     <p id="plan-yearly-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 bg-clip-text text-transparent">$399</p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">/yıl</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">/yıl</span>
                   </div>
 
                   <p class="mt-4 text-sm sm:text-base text-neutral-300 max-w-[44ch]">Kararlı yatırımcılar için en iyi değer.</p>
@@ -5737,7 +5739,7 @@
                   </div>
                   <div class="flex items-end gap-3">
                     <p id="plan-lifetime-title" class="text-5xl sm:text-6xl font-semibold tracking-tight bg-gradient-to-r from-amber-400 via-yellow-300 to-amber-500 bg-clip-text text-transparent"><span id="lifetime-display-price">$999</span></p>
-                    <span class="text-[11px] uppercase text-neutral-400 mb-1">tek seferlik</span>
+                    <span class="text-[11px] uppercase text-neutral-400 mb-1 whitespace-nowrap">tek seferlik</span>
                   </div>
                   <!-- Remaining Counter -->
                   <div class="founding-counter">


### PR DESCRIPTION
- Add whitespace-nowrap to price period spans (/year, /once, /month) to prevent text from wrapping onto multiple lines
- Update pricing card CSS to use flex-grow on feature lists for consistent vertical alignment across all 4 plan cards
- Applied fixes to all 12 language versions