### PR TITLE
Add Russian locale pages and redirect rules to sitemap and Vercel config

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1284,6 +1284,18 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://www.signalpilot.io/ru/affiliates.html</loc>
+    <lastmod>2025-12-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://www.signalpilot.io/ru/faq.html</loc>
+    <lastmod>2025-12-19</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://www.signalpilot.io/ru/manage-subscription.html</loc>
     <lastmod>2025-12-19</lastmod>
     <changefreq>monthly</changefreq>
@@ -1300,6 +1312,12 @@
     <lastmod>2025-12-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://www.signalpilot.io/ru/roadmap.html</loc>
+    <lastmod>2025-12-19</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.signalpilot.io/ru/terms.html</loc>

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,191 @@
       "source": "/free/",
       "destination": "https://education.signalpilot.io/free/",
       "permanent": true
+    },
+    {
+      "source": "/resources/faq",
+      "destination": "/faq.html",
+      "permanent": true
+    },
+    {
+      "source": "/resources/faq/",
+      "destination": "/faq.html",
+      "permanent": true
+    },
+    {
+      "source": "/resources/:path*",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/articles/:path*",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/blog/:path*",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/ar/articles/:path*",
+      "destination": "/ar/",
+      "permanent": true
+    },
+    {
+      "source": "/de/articles/:path*",
+      "destination": "/de/",
+      "permanent": true
+    },
+    {
+      "source": "/es/articles/:path*",
+      "destination": "/es/",
+      "permanent": true
+    },
+    {
+      "source": "/fr/articles/:path*",
+      "destination": "/fr/",
+      "permanent": true
+    },
+    {
+      "source": "/hu/articles/:path*",
+      "destination": "/hu/",
+      "permanent": true
+    },
+    {
+      "source": "/it/articles/:path*",
+      "destination": "/it/",
+      "permanent": true
+    },
+    {
+      "source": "/ja/articles/:path*",
+      "destination": "/ja/",
+      "permanent": true
+    },
+    {
+      "source": "/nl/articles/:path*",
+      "destination": "/nl/",
+      "permanent": true
+    },
+    {
+      "source": "/pt/articles/:path*",
+      "destination": "/pt/",
+      "permanent": true
+    },
+    {
+      "source": "/ru/articles/:path*",
+      "destination": "/ru/",
+      "permanent": true
+    },
+    {
+      "source": "/tr/articles/:path*",
+      "destination": "/tr/",
+      "permanent": true
+    },
+    {
+      "source": "/ar/blog/:path*",
+      "destination": "/ar/",
+      "permanent": true
+    },
+    {
+      "source": "/de/blog/:path*",
+      "destination": "/de/",
+      "permanent": true
+    },
+    {
+      "source": "/es/blog/:path*",
+      "destination": "/es/",
+      "permanent": true
+    },
+    {
+      "source": "/fr/blog/:path*",
+      "destination": "/fr/",
+      "permanent": true
+    },
+    {
+      "source": "/hu/blog/:path*",
+      "destination": "/hu/",
+      "permanent": true
+    },
+    {
+      "source": "/it/blog/:path*",
+      "destination": "/it/",
+      "permanent": true
+    },
+    {
+      "source": "/ja/blog/:path*",
+      "destination": "/ja/",
+      "permanent": true
+    },
+    {
+      "source": "/nl/blog/:path*",
+      "destination": "/nl/",
+      "permanent": true
+    },
+    {
+      "source": "/pt/blog/:path*",
+      "destination": "/pt/",
+      "permanent": true
+    },
+    {
+      "source": "/ru/blog/:path*",
+      "destination": "/ru/",
+      "permanent": true
+    },
+    {
+      "source": "/tr/blog/:path*",
+      "destination": "/tr/",
+      "permanent": true
+    },
+    {
+      "source": "/curriculum/:path*",
+      "destination": "https://education.signalpilot.io/",
+      "permanent": true
+    },
+    {
+      "source": "/lessons/:path*",
+      "destination": "https://education.signalpilot.io/",
+      "permanent": true
+    },
+    {
+      "source": "/posts/:path*",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/news/:path*",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/guides/:path*",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/tutorials/:path*",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "https://docs.signalpilot.io/",
+      "permanent": true
+    },
+    {
+      "source": "/help/:path*",
+      "destination": "https://docs.signalpilot.io/",
+      "permanent": true
+    },
+    {
+      "source": "/support/:path*",
+      "destination": "https://docs.signalpilot.io/",
+      "permanent": true
+    },
+    {
+      "source": "/education/:path*",
+      "destination": "https://education.signalpilot.io/",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
This PR updates the sitemap and Vercel configuration to improve SEO and handle legacy URL redirects. It adds three new Russian locale pages to the sitemap and implements comprehensive redirect rules for deprecated content paths.

## Key Changes

**Sitemap Updates (sitemap.xml):**
- Added `/ru/affiliates.html` with monthly changefreq and 0.5 priority
- Added `/ru/faq.html` with daily changefreq and 0.8 priority
- Added `/ru/roadmap.html` with daily changefreq and 0.7 priority

**Redirect Rules (vercel.json):**
- Added specific redirect for `/resources/faq` → `/faq.html`
- Added catch-all redirects for deprecated content paths:
  - `/resources/*` → `/` (permanent)
  - `/articles/*` → `/` (permanent, with locale-specific variants for all supported languages)
  - `/blog/*` → `/` (permanent, with locale-specific variants for all supported languages)
  - `/posts/*`, `/news/*`, `/guides/*`, `/tutorials/*` → `/` (permanent)
  - `/curriculum/*`, `/lessons/*` → `https://education.signalpilot.io/` (permanent)
  - `/docs/*`, `/help/*`, `/support/*` → `https://docs.signalpilot.io/` (permanent)
  - `/education/*` → `https://education.signalpilot.io/` (permanent)

## Implementation Details
- All redirects are marked as permanent (301) to preserve SEO value
- Locale-specific redirects cover all 11 supported languages (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr)
- Redirects consolidate legacy content paths while maintaining proper routing to appropriate destinations
- Sitemap entries use consistent lastmod date (2025-12-19) for the new pages