### PR TITLE
Add TradingView profile link to hero & clean up Built With section

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -4757,6 +4757,11 @@ html[lang="ar"] [style*="text-align:center"] {
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 أيام</span> استرداد
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6400,9 +6405,9 @@ html[lang="ar"] [style*="text-align:center"] {
         }
         .partners-track {
           display: flex;
-          gap: 4rem;
+          gap: 6rem;
           padding: 0 2rem;
-          animation: partners-scroll-rtl 50s linear infinite;
+          animation: partners-scroll-rtl 30s linear infinite;
           width: max-content;
         }
         .partners-marquee:hover .partners-track {
@@ -6474,60 +6479,6 @@ html[lang="ar"] [style*="text-align:center"] {
               </svg>
               <span>TradingView</span>
             </a>
-            <!-- GitHub -->
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <!-- Discord -->
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <!-- Vercel -->
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <!-- Gumroad -->
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <!-- Claude -->
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <!-- Runway -->
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <!-- GoDaddy -->
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <!-- Pine Script -->
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6536,12 +6487,12 @@ html[lang="ar"] [style*="text-align:center"] {
               </svg>
               <span>Pine Script</span>
             </a>
-            <!-- Unicorn -->
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+            <!-- Vercel -->
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
             <!-- Duplicate set for seamless loop -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6550,53 +6501,6 @@ html[lang="ar"] [style*="text-align:center"] {
               </svg>
               <span>TradingView</span>
             </a>
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
                 <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6604,11 +6508,11 @@ html[lang="ar"] [style*="text-align:center"] {
               </svg>
               <span>Pine Script</span>
             </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
           </div>
         </div>

--- a/ar/index.html
+++ b/ar/index.html
@@ -6405,7 +6405,7 @@ html[lang="ar"] [style*="text-align:center"] {
         }
         .partners-track {
           display: flex;
-          gap: 6rem;
+          gap: 12rem;
           padding: 0 2rem;
           animation: partners-scroll-rtl 30s linear infinite;
           width: max-content;

--- a/de/index.html
+++ b/de/index.html
@@ -6849,7 +6849,7 @@
       }
       .partners-track {
         display: flex;
-        gap: 6rem;
+        gap: 12rem;
         padding: 0 2rem;
         animation: partners-scroll 30s linear infinite;
         width: max-content;

--- a/de/index.html
+++ b/de/index.html
@@ -4754,6 +4754,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7-Tage</span> Geld-zurück
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6844,9 +6849,9 @@
       }
       .partners-track {
         display: flex;
-        gap: 4rem;
+        gap: 6rem;
         padding: 0 2rem;
-        animation: partners-scroll 50s linear infinite;
+        animation: partners-scroll 30s linear infinite;
         width: max-content;
       }
       .partners-marquee:hover .partners-track {
@@ -6918,60 +6923,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <!-- GitHub -->
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <!-- Discord -->
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <!-- Vercel -->
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <!-- Gumroad -->
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <!-- Claude -->
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <!-- Runway -->
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <!-- GoDaddy -->
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <!-- Pine Script -->
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
             <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
@@ -6980,12 +6931,12 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <!-- Unicorn -->
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+          <!-- Vercel -->
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
             <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
           <!-- Duplicate set for seamless loop -->
           <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6994,53 +6945,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
               <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -7048,11 +6952,11 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="currentColor" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
         </div>
       </div>

--- a/es/index.html
+++ b/es/index.html
@@ -4968,6 +4968,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 Días</span> Devolución
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6873,9 +6878,9 @@
       }
       .partners-track {
         display: flex;
-        gap: 4rem;
+        gap: 6rem;
         padding: 0 2rem;
-        animation: partners-scroll 50s linear infinite;
+        animation: partners-scroll 30s linear infinite;
         width: max-content;
       }
       .partners-marquee:hover .partners-track {
@@ -6947,60 +6952,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <!-- GitHub -->
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <!-- Discord -->
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <!-- Vercel -->
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <!-- Gumroad -->
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <!-- Claude -->
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <!-- Runway -->
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <!-- GoDaddy -->
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <!-- Pine Script -->
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -7009,12 +6960,12 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <!-- Unicorn -->
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+          <!-- Vercel -->
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
           <!-- Duplicate set for seamless loop -->
           <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -7023,53 +6974,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
               <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -7077,11 +6981,11 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
         </div>
       </div>

--- a/es/index.html
+++ b/es/index.html
@@ -6878,7 +6878,7 @@
       }
       .partners-track {
         display: flex;
-        gap: 6rem;
+        gap: 12rem;
         padding: 0 2rem;
         animation: partners-scroll 30s linear infinite;
         width: max-content;

--- a/fr/index.html
+++ b/fr/index.html
@@ -5051,6 +5051,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 Jours</span> Remboursé
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -7155,9 +7160,9 @@
       }
       .partners-track {
         display: flex;
-        gap: 4rem;
+        gap: 6rem;
         padding: 0 2rem;
-        animation: partners-scroll 50s linear infinite;
+        animation: partners-scroll 30s linear infinite;
         width: max-content;
       }
       .partners-marquee:hover .partners-track {
@@ -7229,60 +7234,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <!-- GitHub -->
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <!-- Discord -->
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <!-- Vercel -->
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <!-- Gumroad -->
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <!-- Claude -->
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <!-- Runway -->
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <!-- GoDaddy -->
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <!-- Pine Script -->
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -7291,12 +7242,12 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <!-- Unicorn -->
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+          <!-- Vercel -->
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
           <!-- Duplicate set for seamless loop -->
           <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -7305,53 +7256,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
               <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -7359,11 +7263,11 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
         </div>
       </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -7160,7 +7160,7 @@
       }
       .partners-track {
         display: flex;
-        gap: 6rem;
+        gap: 12rem;
         padding: 0 2rem;
         animation: partners-scroll 30s linear infinite;
         width: max-content;

--- a/hu/index.html
+++ b/hu/index.html
@@ -6709,7 +6709,7 @@
         }
         .partners-track {
           display: flex;
-          gap: 6rem;
+          gap: 12rem;
           padding: 0 2rem;
           animation: partners-scroll 30s linear infinite;
           width: max-content;

--- a/hu/index.html
+++ b/hu/index.html
@@ -4701,6 +4701,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 Nap</span> Pénzvisszafizetés
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6704,9 +6709,9 @@
         }
         .partners-track {
           display: flex;
-          gap: 4rem;
+          gap: 6rem;
           padding: 0 2rem;
-          animation: partners-scroll 50s linear infinite;
+          animation: partners-scroll 30s linear infinite;
           width: max-content;
         }
         .partners-marquee:hover .partners-track {
@@ -6778,60 +6783,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <!-- GitHub -->
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <!-- Discord -->
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <!-- Vercel -->
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <!-- Gumroad -->
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <!-- Claude -->
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <!-- Runway -->
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <!-- GoDaddy -->
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <!-- Pine Script -->
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6840,12 +6791,12 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <!-- Unicorn -->
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+            <!-- Vercel -->
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
             <!-- Duplicate set for seamless loop -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6854,53 +6805,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
                 <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6908,11 +6812,11 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -6120,7 +6120,7 @@
       }
       .partners-track {
         display: flex;
-        gap: 6rem;
+        gap: 12rem;
         padding: 0 2rem;
         animation: partners-scroll 30s linear infinite;
         width: max-content;

--- a/index.html
+++ b/index.html
@@ -3687,6 +3687,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7-Day</span> Money-Back
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6115,9 +6120,9 @@
       }
       .partners-track {
         display: flex;
-        gap: 4rem;
+        gap: 6rem;
         padding: 0 2rem;
-        animation: partners-scroll 50s linear infinite;
+        animation: partners-scroll 30s linear infinite;
         width: max-content;
       }
       .partners-marquee:hover .partners-track {
@@ -6188,60 +6193,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <!-- GitHub -->
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <!-- Discord -->
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <!-- Vercel -->
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <!-- Gumroad -->
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <!-- Claude -->
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <!-- Runway -->
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <!-- GoDaddy -->
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <!-- Pine Script -->
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6250,12 +6201,12 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <!-- Unicorn -->
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+          <!-- Vercel -->
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
           <!-- Duplicate set for seamless loop -->
           <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6264,44 +6215,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
               <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6309,11 +6222,11 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
         </div>
       </div>

--- a/it/index.html
+++ b/it/index.html
@@ -6305,7 +6305,7 @@
         }
         .partners-track {
           display: flex;
-          gap: 6rem;
+          gap: 12rem;
           padding: 0 2rem;
           animation: partners-scroll 30s linear infinite;
           width: max-content;

--- a/it/index.html
+++ b/it/index.html
@@ -4666,6 +4666,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 Giorni</span> Rimborso
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6300,9 +6305,9 @@
         }
         .partners-track {
           display: flex;
-          gap: 4rem;
+          gap: 6rem;
           padding: 0 2rem;
-          animation: partners-scroll 50s linear infinite;
+          animation: partners-scroll 30s linear infinite;
           width: max-content;
         }
         .partners-marquee:hover .partners-track {
@@ -6374,60 +6379,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <!-- GitHub -->
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <!-- Discord -->
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <!-- Vercel -->
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <!-- Gumroad -->
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <!-- Claude -->
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <!-- Runway -->
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <!-- GoDaddy -->
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <!-- Pine Script -->
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6436,12 +6387,12 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <!-- Unicorn -->
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+            <!-- Vercel -->
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
             <!-- Duplicate set for seamless loop -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6450,53 +6401,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
                 <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6504,11 +6408,11 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
           </div>
         </div>

--- a/ja/index.html
+++ b/ja/index.html
@@ -5015,6 +5015,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7日間</span> 返金対応
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6539,9 +6544,9 @@
         }
         .partners-track {
           display: flex;
-          gap: 4rem;
+          gap: 6rem;
           padding: 0 2rem;
-          animation: partners-scroll 50s linear infinite;
+          animation: partners-scroll 30s linear infinite;
           width: max-content;
         }
         .partners-marquee:hover .partners-track {
@@ -6613,60 +6618,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <!-- GitHub -->
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <!-- Discord -->
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <!-- Vercel -->
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <!-- Gumroad -->
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <!-- Claude -->
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <!-- Runway -->
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <!-- GoDaddy -->
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <!-- Pine Script -->
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6675,12 +6626,12 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <!-- Unicorn -->
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+            <!-- Vercel -->
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
             <!-- Duplicate set for seamless loop -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6689,53 +6640,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
                 <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6743,11 +6647,11 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
           </div>
         </div>

--- a/ja/index.html
+++ b/ja/index.html
@@ -6544,7 +6544,7 @@
         }
         .partners-track {
           display: flex;
-          gap: 6rem;
+          gap: 12rem;
           padding: 0 2rem;
           animation: partners-scroll 30s linear infinite;
           width: max-content;

--- a/nl/index.html
+++ b/nl/index.html
@@ -6234,7 +6234,7 @@
       }
       .partners-track {
         display: flex;
-        gap: 6rem;
+        gap: 12rem;
         padding: 0 2rem;
         animation: partners-scroll 30s linear infinite;
         width: max-content;

--- a/nl/index.html
+++ b/nl/index.html
@@ -870,7 +870,7 @@
         animation-duration: 30s !important;
       }
       .partners-track {
-        animation-duration: 50s !important;
+        animation-duration: 30s !important;
       }
       .partners-track-reverse {
         animation-duration: 45s !important;
@@ -1599,7 +1599,7 @@
         animation-duration: 30s !important;
       }
       .partners-track {
-        animation-duration: 50s !important;
+        animation-duration: 30s !important;
       }
       .partners-track-reverse {
         animation-duration: 45s !important;
@@ -4320,7 +4320,7 @@
         animation-duration: 30s !important;
       }
       .partners-track {
-        animation-duration: 50s !important;
+        animation-duration: 30s !important;
       }
       .partners-track-reverse {
         animation-duration: 45s !important;
@@ -4692,6 +4692,11 @@
             <span style="color:rgba(255,255,255,0.25)">•</span>
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 Dagen</span> Geld-Terug
+            </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
             </a>
           </div>
 
@@ -6229,9 +6234,9 @@
       }
       .partners-track {
         display: flex;
-        gap: 4rem;
+        gap: 6rem;
         padding: 0 2rem;
-        animation: partners-scroll 50s linear infinite;
+        animation: partners-scroll 30s linear infinite;
         width: max-content;
       }
       .partners-marquee:hover .partners-track {
@@ -6303,60 +6308,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <!-- GitHub -->
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <!-- Discord -->
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <!-- Vercel -->
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <!-- Gumroad -->
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <!-- Claude -->
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <!-- Runway -->
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <!-- GoDaddy -->
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <!-- Pine Script -->
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6365,12 +6316,12 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <!-- Unicorn -->
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+          <!-- Vercel -->
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
           <!-- Duplicate set for seamless loop -->
           <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6379,53 +6330,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
               <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6433,11 +6337,11 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
         </div>
       </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -6591,7 +6591,7 @@
       }
       .partners-track {
         display: flex;
-        gap: 6rem;
+        gap: 12rem;
         padding: 0 2rem;
         animation: partners-scroll 30s linear infinite;
         width: max-content;

--- a/pt/index.html
+++ b/pt/index.html
@@ -4948,6 +4948,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 Dias</span> Reembolso
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6586,9 +6591,9 @@
       }
       .partners-track {
         display: flex;
-        gap: 4rem;
+        gap: 6rem;
         padding: 0 2rem;
-        animation: partners-scroll 50s linear infinite;
+        animation: partners-scroll 30s linear infinite;
         width: max-content;
       }
       .partners-marquee:hover .partners-track {
@@ -6660,60 +6665,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <!-- GitHub -->
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <!-- Discord -->
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <!-- Vercel -->
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <!-- Gumroad -->
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <!-- Claude -->
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <!-- Runway -->
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <!-- GoDaddy -->
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <!-- Pine Script -->
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6722,12 +6673,12 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <!-- Unicorn -->
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+          <!-- Vercel -->
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
           <!-- Duplicate set for seamless loop -->
           <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6736,53 +6687,6 @@
             </svg>
             <span>TradingView</span>
           </a>
-          <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-          <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-              <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-            </svg>
-            <span>Discord</span>
-          </a>
-          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 22 20 2 20 12 2"/>
-            </svg>
-            <span>Vercel</span>
-          </a>
-          <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-              <line x1="12" y1="12" x2="17" y2="12"/>
-              <line x1="17" y1="12" x2="17" y2="17"/>
-            </svg>
-            <span>Gumroad</span>
-          </a>
-          <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-            </svg>
-            <span>Claude</span>
-          </a>
-          <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-            </svg>
-            <span>Runway</span>
-          </a>
-          <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-              <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-            </svg>
-            <span>GoDaddy</span>
-          </a>
           <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
               <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6790,11 +6694,11 @@
             </svg>
             <span>Pine Script</span>
           </a>
-          <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+          <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              <polygon points="12 2 22 20 2 20 12 2"/>
             </svg>
-            <span>Unicorn</span>
+            <span>Vercel</span>
           </a>
         </div>
       </div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -6353,7 +6353,7 @@
         }
         .partners-track {
           display: flex;
-          gap: 6rem;
+          gap: 12rem;
           padding: 0 2rem;
           animation: partners-scroll 30s linear infinite;
           width: max-content;

--- a/ru/index.html
+++ b/ru/index.html
@@ -4795,6 +4795,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 Дней</span> Возврат
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6348,9 +6353,9 @@
         }
         .partners-track {
           display: flex;
-          gap: 4rem;
+          gap: 6rem;
           padding: 0 2rem;
-          animation: partners-scroll 50s linear infinite;
+          animation: partners-scroll 30s linear infinite;
           width: max-content;
         }
         .partners-marquee:hover .partners-track {
@@ -6422,60 +6427,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <!-- GitHub -->
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <!-- Discord -->
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <!-- Vercel -->
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <!-- Gumroad -->
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <!-- Claude -->
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <!-- Runway -->
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <!-- GoDaddy -->
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <!-- Pine Script -->
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6484,12 +6435,12 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <!-- Unicorn -->
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+            <!-- Vercel -->
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
             <!-- Duplicate set for seamless loop -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6498,53 +6449,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
                 <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6552,11 +6456,11 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
           </div>
         </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -4870,6 +4870,11 @@
             <a href="#pricing" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'">
               <span style="color:var(--brand);font-weight:700">7 Gün</span> Para İade
             </a>
+            <span style="color:rgba(255,255,255,0.25)">•</span>
+            <a href="https://www.tradingview.com/u/SignalPilotLabs/#published-scripts" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.4rem;color:var(--muted);font-size:0.95rem;text-decoration:none;transition:color 0.2s" onmouseover="this.style.color='#2962FF'" onmouseout="this.style.color='var(--muted)'">
+              <svg width="16" height="16" viewBox="0 0 36 28" fill="currentColor"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z"/></svg>
+              <span style="color:#2962FF;font-weight:700">TradingView</span>
+            </a>
           </div>
 
         </div>
@@ -6425,9 +6430,9 @@
         }
         .partners-track {
           display: flex;
-          gap: 4rem;
+          gap: 6rem;
           padding: 0 2rem;
-          animation: partners-scroll 50s linear infinite;
+          animation: partners-scroll 30s linear infinite;
           width: max-content;
         }
         .partners-marquee:hover .partners-track {
@@ -6499,60 +6504,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <!-- GitHub -->
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" title="GitHub">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <!-- Discord -->
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" title="Discord">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <!-- Vercel -->
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <!-- Gumroad -->
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" title="Gumroad">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <!-- Claude -->
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" title="Claude AI">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <!-- Runway -->
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" title="Runway">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <!-- GoDaddy -->
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" title="GoDaddy">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <!-- Pine Script -->
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" title="Pine Script">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
@@ -6561,12 +6512,12 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <!-- Unicorn -->
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" title="Unicorn Studio">
+            <!-- Vercel -->
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" title="Vercel">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
             <!-- Duplicate set for seamless loop -->
             <a href="https://www.tradingview.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
@@ -6575,53 +6526,6 @@
               </svg>
               <span>TradingView</span>
             </a>
-            <a href="https://github.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.164 6.839 9.49.5.09.682-.218.682-.484 0-.236-.009-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-              </svg>
-              <span>GitHub</span>
-            </a>
-            <a href="https://discord.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0c-.175-.386-.406-.875-.617-1.25a19.736 19.736 0 00-4.885 1.515C.533 9.046-.32 13.58.099 18.057a19.9 19.9 0 005.993 3.03c.462-.63.874-1.295 1.226-1.994a13.1 13.1 0 01-1.872-.892c.126-.094.252-.192.372-.292 3.928 1.793 8.18 1.793 12.062 0c.12.1.246.2.373.292a12.3 12.3 0 01-1.873.892c.36.698.772 1.362 1.225 1.993a19.84 19.84 0 006.002-3.03c.5-5.177-.838-9.674-3.549-13.66z"/>
-                <circle cx="8.5" cy="13.5" r="1.5"/><circle cx="15.5" cy="13.5" r="1.5"/>
-              </svg>
-              <span>Discord</span>
-            </a>
-            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 22 20 2 20 12 2"/>
-              </svg>
-              <span>Vercel</span>
-            </a>
-            <a href="https://gumroad.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M12 7c-2.8 0-5 2.2-5 5s2.2 5 5 5c1.4 0 2.6-.5 3.5-1.4"/>
-                <line x1="12" y1="12" x2="17" y2="12"/>
-                <line x1="17" y1="12" x2="17" y2="17"/>
-              </svg>
-              <span>Gumroad</span>
-            </a>
-            <a href="https://www.anthropic.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M17.3 3.5h-3.7l6.7 17H24"/><path d="M10.5 3.5L0 20.5h3.7l1.4-3.6h7l1.4 3.6h3.7L10.5 3.5zm-.4 10.2l2.3-6 2.3 6z"/>
-              </svg>
-              <span>Claude</span>
-            </a>
-            <a href="https://runwayml.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M18.4 24c-2.9.3-5.3-3.1-7.2-4.9C10.2 26 0 25.3 0 18.4c0-2.9 0-10 0-12.8C0 4.6.3 3.6.8 2.7c1-1.7 2.9-2.7 4.8-2.7h12.8c6.9 0 7.5 10.3.7 11.2l3.2 3.2c3.5 3.3.9 9.7-4 9.6zm-1.6-4c2-.1 5.2-1.1 3.1-3.1L14.4 11.2h-3.1v3.1l4.8 4.8l.7.8zM3.4 18.4c0 2.9 4.5 2.9 4.4 0V5.6c0-1.4-1.5-2.6-2.8-2.1c-.9.3-1.5 1.2-1.4 2.1v12.8zM18.4 7.8c2.9 0 2.9-4.5 0-4.4h-7.6c.6 1.2.4 3.1.4 4.4h7.2z"/>
-              </svg>
-              <span>Runway</span>
-            </a>
-            <a href="https://www.godaddy.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <path d="M20.702 2.29c-2.494-1.554-5.778-1.187-8.706.654C9.076 1.104 5.79.736 3.3 2.29c-3.941 2.463-4.42 8.806-1.07 14.167 2.47 3.954 6.333 6.269 9.77 6.226 3.439.043 7.301-2.273 9.771-6.226 3.347-5.361 2.872-11.704-1.069-14.167z"/>
-                <circle cx="8" cy="10" r="1.5"/><circle cx="16" cy="10" r="1.5"/>
-              </svg>
-              <span>GoDaddy</span>
-            </a>
             <a href="https://www.tradingview.com/pine-script-docs/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
                 <path d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3H8z"/>
@@ -6629,11 +6533,11 @@
               </svg>
               <span>Pine Script</span>
             </a>
-            <a href="https://unicorn.studio/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
+            <a href="https://vercel.com/" target="_blank" rel="noopener" class="partner-logo" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="stroke-animate">
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                <polygon points="12 2 22 20 2 20 12 2"/>
               </svg>
-              <span>Unicorn</span>
+              <span>Vercel</span>
             </a>
           </div>
         </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -6430,7 +6430,7 @@
         }
         .partners-track {
           display: flex;
-          gap: 6rem;
+          gap: 12rem;
           padding: 0 2rem;
           animation: partners-scroll 30s linear infinite;
           width: max-content;


### PR DESCRIPTION
- Added TradingView published scripts link to hero value props strip
- Reduced Built With marquee to 3 logos: TradingView, Pine Script, Vercel
- Removed: GitHub, Discord, Gumroad, Claude, Runway, GoDaddy, Unicorn
- Increased logo spacing (gap: 6rem) and faster animation (30s)
- Applied changes to all 12 language versions