### PR TITLE
Add Instagram grid preview with 20+ posts

### DIFF
--- a/assets/design-examples/instagram-grid-preview-20posts.html
+++ b/assets/design-examples/instagram-grid-preview-20posts.html
@@ -1,0 +1,638 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SignalPilot — Instagram Grid Preview (20 Posts)</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      background: #000;
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      padding: 20px;
+    }
+
+    .instagram-profile {
+      max-width: 420px;
+      margin: 0 auto;
+      background: #000;
+    }
+
+    /* Profile Header */
+    .profile-header {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      padding: 20px 16px;
+    }
+
+    .profile-pic {
+      width: 77px;
+      height: 77px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #00d4ff, #a855f7);
+      flex-shrink: 0;
+    }
+
+    .profile-info {
+      flex: 1;
+    }
+
+    .profile-name {
+      font-size: 20px;
+      font-weight: 400;
+      margin-bottom: 12px;
+    }
+
+    .profile-stats {
+      display: flex;
+      gap: 24px;
+      font-size: 14px;
+    }
+
+    .profile-stats strong {
+      font-weight: 600;
+    }
+
+    .profile-bio {
+      padding: 0 16px 16px;
+      font-size: 14px;
+      line-height: 1.4;
+    }
+
+    .profile-bio .title {
+      font-weight: 600;
+    }
+
+    /* Grid */
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 2px;
+    }
+
+    .post {
+      aspect-ratio: 1;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .post-number {
+      position: absolute;
+      top: 4px;
+      left: 4px;
+      font-size: 8px;
+      color: rgba(255,255,255,0.4);
+      z-index: 10;
+    }
+
+    /* Base starfield */
+    .starfield {
+      background:
+        radial-gradient(1px 1px at 10px 15px, rgba(255,255,255,0.5), transparent),
+        radial-gradient(1px 1px at 30px 35px, rgba(255,255,255,0.3), transparent),
+        radial-gradient(1px 1px at 55px 20px, rgba(255,255,255,0.6), transparent),
+        radial-gradient(1px 1px at 15px 55px, rgba(255,255,255,0.25), transparent),
+        radial-gradient(1px 1px at 70px 40px, rgba(255,255,255,0.4), transparent),
+        radial-gradient(1px 1px at 45px 70px, rgba(255,255,255,0.3), transparent),
+        radial-gradient(1px 1px at 85px 25px, rgba(255,255,255,0.5), transparent),
+        radial-gradient(1px 1px at 100px 60px, rgba(255,255,255,0.3), transparent),
+        radial-gradient(1px 1px at 25px 95px, rgba(255,255,255,0.4), transparent),
+        radial-gradient(1px 1px at 110px 85px, rgba(255,255,255,0.35), transparent),
+        radial-gradient(1px 1px at 60px 110px, rgba(255,255,255,0.3), transparent),
+        radial-gradient(1px 1px at 90px 100px, rgba(255,255,255,0.4), transparent),
+        linear-gradient(180deg, #0a0a12 0%, #050508 100%);
+    }
+
+    /* ================================
+       BLOG (Purple) - Left Column
+    ================================ */
+    .blog {
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .blog::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(ellipse at 50% 100%, rgba(168, 85, 247, 0.2) 0%, transparent 70%);
+    }
+
+    .blog .tag {
+      position: relative;
+      font-size: 6px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: #a855f7;
+      margin-bottom: 4px;
+    }
+
+    .blog .title {
+      position: relative;
+      font-size: 10px;
+      font-weight: 500;
+      line-height: 1.3;
+      color: #fff;
+    }
+
+    .blog .title em {
+      font-style: italic;
+      color: #c4b5fd;
+    }
+
+    /* ================================
+       CHRONICLE (Magenta) - Left Column
+    ================================ */
+    .chronicle {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      padding: 8px;
+    }
+
+    .chronicle::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(ellipse at 50% 20%, rgba(236, 72, 153, 0.2) 0%, transparent 50%),
+        radial-gradient(ellipse at 70% 80%, rgba(139, 92, 246, 0.12) 0%, transparent 40%);
+    }
+
+    .chronicle .symbol {
+      position: relative;
+      font-size: 16px;
+      color: rgba(236, 72, 153, 0.35);
+      margin-bottom: 4px;
+    }
+
+    .chronicle .chapter {
+      position: relative;
+      font-size: 5px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: #ec4899;
+      margin-bottom: 2px;
+    }
+
+    .chronicle .title {
+      position: relative;
+      font-size: 9px;
+      font-weight: 400;
+      line-height: 1.2;
+      color: #fff;
+    }
+
+    .chronicle .title .accent {
+      color: #f472b6;
+    }
+
+    /* ================================
+       DOCS (Slate) - Left Column
+    ================================ */
+    .docs {
+      padding: 8px;
+      border-left: 2px solid rgba(148, 163, 184, 0.5);
+    }
+
+    .docs .path {
+      font-size: 5px;
+      font-family: monospace;
+      color: rgba(148, 163, 184, 0.5);
+      margin-bottom: 4px;
+    }
+
+    .docs .title {
+      font-size: 9px;
+      font-weight: 500;
+      font-family: monospace;
+      color: #94a3b8;
+      margin-bottom: 6px;
+    }
+
+    .docs .line {
+      font-size: 6px;
+      font-family: monospace;
+      color: rgba(255,255,255,0.4);
+      padding: 2px 0;
+    }
+
+    /* ================================
+       EDUCATION (Cyan) - Center Column
+    ================================ */
+    .education {
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      border-top: 2px solid rgba(0, 212, 255, 0.8);
+    }
+
+    .education::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(ellipse at 50% 0%, rgba(0, 212, 255, 0.12) 0%, transparent 50%);
+    }
+
+    .education .num {
+      position: relative;
+      font-size: 28px;
+      font-weight: 200;
+      color: rgba(0, 212, 255, 0.2);
+      line-height: 1;
+    }
+
+    .education .tag {
+      position: relative;
+      font-size: 5px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: #00d4ff;
+      margin-bottom: 2px;
+    }
+
+    .education .title {
+      position: relative;
+      font-size: 9px;
+      font-weight: 600;
+      color: #fff;
+      line-height: 1.2;
+    }
+
+    .education .title .accent {
+      color: #00d4ff;
+    }
+
+    /* ================================
+       QUOTE (Gold) - Right Column
+    ================================ */
+    .quote {
+      background: linear-gradient(180deg, #0c0c0f 0%, #08080a 100%);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      padding: 10px;
+    }
+
+    .quote .mark {
+      font-size: 20px;
+      color: rgba(255, 215, 0, 0.2);
+      line-height: 1;
+    }
+
+    .quote .text {
+      font-size: 8px;
+      font-weight: 300;
+      line-height: 1.5;
+      color: rgba(255,255,255,0.8);
+    }
+
+    .quote .accent {
+      color: #ffd700;
+      font-weight: 500;
+    }
+
+    /* ================================
+       PRODUCT (Green) - Right Column
+    ================================ */
+    .product {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .product .chart {
+      flex: 1;
+      background:
+        repeating-linear-gradient(90deg, rgba(16,185,129,0.04) 0px, rgba(16,185,129,0.04) 1px, transparent 1px, transparent 10px),
+        repeating-linear-gradient(0deg, rgba(16,185,129,0.04) 0px, rgba(16,185,129,0.04) 1px, transparent 1px, transparent 10px);
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+      padding: 8px;
+      gap: 2px;
+    }
+
+    .product .candle {
+      width: 4px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .product .wick { width: 1px; background: currentColor; }
+    .product .body { width: 3px; min-height: 2px; background: currentColor; }
+    .product .candle.up { color: #10b981; }
+    .product .candle.down { color: #ef4444; }
+
+    .product .info {
+      padding: 6px 8px;
+      border-top: 2px solid #10b981;
+    }
+
+    .product .signal-name {
+      font-size: 5px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: #10b981;
+    }
+
+    .product .signal-title {
+      font-size: 8px;
+      font-weight: 600;
+      color: #fff;
+    }
+
+    /* ================================
+       MARKETING (Orange) - Right Column
+    ================================ */
+    .marketing {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      padding: 10px;
+    }
+
+    .marketing::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(ellipse at 50% 100%, rgba(249, 115, 22, 0.2) 0%, transparent 60%);
+    }
+
+    .marketing .tag {
+      position: relative;
+      font-size: 5px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: #f97316;
+      margin-bottom: 4px;
+    }
+
+    .marketing .stat {
+      position: relative;
+      font-size: 24px;
+      font-weight: 700;
+      color: #f97316;
+      line-height: 1;
+    }
+
+    .marketing .stat-label {
+      position: relative;
+      font-size: 6px;
+      color: rgba(255,255,255,0.5);
+      margin-bottom: 6px;
+    }
+
+    .marketing .cta {
+      position: relative;
+      padding: 4px 10px;
+      background: linear-gradient(90deg, #f97316, #ea580c);
+      border-radius: 3px;
+      font-size: 6px;
+      font-weight: 600;
+      color: #fff;
+      text-transform: uppercase;
+    }
+
+    /* Column indicator lines */
+    .column-hint {
+      max-width: 420px;
+      margin: 20px auto 0;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 2px;
+      text-align: center;
+      font-size: 9px;
+    }
+
+    .column-hint span {
+      padding: 8px;
+      border-radius: 4px;
+    }
+
+    .column-hint .left { background: rgba(168,85,247,0.15); color: #a855f7; }
+    .column-hint .center { background: rgba(0,212,255,0.15); color: #00d4ff; }
+    .column-hint .right { background: rgba(255,215,0,0.15); color: #ffd700; }
+
+  </style>
+</head>
+<body>
+
+  <div class="instagram-profile">
+    <!-- Profile Header -->
+    <div class="profile-header">
+      <div class="profile-pic"></div>
+      <div class="profile-info">
+        <div class="profile-name">signalpilot</div>
+        <div class="profile-stats">
+          <span><strong>156</strong> posts</span>
+          <span><strong>12.4K</strong> followers</span>
+          <span><strong>89</strong> following</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="profile-bio">
+      <div class="title">SignalPilot</div>
+      Trading indicators that don't lie.<br>
+      Free education • Pro signals • Real results
+    </div>
+
+    <!-- THE GRID - Posts 37-57 (21 posts = 7 rows) -->
+    <div class="grid">
+
+      <!-- Row 1: Blog(37) | Education(38) | Quote(39) -->
+      <div class="post starfield blog">
+        <span class="post-number">37</span>
+        <div class="tag">Psychology</div>
+        <div class="title">The Art of <em>Doing Nothing</em></div>
+      </div>
+
+      <div class="post starfield education">
+        <span class="post-number">38</span>
+        <div class="num">38</div>
+        <div class="tag">Lesson</div>
+        <div class="title"><span class="accent">Position</span> Sizing</div>
+      </div>
+
+      <div class="post quote">
+        <span class="post-number">39</span>
+        <div class="mark">"</div>
+        <div class="text">The goal isn't to be right. It's to <span class="accent">make money</span>.</div>
+      </div>
+
+      <!-- Row 2: Chronicle(40) | Education(41) | Product(42) -->
+      <div class="post starfield chronicle">
+        <span class="post-number">40</span>
+        <div class="symbol">◈</div>
+        <div class="chapter">Chronicle VII</div>
+        <div class="title"><span class="accent">Volume</span> Whispers</div>
+      </div>
+
+      <div class="post starfield education">
+        <span class="post-number">41</span>
+        <div class="num">39</div>
+        <div class="tag">Lesson</div>
+        <div class="title"><span class="accent">Stop Loss</span> Basics</div>
+      </div>
+
+      <div class="post starfield product">
+        <span class="post-number">42</span>
+        <div class="chart">
+          <div class="candle up"><div class="wick" style="height:4px"></div><div class="body" style="height:10px"></div></div>
+          <div class="candle up"><div class="wick" style="height:3px"></div><div class="body" style="height:14px"></div></div>
+          <div class="candle down"><div class="wick" style="height:5px"></div><div class="body" style="height:5px"></div></div>
+          <div class="candle up"><div class="wick" style="height:2px"></div><div class="body" style="height:16px"></div></div>
+          <div class="candle up"><div class="wick" style="height:2px"></div><div class="body" style="height:12px"></div></div>
+        </div>
+        <div class="info">
+          <div class="signal-name">Pentarch TD</div>
+          <div class="signal-title">Trend Signal</div>
+        </div>
+      </div>
+
+      <!-- Row 3: Docs(43) | Education(44) | Marketing(45) -->
+      <div class="post starfield docs">
+        <span class="post-number">43</span>
+        <div class="path">/docs/setup</div>
+        <div class="title">Quick Start</div>
+        <div class="line">01 Connect broker</div>
+        <div class="line">02 Add indicator</div>
+      </div>
+
+      <div class="post starfield education">
+        <span class="post-number">44</span>
+        <div class="num">40</div>
+        <div class="tag">Lesson</div>
+        <div class="title"><span class="accent">Risk-Reward</span></div>
+      </div>
+
+      <div class="post starfield marketing">
+        <span class="post-number">45</span>
+        <div class="tag">This Week</div>
+        <div class="stat">93%</div>
+        <div class="stat-label">win rate</div>
+        <div class="cta">Start Free</div>
+      </div>
+
+      <!-- Row 4: Blog(46) | Education(47) | Quote(48) -->
+      <div class="post starfield blog">
+        <span class="post-number">46</span>
+        <div class="tag">Strategy</div>
+        <div class="title">Reading <em>Market Structure</em></div>
+      </div>
+
+      <div class="post starfield education">
+        <span class="post-number">47</span>
+        <div class="num">41</div>
+        <div class="tag">Lesson</div>
+        <div class="title"><span class="accent">Trend</span> Lines</div>
+      </div>
+
+      <div class="post quote">
+        <span class="post-number">48</span>
+        <div class="mark">"</div>
+        <div class="text"><span class="accent">Patience</span> is not waiting. It's how you wait.</div>
+      </div>
+
+      <!-- Row 5: Chronicle(49) | Education(50) | Product(51) -->
+      <div class="post starfield chronicle">
+        <span class="post-number">49</span>
+        <div class="symbol">⬡</div>
+        <div class="chapter">Chronicle VIII</div>
+        <div class="title"><span class="accent">Balance</span> in All</div>
+      </div>
+
+      <div class="post starfield education">
+        <span class="post-number">50</span>
+        <div class="num">42</div>
+        <div class="tag">Lesson</div>
+        <div class="title"><span class="accent">Support</span> & Resist</div>
+      </div>
+
+      <div class="post starfield product">
+        <span class="post-number">51</span>
+        <div class="chart">
+          <div class="candle down"><div class="wick" style="height:5px"></div><div class="body" style="height:8px"></div></div>
+          <div class="candle down"><div class="wick" style="height:3px"></div><div class="body" style="height:5px"></div></div>
+          <div class="candle up"><div class="wick" style="height:2px"></div><div class="body" style="height:12px"></div></div>
+          <div class="candle up"><div class="wick" style="height:2px"></div><div class="body" style="height:18px"></div></div>
+          <div class="candle up"><div class="wick" style="height:2px"></div><div class="body" style="height:14px"></div></div>
+        </div>
+        <div class="info">
+          <div class="signal-name">Volume Oracle</div>
+          <div class="signal-title">Reversal</div>
+        </div>
+      </div>
+
+      <!-- Row 6: Docs(52) | Education(53) | Marketing(54) -->
+      <div class="post starfield docs">
+        <span class="post-number">52</span>
+        <div class="path">/docs/alerts</div>
+        <div class="title">Alert Setup</div>
+        <div class="line">01 Choose signal</div>
+        <div class="line">02 Set trigger</div>
+      </div>
+
+      <div class="post starfield education">
+        <span class="post-number">53</span>
+        <div class="num">43</div>
+        <div class="tag">Lesson</div>
+        <div class="title"><span class="accent">Candlestick</span> Patterns</div>
+      </div>
+
+      <div class="post starfield marketing">
+        <span class="post-number">54</span>
+        <div class="tag">Limited</div>
+        <div class="stat">50%</div>
+        <div class="stat-label">off annual</div>
+        <div class="cta">Claim Now</div>
+      </div>
+
+      <!-- Row 7: Blog(55) | Education(56) | Quote(57) -->
+      <div class="post starfield blog">
+        <span class="post-number">55</span>
+        <div class="tag">Mindset</div>
+        <div class="title">Why <em>Fear</em> Destroys Traders</div>
+      </div>
+
+      <div class="post starfield education">
+        <span class="post-number">56</span>
+        <div class="num">44</div>
+        <div class="tag">Lesson</div>
+        <div class="title"><span class="accent">Moving</span> Averages</div>
+      </div>
+
+      <div class="post quote">
+        <span class="post-number">57</span>
+        <div class="mark">"</div>
+        <div class="text"><span class="accent">Risk</span> is the only thing you control.</div>
+      </div>
+
+    </div>
+
+    <!-- Column Labels -->
+    <div class="column-hint">
+      <span class="left">Stories</span>
+      <span class="center">Learning</span>
+      <span class="right">Action</span>
+    </div>
+
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
Shows how the 9-post rotation looks as an actual Instagram profile:
- Posts 37-57 displayed in 3-column grid
- Visual column lanes clearly visible
- Left: Blog/Chronicle/Docs (purple/magenta/slate)
- Center: Education (cyan with lesson numbers)
- Right: Quote/Product/Marketing (gold/green/orange)

This is the "view from above" showing the full grid rhythm.

https://claude.ai/code/session_01QvF8qNFTzhn5MzzNRJdeYt