### PR TITLE
Add real Google Ads conversion snippet to trial-thanks pages

### DIFF
--- a/ar/trial-thanks.html
+++ b/ar/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>تم تفعيل الفترة التجريبية - Signal Pilot</title>

--- a/de/trial-thanks.html
+++ b/de/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Testversion aktiviert - Signal Pilot</title>

--- a/es/trial-thanks.html
+++ b/es/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Prueba Activada - Signal Pilot</title>

--- a/fr/trial-thanks.html
+++ b/fr/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Essai Activé - Signal Pilot</title>

--- a/hu/trial-thanks.html
+++ b/hu/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Próbaidőszak Aktiválva - Signal Pilot</title>

--- a/it/trial-thanks.html
+++ b/it/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Prova Attivata - Signal Pilot</title>

--- a/ja/trial-thanks.html
+++ b/ja/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>トライアル開始 - Signal Pilot</title>

--- a/nl/trial-thanks.html
+++ b/nl/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Proefperiode Geactiveerd - Signal Pilot</title>

--- a/pt/trial-thanks.html
+++ b/pt/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Teste Ativado - Signal Pilot</title>

--- a/ru/trial-thanks.html
+++ b/ru/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Пробный период активирован - Signal Pilot</title>

--- a/tr/trial-thanks.html
+++ b/tr/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Deneme Etkinleştirildi - Signal Pilot</title>

--- a/trial-thanks.html
+++ b/trial-thanks.html
@@ -10,6 +10,14 @@
     gtag('config', 'G-LE5N7LQ828');
     gtag('config', 'AW-17835897996');
   </script>
+  <!-- Event snippet for Sign-up conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+        'send_to': 'AW-17835897996/_FfnCPSw0fEbEIzp6LhC',
+        'value': 1.0,
+        'currency': 'USD'
+    });
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Trial Activated - Signal Pilot</title>


### PR DESCRIPTION
Added the actual conversion event snippet with label: AW-17835897996/_FfnCPSw0fEbEIzp6LhC

This will now properly track trial sign-up conversions in Google Ads.

https://claude.ai/code/session_01PzYfrtEFRRnCNPmoAxWcqc