### PR TITLE
Convert posts 472-490 to correct grid layout structure

### DIFF
--- a/assets/social/post-472/carousel.html
+++ b/assets/social/post-472/carousel.html
@@ -4,564 +4,284 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 472 — Killzones & High-Probability Windows</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
             --accent-orange: #d9884a;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        /* Slide 1 - Hook */
+        .slide-1 .title { font-family: var(--font-serif); font-size: clamp(26px, 4.8vw, 52px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .slide-1 .subtitle { font-family: var(--font-sans); font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-orange); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        /* Session box styling */
+        .session-box { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border: 1px solid rgba(74, 144, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: 90%; }
+        .session-box.asian { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .session-box.london { background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%); border-color: rgba(217, 136, 74, 0.3); }
+        .session-box.newyork { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .session-box.why { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .session-box.practical { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .session-box h3 { font-family: var(--font-serif); font-size: clamp(19px, 3.5vw, 38px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .session-box.asian h3 { color: var(--accent-blue); }
+        .session-box.london h3 { color: var(--accent-orange); }
+        .session-box.newyork h3 { color: var(--accent-gold); }
+        .session-box.why h3 { color: var(--accent-green); }
+        .session-box.practical h3 { color: var(--accent-purple); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 52px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .session-time { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 20px); color: var(--text-secondary); margin-bottom: clamp(10px, 1.9vw, 20px); font-weight: 500; }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-orange);
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-family: var(--font-sans); font-size: clamp(11px, 2vw, 22px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .session-box.asian .feature-list li::before { color: var(--accent-blue); }
+        .session-box.london .feature-list li::before { color: var(--accent-orange); }
+        .session-box.newyork .feature-list li::before { color: var(--accent-gold); }
+        .session-box.why .feature-list li::before { color: var(--accent-green); }
+        .session-box.practical .feature-list li::before { color: var(--accent-purple); }
 
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
+        /* Visual placeholder */
+        .visual-placeholder { background: linear-gradient(135deg, rgba(201, 169, 98, 0.1) 0%, rgba(201, 169, 98, 0.02) 100%); border: 2px dashed rgba(201, 169, 98, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(40px, 7.4vw, 80px) clamp(20px, 3.7vw, 40px); width: 100%; max-width: 90%; text-align: center; }
+        .visual-placeholder p { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 20px); color: var(--text-muted); margin-bottom: clamp(8px, 1.5vw, 16px); }
+        .visual-placeholder .visual-note { font-family: var(--font-sans); font-size: clamp(9px, 1.7vw, 18px); color: var(--accent-gold); font-style: italic; }
 
-        .session-box {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border: 1px solid rgba(74, 144, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .session-box.asian {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .session-box.london {
-            background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%);
-            border-color: rgba(217, 136, 74, 0.3);
-        }
-
-        .session-box.newyork {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .session-box.why {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .session-box.practical {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .session-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 38px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .session-box.asian h3 {
-            color: var(--accent-blue);
-        }
-
-        .session-box.london h3 {
-            color: var(--accent-orange);
-        }
-
-        .session-box.newyork h3 {
-            color: var(--accent-gold);
-        }
-
-        .session-box.why h3 {
-            color: var(--accent-green);
-        }
-
-        .session-box.practical h3 {
-            color: var(--accent-purple);
-        }
-
-        .session-time {
-            font-size: 20px;
-            color: var(--text-secondary);
-            margin-bottom: 20px;
-            font-weight: 500;
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 22px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .session-box.asian .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .session-box.london .feature-list li::before {
-            color: var(--accent-orange);
-        }
-
-        .session-box.newyork .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .session-box.why .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .session-box.practical .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .visual-placeholder {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.1) 0%, rgba(201, 169, 98, 0.02) 100%);
-            border: 2px dashed rgba(201, 169, 98, 0.3);
-            border-radius: 16px;
-            padding: 80px 40px;
-            width: 100%;
-            max-width: 800px;
-            text-align: center;
-        }
-
-        .visual-placeholder p {
-            font-size: 20px;
-            color: var(--text-muted);
-            margin-bottom: 16px;
-        }
-
-        .visual-placeholder .visual-note {
-            font-size: 18px;
-            color: var(--accent-gold);
-            font-style: italic;
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        /* CTA styling */
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-text { font-family: var(--font-sans); font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Killzones & High-Probability Windows</h1>
+        <p>8 slides · Session Timing</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 08</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">KILLZONES &<br>HIGH-PROBABILITY<br>WINDOWS</h1>
-                        <p class="subtitle">Not all hours are created equal.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="title">KILLZONES &<br>HIGH-PROBABILITY<br>WINDOWS</h1>
+                    <p class="subtitle">Not all hours are created equal.</p>
                 </div>
+                <div class="slide-number">1 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 2: Asian Session -->
         <div class="slide-wrapper" data-slide="2">
             <span class="slide-label">Slide 2 — Asian Session</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 08</span>
-                    <div class="center-content">
-                        <div class="session-box asian">
-                            <h3>ASIAN SESSION</h3>
-                            <p class="session-time">7pm - 12am EST</p>
-                            <ul class="feature-list">
-                                <li>Often range-bound</li>
-                                <li>Sets up daily levels</li>
-                                <li>Lower volatility, builds liquidity</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="session-box asian">
+                        <h3>ASIAN SESSION</h3>
+                        <p class="session-time">7pm - 12am EST</p>
+                        <ul class="feature-list">
+                            <li>Often range-bound</li>
+                            <li>Sets up daily levels</li>
+                            <li>Lower volatility, builds liquidity</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 3: London Open -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — London Open</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 08</span>
-                    <div class="center-content">
-                        <div class="session-box london">
-                            <h3>LONDON OPEN</h3>
-                            <p class="session-time">2am - 5am EST</p>
-                            <ul class="feature-list">
-                                <li>First major volatility</li>
-                                <li>Often sweeps Asian range</li>
-                                <li>Institutional activity begins</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="session-box london">
+                        <h3>LONDON OPEN</h3>
+                        <p class="session-time">2am - 5am EST</p>
+                        <ul class="feature-list">
+                            <li>First major volatility</li>
+                            <li>Often sweeps Asian range</li>
+                            <li>Institutional activity begins</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 4: New York Open -->
         <div class="slide-wrapper" data-slide="4">
             <span class="slide-label">Slide 4 — New York Open</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 08</span>
-                    <div class="center-content">
-                        <div class="session-box newyork">
-                            <h3>NEW YORK OPEN</h3>
-                            <p class="session-time">7am - 10am EST</p>
-                            <ul class="feature-list">
-                                <li>Highest volume overlap</li>
-                                <li>Major moves initiated</li>
-                                <li>Peak activity window</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="session-box newyork">
+                        <h3>NEW YORK OPEN</h3>
+                        <p class="session-time">7am - 10am EST</p>
+                        <ul class="feature-list">
+                            <li>Highest volume overlap</li>
+                            <li>Major moves initiated</li>
+                            <li>Peak activity window</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 5: Chart Visual -->
         <div class="slide-wrapper" data-slide="5">
             <span class="slide-label">Slide 5 — Chart Visual</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 08</span>
-                    <div class="center-content">
-                        <div class="visual-placeholder">
-                            <p>[24-Hour Chart]</p>
-                            <p>Sessions color-coded</p>
-                            <p>Volatility spikes during London and NY</p>
-                            <span class="visual-note">Asian: Flat | London: Movement | NY: Peak</span>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="visual-placeholder">
+                        <p>[24-Hour Chart]</p>
+                        <p>Sessions color-coded</p>
+                        <p>Volatility spikes during London and NY</p>
+                        <span class="visual-note">Asian: Flat | London: Movement | NY: Peak</span>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 6: Why Killzones Matter -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — Why Killzones Matter</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 08</span>
-                    <div class="center-content">
-                        <div class="session-box why">
-                            <h3>WHY KILLZONES MATTER</h3>
-                            <ul class="feature-list">
-                                <li>Institutional activity concentrated</li>
-                                <li>More liquidity = cleaner moves</li>
-                                <li>Better risk:reward potential</li>
-                                <li>Avoid low-volume chop</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="session-box why">
+                        <h3>WHY KILLZONES MATTER</h3>
+                        <ul class="feature-list">
+                            <li>Institutional activity concentrated</li>
+                            <li>More liquidity = cleaner moves</li>
+                            <li>Better risk:reward potential</li>
+                            <li>Avoid low-volume chop</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 7: Practical Application -->
         <div class="slide-wrapper" data-slide="7">
             <span class="slide-label">Slide 7 — Practical Application</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 08</span>
-                    <div class="center-content">
-                        <div class="session-box practical">
-                            <h3>PRACTICAL APPLICATION</h3>
-                            <ul class="feature-list">
-                                <li>Know your timezone conversion</li>
-                                <li>Be present during preferred killzone</li>
-                                <li>Avoid random hours trading</li>
-                                <li>Quality over quantity</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="session-box practical">
+                        <h3>PRACTICAL APPLICATION</h3>
+                        <ul class="feature-list">
+                            <li>Know your timezone conversion</li>
+                            <li>Be present during preferred killzone</li>
+                            <li>Avoid random hours trading</li>
+                            <li>Quality over quantity</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">7 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 8: CTA -->
         <div class="slide-wrapper" data-slide="8">
             <span class="slide-label">Slide 8 — CTA</span>
             <div class="slide slide-8">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">08 / 08</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Time Your Trading to<br>the Market's Rhythm</h2>
-                        <p class="cta-text">Full lesson in curriculum</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Time Your Trading to<br>the Market's Rhythm</h2>
+                    <p class="cta-text">Full lesson in curriculum</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">8 / 8</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        // Export mode functionality
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-473/carousel.html
+++ b/assets/social/post-473/carousel.html
@@ -4,539 +4,260 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 473 — The Compound Effect in Trading</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --accent-teal: #4ad9d9;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        /* Slide 1 - Hook */
+        .slide-1 .title { font-family: var(--font-serif); font-size: clamp(28px, 5.2vw, 56px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .slide-1 .subtitle { font-family: var(--font-sans); font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-green); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        /* Compound box styling */
+        .compound-box { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border: 1px solid rgba(74, 217, 122, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: 90%; }
+        .compound-box.math { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .compound-box.reality { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border-color: rgba(217, 74, 74, 0.3); }
+        .compound-box.mindset { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
+        .compound-box.habits { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .compound-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .compound-box h3 { color: var(--accent-green); }
+        .compound-box.math h3 { color: var(--accent-blue); }
+        .compound-box.reality h3 { color: var(--accent-red); }
+        .compound-box.mindset h3 { color: var(--accent-purple); }
+        .compound-box.habits h3 { color: var(--accent-gold); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 54px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .compound-box .feature-list li::before { color: var(--accent-green); }
+        .compound-box.math .feature-list li::before { color: var(--accent-blue); }
+        .compound-box.reality .feature-list li::before { color: var(--accent-red); }
+        .compound-box.mindset .feature-list li::before { color: var(--accent-purple); }
+        .compound-box.habits .feature-list li::before { color: var(--accent-gold); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-green);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .compound-box {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border: 1px solid rgba(74, 144, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .compound-box.skill {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .compound-box.capital {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .compound-box.psychology {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .compound-box.math {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .compound-box.anti {
-            background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%);
-            border-color: rgba(217, 74, 74, 0.3);
-        }
-
-        .compound-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 38px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .compound-box.skill h3 {
-            color: var(--accent-blue);
-        }
-
-        .compound-box.capital h3 {
-            color: var(--accent-gold);
-        }
-
-        .compound-box.psychology h3 {
-            color: var(--accent-purple);
-        }
-
-        .compound-box.math h3 {
-            color: var(--accent-green);
-        }
-
-        .compound-box.anti h3 {
-            color: var(--accent-red);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 22px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .compound-box.skill .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .compound-box.capital .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .compound-box.psychology .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .compound-box.math .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .compound-box.anti .feature-list li::before {
-            color: var(--accent-red);
-        }
-
-        .math-display {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.2) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border: 1px solid rgba(74, 217, 122, 0.4);
-            border-radius: 12px;
-            padding: 24px;
-            margin-top: 20px;
-            text-align: center;
-        }
-
-        .math-display .equation {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 28px;
-            color: var(--text-primary);
-            margin-bottom: 12px;
-        }
-
-        .math-display .result {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 48px;
-            font-weight: 600;
-            color: var(--accent-gold);
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-title .emphasis {
-            color: var(--accent-gold);
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        /* CTA styling */
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-green); }
+        .cta-text { font-family: var(--font-sans); font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>The Compound Effect in Trading</h1>
+        <p>7 slides · Growth Mindset</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 07</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">THE COMPOUND<br>EFFECT IN TRADING</h1>
-                        <p class="subtitle">Small gains. Big results. Over time.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="title">THE COMPOUND<br>EFFECT IN TRADING</h1>
+                    <p class="subtitle">Small gains. Massive results.</p>
                 </div>
+                <div class="slide-number">1 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 2: Skill Compounds -->
         <div class="slide-wrapper" data-slide="2">
-            <span class="slide-label">Slide 2 — Skill Compounds</span>
+            <span class="slide-label">Slide 2 — The Concept</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 07</span>
-                    <div class="center-content">
-                        <div class="compound-box skill">
-                            <h3>SKILL COMPOUNDS</h3>
-                            <ul class="feature-list">
-                                <li>1% better chart reading</li>
-                                <li>Slightly improved patience</li>
-                                <li>Marginally faster recognition</li>
-                                <li>Daily refinements add up</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="compound-box">
+                        <h3>THE CONCEPT</h3>
+                        <ul class="feature-list">
+                            <li>Small, consistent gains compound over time</li>
+                            <li>1% daily = 37x yearly (in theory)</li>
+                            <li>It's not about home runs</li>
+                            <li>Consistency beats intensity</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 3: Capital Compounds -->
         <div class="slide-wrapper" data-slide="3">
-            <span class="slide-label">Slide 3 — Capital Compounds</span>
+            <span class="slide-label">Slide 3 — The Math</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 07</span>
-                    <div class="center-content">
-                        <div class="compound-box capital">
-                            <h3>CAPITAL COMPOUNDS</h3>
-                            <ul class="feature-list">
-                                <li>Small consistent gains</li>
-                                <li>Preserved through discipline</li>
-                                <li>Grown through reinvestment</li>
-                                <li>Protected from big losses</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="compound-box math">
+                        <h3>THE MATH</h3>
+                        <ul class="feature-list">
+                            <li>$10K → 0.5% daily = $64K/year</li>
+                            <li>$10K → 1% daily = $377K/year</li>
+                            <li>But losses compound too</li>
+                            <li>Protect capital above all</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 4: Psychology Compounds -->
         <div class="slide-wrapper" data-slide="4">
-            <span class="slide-label">Slide 4 — Psychology Compounds</span>
+            <span class="slide-label">Slide 4 — The Reality</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 07</span>
-                    <div class="center-content">
-                        <div class="compound-box psychology">
-                            <h3>PSYCHOLOGY COMPOUNDS</h3>
-                            <ul class="feature-list">
-                                <li>Each controlled reaction</li>
-                                <li>Every rule followed</li>
-                                <li>Accumulated emotional stability</li>
-                                <li>Growing confidence</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="compound-box reality">
+                        <h3>THE REALITY CHECK</h3>
+                        <ul class="feature-list">
+                            <li>Daily consistency is unrealistic</li>
+                            <li>Drawdowns are inevitable</li>
+                            <li>Focus on weekly/monthly growth</li>
+                            <li>Process over perfection</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 5: The Math -->
         <div class="slide-wrapper" data-slide="5">
-            <span class="slide-label">Slide 5 — The Math</span>
+            <span class="slide-label">Slide 5 — The Mindset</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 07</span>
-                    <div class="center-content">
-                        <div class="compound-box math">
-                            <h3>THE MATH</h3>
-                            <ul class="feature-list">
-                                <li>1% daily improvement</li>
-                                <li>Tiny + consistent = massive</li>
-                            </ul>
-                            <div class="math-display">
-                                <p class="equation">1.01^365 =</p>
-                                <p class="result">37.78x better in one year</p>
-                            </div>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="compound-box mindset">
+                        <h3>THE MINDSET SHIFT</h3>
+                        <ul class="feature-list">
+                            <li>Think in months and years</li>
+                            <li>Each trade is one of thousands</li>
+                            <li>Patience is the real edge</li>
+                            <li>Let time work for you</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 6: The Anti-Compound -->
         <div class="slide-wrapper" data-slide="6">
-            <span class="slide-label">Slide 6 — The Anti-Compound</span>
+            <span class="slide-label">Slide 6 — Compound Habits</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 07</span>
-                    <div class="center-content">
-                        <div class="compound-box anti">
-                            <h3>THE ANTI-COMPOUND</h3>
-                            <ul class="feature-list">
-                                <li>Big losses that set you back</li>
-                                <li>Inconsistent effort</li>
-                                <li>Skipped journaling/review</li>
-                                <li>These compound negatively too</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="compound-box habits">
+                        <h3>COMPOUND YOUR HABITS</h3>
+                        <ul class="feature-list">
+                            <li>Daily journaling compounds knowledge</li>
+                            <li>Weekly reviews compound improvement</li>
+                            <li>Consistent risk management compounds capital</li>
+                            <li>Skills compound exponentially</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 7: CTA -->
         <div class="slide-wrapper" data-slide="7">
             <span class="slide-label">Slide 7 — CTA</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 07</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">You Don't Need Breakthroughs.<br>You Need <span class="emphasis">Consistency</span>.</h2>
-                        <p class="cta-text">Full article on blog</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Small Gains Today.<br><span class="emphasis">Massive Results</span> Tomorrow.</h2>
+                    <p class="cta-text">Full breakdown on blog</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">7 / 7</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        // Export mode functionality
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-475/carousel.html
+++ b/assets/social/post-475/carousel.html
@@ -4,479 +4,239 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 475 — OmniDeck Confluence Score Demo</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --accent-teal: #4ad9d9;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        /* Slide 1 - Hook */
+        .slide-1 .title { font-family: var(--font-serif); font-size: clamp(26px, 4.8vw, 52px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .slide-1 .subtitle { font-family: var(--font-sans); font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-teal); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        /* Confluence box styling */
+        .confluence-box { background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%); border: 1px solid rgba(74, 217, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: 90%; }
+        .confluence-box.what { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .confluence-box.how { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .confluence-box.use { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .confluence-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .confluence-box h3 { color: var(--accent-teal); }
+        .confluence-box.what h3 { color: var(--accent-blue); }
+        .confluence-box.how h3 { color: var(--accent-gold); }
+        .confluence-box.use h3 { color: var(--accent-green); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 58px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .confluence-box .feature-list li::before { color: var(--accent-teal); }
+        .confluence-box.what .feature-list li::before { color: var(--accent-blue); }
+        .confluence-box.how .feature-list li::before { color: var(--accent-gold); }
+        .confluence-box.use .feature-list li::before { color: var(--accent-green); }
 
-        .slide-title .product-name {
-            color: var(--accent-gold);
-        }
+        /* Visual placeholder */
+        .visual-placeholder { background: linear-gradient(135deg, rgba(74, 217, 217, 0.1) 0%, rgba(74, 217, 217, 0.02) 100%); border: 2px dashed rgba(74, 217, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(40px, 7.4vw, 80px) clamp(20px, 3.7vw, 40px); width: 100%; max-width: 90%; text-align: center; }
+        .visual-placeholder p { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 20px); color: var(--text-muted); margin-bottom: clamp(8px, 1.5vw, 16px); }
+        .visual-placeholder .visual-note { font-family: var(--font-sans); font-size: clamp(9px, 1.7vw, 18px); color: var(--accent-teal); font-style: italic; }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-blue);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .content-box {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border: 1px solid rgba(201, 169, 98, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .content-box.measures {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .content-box.works {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .content-box.interpret {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .content-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 38px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .content-box.measures h3 {
-            color: var(--accent-blue);
-        }
-
-        .content-box.works h3 {
-            color: var(--accent-green);
-        }
-
-        .content-box.interpret h3 {
-            color: var(--accent-purple);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 22px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .content-box.measures .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .content-box.works .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .content-box.interpret .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .visual-placeholder {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.1) 0%, rgba(201, 169, 98, 0.02) 100%);
-            border: 2px dashed rgba(201, 169, 98, 0.3);
-            border-radius: 16px;
-            padding: 80px 40px;
-            width: 100%;
-            max-width: 800px;
-            text-align: center;
-        }
-
-        .visual-placeholder p {
-            font-size: 20px;
-            color: var(--text-muted);
-            margin-bottom: 16px;
-        }
-
-        .visual-placeholder .visual-note {
-            font-size: 18px;
-            color: var(--accent-gold);
-            font-style: italic;
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        /* CTA styling */
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-teal); }
+        .cta-text { font-family: var(--font-sans); font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>OmniDeck Confluence Score Demo</h1>
+        <p>6 slides · Feature Demo</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 06</span>
-                    <div class="center-content">
-                        <h1 class="slide-title"><span class="product-name">OMNIDECK</span><br>CONFLUENCE SCORE</h1>
-                        <p class="subtitle">All signals. One number.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="title">OMNIDECK<br>CONFLUENCE SCORE</h1>
+                    <p class="subtitle">One number. Multiple signals.</p>
                 </div>
+                <div class="slide-number">1 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 2: What It Measures -->
         <div class="slide-wrapper" data-slide="2">
-            <span class="slide-label">Slide 2 — What It Measures</span>
+            <span class="slide-label">Slide 2 — What It Is</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 06</span>
-                    <div class="center-content">
-                        <div class="content-box measures">
-                            <h3>WHAT IT MEASURES</h3>
-                            <ul class="feature-list">
-                                <li>Pentarch cycle phase</li>
-                                <li>Volume Oracle regime</li>
-                                <li>Harmonic Oscillator momentum</li>
-                                <li>Plutus Flow direction</li>
-                                <li>Janus Atlas level proximity</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="confluence-box what">
+                        <h3>WHAT IT IS</h3>
+                        <ul class="feature-list">
+                            <li>Aggregated score from multiple indicators</li>
+                            <li>Real-time confluence measurement</li>
+                            <li>Ranges from -100 to +100</li>
+                            <li>Higher = stronger alignment</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 3: How It Works -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — How It Works</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 06</span>
-                    <div class="center-content">
-                        <div class="content-box works">
-                            <h3>HOW IT WORKS</h3>
-                            <ul class="feature-list">
-                                <li>Each indicator contributes</li>
-                                <li>Alignment increases score</li>
-                                <li>Divergence decreases score</li>
-                                <li>Real-time calculation</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="confluence-box how">
+                        <h3>HOW IT WORKS</h3>
+                        <ul class="feature-list">
+                            <li>Weighs trend, momentum, structure</li>
+                            <li>Combines session and volume data</li>
+                            <li>Factors in key levels</li>
+                            <li>Auto-updates with price</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 4: Demo Screenshot -->
         <div class="slide-wrapper" data-slide="4">
             <span class="slide-label">Slide 4 — Demo Screenshot</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 06</span>
-                    <div class="center-content">
-                        <div class="visual-placeholder">
-                            <p>[OmniDeck Interface]</p>
-                            <p>Confluence score meter with individual contributions</p>
-                            <p>Green: Contributing positively | Red: Contributing negatively</p>
-                            <span class="visual-note">The Commander unifies the Elite Seven</span>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="visual-placeholder">
+                        <p>[OmniDeck Panel Screenshot]</p>
+                        <p>Confluence Score: +72</p>
+                        <p>Bias: Bullish</p>
+                        <span class="visual-note">Strong alignment across all factors</span>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 5: Interpretation -->
         <div class="slide-wrapper" data-slide="5">
-            <span class="slide-label">Slide 5 — Interpretation</span>
+            <span class="slide-label">Slide 5 — How To Use</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 06</span>
-                    <div class="center-content">
-                        <div class="content-box interpret">
-                            <h3>INTERPRETATION</h3>
-                            <ul class="feature-list">
-                                <li>High confluence = multiple agreements</li>
-                                <li>Low confluence = mixed signals</li>
-                                <li>Not a buy/sell signal</li>
-                                <li>Context for your decisions</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="confluence-box use">
+                        <h3>HOW TO USE IT</h3>
+                        <ul class="feature-list">
+                            <li>Filter trades by score threshold</li>
+                            <li>High score = high conviction entry</li>
+                            <li>Avoid low-score setups</li>
+                            <li>Use as confirmation, not entry</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 6: CTA -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — CTA</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 06</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Stop Juggling Indicators.<br>Read One Score.</h2>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Confluence Made<br><span class="emphasis">Simple</span></h2>
+                    <p class="cta-text">Available in OmniDeck</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">6 / 6</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        // Export mode functionality
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-476/carousel.html
+++ b/assets/social/post-476/carousel.html
@@ -4,555 +4,286 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 476 — Institutional Order Flow Concepts</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --accent-orange: #d9884a;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --accent-teal: #4ad9d9;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        /* Slide 1 - Hook */
+        .slide-1 .title { font-family: var(--font-serif); font-size: clamp(26px, 4.8vw, 52px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .slide-1 .subtitle { font-family: var(--font-sans); font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-purple); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        /* Flow box styling */
+        .flow-box { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border: 1px solid rgba(155, 74, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: 90%; }
+        .flow-box.what { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .flow-box.liquidity { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .flow-box.accumulation { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .flow-box.distribution { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border-color: rgba(217, 74, 74, 0.3); }
+        .flow-box.signs { background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%); border-color: rgba(74, 217, 217, 0.3); }
+        .flow-box.apply { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .flow-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .flow-box h3 { color: var(--accent-purple); }
+        .flow-box.what h3 { color: var(--accent-blue); }
+        .flow-box.liquidity h3 { color: var(--accent-gold); }
+        .flow-box.accumulation h3 { color: var(--accent-green); }
+        .flow-box.distribution h3 { color: var(--accent-red); }
+        .flow-box.signs h3 { color: var(--accent-teal); }
+        .flow-box.apply h3 { color: var(--accent-purple); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 52px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .flow-box .feature-list li::before { color: var(--accent-purple); }
+        .flow-box.what .feature-list li::before { color: var(--accent-blue); }
+        .flow-box.liquidity .feature-list li::before { color: var(--accent-gold); }
+        .flow-box.accumulation .feature-list li::before { color: var(--accent-green); }
+        .flow-box.distribution .feature-list li::before { color: var(--accent-red); }
+        .flow-box.signs .feature-list li::before { color: var(--accent-teal); }
+        .flow-box.apply .feature-list li::before { color: var(--accent-purple); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-gold);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .flow-box {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border: 1px solid rgba(74, 144, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .flow-box.volume {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .flow-box.displacement {
-            background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%);
-            border-color: rgba(217, 136, 74, 0.3);
-        }
-
-        .flow-box.absorption {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .flow-box.matters {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .flow-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 38px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .flow-box.volume h3 {
-            color: var(--accent-blue);
-        }
-
-        .flow-box.displacement h3 {
-            color: var(--accent-orange);
-        }
-
-        .flow-box.absorption h3 {
-            color: var(--accent-purple);
-        }
-
-        .flow-box.matters h3 {
-            color: var(--accent-green);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 22px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .flow-box.volume .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .flow-box.displacement .feature-list li::before {
-            color: var(--accent-orange);
-        }
-
-        .flow-box.absorption .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .flow-box.matters .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .visual-placeholder {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.1) 0%, rgba(201, 169, 98, 0.02) 100%);
-            border: 2px dashed rgba(201, 169, 98, 0.3);
-            border-radius: 16px;
-            padding: 80px 40px;
-            width: 100%;
-            max-width: 800px;
-            text-align: center;
-        }
-
-        .visual-placeholder.volume {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.1) 0%, rgba(74, 144, 217, 0.02) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .visual-placeholder.displacement {
-            background: linear-gradient(135deg, rgba(217, 136, 74, 0.1) 0%, rgba(217, 136, 74, 0.02) 100%);
-            border-color: rgba(217, 136, 74, 0.3);
-        }
-
-        .visual-placeholder p {
-            font-size: 20px;
-            color: var(--text-muted);
-            margin-bottom: 16px;
-        }
-
-        .visual-placeholder .visual-note {
-            font-size: 18px;
-            font-style: italic;
-        }
-
-        .visual-placeholder.volume .visual-note {
-            color: var(--accent-blue);
-        }
-
-        .visual-placeholder.displacement .visual-note {
-            color: var(--accent-orange);
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 44px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        /* CTA styling */
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-purple); }
+        .cta-text { font-family: var(--font-sans); font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Institutional Order Flow Concepts</h1>
+        <p>8 slides · Order Flow</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 08</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">INSTITUTIONAL<br>ORDER FLOW<br>CONCEPTS</h1>
-                        <p class="subtitle">Big money leaves big footprints.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="title">INSTITUTIONAL<br>ORDER FLOW<br>CONCEPTS</h1>
+                    <p class="subtitle">Follow the smart money.</p>
                 </div>
+                <div class="slide-number">1 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 2: Volume Anomalies -->
         <div class="slide-wrapper" data-slide="2">
-            <span class="slide-label">Slide 2 — Volume Anomalies</span>
+            <span class="slide-label">Slide 2 — What It Is</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 08</span>
-                    <div class="center-content">
-                        <div class="flow-box volume">
-                            <h3>VOLUME ANOMALIES</h3>
-                            <ul class="feature-list">
-                                <li>Unusual volume on specific candles</li>
-                                <li>Spikes at key levels</li>
-                                <li>Plutus Flow detects these</li>
-                                <li>Signs of large orders</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="flow-box what">
+                        <h3>WHAT IS ORDER FLOW?</h3>
+                        <ul class="feature-list">
+                            <li>The process of buying and selling</li>
+                            <li>Institutions move markets</li>
+                            <li>They leave footprints</li>
+                            <li>Price reflects order imbalance</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 3: Displacement -->
         <div class="slide-wrapper" data-slide="3">
-            <span class="slide-label">Slide 3 — Displacement</span>
+            <span class="slide-label">Slide 3 — Liquidity</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 08</span>
-                    <div class="center-content">
-                        <div class="flow-box displacement">
-                            <h3>DISPLACEMENT</h3>
-                            <ul class="feature-list">
-                                <li>Large, fast moves</li>
-                                <li>Creates FVGs and imbalances</li>
-                                <li>Shows urgency</li>
-                                <li>Institutional intent revealed</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="flow-box liquidity">
+                        <h3>LIQUIDITY CONCEPTS</h3>
+                        <ul class="feature-list">
+                            <li>Stop losses = liquidity pools</li>
+                            <li>Price seeks liquidity</li>
+                            <li>Highs and lows are targets</li>
+                            <li>Institutions need liquidity to fill orders</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 4: Absorption -->
         <div class="slide-wrapper" data-slide="4">
-            <span class="slide-label">Slide 4 — Absorption</span>
+            <span class="slide-label">Slide 4 — Accumulation</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 08</span>
-                    <div class="center-content">
-                        <div class="flow-box absorption">
-                            <h3>ABSORPTION</h3>
-                            <ul class="feature-list">
-                                <li>Price stalls despite volume</li>
-                                <li>Orders being filled without movement</li>
-                                <li>Often precedes breakouts</li>
-                                <li>Hidden accumulation/distribution</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="flow-box accumulation">
+                        <h3>ACCUMULATION</h3>
+                        <ul class="feature-list">
+                            <li>Institutions build positions</li>
+                            <li>Done quietly in ranges</li>
+                            <li>Absorbs selling pressure</li>
+                            <li>Precedes bullish moves</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 5: Volume Visual -->
         <div class="slide-wrapper" data-slide="5">
-            <span class="slide-label">Slide 5 — Volume Visual</span>
+            <span class="slide-label">Slide 5 — Distribution</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 08</span>
-                    <div class="center-content">
-                        <div class="visual-placeholder volume">
-                            <p>[TradingView Chart]</p>
-                            <p>Volume spike at key level with price reaction</p>
-                            <span class="visual-note">Volume anomaly = institutional activity</span>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="flow-box distribution">
+                        <h3>DISTRIBUTION</h3>
+                        <ul class="feature-list">
+                            <li>Institutions offload positions</li>
+                            <li>Often at market highs</li>
+                            <li>Sells into retail buying</li>
+                            <li>Precedes bearish moves</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 6: Displacement Visual -->
         <div class="slide-wrapper" data-slide="6">
-            <span class="slide-label">Slide 6 — Displacement Visual</span>
+            <span class="slide-label">Slide 6 — Signs</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 08</span>
-                    <div class="center-content">
-                        <div class="visual-placeholder displacement">
-                            <p>[TradingView Chart]</p>
-                            <p>Displacement candle creating FVG</p>
-                            <span class="visual-note">Large candle = institutional urgency</span>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="flow-box signs">
+                        <h3>SIGNS OF INSTITUTIONAL FLOW</h3>
+                        <ul class="feature-list">
+                            <li>Large wicks / sweeps</li>
+                            <li>Quick reversals at key levels</li>
+                            <li>Volume spikes at extremes</li>
+                            <li>Failed breakouts</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 7: Why It Matters -->
         <div class="slide-wrapper" data-slide="7">
-            <span class="slide-label">Slide 7 — Why It Matters</span>
+            <span class="slide-label">Slide 7 — How To Apply</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 08</span>
-                    <div class="center-content">
-                        <div class="flow-box matters">
-                            <h3>WHY IT MATTERS</h3>
-                            <ul class="feature-list">
-                                <li>Retail follows. Institutions lead.</li>
-                                <li>Reading flow = reading intent</li>
-                                <li>Context for your setups</li>
-                                <li>Trade with the big money, not against it</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="flow-box apply">
+                        <h3>HOW TO APPLY</h3>
+                        <ul class="feature-list">
+                            <li>Mark liquidity pools</li>
+                            <li>Wait for sweeps before entries</li>
+                            <li>Trade with the flow, not against</li>
+                            <li>Patience is essential</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">7 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 8: CTA -->
         <div class="slide-wrapper" data-slide="8">
             <span class="slide-label">Slide 8 — CTA</span>
             <div class="slide slide-8">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">08 / 08</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">See What Big Money Does,<br>Not Says.</h2>
-                        <p class="cta-text">Full lesson in curriculum</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Trade With the<br><span class="emphasis">Smart Money</span></h2>
+                    <p class="cta-text">Full lesson in curriculum</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">8 / 8</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-477/carousel.html
+++ b/assets/social/post-477/carousel.html
@@ -4,513 +4,260 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 477 — Why Demo Trading Isn't Enough</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --accent-orange: #d9884a;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        /* Slide 1 - Hook */
+        .slide-1 .title { font-family: var(--font-serif); font-size: clamp(26px, 4.8vw, 52px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .slide-1 .subtitle { font-family: var(--font-sans); font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-orange); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        /* Demo box styling */
+        .demo-box { background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%); border: 1px solid rgba(217, 136, 74, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: 90%; }
+        .demo-box.good { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .demo-box.missing { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border-color: rgba(217, 74, 74, 0.3); }
+        .demo-box.transition { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .demo-box.real { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .demo-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .demo-box h3 { color: var(--accent-orange); }
+        .demo-box.good h3 { color: var(--accent-green); }
+        .demo-box.missing h3 { color: var(--accent-red); }
+        .demo-box.transition h3 { color: var(--accent-blue); }
+        .demo-box.real h3 { color: var(--accent-gold); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 54px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .demo-box .feature-list li::before { color: var(--accent-orange); }
+        .demo-box.good .feature-list li::before { color: var(--accent-green); }
+        .demo-box.missing .feature-list li::before { color: var(--accent-red); }
+        .demo-box.transition .feature-list li::before { color: var(--accent-blue); }
+        .demo-box.real .feature-list li::before { color: var(--accent-gold); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-purple);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .demo-box {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border: 1px solid rgba(74, 217, 122, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .demo-box.teaches {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .demo-box.doesnt {
-            background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%);
-            border-color: rgba(217, 74, 74, 0.3);
-        }
-
-        .demo-box.gap {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .demo-box.bridge {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .demo-box.balance {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .demo-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 36px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .demo-box.teaches h3 {
-            color: var(--accent-green);
-        }
-
-        .demo-box.doesnt h3 {
-            color: var(--accent-red);
-        }
-
-        .demo-box.gap h3 {
-            color: var(--accent-purple);
-        }
-
-        .demo-box.bridge h3 {
-            color: var(--accent-blue);
-        }
-
-        .demo-box.balance h3 {
-            color: var(--accent-gold);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 21px;
-            color: var(--text-primary);
-            padding: 9px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            position: absolute;
-            left: 0;
-        }
-
-        .demo-box.teaches .feature-list li::before {
-            content: "✓";
-            color: var(--accent-green);
-        }
-
-        .demo-box.doesnt .feature-list li::before {
-            content: "✗";
-            color: var(--accent-red);
-        }
-
-        .demo-box.gap .feature-list li::before {
-            content: "→";
-            color: var(--accent-purple);
-        }
-
-        .demo-box.bridge .feature-list li::before {
-            content: "→";
-            color: var(--accent-blue);
-        }
-
-        .demo-box.balance .feature-list li::before {
-            content: "→";
-            color: var(--accent-gold);
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 40px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        /* CTA styling */
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-orange); }
+        .cta-text { font-family: var(--font-sans); font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Why Demo Trading Isn't Enough</h1>
+        <p>7 slides · Trading Psychology</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 07</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">WHY DEMO TRADING<br>ISN'T ENOUGH</h1>
-                        <p class="subtitle">Practice ≠ Performance</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="title">WHY DEMO<br>TRADING ISN'T<br>ENOUGH</h1>
+                    <p class="subtitle">The gap between practice and real.</p>
                 </div>
+                <div class="slide-number">1 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 2: What Demo Teaches -->
         <div class="slide-wrapper" data-slide="2">
-            <span class="slide-label">Slide 2 — What Demo Teaches</span>
+            <span class="slide-label">Slide 2 — What Demo Is Good For</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 07</span>
-                    <div class="center-content">
-                        <div class="demo-box teaches">
-                            <h3>WHAT DEMO TEACHES</h3>
-                            <ul class="feature-list">
-                                <li>Platform mechanics</li>
-                                <li>Order execution</li>
-                                <li>Strategy basics</li>
-                                <li>Pattern recognition</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="demo-box good">
+                        <h3>WHAT DEMO IS GOOD FOR</h3>
+                        <ul class="feature-list">
+                            <li>Learning platform mechanics</li>
+                            <li>Testing strategy logic</li>
+                            <li>Building initial screen time</li>
+                            <li>Risk-free experimentation</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 3: What Demo Doesn't Teach -->
         <div class="slide-wrapper" data-slide="3">
-            <span class="slide-label">Slide 3 — What Demo Doesn't Teach</span>
+            <span class="slide-label">Slide 3 — What Demo Is Missing</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 07</span>
-                    <div class="center-content">
-                        <div class="demo-box doesnt">
-                            <h3>WHAT DEMO DOESN'T TEACH</h3>
-                            <ul class="feature-list">
-                                <li>Fear of real loss</li>
-                                <li>Greed with real gains</li>
-                                <li>FOMO when money's on the line</li>
-                                <li>Discipline under pressure</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="demo-box missing">
+                        <h3>WHAT DEMO IS MISSING</h3>
+                        <ul class="feature-list">
+                            <li>Real emotional pressure</li>
+                            <li>Fear of losing real money</li>
+                            <li>Greed when positions run</li>
+                            <li>The pain of actual loss</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 4: The Gap -->
         <div class="slide-wrapper" data-slide="4">
-            <span class="slide-label">Slide 4 — The Gap</span>
+            <span class="slide-label">Slide 4 — The Psychology Gap</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 07</span>
-                    <div class="center-content">
-                        <div class="demo-box gap">
-                            <h3>THE GAP</h3>
-                            <ul class="feature-list">
-                                <li>Demo you follows rules perfectly</li>
-                                <li>Live you feels every tick</li>
-                                <li>Different mental game entirely</li>
-                                <li>Psychology can't be practiced with fake money</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="demo-box">
+                        <h3>THE PSYCHOLOGY GAP</h3>
+                        <ul class="feature-list">
+                            <li>Demo winners often become live losers</li>
+                            <li>Emotions override logic with real stakes</li>
+                            <li>Hesitation, revenge trading emerge</li>
+                            <li>Psychology is 80% of trading</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 5: The Bridge -->
         <div class="slide-wrapper" data-slide="5">
-            <span class="slide-label">Slide 5 — The Bridge</span>
+            <span class="slide-label">Slide 5 — The Transition</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 07</span>
-                    <div class="center-content">
-                        <div class="demo-box bridge">
-                            <h3>THE BRIDGE</h3>
-                            <ul class="feature-list">
-                                <li>Small real positions</li>
-                                <li>Micro accounts</li>
-                                <li>Risk what you can afford to lose</li>
-                                <li>Learn emotions with real stakes</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="demo-box transition">
+                        <h3>THE RIGHT TRANSITION</h3>
+                        <ul class="feature-list">
+                            <li>Start with micro accounts</li>
+                            <li>Trade the smallest size possible</li>
+                            <li>Make losses small but real</li>
+                            <li>Build emotional tolerance gradually</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 6: The Balance -->
         <div class="slide-wrapper" data-slide="6">
-            <span class="slide-label">Slide 6 — The Balance</span>
+            <span class="slide-label">Slide 6 — Real Stakes, Real Growth</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 07</span>
-                    <div class="center-content">
-                        <div class="demo-box balance">
-                            <h3>THE BALANCE</h3>
-                            <ul class="feature-list">
-                                <li>Demo for new strategies</li>
-                                <li>Live (small) for psychology</li>
-                                <li>Scale up gradually</li>
-                                <li>Never skip the emotional education</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="demo-box real">
+                        <h3>REAL STAKES, REAL GROWTH</h3>
+                        <ul class="feature-list">
+                            <li>Only real money teaches discipline</li>
+                            <li>Mistakes that cost teach best</li>
+                            <li>Confidence comes from live results</li>
+                            <li>The market is the true teacher</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 7: CTA -->
         <div class="slide-wrapper" data-slide="7">
             <span class="slide-label">Slide 7 — CTA</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 07</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Demo Forever =<br>Avoiding the Real Lesson</h2>
-                        <p class="cta-text">Full article on blog</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Demo Trains Strategy.<br><span class="emphasis">Live</span> Trains Psychology.</h2>
+                    <p class="cta-text">Full article on blog</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">7 / 7</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-479/carousel.html
+++ b/assets/social/post-479/carousel.html
@@ -4,556 +4,287 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 479 — Asian Range Strategy Concepts</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
+            --accent-teal: #4ad9d9;
             --accent-orange: #d9884a;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        /* Slide 1 - Hook */
+        .slide-1 .title { font-family: var(--font-serif); font-size: clamp(26px, 4.8vw, 52px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .slide-1 .subtitle { font-family: var(--font-sans); font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-blue); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        /* Asian box styling */
+        .asian-box { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border: 1px solid rgba(74, 144, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: 90%; }
+        .asian-box.what { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .asian-box.why { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .asian-box.high { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .asian-box.low { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border-color: rgba(217, 74, 74, 0.3); }
+        .asian-box.strategy { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
+        .asian-box.tips { background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%); border-color: rgba(74, 217, 217, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .asian-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .asian-box h3 { color: var(--accent-blue); }
+        .asian-box.what h3 { color: var(--accent-blue); }
+        .asian-box.why h3 { color: var(--accent-gold); }
+        .asian-box.high h3 { color: var(--accent-green); }
+        .asian-box.low h3 { color: var(--accent-red); }
+        .asian-box.strategy h3 { color: var(--accent-purple); }
+        .asian-box.tips h3 { color: var(--accent-teal); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 54px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .asian-box .feature-list li::before { color: var(--accent-blue); }
+        .asian-box.what .feature-list li::before { color: var(--accent-blue); }
+        .asian-box.why .feature-list li::before { color: var(--accent-gold); }
+        .asian-box.high .feature-list li::before { color: var(--accent-green); }
+        .asian-box.low .feature-list li::before { color: var(--accent-red); }
+        .asian-box.strategy .feature-list li::before { color: var(--accent-purple); }
+        .asian-box.tips .feature-list li::before { color: var(--accent-teal); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-blue);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .step-box {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border: 1px solid rgba(74, 144, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .step-box.concept {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .step-box.why {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .step-box.step1 {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .step-box.step2 {
-            background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%);
-            border-color: rgba(217, 136, 74, 0.3);
-        }
-
-        .step-box.step3 {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .step-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 38px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .step-box.concept h3 {
-            color: var(--accent-blue);
-        }
-
-        .step-box.why h3 {
-            color: var(--accent-green);
-        }
-
-        .step-box.step1 h3 {
-            color: var(--accent-gold);
-        }
-
-        .step-box.step2 h3 {
-            color: var(--accent-orange);
-        }
-
-        .step-box.step3 h3 {
-            color: var(--accent-purple);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 22px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .step-box.concept .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .step-box.why .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .step-box.step1 .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .step-box.step2 .feature-list li::before {
-            color: var(--accent-orange);
-        }
-
-        .step-box.step3 .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .visual-placeholder {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.1) 0%, rgba(201, 169, 98, 0.02) 100%);
-            border: 2px dashed rgba(201, 169, 98, 0.3);
-            border-radius: 16px;
-            padding: 80px 40px;
-            width: 100%;
-            max-width: 800px;
-            text-align: center;
-        }
-
-        .visual-placeholder p {
-            font-size: 20px;
-            color: var(--text-muted);
-            margin-bottom: 16px;
-        }
-
-        .visual-placeholder .visual-note {
-            font-size: 18px;
-            color: var(--accent-gold);
-            font-style: italic;
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 48px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        /* CTA styling */
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-blue); }
+        .cta-text { font-family: var(--font-sans); font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Asian Range Strategy Concepts</h1>
+        <p>8 slides · Session Strategy</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 08</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">ASIAN RANGE<br>STRATEGY CONCEPTS</h1>
-                        <p class="subtitle">The setup before the show.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="title">ASIAN RANGE<br>STRATEGY CONCEPTS</h1>
+                    <p class="subtitle">The quiet hours that set up the day.</p>
                 </div>
+                <div class="slide-number">1 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 2: The Concept -->
         <div class="slide-wrapper" data-slide="2">
-            <span class="slide-label">Slide 2 — The Concept</span>
+            <span class="slide-label">Slide 2 — What It Is</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 08</span>
-                    <div class="center-content">
-                        <div class="step-box concept">
-                            <h3>THE CONCEPT</h3>
-                            <ul class="feature-list">
-                                <li>Mark Asian session high and low</li>
-                                <li>These become targets for later sessions</li>
-                                <li>London/NY often sweep one side</li>
-                                <li>Real move often follows the sweep</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="asian-box what">
+                        <h3>WHAT IS THE ASIAN RANGE?</h3>
+                        <ul class="feature-list">
+                            <li>Price range during Asian session</li>
+                            <li>Typically 7pm - 12am EST</li>
+                            <li>Often consolidation / low volatility</li>
+                            <li>Defines high and low for the day</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 3: Why It Works -->
         <div class="slide-wrapper" data-slide="3">
-            <span class="slide-label">Slide 3 — Why It Works</span>
+            <span class="slide-label">Slide 3 — Why It Matters</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 08</span>
-                    <div class="center-content">
-                        <div class="step-box why">
-                            <h3>WHY IT WORKS</h3>
-                            <ul class="feature-list">
-                                <li>Asian range builds liquidity</li>
-                                <li>Stops accumulate above and below</li>
-                                <li>Active sessions hunt this liquidity</li>
-                                <li>Sweep creates entry opportunity</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="asian-box why">
+                        <h3>WHY IT MATTERS</h3>
+                        <ul class="feature-list">
+                            <li>Liquidity builds at range extremes</li>
+                            <li>London often sweeps these levels</li>
+                            <li>Sets bias for directional trades</li>
+                            <li>Key reference for entries</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 4: Step 1 -->
         <div class="slide-wrapper" data-slide="4">
-            <span class="slide-label">Slide 4 — Step 1</span>
+            <span class="slide-label">Slide 4 — Asian High</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 08</span>
-                    <div class="center-content">
-                        <div class="step-box step1">
-                            <h3>STEP 1: MARK THE RANGE</h3>
-                            <ul class="feature-list">
-                                <li>Identify Asian session (7pm-12am EST)</li>
-                                <li>Mark the high</li>
-                                <li>Mark the low</li>
-                                <li>Wait for session close</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="asian-box high">
+                        <h3>ASIAN HIGH</h3>
+                        <ul class="feature-list">
+                            <li>Upper boundary of the range</li>
+                            <li>Resistance for the session</li>
+                            <li>Sweep = potential short entry</li>
+                            <li>Break = bullish continuation</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 5: Step 2 -->
         <div class="slide-wrapper" data-slide="5">
-            <span class="slide-label">Slide 5 — Step 2</span>
+            <span class="slide-label">Slide 5 — Asian Low</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 08</span>
-                    <div class="center-content">
-                        <div class="step-box step2">
-                            <h3>STEP 2: WAIT FOR SWEEP</h3>
-                            <ul class="feature-list">
-                                <li>London or NY opens</li>
-                                <li>Watch for break of Asian high or low</li>
-                                <li>Quick wick and reversal = sweep</li>
-                                <li>Sustained break = possible trend</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="asian-box low">
+                        <h3>ASIAN LOW</h3>
+                        <ul class="feature-list">
+                            <li>Lower boundary of the range</li>
+                            <li>Support for the session</li>
+                            <li>Sweep = potential long entry</li>
+                            <li>Break = bearish continuation</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 6: Step 3 -->
         <div class="slide-wrapper" data-slide="6">
-            <span class="slide-label">Slide 6 — Step 3</span>
+            <span class="slide-label">Slide 6 — Strategy</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 08</span>
-                    <div class="center-content">
-                        <div class="step-box step3">
-                            <h3>STEP 3: LOOK FOR REVERSAL</h3>
-                            <ul class="feature-list">
-                                <li>After sweep, look for reversal setup</li>
-                                <li>Confirmation from price action</li>
-                                <li>Target opposite side of range or beyond</li>
-                                <li>Manage risk appropriately</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="asian-box strategy">
+                        <h3>THE STRATEGY</h3>
+                        <ul class="feature-list">
+                            <li>Mark Asian high and low</li>
+                            <li>Wait for London to sweep one side</li>
+                            <li>Look for reversal confirmation</li>
+                            <li>Target opposite side of range</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 7: Chart Visual -->
         <div class="slide-wrapper" data-slide="7">
-            <span class="slide-label">Slide 7 — Chart Visual</span>
+            <span class="slide-label">Slide 7 — Tips</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 08</span>
-                    <div class="center-content">
-                        <div class="visual-placeholder">
-                            <p>[TradingView Chart]</p>
-                            <p>Asian range marked, London sweep of high</p>
-                            <p>Reversal and move toward low</p>
-                            <span class="visual-note">Asian (blue) | London (orange) | Move (green)</span>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="asian-box tips">
+                        <h3>PRACTICAL TIPS</h3>
+                        <ul class="feature-list">
+                            <li>Works best on major pairs</li>
+                            <li>Combine with session timing</li>
+                            <li>Use SMC for confirmation</li>
+                            <li>Be patient for the sweep</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">7 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 8: CTA -->
         <div class="slide-wrapper" data-slide="8">
             <span class="slide-label">Slide 8 — CTA</span>
             <div class="slide slide-8">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">08 / 08</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Simple. Repeatable.<br>Educational.</h2>
-                        <p class="cta-text">Full lesson in curriculum</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">The Asian Range<br>Sets Up the <span class="emphasis">Day</span></h2>
+                    <p class="cta-text">Full breakdown on blog</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">8 / 8</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-480/carousel.html
+++ b/assets/social/post-480/carousel.html
@@ -4,481 +4,240 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 480 — Keyboard Shortcuts Guide</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --accent-teal: #4ad9d9;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        /* Slide 1 - Hook */
+        .slide-1 .title { font-family: var(--font-serif); font-size: clamp(28px, 5.2vw, 56px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .slide-1 .subtitle { font-family: var(--font-sans); font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-teal); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        /* Keyboard box styling */
+        .keyboard-box { background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%); border: 1px solid rgba(74, 217, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: 90%; }
+        .keyboard-box.chart { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .keyboard-box.drawing { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .keyboard-box.execution { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .keyboard-box.pro { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .keyboard-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .keyboard-box h3 { color: var(--accent-teal); }
+        .keyboard-box.chart h3 { color: var(--accent-blue); }
+        .keyboard-box.drawing h3 { color: var(--accent-gold); }
+        .keyboard-box.execution h3 { color: var(--accent-green); }
+        .keyboard-box.pro h3 { color: var(--accent-purple); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 58px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .keyboard-box .feature-list li::before { color: var(--accent-teal); }
+        .keyboard-box.chart .feature-list li::before { color: var(--accent-blue); }
+        .keyboard-box.drawing .feature-list li::before { color: var(--accent-gold); }
+        .keyboard-box.execution .feature-list li::before { color: var(--accent-green); }
+        .keyboard-box.pro .feature-list li::before { color: var(--accent-purple); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-teal);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .shortcut-box {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border: 1px solid rgba(74, 144, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .shortcut-box.timeframes {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .shortcut-box.drawing {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .shortcut-box.navigation {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .shortcut-box.protips {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .shortcut-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 38px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .shortcut-box.timeframes h3 {
-            color: var(--accent-blue);
-        }
-
-        .shortcut-box.drawing h3 {
-            color: var(--accent-green);
-        }
-
-        .shortcut-box.navigation h3 {
-            color: var(--accent-gold);
-        }
-
-        .shortcut-box.protips h3 {
-            color: var(--accent-purple);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 22px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .shortcut-box.timeframes .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .shortcut-box.drawing .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .shortcut-box.navigation .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .shortcut-box.protips .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .key-badge {
-            display: inline-block;
-            background: rgba(255, 255, 255, 0.1);
-            border: 1px solid rgba(255, 255, 255, 0.2);
-            border-radius: 6px;
-            padding: 4px 10px;
-            font-family: 'Inter', monospace;
-            font-size: 16px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-right: 8px;
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 40px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        /* CTA styling */
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-teal); }
+        .cta-text { font-family: var(--font-sans); font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Keyboard Shortcuts Guide</h1>
+        <p>6 slides · TradingView Tips</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 06</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">KEYBOARD<br>SHORTCUTS GUIDE</h1>
-                        <p class="subtitle">Speed is an edge.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="title">KEYBOARD<br>SHORTCUTS GUIDE</h1>
+                    <p class="subtitle">Speed up your workflow.</p>
                 </div>
+                <div class="slide-number">1 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 2: Timeframes -->
         <div class="slide-wrapper" data-slide="2">
-            <span class="slide-label">Slide 2 — Timeframes</span>
+            <span class="slide-label">Slide 2 — Chart Navigation</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 06</span>
-                    <div class="center-content">
-                        <div class="shortcut-box timeframes">
-                            <h3>TIMEFRAMES</h3>
-                            <ul class="feature-list">
-                                <li><span class="key-badge">1-9</span> Number keys for presets</li>
-                                <li>Quick switching without clicking</li>
-                                <li>Customize in settings</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="keyboard-box chart">
+                        <h3>CHART NAVIGATION</h3>
+                        <ul class="feature-list">
+                            <li>Alt + T → Trendline tool</li>
+                            <li>Alt + H → Horizontal line</li>
+                            <li>Alt + F → Fibonacci tool</li>
+                            <li>Ctrl + Z → Undo last action</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 3: Drawing Tools -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — Drawing Tools</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 06</span>
-                    <div class="center-content">
-                        <div class="shortcut-box drawing">
-                            <h3>DRAWING TOOLS</h3>
-                            <ul class="feature-list">
-                                <li><span class="key-badge">Alt+T</span> Trendline</li>
-                                <li><span class="key-badge">Alt+H</span> Horizontal line</li>
-                                <li><span class="key-badge">Alt+F</span> Fibonacci</li>
-                                <li>Speed up your markup</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="keyboard-box drawing">
+                        <h3>DRAWING TOOLS</h3>
+                        <ul class="feature-list">
+                            <li>Alt + V → Vertical line</li>
+                            <li>Alt + R → Rectangle</li>
+                            <li>Ctrl + Click → Multi-select</li>
+                            <li>Delete → Remove selected</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 4: Navigation -->
         <div class="slide-wrapper" data-slide="4">
-            <span class="slide-label">Slide 4 — Navigation</span>
+            <span class="slide-label">Slide 4 — Trade Execution</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 06</span>
-                    <div class="center-content">
-                        <div class="shortcut-box navigation">
-                            <h3>NAVIGATION</h3>
-                            <ul class="feature-list">
-                                <li><span class="key-badge">← →</span> Move chart</li>
-                                <li><span class="key-badge">+ -</span> Zoom in/out</li>
-                                <li><span class="key-badge">Home</span> Go to current</li>
-                                <li><span class="key-badge">Esc</span> Cancel action</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="keyboard-box execution">
+                        <h3>TRADE EXECUTION</h3>
+                        <ul class="feature-list">
+                            <li>Shift + B → Buy order</li>
+                            <li>Shift + S → Sell order</li>
+                            <li>Shift + T → Trading panel</li>
+                            <li>Esc → Cancel / Exit</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 5: Pro Tips -->
         <div class="slide-wrapper" data-slide="5">
             <span class="slide-label">Slide 5 — Pro Tips</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 06</span>
-                    <div class="center-content">
-                        <div class="shortcut-box protips">
-                            <h3>PRO TIPS</h3>
-                            <ul class="feature-list">
-                                <li><span class="key-badge">Alt+S</span> Screenshot</li>
-                                <li><span class="key-badge">Alt+W</span> Add to watchlist</li>
-                                <li>Set custom hotkeys for indicator visibility</li>
-                                <li>Practice until muscle memory</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="keyboard-box pro">
+                        <h3>PRO TIPS</h3>
+                        <ul class="feature-list">
+                            <li>Space → Toggle crosshair</li>
+                            <li>/ → Quick search symbols</li>
+                            <li>, → Change timeframes</li>
+                            <li>Customize in Settings</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 6: CTA -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — CTA</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 06</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Faster Workflow =<br>More Time for Analysis</h2>
-                        <p class="cta-text">Full guide in docs</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Work Smarter,<br><span class="emphasis">Not Harder</span></h2>
+                    <p class="cta-text">Full shortcuts list in docs</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">6 / 6</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-482/carousel.html
+++ b/assets/social/post-482/carousel.html
@@ -4,568 +4,287 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 482 — Power of Three (AMD)</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
+            --accent-teal: #4ad9d9;
             --accent-orange: #d9884a;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        /* Slide 1 - Hook */
+        .slide-1 .title { font-family: var(--font-serif); font-size: clamp(30px, 5.6vw, 60px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .slide-1 .subtitle { font-family: var(--font-sans); font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-purple); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        /* AMD box styling */
+        .amd-box { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border: 1px solid rgba(155, 74, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: 90%; }
+        .amd-box.what { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .amd-box.accumulation { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .amd-box.manipulation { background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%); border-color: rgba(217, 136, 74, 0.3); }
+        .amd-box.distribution { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border-color: rgba(217, 74, 74, 0.3); }
+        .amd-box.how { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .amd-box.identify { background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%); border-color: rgba(74, 217, 217, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .amd-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .amd-box h3 { color: var(--accent-purple); }
+        .amd-box.what h3 { color: var(--accent-blue); }
+        .amd-box.accumulation h3 { color: var(--accent-green); }
+        .amd-box.manipulation h3 { color: var(--accent-orange); }
+        .amd-box.distribution h3 { color: var(--accent-red); }
+        .amd-box.how h3 { color: var(--accent-gold); }
+        .amd-box.identify h3 { color: var(--accent-teal); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 58px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-family: var(--font-sans); font-size: clamp(10px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .amd-box .feature-list li::before { color: var(--accent-purple); }
+        .amd-box.what .feature-list li::before { color: var(--accent-blue); }
+        .amd-box.accumulation .feature-list li::before { color: var(--accent-green); }
+        .amd-box.manipulation .feature-list li::before { color: var(--accent-orange); }
+        .amd-box.distribution .feature-list li::before { color: var(--accent-red); }
+        .amd-box.how .feature-list li::before { color: var(--accent-gold); }
+        .amd-box.identify .feature-list li::before { color: var(--accent-teal); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-orange);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .amd-box {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border: 1px solid rgba(74, 144, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .amd-box.accumulation {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .amd-box.manipulation {
-            background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%);
-            border-color: rgba(217, 74, 74, 0.3);
-        }
-
-        .amd-box.distribution {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .amd-box.framework {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .amd-box.keys {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .amd-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 38px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .amd-box.accumulation h3 {
-            color: var(--accent-blue);
-        }
-
-        .amd-box.manipulation h3 {
-            color: var(--accent-red);
-        }
-
-        .amd-box.distribution h3 {
-            color: var(--accent-green);
-        }
-
-        .amd-box.framework h3 {
-            color: var(--accent-gold);
-        }
-
-        .amd-box.keys h3 {
-            color: var(--accent-purple);
-        }
-
-        .phase-letter {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 72px;
-            font-weight: 700;
-            opacity: 0.2;
-            position: absolute;
-            top: 20px;
-            right: 30px;
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 22px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .amd-box.accumulation .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .amd-box.manipulation .feature-list li::before {
-            color: var(--accent-red);
-        }
-
-        .amd-box.distribution .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .amd-box.framework .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .amd-box.keys .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .visual-placeholder {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.1) 0%, rgba(201, 169, 98, 0.02) 100%);
-            border: 2px dashed rgba(201, 169, 98, 0.3);
-            border-radius: 16px;
-            padding: 80px 40px;
-            width: 100%;
-            max-width: 800px;
-            text-align: center;
-        }
-
-        .visual-placeholder p {
-            font-size: 20px;
-            color: var(--text-muted);
-            margin-bottom: 16px;
-        }
-
-        .visual-placeholder .visual-note {
-            font-size: 18px;
-            color: var(--accent-gold);
-            font-style: italic;
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        /* CTA styling */
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-purple); }
+        .cta-text { font-family: var(--font-sans); font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Power of Three (AMD)</h1>
+        <p>8 slides · ICT Concepts</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 08</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">POWER OF THREE<br>(AMD)</h1>
-                        <p class="subtitle">The daily market rhythm in three acts.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="title">POWER OF THREE<br>(AMD)</h1>
+                    <p class="subtitle">The daily market cycle.</p>
                 </div>
+                <div class="slide-number">1 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 2: Accumulation -->
         <div class="slide-wrapper" data-slide="2">
-            <span class="slide-label">Slide 2 — Accumulation</span>
+            <span class="slide-label">Slide 2 — What It Is</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 08</span>
-                    <div class="center-content">
-                        <div class="amd-box accumulation" style="position: relative;">
-                            <span class="phase-letter" style="color: var(--accent-blue);">A</span>
-                            <h3>ACCUMULATION</h3>
-                            <ul class="feature-list">
-                                <li>Usually Asian session</li>
-                                <li>Range forms</li>
-                                <li>Liquidity builds on both sides</li>
-                                <li>Low volatility, tight range</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="amd-box what">
+                        <h3>WHAT IS POWER OF THREE?</h3>
+                        <ul class="feature-list">
+                            <li>AMD = Accumulation, Manipulation, Distribution</li>
+                            <li>Describes daily/session market cycle</li>
+                            <li>Three distinct phases</li>
+                            <li>ICT concept for timing trades</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 3: Manipulation -->
         <div class="slide-wrapper" data-slide="3">
-            <span class="slide-label">Slide 3 — Manipulation</span>
+            <span class="slide-label">Slide 3 — Accumulation</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 08</span>
-                    <div class="center-content">
-                        <div class="amd-box manipulation" style="position: relative;">
-                            <span class="phase-letter" style="color: var(--accent-red);">M</span>
-                            <h3>MANIPULATION</h3>
-                            <ul class="feature-list">
-                                <li>Often London open</li>
-                                <li>False move in one direction</li>
-                                <li>Sweeps liquidity</li>
-                                <li>Traps early traders</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="amd-box accumulation">
+                        <h3>A: ACCUMULATION</h3>
+                        <ul class="feature-list">
+                            <li>Typically Asian session</li>
+                            <li>Range-bound consolidation</li>
+                            <li>Smart money builds positions</li>
+                            <li>Low volatility, setting up the day</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 4: Distribution -->
         <div class="slide-wrapper" data-slide="4">
-            <span class="slide-label">Slide 4 — Distribution</span>
+            <span class="slide-label">Slide 4 — Manipulation</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 08</span>
-                    <div class="center-content">
-                        <div class="amd-box distribution" style="position: relative;">
-                            <span class="phase-letter" style="color: var(--accent-green);">D</span>
-                            <h3>DISTRIBUTION</h3>
-                            <ul class="feature-list">
-                                <li>Typically NY session</li>
-                                <li>Real directional move</li>
-                                <li>Opposite of manipulation</li>
-                                <li>Where the day's move completes</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="amd-box manipulation">
+                        <h3>M: MANIPULATION</h3>
+                        <ul class="feature-list">
+                            <li>Typically London open</li>
+                            <li>False move in wrong direction</li>
+                            <li>Sweeps liquidity (stops)</li>
+                            <li>Traps retail traders</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 5: Visual Example -->
         <div class="slide-wrapper" data-slide="5">
-            <span class="slide-label">Slide 5 — Visual Example</span>
+            <span class="slide-label">Slide 5 — Distribution</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 08</span>
-                    <div class="center-content">
-                        <div class="visual-placeholder">
-                            <p>[TradingView Chart]</p>
-                            <p>Asian range (blue) → London sweep (red) → NY reversal and trend (green)</p>
-                            <span class="visual-note">Clear AMD sequence on intraday timeframe</span>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="amd-box distribution">
+                        <h3>D: DISTRIBUTION</h3>
+                        <ul class="feature-list">
+                            <li>Typically NY session</li>
+                            <li>Real directional move</li>
+                            <li>Opposite to manipulation</li>
+                            <li>Where profits are made</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 6: The Framework -->
         <div class="slide-wrapper" data-slide="6">
-            <span class="slide-label">Slide 6 — The Framework</span>
+            <span class="slide-label">Slide 6 — How To Trade It</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 08</span>
-                    <div class="center-content">
-                        <div class="amd-box framework">
-                            <h3>THE FRAMEWORK</h3>
-                            <ul class="feature-list">
-                                <li>Identify the accumulation range</li>
-                                <li>Watch for manipulation sweep</li>
-                                <li>Position for distribution move</li>
-                                <li>Manage risk appropriately</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="amd-box how">
+                        <h3>HOW TO TRADE IT</h3>
+                        <ul class="feature-list">
+                            <li>Identify the phase you're in</li>
+                            <li>Wait for manipulation to complete</li>
+                            <li>Enter during distribution</li>
+                            <li>Patience is key</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 7: Key Points -->
         <div class="slide-wrapper" data-slide="7">
-            <span class="slide-label">Slide 7 — Key Points</span>
+            <span class="slide-label">Slide 7 — How To Identify</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 08</span>
-                    <div class="center-content">
-                        <div class="amd-box keys">
-                            <h3>KEY POINTS</h3>
-                            <ul class="feature-list">
-                                <li>Not every day follows AMD</li>
-                                <li>But often enough to matter</li>
-                                <li>Combine with other context</li>
-                                <li>Don't force the pattern</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="amd-box identify">
+                        <h3>IDENTIFYING THE PHASES</h3>
+                        <ul class="feature-list">
+                            <li>Mark Asian range (A)</li>
+                            <li>Watch for sweep at London open (M)</li>
+                            <li>Confirm reversal for entry (D)</li>
+                            <li>Combine with other SMC tools</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">7 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 8: CTA -->
         <div class="slide-wrapper" data-slide="8">
             <span class="slide-label">Slide 8 — CTA</span>
             <div class="slide slide-8">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">08 / 08</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Not Every Day.<br>But Often Enough to Matter.</h2>
-                        <p class="cta-text">Full lesson in curriculum</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Understand the Cycle.<br><span class="emphasis">Trade the Distribution.</span></h2>
+                    <p class="cta-text">Full breakdown on blog</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">8 / 8</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-483/carousel.html
+++ b/assets/social/post-483/carousel.html
@@ -4,514 +4,258 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 483 — The Myth of the Holy Grail Indicator</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        .slide-title { font-family: var(--font-serif); font-size: clamp(24px, 4.6vw, 50px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .subtitle { font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-red); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        .myth-box { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border: 1px solid rgba(201, 169, 98, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: clamp(375px, 69vw, 750px); }
+        .myth-box.want { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .myth-box.reality { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border-color: rgba(217, 74, 74, 0.3); }
+        .myth-box.why { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
+        .myth-box.works { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .myth-box.edge { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .myth-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .myth-box.want h3 { color: var(--accent-gold); }
+        .myth-box.reality h3 { color: var(--accent-red); }
+        .myth-box.why h3 { color: var(--accent-purple); }
+        .myth-box.works h3 { color: var(--accent-blue); }
+        .myth-box.edge h3 { color: var(--accent-green); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 50px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-size: clamp(11px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.8vw, 9px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .myth-box.want .feature-list li::before { color: var(--accent-gold); }
+        .myth-box.reality .feature-list li::before { color: var(--accent-red); }
+        .myth-box.why .feature-list li::before { color: var(--accent-purple); }
+        .myth-box.works .feature-list li::before { color: var(--accent-blue); }
+        .myth-box.edge .feature-list li::before { color: var(--accent-green); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-red);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .myth-box {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border: 1px solid rgba(201, 169, 98, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .myth-box.want {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .myth-box.reality {
-            background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%);
-            border-color: rgba(217, 74, 74, 0.3);
-        }
-
-        .myth-box.why {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .myth-box.works {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .myth-box.edge {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .myth-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 36px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .myth-box.want h3 {
-            color: var(--accent-gold);
-        }
-
-        .myth-box.reality h3 {
-            color: var(--accent-red);
-        }
-
-        .myth-box.why h3 {
-            color: var(--accent-purple);
-        }
-
-        .myth-box.works h3 {
-            color: var(--accent-blue);
-        }
-
-        .myth-box.edge h3 {
-            color: var(--accent-green);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 21px;
-            color: var(--text-primary);
-            padding: 9px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .myth-box.want .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .myth-box.reality .feature-list li::before {
-            color: var(--accent-red);
-        }
-
-        .myth-box.why .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .myth-box.works .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .myth-box.edge .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-title .emphasis {
-            color: var(--accent-gold);
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-gold); }
+        .cta-text { font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>The Myth of the Holy Grail Indicator</h1>
+        <p>7 slides · Trading Psychology</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 07</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">THE MYTH OF THE<br>HOLY GRAIL INDICATOR</h1>
-                        <p class="subtitle">It doesn't exist. Stop searching.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="slide-title">THE MYTH OF THE<br>HOLY GRAIL INDICATOR</h1>
+                    <p class="subtitle">It doesn't exist. Stop searching.</p>
                 </div>
+                <div class="slide-number">1 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 2: What People Want -->
         <div class="slide-wrapper" data-slide="2">
             <span class="slide-label">Slide 2 — What People Want</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 07</span>
-                    <div class="center-content">
-                        <div class="myth-box want">
-                            <h3>WHAT PEOPLE WANT</h3>
-                            <ul class="feature-list">
-                                <li>Green arrow = buy = profit</li>
-                                <li>Red arrow = sell = profit</li>
-                                <li>No thinking required</li>
-                                <li>100% win rate</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="myth-box want">
+                        <h3>WHAT PEOPLE WANT</h3>
+                        <ul class="feature-list">
+                            <li>Green arrow = buy = profit</li>
+                            <li>Red arrow = sell = profit</li>
+                            <li>No thinking required</li>
+                            <li>100% win rate</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 3: The Reality -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — The Reality</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 07</span>
-                    <div class="center-content">
-                        <div class="myth-box reality">
-                            <h3>THE REALITY</h3>
-                            <ul class="feature-list">
-                                <li>All indicators lag or lead imperfectly</li>
-                                <li>Context determines signal validity</li>
-                                <li>No tool works in all conditions</li>
-                                <li>Risk management IS the edge</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="myth-box reality">
+                        <h3>THE REALITY</h3>
+                        <ul class="feature-list">
+                            <li>All indicators lag or lead imperfectly</li>
+                            <li>Context determines signal validity</li>
+                            <li>No tool works in all conditions</li>
+                            <li>Risk management IS the edge</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 4: Why It Doesn't Exist -->
         <div class="slide-wrapper" data-slide="4">
             <span class="slide-label">Slide 4 — Why It Doesn't Exist</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 07</span>
-                    <div class="center-content">
-                        <div class="myth-box why">
-                            <h3>WHY IT DOESN'T EXIST</h3>
-                            <ul class="feature-list">
-                                <li>Markets are adaptive</li>
-                                <li>What works gets arbitraged away</li>
-                                <li>Conditions constantly change</li>
-                                <li>Uncertainty is inherent</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="myth-box why">
+                        <h3>WHY IT DOESN'T EXIST</h3>
+                        <ul class="feature-list">
+                            <li>Markets are adaptive</li>
+                            <li>What works gets arbitraged away</li>
+                            <li>Conditions constantly change</li>
+                            <li>Uncertainty is inherent</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 5: What Actually Works -->
         <div class="slide-wrapper" data-slide="5">
             <span class="slide-label">Slide 5 — What Actually Works</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 07</span>
-                    <div class="center-content">
-                        <div class="myth-box works">
-                            <h3>WHAT ACTUALLY WORKS</h3>
-                            <ul class="feature-list">
-                                <li>Solid tools + proper context</li>
-                                <li>Clear rules + consistent execution</li>
-                                <li>Realistic expectations + patience</li>
-                                <li>Process over outcomes</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="myth-box works">
+                        <h3>WHAT ACTUALLY WORKS</h3>
+                        <ul class="feature-list">
+                            <li>Solid tools + proper context</li>
+                            <li>Clear rules + consistent execution</li>
+                            <li>Realistic expectations + patience</li>
+                            <li>Process over outcomes</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 6: The Real Edge -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — The Real Edge</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 07</span>
-                    <div class="center-content">
-                        <div class="myth-box edge">
-                            <h3>THE REAL EDGE</h3>
-                            <ul class="feature-list">
-                                <li>Disciplined execution</li>
-                                <li>Risk management</li>
-                                <li>Continuous learning</li>
-                                <li>Emotional control</li>
-                                <li>It's the trader, not the tool</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="myth-box edge">
+                        <h3>THE REAL EDGE</h3>
+                        <ul class="feature-list">
+                            <li>Disciplined execution</li>
+                            <li>Risk management</li>
+                            <li>Continuous learning</li>
+                            <li>Emotional control</li>
+                            <li>It's the trader, not the tool</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 7: CTA -->
         <div class="slide-wrapper" data-slide="7">
             <span class="slide-label">Slide 7 — CTA</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 07</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">The Grail Isn't a Tool.<br>It's the <span class="emphasis">Trader</span> Using It.</h2>
-                        <p class="cta-text">Full article on blog</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">The Grail Isn't a Tool.<br>It's the <span class="emphasis">Trader</span> Using It.</h2>
+                    <p class="cta-text">Full article on blog</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">7 / 7</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-485/carousel.html
+++ b/assets/social/post-485/carousel.html
@@ -4,479 +4,232 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 485 — Harmonic Oscillator Exhaustion Signals</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        .slide-title { font-family: var(--font-serif); font-size: clamp(29px, 5.4vw, 58px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .subtitle { font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-purple); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        .signal-box { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border: 1px solid rgba(155, 74, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: clamp(375px, 69vw, 750px); }
+        .signal-box.what { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .signal-box.identify { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .signal-box.trade { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .signal-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .signal-box.what h3 { color: var(--accent-blue); }
+        .signal-box.identify h3 { color: var(--accent-gold); }
+        .signal-box.trade h3 { color: var(--accent-green); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 58px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-size: clamp(11px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .signal-box.what .feature-list li::before { color: var(--accent-blue); }
+        .signal-box.identify .feature-list li::before { color: var(--accent-gold); }
+        .signal-box.trade .feature-list li::before { color: var(--accent-green); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-purple);
-        }
+        .visual-placeholder { background: linear-gradient(135deg, rgba(155, 74, 217, 0.1) 0%, rgba(155, 74, 217, 0.02) 100%); border: 2px dashed rgba(155, 74, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(40px, 7.4vw, 80px) clamp(20px, 3.7vw, 40px); width: 100%; max-width: clamp(400px, 74vw, 800px); text-align: center; }
+        .visual-placeholder p { font-size: clamp(10px, 1.9vw, 20px); color: var(--text-muted); margin-bottom: clamp(8px, 1.5vw, 16px); }
+        .visual-placeholder .visual-note { font-size: clamp(9px, 1.7vw, 18px); color: var(--accent-purple); font-style: italic; }
 
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .signal-box {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border: 1px solid rgba(155, 74, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .signal-box.what {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .signal-box.identify {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .signal-box.trade {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .signal-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 36px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .signal-box.what h3 {
-            color: var(--accent-blue);
-        }
-
-        .signal-box.identify h3 {
-            color: var(--accent-gold);
-        }
-
-        .signal-box.trade h3 {
-            color: var(--accent-green);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 21px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .signal-box.what .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .signal-box.identify .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .signal-box.trade .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .visual-placeholder {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.1) 0%, rgba(155, 74, 217, 0.02) 100%);
-            border: 2px dashed rgba(155, 74, 217, 0.3);
-            border-radius: 16px;
-            padding: 80px 40px;
-            width: 100%;
-            max-width: 800px;
-            text-align: center;
-        }
-
-        .visual-placeholder p {
-            font-size: 20px;
-            color: var(--text-muted);
-            margin-bottom: 16px;
-        }
-
-        .visual-placeholder .visual-note {
-            font-size: 18px;
-            color: var(--accent-purple);
-            font-style: italic;
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-title .emphasis {
-            color: var(--accent-purple);
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-purple); }
+        .cta-text { font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Harmonic Oscillator Exhaustion Signals</h1>
+        <p>6 slides · Technical Concepts</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 06</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">HARMONIC OSCILLATOR<br>EXHAUSTION SIGNALS</h1>
-                        <p class="subtitle">Catch reversals before they happen.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="slide-title">HARMONIC OSCILLATOR<br>EXHAUSTION SIGNALS</h1>
+                    <p class="subtitle">Catch reversals before they happen.</p>
                 </div>
+                <div class="slide-number">1 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 2: What It Is -->
         <div class="slide-wrapper" data-slide="2">
             <span class="slide-label">Slide 2 — What It Is</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 06</span>
-                    <div class="center-content">
-                        <div class="signal-box what">
-                            <h3>WHAT IT IS</h3>
-                            <ul class="feature-list">
-                                <li>Harmonic Oscillator measures momentum cycles</li>
-                                <li>Exhaustion = momentum reaching extremes</li>
-                                <li>Price often reverses at exhaustion points</li>
-                                <li>Early warning system for turns</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="signal-box what">
+                        <h3>WHAT IT IS</h3>
+                        <ul class="feature-list">
+                            <li>Harmonic Oscillator measures momentum cycles</li>
+                            <li>Exhaustion = momentum reaching extremes</li>
+                            <li>Price often reverses at exhaustion points</li>
+                            <li>Early warning system for turns</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 3: How To Identify -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — How To Identify</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 06</span>
-                    <div class="center-content">
-                        <div class="signal-box identify">
-                            <h3>HOW TO IDENTIFY</h3>
-                            <ul class="feature-list">
-                                <li>Oscillator reaches extreme bands</li>
-                                <li>Divergence between price and oscillator</li>
-                                <li>Volume confirmation declining</li>
-                                <li>Price stalling at key levels</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="signal-box identify">
+                        <h3>HOW TO IDENTIFY</h3>
+                        <ul class="feature-list">
+                            <li>Oscillator reaches extreme bands</li>
+                            <li>Divergence between price and oscillator</li>
+                            <li>Volume confirmation declining</li>
+                            <li>Price stalling at key levels</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 4: How To Trade It -->
         <div class="slide-wrapper" data-slide="4">
             <span class="slide-label">Slide 4 — How To Trade It</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 06</span>
-                    <div class="center-content">
-                        <div class="signal-box trade">
-                            <h3>HOW TO TRADE IT</h3>
-                            <ul class="feature-list">
-                                <li>Wait for exhaustion + confluence</li>
-                                <li>Enter on reversal confirmation</li>
-                                <li>Stop beyond the extreme</li>
-                                <li>Target previous structure levels</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="signal-box trade">
+                        <h3>HOW TO TRADE IT</h3>
+                        <ul class="feature-list">
+                            <li>Wait for exhaustion + confluence</li>
+                            <li>Enter on reversal confirmation</li>
+                            <li>Stop beyond the extreme</li>
+                            <li>Target previous structure levels</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 5: Demo Screenshot -->
         <div class="slide-wrapper" data-slide="5">
             <span class="slide-label">Slide 5 — Demo Screenshot</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 06</span>
-                    <div class="center-content">
-                        <div class="visual-placeholder">
-                            <p>[Harmonic Oscillator Chart]</p>
-                            <p>Exhaustion signal at extreme</p>
-                            <p>Price reversal following exhaustion</p>
-                            <span class="visual-note">Exhaustion signals precede major reversals</span>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="visual-placeholder">
+                        <p>[Harmonic Oscillator Chart]</p>
+                        <p>Exhaustion signal at extreme</p>
+                        <p>Price reversal following exhaustion</p>
+                        <span class="visual-note">Exhaustion signals precede major reversals</span>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 6: CTA -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — CTA</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 06</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Exhaustion Precedes<br><span class="emphasis">Reversal</span></h2>
-                        <p class="cta-text">Full breakdown in docs</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Exhaustion Precedes<br><span class="emphasis">Reversal</span></h2>
+                    <p class="cta-text">Full breakdown in docs</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">6 / 6</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-486/carousel.html
+++ b/assets/social/post-486/carousel.html
@@ -4,554 +4,281 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 486 — ICT Judas Swing Concept</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
             --accent-orange: #d9884a;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        .slide-title { font-family: var(--font-serif); font-size: clamp(32px, 5.9vw, 64px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .subtitle { font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-red); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        .judas-box { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border: 1px solid rgba(217, 74, 74, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: clamp(375px, 69vw, 750px); }
+        .judas-box.what { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .judas-box.psychology { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
+        .judas-box.identify { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .judas-box.bullish { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .judas-box.bearish { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border-color: rgba(217, 74, 74, 0.3); }
+        .judas-box.avoid { background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%); border-color: rgba(217, 136, 74, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .judas-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .judas-box.what h3 { color: var(--accent-blue); }
+        .judas-box.psychology h3 { color: var(--accent-purple); }
+        .judas-box.identify h3 { color: var(--accent-gold); }
+        .judas-box.bullish h3 { color: var(--accent-green); }
+        .judas-box.bearish h3 { color: var(--accent-red); }
+        .judas-box.avoid h3 { color: var(--accent-orange); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 64px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-size: clamp(11px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.8vw, 9px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .judas-box.what .feature-list li::before { color: var(--accent-blue); }
+        .judas-box.psychology .feature-list li::before { color: var(--accent-purple); }
+        .judas-box.identify .feature-list li::before { color: var(--accent-gold); }
+        .judas-box.bullish .feature-list li::before { color: var(--accent-green); }
+        .judas-box.bearish .feature-list li::before { color: var(--accent-red); }
+        .judas-box.avoid .feature-list li::before { color: var(--accent-orange); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-red);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .judas-box {
-            background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%);
-            border: 1px solid rgba(217, 74, 74, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .judas-box.what {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .judas-box.psychology {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .judas-box.identify {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .judas-box.bullish {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .judas-box.bearish {
-            background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%);
-            border-color: rgba(217, 74, 74, 0.3);
-        }
-
-        .judas-box.avoid {
-            background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%);
-            border-color: rgba(217, 136, 74, 0.3);
-        }
-
-        .judas-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 36px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .judas-box.what h3 {
-            color: var(--accent-blue);
-        }
-
-        .judas-box.psychology h3 {
-            color: var(--accent-purple);
-        }
-
-        .judas-box.identify h3 {
-            color: var(--accent-gold);
-        }
-
-        .judas-box.bullish h3 {
-            color: var(--accent-green);
-        }
-
-        .judas-box.bearish h3 {
-            color: var(--accent-red);
-        }
-
-        .judas-box.avoid h3 {
-            color: var(--accent-orange);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 21px;
-            color: var(--text-primary);
-            padding: 9px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .judas-box.what .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .judas-box.psychology .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .judas-box.identify .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .judas-box.bullish .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .judas-box.bearish .feature-list li::before {
-            color: var(--accent-red);
-        }
-
-        .judas-box.avoid .feature-list li::before {
-            color: var(--accent-orange);
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-title .emphasis {
-            color: var(--accent-red);
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-red); }
+        .cta-text { font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>ICT Judas Swing Concept</h1>
+        <p>8 slides · ICT Concepts</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 08</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">ICT JUDAS<br>SWING CONCEPT</h1>
-                        <p class="subtitle">The false move before the real one.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="slide-title">ICT JUDAS<br>SWING CONCEPT</h1>
+                    <p class="subtitle">The false move before the real one.</p>
                 </div>
+                <div class="slide-number">1 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 2: What It Is -->
         <div class="slide-wrapper" data-slide="2">
             <span class="slide-label">Slide 2 — What It Is</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 08</span>
-                    <div class="center-content">
-                        <div class="judas-box what">
-                            <h3>WHAT IS A JUDAS SWING?</h3>
-                            <ul class="feature-list">
-                                <li>Deceptive price move at session open</li>
-                                <li>Traps retail traders on wrong side</li>
-                                <li>Named after biblical betrayal</li>
-                                <li>Sets up the real directional move</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="judas-box what">
+                        <h3>WHAT IS A JUDAS SWING?</h3>
+                        <ul class="feature-list">
+                            <li>Deceptive price move at session open</li>
+                            <li>Traps retail traders on wrong side</li>
+                            <li>Named after biblical betrayal</li>
+                            <li>Sets up the real directional move</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 3: Psychology -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — Psychology</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 08</span>
-                    <div class="center-content">
-                        <div class="judas-box psychology">
-                            <h3>WHY IT WORKS</h3>
-                            <ul class="feature-list">
-                                <li>Retail chases early momentum</li>
-                                <li>Smart money needs liquidity</li>
-                                <li>Stop hunts fuel real moves</li>
-                                <li>Exploits FOMO psychology</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="judas-box psychology">
+                        <h3>WHY IT WORKS</h3>
+                        <ul class="feature-list">
+                            <li>Retail chases early momentum</li>
+                            <li>Smart money needs liquidity</li>
+                            <li>Stop hunts fuel real moves</li>
+                            <li>Exploits FOMO psychology</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 4: How To Identify -->
         <div class="slide-wrapper" data-slide="4">
             <span class="slide-label">Slide 4 — How To Identify</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 08</span>
-                    <div class="center-content">
-                        <div class="judas-box identify">
-                            <h3>HOW TO IDENTIFY</h3>
-                            <ul class="feature-list">
-                                <li>Occurs during London/NY open</li>
-                                <li>Quick move opposite to bias</li>
-                                <li>Runs obvious liquidity pool</li>
-                                <li>Then reverses sharply</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="judas-box identify">
+                        <h3>HOW TO IDENTIFY</h3>
+                        <ul class="feature-list">
+                            <li>Occurs during London/NY open</li>
+                            <li>Quick move opposite to bias</li>
+                            <li>Runs obvious liquidity pool</li>
+                            <li>Then reverses sharply</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 5: Bullish Judas -->
         <div class="slide-wrapper" data-slide="5">
             <span class="slide-label">Slide 5 — Bullish Judas</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 08</span>
-                    <div class="center-content">
-                        <div class="judas-box bullish">
-                            <h3>BULLISH JUDAS SWING</h3>
-                            <ul class="feature-list">
-                                <li>Price drops first at session open</li>
-                                <li>Sweeps lows / stops below</li>
-                                <li>Reverses and rallies higher</li>
-                                <li>Real direction was bullish</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="judas-box bullish">
+                        <h3>BULLISH JUDAS SWING</h3>
+                        <ul class="feature-list">
+                            <li>Price drops first at session open</li>
+                            <li>Sweeps lows / stops below</li>
+                            <li>Reverses and rallies higher</li>
+                            <li>Real direction was bullish</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 6: Bearish Judas -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — Bearish Judas</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 08</span>
-                    <div class="center-content">
-                        <div class="judas-box bearish">
-                            <h3>BEARISH JUDAS SWING</h3>
-                            <ul class="feature-list">
-                                <li>Price spikes up at session open</li>
-                                <li>Sweeps highs / stops above</li>
-                                <li>Reverses and drops lower</li>
-                                <li>Real direction was bearish</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="judas-box bearish">
+                        <h3>BEARISH JUDAS SWING</h3>
+                        <ul class="feature-list">
+                            <li>Price spikes up at session open</li>
+                            <li>Sweeps highs / stops above</li>
+                            <li>Reverses and drops lower</li>
+                            <li>Real direction was bearish</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 7: Avoiding the Trap -->
         <div class="slide-wrapper" data-slide="7">
             <span class="slide-label">Slide 7 — Avoiding the Trap</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 08</span>
-                    <div class="center-content">
-                        <div class="judas-box avoid">
-                            <h3>AVOIDING THE TRAP</h3>
-                            <ul class="feature-list">
-                                <li>Wait for session open to complete</li>
-                                <li>Don't chase early moves</li>
-                                <li>Look for reversal confirmation</li>
-                                <li>Trade after the sweep</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="judas-box avoid">
+                        <h3>AVOIDING THE TRAP</h3>
+                        <ul class="feature-list">
+                            <li>Wait for session open to complete</li>
+                            <li>Don't chase early moves</li>
+                            <li>Look for reversal confirmation</li>
+                            <li>Trade after the sweep</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">7 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 8: CTA -->
         <div class="slide-wrapper" data-slide="8">
             <span class="slide-label">Slide 8 — CTA</span>
             <div class="slide slide-8">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">08 / 08</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">The First Move Is Often<br>the <span class="emphasis">Fake Move</span></h2>
-                        <p class="cta-text">Full breakdown on blog</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">The First Move Is Often<br>the <span class="emphasis">Fake Move</span></h2>
+                    <p class="cta-text">Full breakdown on blog</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">8 / 8</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-487/carousel.html
+++ b/assets/social/post-487/carousel.html
@@ -4,513 +4,257 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 487 — Building Trading Confidence</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        .slide-title { font-family: var(--font-serif); font-size: clamp(30px, 5.6vw, 60px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .subtitle { font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-gold); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        .confidence-box { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border: 1px solid rgba(201, 169, 98, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: clamp(375px, 69vw, 750px); }
+        .confidence-box.problem { background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%); border-color: rgba(217, 74, 74, 0.3); }
+        .confidence-box.foundation { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .confidence-box.build { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .confidence-box.maintain { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
+        .confidence-box.signs { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .confidence-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .confidence-box.problem h3 { color: var(--accent-red); }
+        .confidence-box.foundation h3 { color: var(--accent-blue); }
+        .confidence-box.build h3 { color: var(--accent-green); }
+        .confidence-box.maintain h3 { color: var(--accent-purple); }
+        .confidence-box.signs h3 { color: var(--accent-gold); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 60px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-size: clamp(11px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.8vw, 9px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .confidence-box.problem .feature-list li::before { color: var(--accent-red); }
+        .confidence-box.foundation .feature-list li::before { color: var(--accent-blue); }
+        .confidence-box.build .feature-list li::before { color: var(--accent-green); }
+        .confidence-box.maintain .feature-list li::before { color: var(--accent-purple); }
+        .confidence-box.signs .feature-list li::before { color: var(--accent-gold); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-gold);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .confidence-box {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border: 1px solid rgba(201, 169, 98, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .confidence-box.problem {
-            background: linear-gradient(135deg, rgba(217, 74, 74, 0.15) 0%, rgba(217, 74, 74, 0.05) 100%);
-            border-color: rgba(217, 74, 74, 0.3);
-        }
-
-        .confidence-box.foundation {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .confidence-box.build {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .confidence-box.maintain {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .confidence-box.signs {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .confidence-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 36px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .confidence-box.problem h3 {
-            color: var(--accent-red);
-        }
-
-        .confidence-box.foundation h3 {
-            color: var(--accent-blue);
-        }
-
-        .confidence-box.build h3 {
-            color: var(--accent-green);
-        }
-
-        .confidence-box.maintain h3 {
-            color: var(--accent-purple);
-        }
-
-        .confidence-box.signs h3 {
-            color: var(--accent-gold);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 21px;
-            color: var(--text-primary);
-            padding: 9px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .confidence-box.problem .feature-list li::before {
-            color: var(--accent-red);
-        }
-
-        .confidence-box.foundation .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .confidence-box.build .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .confidence-box.maintain .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .confidence-box.signs .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-title .emphasis {
-            color: var(--accent-gold);
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-gold); }
+        .cta-text { font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Building Trading Confidence</h1>
+        <p>7 slides · Trading Psychology</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 07</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">BUILDING TRADING<br>CONFIDENCE</h1>
-                        <p class="subtitle">From hesitation to execution.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="slide-title">BUILDING TRADING<br>CONFIDENCE</h1>
+                    <p class="subtitle">From hesitation to execution.</p>
                 </div>
+                <div class="slide-number">1 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 2: The Problem -->
         <div class="slide-wrapper" data-slide="2">
             <span class="slide-label">Slide 2 — The Problem</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 07</span>
-                    <div class="center-content">
-                        <div class="confidence-box problem">
-                            <h3>THE CONFIDENCE PROBLEM</h3>
-                            <ul class="feature-list">
-                                <li>Hesitating on valid setups</li>
-                                <li>Second-guessing every decision</li>
-                                <li>Missing trades from fear</li>
-                                <li>Closing winners too early</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="confidence-box problem">
+                        <h3>THE CONFIDENCE PROBLEM</h3>
+                        <ul class="feature-list">
+                            <li>Hesitating on valid setups</li>
+                            <li>Second-guessing every decision</li>
+                            <li>Missing trades from fear</li>
+                            <li>Closing winners too early</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 3: Foundation -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — Foundation</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 07</span>
-                    <div class="center-content">
-                        <div class="confidence-box foundation">
-                            <h3>THE FOUNDATION</h3>
-                            <ul class="feature-list">
-                                <li>Confidence comes from evidence</li>
-                                <li>Backtesting proves your edge</li>
-                                <li>Sample size matters</li>
-                                <li>Data removes emotion</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="confidence-box foundation">
+                        <h3>THE FOUNDATION</h3>
+                        <ul class="feature-list">
+                            <li>Confidence comes from evidence</li>
+                            <li>Backtesting proves your edge</li>
+                            <li>Sample size matters</li>
+                            <li>Data removes emotion</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 4: How To Build It -->
         <div class="slide-wrapper" data-slide="4">
             <span class="slide-label">Slide 4 — How To Build It</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 07</span>
-                    <div class="center-content">
-                        <div class="confidence-box build">
-                            <h3>HOW TO BUILD IT</h3>
-                            <ul class="feature-list">
-                                <li>Start with small position sizes</li>
-                                <li>Track every trade meticulously</li>
-                                <li>Celebrate process, not profits</li>
-                                <li>Review and iterate weekly</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="confidence-box build">
+                        <h3>HOW TO BUILD IT</h3>
+                        <ul class="feature-list">
+                            <li>Start with small position sizes</li>
+                            <li>Track every trade meticulously</li>
+                            <li>Celebrate process, not profits</li>
+                            <li>Review and iterate weekly</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 5: Maintaining Confidence -->
         <div class="slide-wrapper" data-slide="5">
             <span class="slide-label">Slide 5 — Maintaining Confidence</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 07</span>
-                    <div class="center-content">
-                        <div class="confidence-box maintain">
-                            <h3>MAINTAINING CONFIDENCE</h3>
-                            <ul class="feature-list">
-                                <li>Accept losses as part of the game</li>
-                                <li>Focus on execution quality</li>
-                                <li>Don't let drawdowns destroy belief</li>
-                                <li>Remember your edge is statistical</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="confidence-box maintain">
+                        <h3>MAINTAINING CONFIDENCE</h3>
+                        <ul class="feature-list">
+                            <li>Accept losses as part of the game</li>
+                            <li>Focus on execution quality</li>
+                            <li>Don't let drawdowns destroy belief</li>
+                            <li>Remember your edge is statistical</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 6: Signs of True Confidence -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — Signs of True Confidence</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 07</span>
-                    <div class="center-content">
-                        <div class="confidence-box signs">
-                            <h3>SIGNS OF TRUE CONFIDENCE</h3>
-                            <ul class="feature-list">
-                                <li>Execute without hesitation</li>
-                                <li>Comfortable during drawdowns</li>
-                                <li>Trust your process fully</li>
-                                <li>No need for validation</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="confidence-box signs">
+                        <h3>SIGNS OF TRUE CONFIDENCE</h3>
+                        <ul class="feature-list">
+                            <li>Execute without hesitation</li>
+                            <li>Comfortable during drawdowns</li>
+                            <li>Trust your process fully</li>
+                            <li>No need for validation</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 7</div>
             </div>
         </div>
 
-        <!-- Slide 7: CTA -->
         <div class="slide-wrapper" data-slide="7">
             <span class="slide-label">Slide 7 — CTA</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 07</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Confidence Is Built,<br>Not <span class="emphasis">Found</span></h2>
-                        <p class="cta-text">Full guide on blog</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Confidence Is Built,<br>Not <span class="emphasis">Found</span></h2>
+                    <p class="cta-text">Full guide on blog</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">7 / 7</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-489/carousel.html
+++ b/assets/social/post-489/carousel.html
@@ -4,554 +4,282 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 489 — Quarterly Theory Basics</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
+            --accent-teal: #4ad9d9;
             --accent-orange: #d9884a;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        .slide-title { font-family: var(--font-serif); font-size: clamp(32px, 5.9vw, 64px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .subtitle { font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-teal); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        .quarter-box { background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%); border: 1px solid rgba(74, 217, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: clamp(375px, 69vw, 750px); }
+        .quarter-box.what { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .quarter-box.q1 { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .quarter-box.q2 { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .quarter-box.q3 { background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%); border-color: rgba(217, 136, 74, 0.3); }
+        .quarter-box.q4 { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
+        .quarter-box.apply { background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%); border-color: rgba(74, 217, 217, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .quarter-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .quarter-box.what h3 { color: var(--accent-blue); }
+        .quarter-box.q1 h3 { color: var(--accent-green); }
+        .quarter-box.q2 h3 { color: var(--accent-gold); }
+        .quarter-box.q3 h3 { color: var(--accent-orange); }
+        .quarter-box.q4 h3 { color: var(--accent-purple); }
+        .quarter-box.apply h3 { color: var(--accent-teal); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 64px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-size: clamp(11px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.8vw, 9px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .quarter-box.what .feature-list li::before { color: var(--accent-blue); }
+        .quarter-box.q1 .feature-list li::before { color: var(--accent-green); }
+        .quarter-box.q2 .feature-list li::before { color: var(--accent-gold); }
+        .quarter-box.q3 .feature-list li::before { color: var(--accent-orange); }
+        .quarter-box.q4 .feature-list li::before { color: var(--accent-purple); }
+        .quarter-box.apply .feature-list li::before { color: var(--accent-teal); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-teal);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .quarter-box {
-            background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%);
-            border: 1px solid rgba(74, 217, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .quarter-box.what {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .quarter-box.q1 {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .quarter-box.q2 {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .quarter-box.q3 {
-            background: linear-gradient(135deg, rgba(217, 136, 74, 0.15) 0%, rgba(217, 136, 74, 0.05) 100%);
-            border-color: rgba(217, 136, 74, 0.3);
-        }
-
-        .quarter-box.q4 {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .quarter-box.apply {
-            background: linear-gradient(135deg, rgba(74, 217, 217, 0.15) 0%, rgba(74, 217, 217, 0.05) 100%);
-            border-color: rgba(74, 217, 217, 0.3);
-        }
-
-        .quarter-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 36px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .quarter-box.what h3 {
-            color: var(--accent-blue);
-        }
-
-        .quarter-box.q1 h3 {
-            color: var(--accent-green);
-        }
-
-        .quarter-box.q2 h3 {
-            color: var(--accent-gold);
-        }
-
-        .quarter-box.q3 h3 {
-            color: var(--accent-orange);
-        }
-
-        .quarter-box.q4 h3 {
-            color: var(--accent-purple);
-        }
-
-        .quarter-box.apply h3 {
-            color: var(--accent-teal);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 21px;
-            color: var(--text-primary);
-            padding: 9px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .quarter-box.what .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .quarter-box.q1 .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .quarter-box.q2 .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .quarter-box.q3 .feature-list li::before {
-            color: var(--accent-orange);
-        }
-
-        .quarter-box.q4 .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .quarter-box.apply .feature-list li::before {
-            color: var(--accent-teal);
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-title .emphasis {
-            color: var(--accent-teal);
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-teal); }
+        .cta-text { font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Quarterly Theory Basics</h1>
+        <p>8 slides · ICT Concepts</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 08</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">QUARTERLY<br>THEORY BASICS</h1>
-                        <p class="subtitle">Time divides into four phases.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="slide-title">QUARTERLY<br>THEORY BASICS</h1>
+                    <p class="subtitle">Time divides into four phases.</p>
                 </div>
+                <div class="slide-number">1 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 2: What It Is -->
         <div class="slide-wrapper" data-slide="2">
             <span class="slide-label">Slide 2 — What It Is</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 08</span>
-                    <div class="center-content">
-                        <div class="quarter-box what">
-                            <h3>WHAT IS QUARTERLY THEORY?</h3>
-                            <ul class="feature-list">
-                                <li>Divides any timeframe into 4 quarters</li>
-                                <li>Each quarter has distinct behavior</li>
-                                <li>Fractal - works on any scale</li>
-                                <li>Helps anticipate market phases</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="quarter-box what">
+                        <h3>WHAT IS QUARTERLY THEORY?</h3>
+                        <ul class="feature-list">
+                            <li>Divides any timeframe into 4 quarters</li>
+                            <li>Each quarter has distinct behavior</li>
+                            <li>Fractal - works on any scale</li>
+                            <li>Helps anticipate market phases</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 3: Q1 -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — Q1 Accumulation</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 08</span>
-                    <div class="center-content">
-                        <div class="quarter-box q1">
-                            <h3>Q1: ACCUMULATION</h3>
-                            <ul class="feature-list">
-                                <li>First quarter of the period</li>
-                                <li>Smart money builds positions</li>
-                                <li>Range-bound / consolidation</li>
-                                <li>Low volatility preparation</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="quarter-box q1">
+                        <h3>Q1: ACCUMULATION</h3>
+                        <ul class="feature-list">
+                            <li>First quarter of the period</li>
+                            <li>Smart money builds positions</li>
+                            <li>Range-bound / consolidation</li>
+                            <li>Low volatility preparation</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 4: Q2 -->
         <div class="slide-wrapper" data-slide="4">
             <span class="slide-label">Slide 4 — Q2 Manipulation</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 08</span>
-                    <div class="center-content">
-                        <div class="quarter-box q2">
-                            <h3>Q2: MANIPULATION</h3>
-                            <ul class="feature-list">
-                                <li>Second quarter of the period</li>
-                                <li>False moves / stop hunts</li>
-                                <li>Liquidity grab phase</li>
-                                <li>Trap retail traders</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="quarter-box q2">
+                        <h3>Q2: MANIPULATION</h3>
+                        <ul class="feature-list">
+                            <li>Second quarter of the period</li>
+                            <li>False moves / stop hunts</li>
+                            <li>Liquidity grab phase</li>
+                            <li>Trap retail traders</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 5: Q3 -->
         <div class="slide-wrapper" data-slide="5">
             <span class="slide-label">Slide 5 — Q3 Distribution</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 08</span>
-                    <div class="center-content">
-                        <div class="quarter-box q3">
-                            <h3>Q3: DISTRIBUTION</h3>
-                            <ul class="feature-list">
-                                <li>Third quarter of the period</li>
-                                <li>Real directional move begins</li>
-                                <li>Highest momentum phase</li>
-                                <li>Smart money distributes to retail</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="quarter-box q3">
+                        <h3>Q3: DISTRIBUTION</h3>
+                        <ul class="feature-list">
+                            <li>Third quarter of the period</li>
+                            <li>Real directional move begins</li>
+                            <li>Highest momentum phase</li>
+                            <li>Smart money distributes to retail</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 6: Q4 -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — Q4 Continuation/Reversal</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 08</span>
-                    <div class="center-content">
-                        <div class="quarter-box q4">
-                            <h3>Q4: CONTINUATION / REVERSAL</h3>
-                            <ul class="feature-list">
-                                <li>Fourth quarter of the period</li>
-                                <li>Move completes or reverses</li>
-                                <li>Consolidation returns</li>
-                                <li>Sets up next cycle</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="quarter-box q4">
+                        <h3>Q4: CONTINUATION / REVERSAL</h3>
+                        <ul class="feature-list">
+                            <li>Fourth quarter of the period</li>
+                            <li>Move completes or reverses</li>
+                            <li>Consolidation returns</li>
+                            <li>Sets up next cycle</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">6 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 7: How To Apply -->
         <div class="slide-wrapper" data-slide="7">
             <span class="slide-label">Slide 7 — How To Apply</span>
             <div class="slide slide-7">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">07 / 08</span>
-                    <div class="center-content">
-                        <div class="quarter-box apply">
-                            <h3>HOW TO APPLY IT</h3>
-                            <ul class="feature-list">
-                                <li>Divide session into 4 parts</li>
-                                <li>Identify current quarter</li>
-                                <li>Trade Q3 for momentum</li>
-                                <li>Avoid Q2 false moves</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="quarter-box apply">
+                        <h3>HOW TO APPLY IT</h3>
+                        <ul class="feature-list">
+                            <li>Divide session into 4 parts</li>
+                            <li>Identify current quarter</li>
+                            <li>Trade Q3 for momentum</li>
+                            <li>Avoid Q2 false moves</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">7 / 8</div>
             </div>
         </div>
 
-        <!-- Slide 8: CTA -->
         <div class="slide-wrapper" data-slide="8">
             <span class="slide-label">Slide 8 — CTA</span>
             <div class="slide slide-8">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">08 / 08</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Know Which Quarter<br>You're <span class="emphasis">Trading In</span></h2>
-                        <p class="cta-text">Full breakdown on blog</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Know Which Quarter<br>You're <span class="emphasis">Trading In</span></h2>
+                    <p class="cta-text">Full breakdown on blog</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">8 / 8</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>

--- a/assets/social/post-490/carousel.html
+++ b/assets/social/post-490/carousel.html
@@ -4,473 +4,234 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Post 490 — Mobile Access Guide</title>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-dark: #0a0a0f;
+            --bg-card: rgba(20, 20, 30, 0.85);
+            --text-primary: #f0f0f0;
+            --text-secondary: #a0a0a0;
+            --text-muted: #606070;
             --accent-blue: #4a90d9;
             --accent-gold: #c9a962;
+            --accent-gold-glow: rgba(201, 169, 98, 0.3);
             --accent-green: #4ad97a;
             --accent-red: #d94a4a;
-            --accent-teal: #4ad9d9;
             --accent-purple: #9b4ad9;
-            --text-primary: #e8e6e3;
-            --text-secondary: #a9a6a2;
-            --text-muted: #6b6965;
+            --border-subtle: rgba(255, 255, 255, 0.1);
+            --font-serif: 'Cormorant Garamond', Georgia, serif;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --video-opacity: 0.08;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+        body { background-color: #000; min-height: 100vh; font-family: var(--font-sans); color: var(--text-primary); padding: 2rem; }
 
-        body {
-            background-color: #050507;
-            font-family: 'Inter', sans-serif;
-            color: var(--text-primary);
-            padding: 40px 20px;
-            min-height: 100vh;
-        }
+        .controls { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); z-index: 1000; display: flex; gap: 1rem; background: var(--bg-card); padding: 0.75rem 1.5rem; border-radius: 9999px; border: 1px solid var(--border-subtle); }
+        .controls label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .controls select { background: var(--bg-dark); color: var(--text-primary); border: 1px solid var(--border-subtle); border-radius: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.875rem; cursor: pointer; }
+        #export-btn { background: var(--accent-gold); color: var(--bg-dark); border: none; border-radius: 9999px; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+        #export-btn:hover { filter: brightness(1.1); }
 
-        .carousel-container {
-            display: flex;
-            flex-direction: column;
-            gap: 60px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+        .page-title { text-align: center; margin: 5rem auto 3rem; }
+        .page-title h1 { font-family: var(--font-serif); font-size: clamp(2rem, 4vw, 3rem); font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
+        .page-title p { font-size: 1rem; color: var(--text-muted); }
 
-        .slide-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 16px;
-        }
+        .carousel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem; max-width: 1800px; margin: 0 auto; justify-items: center; }
+        .slide-wrapper { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+        .slide-label { font-size: 0.875rem; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
-        .slide-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 2px;
-        }
+        .slide { width: 100%; max-width: 540px; aspect-ratio: 1 / 1; background: var(--bg-dark); border-radius: 12px; position: relative; overflow: hidden; }
 
-        .slide {
-            width: 1080px;
-            height: 1080px;
-            background-color: var(--bg-dark);
-            position: relative;
-            overflow: hidden;
-            flex-shrink: 0;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-        }
+        body.export-mode .slide { width: 1080px; height: 1080px; max-width: none; border-radius: 0; }
+        body.export-mode .carousel-grid { display: block; }
+        body.export-mode .slide-wrapper { display: none; }
+        body.export-mode .slide-wrapper.exporting { display: flex; }
+        body.export-mode .slide-label { display: none; }
+        body.export-mode .page-title, body.export-mode .controls { display: none; }
 
-        .slide-bg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 0;
-        }
+        .video-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+        .video-background video { width: 100%; height: 100%; object-fit: cover; opacity: var(--video-opacity); }
 
-        .slide-bg video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0.08;
-        }
+        .slide-content { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: clamp(30px, 5.6vw, 60px); text-align: center; }
+        .slide-number { position: absolute; bottom: clamp(15px, 2.8vw, 30px); right: clamp(20px, 3.7vw, 40px); font-family: var(--font-sans); font-size: clamp(7px, 1.3vw, 14px); color: var(--text-secondary); opacity: 0.6; }
+        .brand-header { position: absolute; top: clamp(20px, 3.7vw, 40px); left: 0; right: 0; text-align: center; font-family: var(--font-serif); font-size: clamp(9px, 1.7vw, 18px); font-weight: 600; color: var(--accent-gold); letter-spacing: 3px; text-transform: uppercase; }
 
-        .slide-content {
-            position: relative;
-            z-index: 1;
-            height: 100%;
-            padding: 72px;
-            display: flex;
-            flex-direction: column;
-        }
+        .slide-title { font-family: var(--font-serif); font-size: clamp(32px, 5.9vw, 64px); font-weight: 600; line-height: 1.1; color: var(--text-primary); margin-bottom: clamp(12px, 2.2vw, 24px); }
+        .subtitle { font-size: clamp(13px, 2.4vw, 26px); font-weight: 400; color: var(--accent-blue); }
 
-        .slide-number {
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-muted);
-            letter-spacing: 3px;
-            margin-bottom: auto;
-        }
+        .mobile-box { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border: 1px solid rgba(74, 144, 217, 0.3); border-radius: clamp(8px, 1.5vw, 16px); padding: clamp(22px, 4.1vw, 44px); width: 100%; max-width: clamp(375px, 69vw, 750px); }
+        .mobile-box.setup { background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%); border-color: rgba(74, 144, 217, 0.3); }
+        .mobile-box.features { background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%); border-color: rgba(74, 217, 122, 0.3); }
+        .mobile-box.tips { background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%); border-color: rgba(201, 169, 98, 0.3); }
+        .mobile-box.alerts { background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%); border-color: rgba(155, 74, 217, 0.3); }
 
-        .brand-mark {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 4px;
-            color: var(--text-muted);
-            margin-top: auto;
-            text-align: center;
-        }
+        .mobile-box h3 { font-family: var(--font-serif); font-size: clamp(18px, 3.3vw, 36px); font-weight: 600; margin-bottom: clamp(14px, 2.6vw, 28px); }
+        .mobile-box.setup h3 { color: var(--accent-blue); }
+        .mobile-box.features h3 { color: var(--accent-green); }
+        .mobile-box.tips h3 { color: var(--accent-gold); }
+        .mobile-box.alerts h3 { color: var(--accent-purple); }
 
-        h1.slide-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 64px;
-            font-weight: 600;
-            line-height: 1.1;
-            color: var(--text-primary);
-            margin-bottom: 24px;
-        }
+        .feature-list { list-style: none; text-align: left; }
+        .feature-list li { font-size: clamp(11px, 1.9vw, 21px); color: var(--text-primary); padding: clamp(5px, 0.9vw, 10px) 0; padding-left: clamp(18px, 3.3vw, 36px); position: relative; }
+        .feature-list li::before { content: "→"; position: absolute; left: 0; }
+        .mobile-box.setup .feature-list li::before { color: var(--accent-blue); }
+        .mobile-box.features .feature-list li::before { color: var(--accent-green); }
+        .mobile-box.tips .feature-list li::before { color: var(--accent-gold); }
+        .mobile-box.alerts .feature-list li::before { color: var(--accent-purple); }
 
-        .subtitle {
-            font-size: 26px;
-            font-weight: 400;
-            color: var(--accent-blue);
-        }
-
-        .center-content {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-        }
-
-        .mobile-box {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border: 1px solid rgba(74, 144, 217, 0.3);
-            border-radius: 16px;
-            padding: 44px;
-            width: 100%;
-            max-width: 750px;
-        }
-
-        .mobile-box.setup {
-            background: linear-gradient(135deg, rgba(74, 144, 217, 0.15) 0%, rgba(74, 144, 217, 0.05) 100%);
-            border-color: rgba(74, 144, 217, 0.3);
-        }
-
-        .mobile-box.features {
-            background: linear-gradient(135deg, rgba(74, 217, 122, 0.15) 0%, rgba(74, 217, 122, 0.05) 100%);
-            border-color: rgba(74, 217, 122, 0.3);
-        }
-
-        .mobile-box.tips {
-            background: linear-gradient(135deg, rgba(201, 169, 98, 0.15) 0%, rgba(201, 169, 98, 0.05) 100%);
-            border-color: rgba(201, 169, 98, 0.3);
-        }
-
-        .mobile-box.alerts {
-            background: linear-gradient(135deg, rgba(155, 74, 217, 0.15) 0%, rgba(155, 74, 217, 0.05) 100%);
-            border-color: rgba(155, 74, 217, 0.3);
-        }
-
-        .mobile-box h3 {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 36px;
-            font-weight: 600;
-            margin-bottom: 28px;
-        }
-
-        .mobile-box.setup h3 {
-            color: var(--accent-blue);
-        }
-
-        .mobile-box.features h3 {
-            color: var(--accent-green);
-        }
-
-        .mobile-box.tips h3 {
-            color: var(--accent-gold);
-        }
-
-        .mobile-box.alerts h3 {
-            color: var(--accent-purple);
-        }
-
-        .feature-list {
-            list-style: none;
-            text-align: left;
-        }
-
-        .feature-list li {
-            font-size: 21px;
-            color: var(--text-primary);
-            padding: 10px 0;
-            padding-left: 36px;
-            position: relative;
-        }
-
-        .feature-list li::before {
-            content: "→";
-            position: absolute;
-            left: 0;
-        }
-
-        .mobile-box.setup .feature-list li::before {
-            color: var(--accent-blue);
-        }
-
-        .mobile-box.features .feature-list li::before {
-            color: var(--accent-green);
-        }
-
-        .mobile-box.tips .feature-list li::before {
-            color: var(--accent-gold);
-        }
-
-        .mobile-box.alerts .feature-list li::before {
-            color: var(--accent-purple);
-        }
-
-        .cta-title {
-            font-family: 'Cormorant Garamond', serif;
-            font-size: 42px;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            line-height: 1.3;
-        }
-
-        .cta-title .emphasis {
-            color: var(--accent-blue);
-        }
-
-        .cta-text {
-            font-size: 24px;
-            color: var(--text-secondary);
-            margin-bottom: 8px;
-        }
-
-        /* Export Mode */
-        body.export-mode {
-            padding: 0;
-            background: none;
-        }
-
-        body.export-mode .carousel-container {
-            gap: 0;
-        }
-
-        body.export-mode .slide-wrapper {
-            display: none;
-        }
-
-        body.export-mode .slide-wrapper.active {
-            display: flex;
-        }
-
-        body.export-mode .slide-label {
-            display: none;
-        }
-
-        body.export-mode .slide {
-            border: none;
-        }
+        .cta-title { font-family: var(--font-serif); font-size: clamp(21px, 3.9vw, 42px); font-weight: 600; color: var(--text-primary); margin-bottom: clamp(10px, 1.9vw, 20px); line-height: 1.3; }
+        .cta-title .emphasis { color: var(--accent-blue); }
+        .cta-text { font-size: clamp(12px, 2.2vw, 24px); color: var(--text-secondary); margin-bottom: clamp(4px, 0.7vw, 8px); }
     </style>
 </head>
 <body>
-    <div class="carousel-container">
+    <div class="controls">
+        <label>Background: <select id="bg-toggle"><option value="video">Starfield</option><option value="solid">Solid</option></select></label>
+        <label>Opacity: <select id="opacity-control"><option value="0.08" selected>8%</option><option value="0.12">12%</option><option value="0.16">16%</option><option value="0.24">24%</option></select></label>
+        <button id="export-btn">Export Mode</button>
+    </div>
 
-        <!-- Slide 1: Hook -->
+    <div class="page-title">
+        <h1>Mobile Access Guide</h1>
+        <p>6 slides · Product Guide</p>
+    </div>
+
+    <div class="carousel-grid">
         <div class="slide-wrapper" data-slide="1">
             <span class="slide-label">Slide 1 — Hook</span>
             <div class="slide slide-1">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">01 / 06</span>
-                    <div class="center-content">
-                        <h1 class="slide-title">MOBILE<br>ACCESS GUIDE</h1>
-                        <p class="subtitle">Trade from anywhere.</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h1 class="slide-title">MOBILE<br>ACCESS GUIDE</h1>
+                    <p class="subtitle">Trade from anywhere.</p>
                 </div>
+                <div class="slide-number">1 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 2: Setup -->
         <div class="slide-wrapper" data-slide="2">
             <span class="slide-label">Slide 2 — Setup</span>
             <div class="slide slide-2">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">02 / 06</span>
-                    <div class="center-content">
-                        <div class="mobile-box setup">
-                            <h3>MOBILE SETUP</h3>
-                            <ul class="feature-list">
-                                <li>Download TradingView app</li>
-                                <li>Login with your account</li>
-                                <li>Signal Pilot syncs automatically</li>
-                                <li>Access all your indicators</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="mobile-box setup">
+                        <h3>MOBILE SETUP</h3>
+                        <ul class="feature-list">
+                            <li>Download TradingView app</li>
+                            <li>Login with your account</li>
+                            <li>Signal Pilot syncs automatically</li>
+                            <li>Access all your indicators</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">2 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 3: Features -->
         <div class="slide-wrapper" data-slide="3">
             <span class="slide-label">Slide 3 — Features</span>
             <div class="slide slide-3">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">03 / 06</span>
-                    <div class="center-content">
-                        <div class="mobile-box features">
-                            <h3>MOBILE FEATURES</h3>
-                            <ul class="feature-list">
-                                <li>Full indicator functionality</li>
-                                <li>Real-time alerts on the go</li>
-                                <li>Multi-chart layouts</li>
-                                <li>Quick trade management</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="mobile-box features">
+                        <h3>MOBILE FEATURES</h3>
+                        <ul class="feature-list">
+                            <li>Full indicator functionality</li>
+                            <li>Real-time alerts on the go</li>
+                            <li>Multi-chart layouts</li>
+                            <li>Quick trade management</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">3 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 4: Tips -->
         <div class="slide-wrapper" data-slide="4">
             <span class="slide-label">Slide 4 — Tips</span>
             <div class="slide slide-4">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">04 / 06</span>
-                    <div class="center-content">
-                        <div class="mobile-box tips">
-                            <h3>MOBILE TIPS</h3>
-                            <ul class="feature-list">
-                                <li>Save layouts for mobile view</li>
-                                <li>Use simplified charts</li>
-                                <li>Focus on key indicators only</li>
-                                <li>Manage trades, not entries</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="mobile-box tips">
+                        <h3>MOBILE TIPS</h3>
+                        <ul class="feature-list">
+                            <li>Save layouts for mobile view</li>
+                            <li>Use simplified charts</li>
+                            <li>Focus on key indicators only</li>
+                            <li>Manage trades, not entries</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">4 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 5: Alerts -->
         <div class="slide-wrapper" data-slide="5">
             <span class="slide-label">Slide 5 — Alerts</span>
             <div class="slide slide-5">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">05 / 06</span>
-                    <div class="center-content">
-                        <div class="mobile-box alerts">
-                            <h3>MOBILE ALERTS</h3>
-                            <ul class="feature-list">
-                                <li>Enable push notifications</li>
-                                <li>Set key level alerts</li>
-                                <li>Signal Pilot alerts work mobile</li>
-                                <li>Never miss a setup</li>
-                            </ul>
-                        </div>
+                    <div class="brand-header">Signal Pilot</div>
+                    <div class="mobile-box alerts">
+                        <h3>MOBILE ALERTS</h3>
+                        <ul class="feature-list">
+                            <li>Enable push notifications</li>
+                            <li>Set key level alerts</li>
+                            <li>Signal Pilot alerts work mobile</li>
+                            <li>Never miss a setup</li>
+                        </ul>
                     </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
                 </div>
+                <div class="slide-number">5 / 6</div>
             </div>
         </div>
 
-        <!-- Slide 6: CTA -->
         <div class="slide-wrapper" data-slide="6">
             <span class="slide-label">Slide 6 — CTA</span>
             <div class="slide slide-6">
-                <div class="slide-bg">
-                    <video autoplay loop muted playsinline>
-                        <source src="../../videos/starfield-bg.mp4" type="video/mp4">
-                    </video>
-                </div>
+                <div class="video-background"><video autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
                 <div class="slide-content">
-                    <span class="slide-number">06 / 06</span>
-                    <div class="center-content">
-                        <h2 class="cta-title">Your Charts,<br><span class="emphasis">Wherever You Are</span></h2>
-                        <p class="cta-text">Full mobile guide in docs</p>
-                        <p class="cta-text">Link in bio</p>
-                    </div>
-                    <span class="brand-mark">SIGNALPILOT</span>
+                    <div class="brand-header">Signal Pilot</div>
+                    <h2 class="cta-title">Your Charts,<br><span class="emphasis">Wherever You Are</span></h2>
+                    <p class="cta-text">Full mobile guide in docs</p>
+                    <p class="cta-text">Link in bio</p>
                 </div>
+                <div class="slide-number">6 / 6</div>
             </div>
         </div>
-
     </div>
 
     <script>
-        let currentSlide = 0;
-        const slides = document.querySelectorAll('.slide-wrapper');
-        const totalSlides = slides.length;
-        let exportMode = false;
+        (function() {
+            const defined = (v) => typeof v !== 'undefined' && v !== null;
+            let exportMode = false, currentSlide = 0;
+            const slideWrappers = document.querySelectorAll('.slide-wrapper');
+            const totalSlides = slideWrappers.length;
+            const bgToggle = document.getElementById('bg-toggle');
+            const opacityControl = document.getElementById('opacity-control');
+            const exportBtn = document.getElementById('export-btn');
 
-        function enterExportMode() {
-            exportMode = true;
-            document.body.classList.add('export-mode');
-            currentSlide = 0;
-            updateExportView();
-        }
+            function updateExportView() { slideWrappers.forEach((wrapper, index) => { wrapper.classList.toggle('exporting', index === currentSlide); }); }
 
-        function exitExportMode() {
-            exportMode = false;
-            document.body.classList.remove('export-mode');
-            slides.forEach(slide => slide.classList.remove('active'));
-        }
+            if (defined(bgToggle)) { bgToggle.addEventListener('change', (e) => { document.querySelectorAll('.video-background').forEach(bg => { bg.style.display = e.target.value === 'video' ? 'block' : 'none'; }); }); }
+            if (defined(opacityControl)) { opacityControl.addEventListener('change', (e) => { document.documentElement.style.setProperty('--video-opacity', e.target.value); }); }
+            if (defined(exportBtn)) { exportBtn.addEventListener('click', () => { exportMode = !exportMode; document.body.classList.toggle('export-mode', exportMode); exportBtn.textContent = exportMode ? 'Exit Export' : 'Export Mode'; if (exportMode) { currentSlide = 0; updateExportView(); } }); }
 
-        function updateExportView() {
-            slides.forEach((slide, index) => {
-                slide.classList.toggle('active', index === currentSlide);
+            document.addEventListener('keydown', (e) => {
+                if (!exportMode) return;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { currentSlide = Math.min(currentSlide + 1, totalSlides - 1); updateExportView(); }
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { currentSlide = Math.max(currentSlide - 1, 0); updateExportView(); }
+                else if (e.key === 'Escape') { exportMode = false; document.body.classList.remove('export-mode'); exportBtn.textContent = 'Export Mode'; }
             });
-        }
-
-        function nextSlide() {
-            if (exportMode && currentSlide < totalSlides - 1) {
-                currentSlide++;
-                updateExportView();
-            }
-        }
-
-        function prevSlide() {
-            if (exportMode && currentSlide > 0) {
-                currentSlide--;
-                updateExportView();
-            }
-        }
-
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'e' || e.key === 'E') {
-                if (!exportMode) enterExportMode();
-            } else if (e.key === 'Escape') {
-                exitExportMode();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
-            } else if (e.key === 'ArrowLeft') {
-                prevSlide();
-            }
-        });
-
-        console.log('Press E to enter export mode, Escape to exit, Arrow keys to navigate');
+        })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
All 14 posts in the 472-490 range converted to new grid layout:
- Controls section with background toggle, opacity control, export button
- Page title with slide count and category
- carousel-grid class with responsive design
- video-background class with CSS variable opacity
- Brand header "Signal Pilot" on each slide
- Slide numbers in "X / Y" format at bottom right
- Export mode for 1080x1080 screenshots with arrow key navigation
- clamp() for responsive sizing