### PR TITLE
Fix curriculum URL path for volume analysis lesson

### DIFF
--- a/content-plan/CONTENT_PLAN_PART1.md
+++ b/content-plan/CONTENT_PLAN_PART1.md
@@ -3805,7 +3805,7 @@ See the difference in bio 🔗
 |-------|-------|
 | Pillar | P3: Market Mechanics |
 | Type | Education Hub Lesson (Deep Dive) |
-| Source | https://education.signalpilot.io/curriculum/beginner/05-volume-doesnt-lie.html |
+| Source | https://education.signalpilot.io/curriculum/beginner/02-volume-doesnt-lie.html |
 | CTA | Lead Magnet |
 | Format | Twitter: Thread | Instagram: Carousel |
 
@@ -3844,7 +3844,7 @@ The crowd sells the bottom. Someone has to buy it.
 ```
 Full lesson on volume analysis:
 
-https://education.signalpilot.io/curriculum/beginner/05-volume-doesnt-lie.html
+https://education.signalpilot.io/curriculum/beginner/02-volume-doesnt-lie.html
 
 #volume #absorption #smartmoney
 ```


### PR DESCRIPTION
## Summary
Updated incorrect curriculum URL paths in the content plan from lesson 05 to lesson 02 for the "Volume Doesn't Lie" educational content.

## Changes
- Corrected Source URL in content metadata from `05-volume-doesnt-lie.html` to `02-volume-doesnt-lie.html`
- Updated lesson link in Twitter/Instagram content copy to match the correct curriculum path

## Details
The volume analysis lesson is positioned as lesson 02 in the beginner curriculum, not lesson 05. This fix ensures that both the content plan metadata and the actual CTA link direct users to the correct educational resource.

https://claude.ai/code/session_01QvF8qNFTzhn5MzzNRJdeYt