### PR TITLE
Update Augury Grid TradingView script ID across all locales

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5100,7 +5100,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5320,7 +5320,7 @@ html[lang="ar"] [style*="text-align:center"] {
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/de/index.html
+++ b/de/index.html
@@ -5057,7 +5057,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5636,7 +5636,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/es/index.html
+++ b/es/index.html
@@ -5255,7 +5255,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5521,7 +5521,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/fr/index.html
+++ b/fr/index.html
@@ -5443,7 +5443,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5880,7 +5880,7 @@
           </a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/hu/index.html
+++ b/hu/index.html
@@ -4985,7 +4985,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5611,7 +5611,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/index.html
+++ b/index.html
@@ -4203,7 +4203,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -4671,7 +4671,7 @@
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">
             Janus Atlas
           </a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">
             Augury Grid
           </a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">

--- a/it/index.html
+++ b/it/index.html
@@ -4952,7 +4952,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5208,7 +5208,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/ja/index.html
+++ b/ja/index.html
@@ -5301,7 +5301,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5521,7 +5521,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/nl/index.html
+++ b/nl/index.html
@@ -4979,7 +4979,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5344,7 +5344,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/pt/index.html
+++ b/pt/index.html
@@ -5236,7 +5236,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5639,7 +5639,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/ru/index.html
+++ b/ru/index.html
@@ -5183,7 +5183,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5552,7 +5552,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>

--- a/tr/index.html
+++ b/tr/index.html
@@ -5258,7 +5258,7 @@
               <p class="elite-card-title">Augury Grid</p>
               <p class="elite-card-subtitle">Multi-Timeframe Scanner</p>
               <a href="https://docs.signalpilot.io/augury-grid-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
-              <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
         </div>
@@ -5627,7 +5627,7 @@
           <a href="https://www.tradingview.com/script/uaP60XpM-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/iHa2Ct7A-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
-          <a href="https://www.tradingview.com/script/ghaLEHFz-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
+          <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
           <a href="https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/" target="_blank" rel="noopener" class="tv-preview-btn">Plutus Flow</a>
           <a href="https://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/" target="_blank" rel="noopener" class="tv-preview-btn">Harmonic Oscillator</a>
           <a href="https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/" target="_blank" rel="noopener" class="tv-preview-btn">Volume Oracle</a>


### PR DESCRIPTION
## Summary
Updates the TradingView script ID for the Augury Grid indicator from `ghaLEHFz` to `H2REdDlY` across all language versions of the website.

## Changes
- Updated Augury Grid TradingView links in 12 localized index.html files (ar, de, es, fr, hu, it, ja, nl, pt, ru, tr, and main index.html)
- Changed script ID in both the elite card section and the TradingView preview buttons section for each locale
- Total of 24 link updates (2 per locale file)

## Details
This appears to be a script update or migration on TradingView, requiring the old script ID to be replaced with the new one. The changes maintain consistency across all supported languages and ensure users are directed to the correct, updated version of the Augury Grid Multi-Timeframe Scanner indicator.

https://claude.ai/code/session_01XwcoLvC5jmSYLLaKjPt8iy