### PR TITLE
Add 'All markets • All timeframes' to hero + update trader types

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4738,6 +4738,14 @@ html[lang="ar"] [style*="text-align:center"] {
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">جميع</span> الأسواق
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">جميع</span> الأطر الزمنية
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> درس مجاني
             </a>
@@ -8256,7 +8264,7 @@ if ('serviceWorker' in navigator) {
   function initTypingEffect() {
     const el = document.getElementById('typed-text');
     if (!el) return;
-    const words = ['المتداولين الجادين', 'متداولي اليوم', 'المتداولين المتأرجحين', 'المضاربين السريعين', 'متداولي المراكز', 'جميع المتداولين'];
+    const words = ['متداولي اليوم', 'متداولي السوينغ', 'المضاربين', 'متداولي الفوركس', 'متداولي الكريبتو', 'متداولي الأسهم', 'متداولي العقود الآجلة', 'جميع المتداولين'];
     let idx = 0;
     const chars = '!<>-_\\/[]{}—=+*^?#_______';
     class SignalDecode {

--- a/de/index.html
+++ b/de/index.html
@@ -4735,6 +4735,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Alle</span> Märkte
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Alle</span> Zeitrahmen
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Kostenlose Lektionen
             </a>
@@ -8703,11 +8711,13 @@ if ('serviceWorker' in navigator) {
     if (!textElement) return;
 
     const words = [
-      'ernsthafte Trader',
       'Day Trader',
       'Swing Trader',
       'Scalper',
-      'Positions-Trader',
+      'Forex Trader',
+      'Krypto Trader',
+      'Aktien Trader',
+      'Futures Trader',
       'alle Trader'
     ];
     let wordIndex = 0;

--- a/es/index.html
+++ b/es/index.html
@@ -4949,6 +4949,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Todos</span> los mercados
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Todos</span> los timeframes
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Lecciones Gratuitas
             </a>
@@ -8736,11 +8744,13 @@ if ('serviceWorker' in navigator) {
     if (!textElement) return;
 
     const words = [
-      'traders profesionales',
       'traders intradía',
       'traders de swing',
-      'especuladores',
-      'traders posicionales',
+      'scalpers',
+      'traders de forex',
+      'traders de cripto',
+      'traders de acciones',
+      'traders de futuros',
       'todos los traders'
     ];
     let wordIndex = 0;

--- a/fr/index.html
+++ b/fr/index.html
@@ -5032,6 +5032,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Tous</span> les marchés
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Tous</span> les timeframes
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Leçons Gratuites
             </a>
@@ -9017,11 +9025,13 @@ if ('serviceWorker' in navigator) {
     if (!textElement) return;
 
     const words = [
-      'traders sérieux',
-      'traders quotidiens',
+      'day traders',
       'swing traders',
       'scalpers',
-      'traders de position',
+      'traders forex',
+      'traders crypto',
+      'traders actions',
+      'traders futures',
       'tous les traders'
     ];
     let wordIndex = 0;

--- a/hu/index.html
+++ b/hu/index.html
@@ -4682,6 +4682,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Minden</span> piac
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Minden</span> időkeret
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Ingyenes Lecke
             </a>
@@ -8559,7 +8567,7 @@ if ('serviceWorker' in navigator) {
   function initTypingEffect() {
     const el = document.getElementById('typed-text');
     if (!el) return;
-    const words = ['komoly kereskedőknek','napi kereskedőknek','swing kereskedőknek','scalpereknek','pozíciós kereskedőknek','minden kereskedőnek'];
+    const words = ['napi kereskedőknek','swing kereskedőknek','scalpereknek','forex kereskedőknek','kripto kereskedőknek','részvény kereskedőknek','futures kereskedőknek','minden kereskedőnek'];
     let idx = 0;
     const chars = '!<>-_\\/[]{}—=+*^?#_______';
     class SignalDecode {

--- a/index.html
+++ b/index.html
@@ -7981,13 +7981,13 @@ if ('serviceWorker' in navigator) {
     if (!textElement) return;
 
     const words = [
-      'serious traders',
       'day traders',
       'swing traders',
       'scalpers',
-      'position traders',
       'forex traders',
       'crypto traders',
+      'stock traders',
+      'futures traders',
       'all traders'
     ];
 

--- a/it/index.html
+++ b/it/index.html
@@ -4647,6 +4647,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Tutti</span> i mercati
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Tutti</span> i timeframe
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Lezioni Gratuite
             </a>
@@ -8145,11 +8153,13 @@ if ('serviceWorker' in navigator) {
     if (!textElement) return;
 
     const words = [
-      'trader professionisti',
       'day trader',
       'swing trader',
       'scalper',
-      'trader di posizione',
+      'trader forex',
+      'trader crypto',
+      'trader azionari',
+      'trader futures',
       'tutti i trader'
     ];
     let wordIndex = 0;

--- a/ja/index.html
+++ b/ja/index.html
@@ -4996,6 +4996,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">全</span>市場
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">全</span>時間足
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> 無料レッスン
             </a>
@@ -8386,7 +8394,7 @@ if ('serviceWorker' in navigator) {
   function initTypingEffect() {
     const el = document.getElementById('typed-text');
     if (!el) return;
-    const words = ['本格的なトレーダー向け','デイトレーダー向け','スイングトレーダー向け','スキャルパー向け','ポジショントレーダー向け','すべてのトレーダー向け'];
+    const words = ['デイトレーダー向け','スイングトレーダー向け','スキャルパー向け','FXトレーダー向け','仮想通貨トレーダー向け','株式トレーダー向け','先物トレーダー向け','すべてのトレーダー向け'];
     let idx = 0;
     const chars = '!<>-_\\/[]{}—=+*^?#_______';
     class SignalDecode {

--- a/nl/index.html
+++ b/nl/index.html
@@ -4674,6 +4674,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Alle</span> markten
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Alle</span> timeframes
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Gratis Lessen
             </a>
@@ -8074,7 +8082,7 @@ if ('serviceWorker' in navigator) {
   function initTypingEffect() {
     const el = document.getElementById('typed-text');
     if (!el) return;
-    const words = ['serieuze traders','daytraders','swingtraders','scalpers','positietraders','alle traders'];
+    const words = ['daytraders','swingtraders','scalpers','forex traders','crypto traders','aandelen traders','futures traders','alle traders'];
     let idx = 0;
     const chars = '!<>-_\\/[]{}—=+*^?#_______';
     class SignalDecode {

--- a/pt/index.html
+++ b/pt/index.html
@@ -4929,6 +4929,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Todos</span> os mercados
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Todos</span> os timeframes
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Lições Gratuitas
             </a>
@@ -8431,7 +8439,7 @@ if ('serviceWorker' in navigator) {
   function initTypingEffect() {
     const el = document.getElementById('typed-text');
     if (!el) return;
-    const words = ['traders sérios','traders diários','swing traders','scalpers','traders de posição','todos os traders'];
+    const words = ['day traders','swing traders','scalpers','traders forex','traders crypto','traders de ações','traders de futuros','todos os traders'];
     let idx = 0;
     const chars = '!<>-_\\/[]{}—=+*^?#_______';
     class SignalDecode {

--- a/ru/index.html
+++ b/ru/index.html
@@ -4776,6 +4776,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Все</span> рынки
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Все</span> таймфреймы
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Бесплатных Урока
             </a>
@@ -8193,7 +8201,7 @@ if ('serviceWorker' in navigator) {
   function initTypingEffect() {
     const el = document.getElementById('typed-text');
     if (!el) return;
-    const words = ['серьёзных трейдеров','дневных трейдеров','свинг-трейдеров','скальперов','позиционных трейдеров','всех трейдеров'];
+    const words = ['дневных трейдеров','свинг-трейдеров','скальперов','форекс-трейдеров','крипто-трейдеров','фондовых трейдеров','фьючерсных трейдеров','всех трейдеров'];
     let idx = 0;
     const chars = '!<>-_\\/[]{}—=+*^?#_______';
     class SignalDecode {

--- a/tr/index.html
+++ b/tr/index.html
@@ -4851,6 +4851,14 @@
 
           <!-- Value Props Strip -->
           <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem 1.25rem;margin-top:1.5rem">
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Tüm</span> piyasalar
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <span style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem">
+              <span style="color:var(--brand);font-weight:700">Tüm</span> zaman dilimleri
+            </span>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="https://education.signalpilot.io" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">82</span> Ücretsiz Ders
             </a>
@@ -8273,7 +8281,7 @@ if ('serviceWorker' in navigator) {
   function initTypingEffect() {
     const el = document.getElementById('typed-text');
     if (!el) return;
-    const words = ['ciddi yatırımcılar', 'günlük yatırımcılar', 'salınım yatırımcıları', 'scalper\'lar', 'pozisyon yatırımcıları', 'tüm yatırımcılar'];
+    const words = ['günlük traderlar', 'swing traderlar', 'scalperlar', 'forex traderları', 'kripto traderları', 'hisse traderları', 'vadeli işlem traderları', 'tüm traderlar'];
     let idx = 0;
     const chars = '!<>-_\\/[]{}—=+*^?#_______';
     class SignalDecode {


### PR DESCRIPTION
- Added universal usability messaging to value props strip (all 12 languages)
- Updated typed text animation with market-specific trader types: day traders, swing traders, scalpers, forex/crypto/stock/futures traders
- Removed vague 'serious traders', kept focused on searchable trader types