### PR TITLE
Fix carousel responsive CSS - remove media query overrides

### DIFF
--- a/assets/social/post-022/carousel.html
+++ b/assets/social/post-022/carousel.html
@@ -353,18 +353,6 @@
         grid-template-columns: 1fr;
         max-width: 400px;
       }
-
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 32px;
-      }
     }
   </style>
 </head>

--- a/assets/social/post-023/carousel.html
+++ b/assets/social/post-023/carousel.html
@@ -437,18 +437,6 @@
         grid-template-columns: 1fr;
         max-width: 400px;
       }
-
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 32px;
-      }
     }
   </style>
 </head>

--- a/assets/social/post-025/carousel.html
+++ b/assets/social/post-025/carousel.html
@@ -124,43 +124,43 @@
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      padding: 48px;
+      padding: 8%;
       text-align: center;
     }
 
     .slide-number {
       position: absolute;
-      top: 16px;
-      left: 16px;
-      font-size: 11px;
+      top: 4%;
+      left: 4%;
+      font-size: clamp(9px, 2vw, 11px);
       color: var(--text-dim);
       letter-spacing: 1px;
     }
 
     .brand-mark {
       position: absolute;
-      bottom: 16px;
-      right: 16px;
-      font-size: 10px;
+      bottom: 4%;
+      right: 4%;
+      font-size: clamp(8px, 1.8vw, 10px);
       color: var(--text-dim);
       letter-spacing: 1px;
     }
 
     .slide-icon {
-      font-size: 48px;
-      margin-bottom: 20px;
+      font-size: clamp(32px, 8vw, 56px);
+      margin-bottom: 4%;
     }
 
     .slide-title {
       font-family: 'Cormorant Garamond', serif;
-      font-size: 32px;
+      font-size: clamp(18px, 5vw, 32px);
       font-weight: 600;
-      margin-bottom: 16px;
+      margin-bottom: 3%;
       line-height: 1.2;
     }
 
     .slide-title.large {
-      font-size: 38px;
+      font-size: clamp(26px, 7vw, 48px);
     }
 
     .slide-title.red {
@@ -168,18 +168,18 @@
     }
 
     .slide-subtitle {
-      font-size: 14px;
+      font-size: clamp(10px, 2.5vw, 14px);
       color: var(--accent-gold);
       text-transform: uppercase;
       letter-spacing: 3px;
-      margin-bottom: 20px;
+      margin-bottom: 4%;
     }
 
     .slide-body {
-      font-size: 16px;
+      font-size: clamp(12px, 3vw, 16px);
       color: var(--text-secondary);
       line-height: 1.7;
-      max-width: 320px;
+      max-width: 90%;
     }
 
     .slide-body .green {
@@ -336,18 +336,6 @@
       .carousel-grid {
         grid-template-columns: 1fr;
         max-width: 400px;
-      }
-
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 32px;
       }
     }
   </style>

--- a/assets/social/post-026/carousel.html
+++ b/assets/social/post-026/carousel.html
@@ -458,18 +458,6 @@
         grid-template-columns: 1fr;
         max-width: 400px;
       }
-
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 32px;
-      }
     }
   </style>
 </head>

--- a/assets/social/post-027/carousel.html
+++ b/assets/social/post-027/carousel.html
@@ -432,17 +432,6 @@
         max-width: 400px;
       }
 
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 32px;
-      }
     }
   </style>
 </head>

--- a/assets/social/post-028/carousel.html
+++ b/assets/social/post-028/carousel.html
@@ -447,18 +447,6 @@
         grid-template-columns: 1fr;
         max-width: 400px;
       }
-
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 32px;
-      }
     }
   </style>
 </head>

--- a/assets/social/post-029/carousel.html
+++ b/assets/social/post-029/carousel.html
@@ -356,18 +356,6 @@
         grid-template-columns: 1fr;
         max-width: 400px;
       }
-
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 36px;
-      }
     }
   </style>
 </head>

--- a/assets/social/post-030/carousel.html
+++ b/assets/social/post-030/carousel.html
@@ -289,18 +289,6 @@
         grid-template-columns: 1fr;
         max-width: 400px;
       }
-
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 32px;
-      }
     }
   </style>
 </head>

--- a/assets/social/post-031/carousel.html
+++ b/assets/social/post-031/carousel.html
@@ -387,18 +387,6 @@
         grid-template-columns: 1fr;
         max-width: 400px;
       }
-
-      .slide-wrapper .slide-content {
-        padding: 32px;
-      }
-
-      .slide-title {
-        font-size: 26px;
-      }
-
-      .slide-title.large {
-        font-size: 30px;
-      }
     }
   </style>
 </head>


### PR DESCRIPTION
Removed font-size overrides in media queries that were breaking responsive clamp() values at smaller screen sizes. Also converted post-025 to fully responsive CSS.

https://claude.ai/code/session_01QvF8qNFTzhn5MzzNRJdeYt