### PR TITLE
Remove incorrect REMAPPED POST SCHEDULE section

### DIFF
--- a/INSTAGRAM_CONTENT_HUB/POST_MAPPING.md
+++ b/INSTAGRAM_CONTENT_HUB/POST_MAPPING.md
@@ -102,911 +102,220 @@
 
 ---
 
-### 📋 CONTINUE WITH (Posts 37-48)
-
-**ROW 13 (Posts 37-39):**
-| Post Order | Post # | Type | Topic | Column |
-|------------|--------|------|-------|--------|
-| 37 | 035 | Product | Plutus Flow Demo | Orange |
-| 38 | 036 | EDU | Absorption Patterns | Neutral |
-| 39 | 040 | Docs | Plutus Flow Cheatsheet | Teal |
-
-**ROW 14 (Posts 40-42):**
-| Post Order | Post # | Type | Topic | Column |
-|------------|--------|------|-------|--------|
-| 40 | 044 | Quote | "Entries vs Exits" | Orange |
-| 41 | 039 | EDU | Position Sizing (Lesson) | Neutral |
-| 42 | 041 | Blog | The Elite Seven | Teal |
-
-**ROW 15 (Posts 43-45):**
-| Post Order | Post # | Type | Topic | Column |
-|------------|--------|------|-------|--------|
-| 43 | 045 | Product | Augury Grid Demo | Orange |
-| 44 | 042 | EDU | Risk-Reward Ratio | Neutral |
-| 45 | 043 | Docs | Volume Profile Guide | Teal |
-
-**ROW 16 (Posts 46-48):**
-| Post Order | Post # | Type | Topic | Column |
-|------------|--------|------|-------|--------|
-| 46 | 048 | Quote | TBD | Orange |
-| 47 | 046 | EDU | Stop Loss Strategies | Neutral |
-| 48 | 047 | Blog | Smart Money Concepts | Teal |
+### 📋 ROW 13 (Posts 37-39):
+| Order | Post # | Type | Column |
+|-------|--------|------|--------|
+| 37 | 035 | Product | Orange |
+| 38 | 036 | EDU | Neutral |
+| 39 | 040 | Docs | Teal |
 
 ---
 
-# THE 9-GRID SYSTEM
-
-## Visual Grid Layout (Instagram View)
-
-```
-┌─────────────────┬─────────────────┬─────────────────┐
-│  LEFT COLUMN    │  CENTER COLUMN  │  RIGHT COLUMN   │
-│  (Teal Tones)   │  (Neutral)      │  (Orange Tones) │
-├─────────────────┼─────────────────┼─────────────────┤
-│ 1. BLOG         │ 2. EDU          │ 3. QUOTE        │
-├─────────────────┼─────────────────┼─────────────────┤
-│ 4. CHRON        │ 5. EDU          │ 6. PROD         │
-├─────────────────┼─────────────────┼─────────────────┤
-│ 7. DOCS         │ 8. EDU          │ 9. MKTG         │
-└─────────────────┴─────────────────┴─────────────────┘
-```
-
-## Column Rules
-- **LEFT COLUMN (Teal)**: Blog → Chronicle → Docs (rotating)
-- **CENTER COLUMN (Neutral)**: ALWAYS Education (every single center post)
-- **RIGHT COLUMN (Orange)**: Quote → Product → Marketing (rotating)
-
-## Post Number to Grid Position Formula
-
-| Post # mod 9 | Grid Position | Type | Column |
-|--------------|---------------|------|--------|
-| 1 | 1 | BLOG | Left |
-| 2 | 2 | EDU | Center |
-| 3 | 3 | QUOTE | Right |
-| 4 | 4 | CHRON | Left |
-| 5 | 5 | EDU | Center |
-| 6 | 6 | PROD | Right |
-| 7 | 7 | DOCS | Left |
-| 8 | 8 | EDU | Center |
-| 0 (9) | 9 | MKTG | Right |
-
----
-
-# SPECIAL POST: 000 — Launch Manifesto
-
-| Post | Grid | Type | Topic | Notes |
-|------|------|------|-------|-------|
-| **000** | SPECIAL | Manifesto | To The 3AM Version of You | Pin to profile - this breaks the grid intentionally |
-
----
-
-# COMPLETE REMAPPED POST SCHEDULE
-
-## Posts 001-045 (Current Progress - You're at 37)
-
-| Post | Grid Pos | Type | Original Topic | Pillar |
-|------|----------|------|----------------|--------|
-| 001 | 1-BLOG | Blog | Why Markets Move in Cycles | P3: Market Mechanics |
-| 002 | 2-EDU | Education | The Liquidity Lie | P1: Liquidity Lie |
-| 003 | 3-QUOTE | Quote | "The Edge" | P4: Psychology |
-| 004 | 4-CHRON | Chronicle | Meet The Sovereign | P5: Chronicle |
-| 005 | 5-EDU | Education | Volume Doesn't Lie | P3: Market Mechanics |
-| 006 | 6-PROD | Product | Pentarch TD Signal | P2: Indicator Truth |
-| 007 | 7-DOCS | Docs | Pentarch Cheatsheet | P2: Indicator Truth |
-| 008 | 8-EDU | Education | The Repainting Problem | P2: Indicator Truth |
-| 009 | 9-MKTG | Marketing | 82 Lessons, 7 Indicators | Product |
-| 010 | 1-BLOG | Blog | How Smart Money Moves | P1: Liquidity Lie |
-| 011 | 2-EDU | Education | Price Action Is Dead | P3: Market Mechanics |
-| 012 | 3-QUOTE | Quote | "Stop Chasing Signals" | P4: Psychology |
-| 013 | 4-CHRON | Chronicle | The Prophet (Volume Oracle) | P5: Chronicle |
-| 014 | 5-EDU | Education | Stop Hunting Deep Dive | P1: Liquidity Lie |
-| 015 | 6-PROD | Product | Volume Oracle Dashboard | P2: Indicator Truth |
-| 016 | 7-DOCS | Docs | Quick Start Guide | P2: Indicator Truth |
-| 017 | 8-EDU | Education | Delta Analysis Deep Dive | P3: Market Mechanics |
-| 018 | 9-MKTG | Marketing | 7-Day Money Back Guarantee | Product |
-| 019 | 1-BLOG | Blog | Accumulation vs Distribution | P3: Market Mechanics |
-| 020 | 2-EDU | Education | RSI Extremes | P2: Indicator Truth |
-| 021 | 3-QUOTE | Quote | "Prepare for Transitions" | P4: Psychology |
-| 022 | 4-CHRON | Chronicle | The Cartographer (Janus Atlas) | P5: Chronicle |
-| 023 | 5-EDU | Education | Moving Averages | P2: Indicator Truth |
-| 024 | 6-PROD | Product | Janus Atlas Multi-Timeframe | P2: Indicator Truth |
-| 025 | 7-DOCS | Docs | Janus Atlas Cheatsheet | P2: Indicator Truth |
-| 026 | 8-EDU | Education | Liquidity Sweeps Deep Dive | P1: Liquidity Lie |
-| 027 | 9-MKTG | Marketing | "We Could Send Alerts" | Product |
-| 028 | 1-BLOG | Blog | Why Indicators Keep Failing | P2: Indicator Truth |
-| 029 | 2-EDU | Education | Revenge Trading | P4: Psychology |
-| 030 | 3-QUOTE | Quote | "Right vs Profitable" | P4: Psychology |
-| 031 | 4-CHRON | Chronicle | The Scales (Plutus) | P5: Chronicle |
-| 032 | 5-EDU | Education | Confirmation Bias | P4: Psychology |
-| 033 | 6-PROD | Product | Harmonic Oscillator | P2: Indicator Truth |
-| 034 | 7-DOCS | Docs | Plutus Flow Cheatsheet | P2: Indicator Truth |
-| 035 | 8-EDU | Education | Absorption Patterns | P3: Market Mechanics |
-| 036 | 9-MKTG | Marketing | Plutus Flow Promo | P2: Indicator Truth |
-| **037** | **1-BLOG** | **Blog** | **The Confirmation Trap** | **P4: Psychology** |
-| **038** | **2-EDU** | **Education** | **Position Sizing** | **P4: Psychology** |
-| **039** | **3-QUOTE** | **Quote** | **"Entries vs Exits"** | **P4: Psychology** |
-| 040 | 4-CHRON | Chronicle | The Arbiter (Harmonic Oscillator) | P5: Chronicle |
-| 041 | 5-EDU | Education | Risk-Reward Ratio | P4: Psychology |
-| 042 | 6-PROD | Product | Augury Grid (The Watchman) | P2: Indicator Truth |
-| 043 | 7-DOCS | Docs | Quick Start Checklist | P2: Indicator Truth |
-| 044 | 8-EDU | Education | Stop Loss Strategies | P4: Psychology |
-| 045 | 9-MKTG | Marketing | The Elite Seven | Product |
-
----
-
-## Posts 046-090
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 046 | 1-BLOG | Blog | Smart Money Concepts | P1: Liquidity Lie |
-| 047 | 2-EDU | Education | Trend Identification | P3: Market Mechanics |
-| 048 | 3-QUOTE | Quote | "Patience" | P4: Psychology |
-| 049 | 4-CHRON | Chronicle | The Watchman (Augury Grid) | P5: Chronicle |
-| 050 | 5-EDU | Education | Support and Resistance | P3: Market Mechanics |
-| 051 | 6-PROD | Product | OmniDeck (The Commander) | P2: Indicator Truth |
-| 052 | 7-DOCS | Docs | Harmonic Oscillator Settings | P2: Indicator Truth |
-| 053 | 8-EDU | Education | Candlestick Patterns - Doji | P3: Market Mechanics |
-| 054 | 9-MKTG | Marketing | 7-Day Money-Back Guarantee | Product |
-| 055 | 1-BLOG | Blog | Why Most Traders Fail | P4: Psychology |
-| 056 | 2-EDU | Education | Moving Averages - Crossovers | P2: Indicator Truth |
-| 057 | 3-QUOTE | Quote | "Plan-Trade-Review Loop" | P4: Psychology |
-| 058 | 4-CHRON | Chronicle | The Commander | P5: Chronicle |
-| 059 | 5-EDU | Education | Psychology of Round Numbers | P4: Psychology |
-| 060 | 6-PROD | Product | Pentarch Full Cycle | P2: Indicator Truth |
-| 061 | 7-DOCS | Docs | Janus Atlas Timeframes | P3: Market Mechanics |
-| 062 | 8-EDU | Education | Candlestick Patterns | P2: Indicator Truth |
-| 063 | 9-MKTG | Marketing | Lifetime Access Value | P5: Chronicle |
-| 064 | 1-BLOG | Blog | Breakout vs Fakeout | P3: Market Mechanics |
-| 065 | 2-EDU | Education | Fibonacci Retracements | P2: Indicator Truth |
-| 066 | 3-QUOTE | Quote | "Early vs Wrong" | P4: Psychology |
-| 067 | 4-CHRON | Chronicle | The Prophet | P5: Chronicle |
-| 068 | 5-EDU | Education | Volume Analysis | P2: Indicator Truth |
-| 069 | 6-PROD | Product | Volume Oracle Regimes | P2: Indicator Truth |
-| 070 | 7-DOCS | Docs | Pentarch Signal Meanings | P1: Liquidity Lie |
-| 071 | 8-EDU | Education | Trading Journals | P4: Psychology |
-| 072 | 9-MKTG | Marketing | 82 Free Lessons | P5: Chronicle |
-| 073 | 1-BLOG | Blog | Multi-Timeframe Analysis | P3: Market Mechanics |
-| 074 | 2-EDU | Education | Backtesting Basics | P2: Indicator Truth |
-| 075 | 3-QUOTE | Quote | "Irrationality Quote" | P4: Psychology |
-| 076 | 4-CHRON | Chronicle | Birth of Elite Seven | P5: Chronicle |
-| 077 | 5-EDU | Education | Paper Trading | P4: Psychology |
-| 078 | 6-PROD | Product | Janus Atlas Confluence | P3: Market Mechanics |
-| 079 | 7-DOCS | Docs | Volume Oracle Settings | P2: Indicator Truth |
-| 080 | 8-EDU | Education | Market Structure | P3: Market Mechanics |
-| 081 | 9-MKTG | Marketing | Annual Plan Savings | P5: Chronicle |
-| 082 | 1-BLOG | Blog | Wyckoff Method | P1: Liquidity Lie |
-| 083 | 2-EDU | Education | Going Live | P4: Psychology |
-| 084 | 3-QUOTE | Quote | "Discipline Quote" | P4: Psychology |
-| 085 | 4-CHRON | Chronicle | The Council Assembles | P5: Chronicle |
-| 086 | 5-EDU | Education | Supply & Demand Zones | P3: Market Mechanics |
-| 087 | 6-PROD | Product | Harmonic Oscillator Divergence | P2: Indicator Truth |
-| 088 | 7-DOCS | Docs | Getting Started Workflow | P5: Chronicle |
-| 089 | 8-EDU | Education | Fair Value Gaps | P3: Market Mechanics |
-| 090 | 9-MKTG | Marketing | Non-Repainting Guarantee | P5: Chronicle |
-
----
-
-## Posts 091-135
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 091 | 1-BLOG | Blog | Order Blocks | P1: Liquidity Lie |
-| 092 | 2-EDU | Education | Inducement & Liquidity | P1: Liquidity Lie |
-| 093 | 3-QUOTE | Quote | "Tuition vs Expulsion" | P4: Psychology |
-| 094 | 4-CHRON | Chronicle | The Pilot's Oath | P5: Chronicle |
-| 095 | 5-EDU | Education | Trend Continuation Patterns | P3: Market Mechanics |
-| 096 | 6-PROD | Product | Pentarch TD Signal | P1: Liquidity Lie |
-| 097 | 7-DOCS | Docs | Augury Grid Setup | P2: Indicator Truth |
-| 098 | 8-EDU | Education | Reversal Patterns | P3: Market Mechanics |
-| 099 | 9-MKTG | Marketing | 100 Posts Milestone | P5: Chronicle |
-| 100 | 1-BLOG | Blog | Trading with the Trend | P3: Market Mechanics |
-| 101 | 2-EDU | Education | Liquidity Pools | P1: Liquidity Lie |
-| 102 | 3-QUOTE | Quote | "Right vs Profitable" | P4: Psychology |
-| 103 | 4-CHRON | Chronicle | Hierarchy of Signals | P5: Chronicle |
-| 104 | 5-EDU | Education | Confluence Trading | P2: Indicator Truth |
-| 105 | 6-PROD | Product | Volume Oracle ACCUMULATION | P2: Indicator Truth |
-| 106 | 7-DOCS | Docs | Plutus Flow Divergence | P2: Indicator Truth |
-| 107 | 8-EDU | Education | Momentum Trading | P2: Indicator Truth |
-| 108 | 9-MKTG | Marketing | Affiliate Program | P5: Chronicle |
-| 109 | 1-BLOG | Blog | Psychology of FOMO | P4: Psychology |
-| 110 | 2-EDU | Education | Risk Management Deep Dive | P4: Psychology |
-| 111 | 3-QUOTE | Quote | "Emotional Control" | P4: Psychology |
-| 112 | 4-CHRON | Chronicle | Why Non-Repainting Matters | P5: Chronicle |
-| 113 | 5-EDU | Education | Volume Spread Analysis | P2: Indicator Truth |
-| 114 | 6-PROD | Product | Janus Atlas MTF | P3: Market Mechanics |
-| 115 | 7-DOCS | Docs | Indicator Combinations | P2: Indicator Truth |
-| 116 | 8-EDU | Education | Swing Trading | P3: Market Mechanics |
-| 117 | 9-MKTG | Marketing | Community Testimonials | P5: Chronicle |
-| 118 | 1-BLOG | Blog | Compound Effect | P4: Psychology |
-| 119 | 2-EDU | Education | Day Trading | P3: Market Mechanics |
-| 120 | 3-QUOTE | Quote | "Trade What You See" | P4: Psychology |
-| 121 | 4-CHRON | Chronicle | The Sovereign's Wisdom | P5: Chronicle |
-| 122 | 5-EDU | Education | Position Management | P4: Psychology |
-| 123 | 6-PROD | Product | Augury Grid Alert Setup | P2: Indicator Truth |
-| 124 | 7-DOCS | Docs | Troubleshooting Guide | P2: Indicator Truth |
-| 125 | 8-EDU | Education | Scalping Strategies | P3: Market Mechanics |
-| 126 | 9-MKTG | Marketing | Roadmap Preview | P5: Chronicle |
-| 127 | 1-BLOG | Blog | Stop Loss Placement | P1: Liquidity Lie |
-| 128 | 2-EDU | Education | Trading Psychology Mastery | P4: Psychology |
-| 129 | 3-QUOTE | Quote | "Market Is Never Wrong" | P4: Psychology |
-| 130 | 4-CHRON | Chronicle | The Cartographer's Map | P5: Chronicle |
-| 131 | 5-EDU | Education | Advanced Candlestick Patterns | P3: Market Mechanics |
-| 132 | 6-PROD | Product | Pentarch IGN Signal Deep Dive | P2: Indicator Truth |
-| 133 | 7-DOCS | Docs | Keyboard Shortcuts | P2: Indicator Truth |
-| 134 | 8-EDU | Education | Correlation Trading | P3: Market Mechanics |
-| 135 | 9-MKTG | Marketing | Signal Pilot Quiz | P2: Indicator Truth |
-
----
-
-## Posts 136-180
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 136 | 1-BLOG | Blog | Building a Trading Routine | P3: Market Mechanics |
-| 137 | 2-EDU | Education | Drawdown Management | P3: Market Mechanics |
-| 138 | 3-QUOTE | Quote | "Every Expert Was A Beginner" | P4: Psychology |
-| 139 | 4-CHRON | Chronicle | The Elite Seven United | P5: Chronicle |
-| 140 | 5-EDU | Education | MTF Confluence | P3: Market Mechanics |
-| 141 | 6-PROD | Product | Harmonic Oscillator Overbought/Oversold | P2: Indicator Truth |
-| 142 | 7-DOCS | Docs | Mobile TradingView Setup | P2: Indicator Truth |
-| 143 | 8-EDU | Education | Gap Trading | P3: Market Mechanics |
-| 144 | 9-MKTG | Marketing | Success Story | P5: Chronicle |
-| 145 | 1-BLOG | Blog | Reading Order Flow | P3: Market Mechanics |
-| 146 | 2-EDU | Education | Trend Exhaustion Signals | P3: Market Mechanics |
-| 147 | 3-QUOTE | Quote | "Best Trade Is No Trade" | P4: Psychology |
-| 148 | 4-CHRON | Chronicle | The Arbiter's Judgment | P5: Chronicle |
-| 149 | 5-EDU | Education | Breakout Trading | P3: Market Mechanics |
-| 150 | 6-PROD | Product | Volume Oracle DISTRIBUTION Regime | P2: Indicator Truth |
-| 151 | 7-DOCS | Docs | Custom Alert Conditions | P2: Indicator Truth |
-| 152 | 8-EDU | Education | Mean Reversion | P3: Market Mechanics |
-| 153 | 9-MKTG | Marketing | Compare vs Competitors | P2: Indicator Truth |
-| 154 | 1-BLOG | Blog | Trading During News Events | P3: Market Mechanics |
-| 155 | 2-EDU | Education | Fibonacci Extensions | P3: Market Mechanics |
-| 156 | 3-QUOTE | Quote | "Simplicity Quote" | P4: Psychology |
-| 157 | 4-CHRON | Chronicle | The Prophet's Vision | P5: Chronicle |
-| 158 | 5-EDU | Education | Divergence Trading | P3: Market Mechanics |
-| 159 | 6-PROD | Product | Plutus Flow Accumulation Detection | P2: Indicator Truth |
-| 160 | 7-DOCS | Docs | Indicator Update Log | P2: Indicator Truth |
-| 161 | 8-EDU | Education | Range Trading | P3: Market Mechanics |
-| 162 | 9-MKTG | Marketing | Free Trial Reminder | P2: Indicator Truth |
-| 163 | 1-BLOG | Blog | The Journaling Habit | P4: Psychology |
-| 164 | 2-EDU | Education | Advanced Entry Techniques | P3: Market Mechanics |
-| 165 | 3-QUOTE | Quote | "Risk Comes From Not Knowing" | P4: Psychology |
-| 166 | 4-CHRON | Chronicle | The Scales of Truth | P5: Chronicle |
-| 167 | 5-EDU | Education | Institutional Order Flow | P3: Market Mechanics |
-| 168 | 6-PROD | Product | Pentarch WRN Signal Deep Dive | P2: Indicator Truth |
-| 169 | 7-DOCS | Docs | FAQ - Common Questions | P2: Indicator Truth |
-| 170 | 8-EDU | Education | Wyckoff Accumulation Schematic | P3: Market Mechanics |
-| 171 | 9-MKTG | Marketing | Social Proof - User Count | P1: Liquidity Lie |
-| 172 | 1-BLOG | Blog | Managing Winning Trades | P3: Market Mechanics |
-| 173 | 2-EDU | Education | Wyckoff Distribution Schematic | P3: Market Mechanics |
-| 174 | 3-QUOTE | Quote | "Managing Risk Quote" | P4: Psychology |
-| 175 | 4-CHRON | Chronicle | The Watchman's Vigil | P5: Chronicle |
-| 176 | 5-EDU | Education | Auction Market Theory | P3: Market Mechanics |
-| 177 | 6-PROD | Product | OmniDeck Unified View Demo | P2: Indicator Truth |
-| 178 | 7-DOCS | Docs | Best Practices Guide | P2: Indicator Truth |
-| 179 | 8-EDU | Education | Delta Volume Analysis | P3: Market Mechanics |
-| 180 | 9-MKTG | Marketing | Education Hub Spotlight | P2: Indicator Truth |
-
----
-
-## Posts 181-225
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 181 | 1-BLOG | Blog | The Importance of Screen Time | P4: Psychology |
-| 182 | 2-EDU | Education | Market Profile Basics | P3: Market Mechanics |
-| 183 | 3-QUOTE | Quote | "Patience vs Greed" | P4: Psychology |
-| 184 | 4-CHRON | Chronicle | The Commander's Strategy | P5: Chronicle |
-| 185 | 5-EDU | Education | Intermarket Analysis | P3: Market Mechanics |
-| 186 | 6-PROD | Product | Janus Atlas Fresh vs Tested Levels | P2: Indicator Truth |
-| 187 | 7-DOCS | Docs | Indicator Comparison Chart | P2: Indicator Truth |
-| 188 | 8-EDU | Education | Price Action Context | P3: Market Mechanics |
-| 189 | 9-MKTG | Marketing | 200 Posts Milestone | P1: Liquidity Lie |
-| 190 | 1-BLOG | Blog | Trading as a Business | P4: Psychology |
-| 191 | 2-EDU | Education | Trading the Open | P3: Market Mechanics |
-| 192 | 3-QUOTE | Quote | "1% Difference Quote" | P4: Psychology |
-| 193 | 4-CHRON | Chronicle | The Sovereign's Cycle | P5: Chronicle |
-| 194 | 5-EDU | Education | Optimal Trade Entry (OTE) | P3: Market Mechanics |
-| 195 | 6-PROD | Product | Volume Oracle NEUTRAL Regime | P2: Indicator Truth |
-| 196 | 7-DOCS | Docs | Alert Notification Options | P2: Indicator Truth |
-| 197 | 8-EDU | Education | Liquidity Voids | P3: Market Mechanics |
-| 198 | 9-MKTG | Marketing | Why Education First | P1: Liquidity Lie |
-| 199 | 1-BLOG | Blog | Trader's Morning Routine | P4: Psychology |
-| 200 | 2-EDU | Education | Breaker Blocks | P3: Market Mechanics |
-| 201 | 3-QUOTE | Quote | "Expensive Lessons Quote" | P4: Psychology |
-| 202 | 4-CHRON | Chronicle | The Scales' Balance | P5: Chronicle |
-| 203 | 5-EDU | Education | Mitigation Blocks | P3: Market Mechanics |
-| 204 | 6-PROD | Product | Pentarch CAP Signal Deep Dive | P2: Indicator Truth |
-| 205 | 7-DOCS | Docs | Performance Optimization | P2: Indicator Truth |
-| 206 | 8-EDU | Education | Premium & Discount Zones | P3: Market Mechanics |
-| 207 | 9-MKTG | Marketing | Trader Transformation Story | P1: Liquidity Lie |
-| 208 | 1-BLOG | Blog | Avoiding Tilt | P4: Psychology |
-| 209 | 2-EDU | Education | Kill Zones | P3: Market Mechanics |
-| 210 | 3-QUOTE | Quote | "Trading Journal Quote" | P4: Psychology |
-| 211 | 4-CHRON | Chronicle | The Cartographer's Journey | P5: Chronicle |
-| 212 | 5-EDU | Education | ICT Market Structure Shift | P3: Market Mechanics |
-| 213 | 6-PROD | Product | Harmonic Oscillator Components | P2: Indicator Truth |
-| 214 | 7-DOCS | Docs | Multi-Monitor Setup | P2: Indicator Truth |
-| 215 | 8-EDU | Education | Power of Three (AMD) | P3: Market Mechanics |
-| 216 | 9-MKTG | Marketing | Join the Discord | P1: Liquidity Lie |
-| 217 | 1-BLOG | Blog | Danger of Social Media Trading | P4: Psychology |
-| 218 | 2-EDU | Education | Judas Swing | P3: Market Mechanics |
-| 219 | 3-QUOTE | Quote | "Process Over Outcome" | P4: Psychology |
-| 220 | 4-CHRON | Chronicle | The Prophet's Revelation | P5: Chronicle |
-| 221 | 5-EDU | Education | Optimal Trade Management | P3: Market Mechanics |
-| 222 | 6-PROD | Product | Volume Oracle: Regime Transitions | P2: Indicator Truth |
-| 223 | 7-DOCS | Docs | Indicator Stacking Guide | P2: Indicator Truth |
-| 224 | 8-EDU | Education | Session Timing & Institutional Flow | P3: Market Mechanics |
-| 225 | 9-MKTG | Marketing | Price Increase Coming | P1: Liquidity Lie |
-
----
-
-## Posts 226-270
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 226 | 1-BLOG | Blog | Strategy Stops Working | P4: Psychology |
-| 227 | 2-EDU | Education | Fair Value Gaps: Institutional Footprints | P3: Market Mechanics |
-| 228 | 3-QUOTE | Quote | "Risk First" | P4: Psychology |
-| 229 | 4-CHRON | Chronicle | The Cartographer's First Map | P5: Chronicle |
-| 230 | 5-EDU | Education | Liquidity Pools: Where Stops Cluster | P3: Market Mechanics |
-| 231 | 6-PROD | Product | Janus Atlas: Multi-Timeframe Confluence | P2: Indicator Truth |
-| 232 | 7-DOCS | Docs | Alert Setup Guide | P2: Indicator Truth |
-| 233 | 8-EDU | Education | Order Blocks: Institutional Entry Zones | P3: Market Mechanics |
-| 234 | 9-MKTG | Marketing | Join the Community | P1: Liquidity Lie |
-| 235 | 1-BLOG | Blog | Why Most Indicators Fail | P2: Indicator Truth |
-| 236 | 2-EDU | Education | Breaker Blocks: Failed Order Blocks | P3: Market Mechanics |
-| 237 | 3-QUOTE | Quote | "Survive First" | P4: Psychology |
-| 238 | 4-CHRON | Chronicle | The Arbiter's Balance | P5: Chronicle |
-| 239 | 5-EDU | Education | Mitigation Blocks: Unfilled Orders | P3: Market Mechanics |
-| 240 | 6-PROD | Product | Plutus Flow: Statistical OBV | P2: Indicator Truth |
-| 241 | 7-DOCS | Docs | Mobile Trading Setup | P2: Indicator Truth |
-| 242 | 8-EDU | Education | Optimal Trade Entry (OTE) | P3: Market Mechanics |
-| 243 | 9-MKTG | Marketing | Testimonial Feature | P1: Liquidity Lie |
-| 244 | 1-BLOG | Blog | The Compound Effect in Trading | P4: Psychology |
-| 245 | 2-EDU | Education | Kill Zones: High-Probability Windows | P3: Market Mechanics |
-| 246 | 3-QUOTE | Quote | "The Market Will Teach You" | P4: Psychology |
-| 247 | 4-CHRON | Chronicle | The Watchman's Vigil | P5: Chronicle |
-| 248 | 5-EDU | Education | Displacement: Momentum Reveals Intent | P3: Market Mechanics |
-| 249 | 6-PROD | Product | Augury Grid: Multi-Symbol Scanning | P2: Indicator Truth |
-| 250 | 7-DOCS | Docs | Custom Color Schemes | P2: Indicator Truth |
-| 251 | 8-EDU | Education | Liquidity Sweeps vs Breakouts | P3: Market Mechanics |
-| 252 | 9-MKTG | Marketing | Limited Time Pricing | P1: Liquidity Lie |
-| 253 | 1-BLOG | Blog | Trading Journal: Your Most Valuable Tool | P4: Psychology |
-| 254 | 2-EDU | Education | Market Maker Models: Understanding Manipulation | P3: Market Mechanics |
-| 255 | 3-QUOTE | Quote | "Protect the Downside" | P4: Psychology |
-| 256 | 4-CHRON | Chronicle | The Commander's Strategy | P5: Chronicle |
-| 257 | 5-EDU | Education | Premium & Discount Arrays | P3: Market Mechanics |
-| 258 | 6-PROD | Product | OmniDeck: Everything in One | P2: Indicator Truth |
-| 259 | 7-DOCS | Docs | Troubleshooting Guide | P2: Indicator Truth |
-| 260 | 8-EDU | Education | Inducement: The Trap Before the Move | P3: Market Mechanics |
-| 261 | 9-MKTG | Marketing | Education Hub Highlight | P1: Liquidity Lie |
-| 262 | 1-BLOG | Blog | The Myth of the Holy Grail Strategy | P4: Psychology |
-| 263 | 2-EDU | Education | Return to Origin (RTO) | P3: Market Mechanics |
-| 264 | 3-QUOTE | Quote | "Simplicity Wins" | P4: Psychology |
-| 265 | 4-CHRON | Chronicle | The Founding of Signal Pilot | P5: Chronicle |
-| 266 | 5-EDU | Education | Institutional Order Flow Entry Drills | P3: Market Mechanics |
-| 267 | 6-PROD | Product | Pentarch: Five Signals Explained | P2: Indicator Truth |
-| 268 | 7-DOCS | Docs | FAQ Compilation | P2: Indicator Truth |
-| 269 | 8-EDU | Education | Market Structure Fundamentals | P3: Market Mechanics |
-| 270 | 9-MKTG | Marketing | 7-Day Money-Back Guarantee | P5: Chronicle |
-
----
-
-## Posts 271-315
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 271 | 1-BLOG | Blog | Why Backtesting Lies | P4: Psychology |
-| 272 | 2-EDU | Education | Support & Resistance Basics | P3: Market Mechanics |
-| 273 | 3-QUOTE | Quote | "Patience is Profitable" | P4: Psychology |
-| 274 | 4-CHRON | Chronicle | The Seven United | P5: Chronicle |
-| 275 | 5-EDU | Education | Candlestick Basics | P3: Market Mechanics |
-| 276 | 6-PROD | Product | Harmonic Oscillator: Momentum Components | P2: Indicator Truth |
-| 277 | 7-DOCS | Docs | Keyboard Shortcuts | P2: Indicator Truth |
-| 278 | 8-EDU | Education | Trend Identification | P3: Market Mechanics |
-| 279 | 9-MKTG | Marketing | 300 Posts Milestone | P5: Chronicle |
-| 280 | 1-BLOG | Blog | The Psychology of Drawdowns | P4: Psychology |
-| 281 | 2-EDU | Education | Risk-Reward Ratios | P3: Market Mechanics |
-| 282 | 3-QUOTE | Quote | "The Market Doesn't Care" | P4: Psychology |
-| 283 | 4-CHRON | Chronicle | The Scales of Balance | P5: Chronicle |
-| 284 | 5-EDU | Education | Volume Basics | P3: Market Mechanics |
-| 285 | 6-PROD | Product | Janus Atlas: Level Strength | P2: Indicator Truth |
-| 286 | 7-DOCS | Docs | Updating Indicators | P2: Indicator Truth |
-| 287 | 8-EDU | Education | Timeframe Selection | P3: Market Mechanics |
-| 288 | 9-MKTG | Marketing | What Makes Us Different | P5: Chronicle |
-| 289 | 1-BLOG | Blog | Paper Trading Too Long | P4: Psychology |
-| 290 | 2-EDU | Education | Trading Plan Essentials | P3: Market Mechanics |
-| 291 | 3-QUOTE | Quote | "Lose Small, Win Big" | P4: Psychology |
-| 292 | 4-CHRON | Chronicle | The Sovereign's Crown | P5: Chronicle |
-| 293 | 5-EDU | Education | Fear and Greed | P4: Psychology |
-| 294 | 6-PROD | Product | Volume Oracle: Divergence Detection | P2: Indicator Truth |
-| 295 | 7-DOCS | Docs | Indicator Compatibility | P2: Indicator Truth |
-| 296 | 8-EDU | Education | Multiple Timeframe Analysis | P3: Market Mechanics |
-| 297 | 9-MKTG | Marketing | Yearly Plan Value | P5: Chronicle |
-| 298 | 1-BLOG | Blog | Why Trading Courses Fail | P4: Psychology |
-| 299 | 2-EDU | Education | Confluence Trading | P3: Market Mechanics |
-| 300 | 3-QUOTE | Quote | "Plan Your Trade" | P4: Psychology |
-| 301 | 4-CHRON | Chronicle | The Gathering Storm | P5: Chronicle |
-| 302 | 5-EDU | Education | Stop Loss Placement | P3: Market Mechanics |
-| 303 | 6-PROD | Product | Pentarch: Cycle Phase Transitions | P2: Indicator Truth |
-| 304 | 7-DOCS | Docs | Chart Layout Templates | P2: Indicator Truth |
-| 305 | 8-EDU | Education | The Overnight Edge: Sleep | P4: Psychology |
-| 306 | 9-MKTG | Marketing | Free vs Paid Comparison | P5: Chronicle |
-| 307 | 1-BLOG | Blog | The Cost of FOMO | P4: Psychology |
-| 308 | 2-EDU | Education | Trading Psychology Fundamentals | P4: Psychology |
-| 309 | 3-QUOTE | Quote | "Edge vs Outcome" | P4: Psychology |
-| 310 | 4-CHRON | Chronicle | The Final Lesson | P5: Chronicle |
-| 311 | 5-EDU | Education | Reversal Patterns | P3: Market Mechanics |
-| 312 | 6-PROD | Product | Augury Grid: Filtering | P2: Indicator Truth |
-| 313 | 7-DOCS | Docs | Contact & Support | P2: Indicator Truth |
-| 314 | 8-EDU | Education | Trend Continuation Patterns | P3: Market Mechanics |
-| 315 | 9-MKTG | Marketing | Complete Indicator Overview | P2: Indicator Truth |
-
----
-
-## Posts 316-360
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 316 | 1-BLOG | Blog | The Sunk Cost Fallacy | P4: Psychology |
-| 317 | 2-EDU | Education | Moving Averages Basics | P3: Market Mechanics |
-| 318 | 3-QUOTE | Quote | "Adapt or Die" | P4: Psychology |
-| 319 | 4-CHRON | Chronicle | The Watchman Never Sleeps | P5: Chronicle |
-| 320 | 5-EDU | Education | Candlestick Patterns | P3: Market Mechanics |
-| 321 | 6-PROD | Product | Plutus Flow: Accumulation/Distribution | P2: Indicator Truth |
-| 322 | 7-DOCS | Docs | Performance Optimization | P2: Indicator Truth |
-| 323 | 8-EDU | Education | Position Sizing Formulas | P3: Market Mechanics |
-| 324 | 9-MKTG | Marketing | 350 Posts Milestone | P1: Liquidity Lie |
-| 325 | 1-BLOG | Blog | When to Walk Away | P4: Psychology |
-| 326 | 2-EDU | Education | Fibonacci Retracements | P3: Market Mechanics |
-| 327 | 3-QUOTE | Quote | "Trade the Chart in Front of You" | P4: Psychology |
-| 328 | 4-CHRON | Chronicle | The Path Forward | P5: Chronicle |
-| 329 | 5-EDU | Education | Breakout Trading | P3: Market Mechanics |
-| 330 | 6-PROD | Product | OmniDeck: The Unified View | P2: Indicator Truth |
-| 331 | 7-DOCS | Docs | Mobile App Usage | P2: Indicator Truth |
-| 332 | 8-EDU | Education | Trading and Relationships | P4: Psychology |
-| 333 | 9-MKTG | Marketing | Why Education First | P1: Liquidity Lie |
-| 334 | 1-BLOG | Blog | Trading Mentor Value | P4: Psychology |
-| 335 | 2-EDU | Education | Trading Sessions Overview | P3: Market Mechanics |
-| 336 | 3-QUOTE | Quote | "Boring Is Profitable" | P4: Psychology |
-| 337 | 4-CHRON | Chronicle | The Seven Aligned | P5: Chronicle |
-| 338 | 5-EDU | Education | Entry Techniques | P3: Market Mechanics |
-| 339 | 6-PROD | Product | Volume Oracle: Volume Regimes | P2: Indicator Truth |
-| 340 | 7-DOCS | Docs | Alert Configuration | P2: Indicator Truth |
-| 341 | 8-EDU | Education | The Comparison Trap | P4: Psychology |
-| 342 | 9-MKTG | Marketing | The Signal Pilot Promise | P1: Liquidity Lie |
-| 343 | 1-BLOG | Blog | Imposter Syndrome | P4: Psychology |
-| 344 | 2-EDU | Education | Chart Patterns Overview | P3: Market Mechanics |
-| 345 | 3-QUOTE | Quote | "Your Only Competition" | P4: Psychology |
-| 346 | 4-CHRON | Chronicle | Where It All Began | P5: Chronicle |
-| 347 | 5-EDU | Education | Risk Per Trade | P3: Market Mechanics |
-| 348 | 6-PROD | Product | Janus Atlas: Timeframe Hierarchy | P2: Indicator Truth |
-| 349 | 7-DOCS | Docs | Multi-Chart Layouts | P2: Indicator Truth |
-| 350 | 8-EDU | Education | When Trading Becomes Gambling | P4: Psychology |
-| 351 | 9-MKTG | Marketing | Community Spotlight | P1: Liquidity Lie |
-| 352 | 1-BLOG | Blog | Power of "I Don't Know" | P4: Psychology |
-| 353 | 2-EDU | Education | Trade Management | P3: Market Mechanics |
-| 354 | 3-QUOTE | Quote | "The Process Is the Goal" | P4: Psychology |
-| 355 | 4-CHRON | Chronicle | The Eternal Student | P5: Chronicle |
-| 356 | 5-EDU | Education | Correlation in Trading | P3: Market Mechanics |
-| 357 | 6-PROD | Product | Harmonic Oscillator Divergence Alerts | P2: Indicator Truth |
-| 358 | 7-DOCS | Docs | Community Guidelines | P3: Market Mechanics |
-| 359 | 8-EDU | Education | Stop Loss Types | P3: Market Mechanics |
-| 360 | 9-MKTG | Marketing | 400 Posts Approaching | P5: Chronicle |
-
----
-
-## Posts 361-405
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 361 | 1-BLOG | Blog | Building Confidence | P4: Psychology |
-| 362 | 2-EDU | Education | Market Types | P3: Market Mechanics |
-| 363 | 3-QUOTE | Quote | "Small Consistent Wins" | P4: Psychology |
-| 364 | 4-CHRON | Chronicle | The Market's Memory | P5: Chronicle |
-| 365 | 5-EDU | Education | Journaling for Improvement | P3: Market Mechanics |
-| 366 | 6-PROD | Product | Pentarch + Volume Oracle Combo | P2: Indicator Truth |
-| 367 | 7-DOCS | Docs | Multi-Chart Layouts | P3: Market Mechanics |
-| 368 | 8-EDU | Education | Your Trading Identity | P4: Psychology |
-| 369 | 9-MKTG | Marketing | 400 Posts Milestone | P5: Chronicle |
-| 370 | 1-BLOG | Blog | The 10,000 Hour Myth | P4: Psychology |
-| 371 | 2-EDU | Education | Looking Ahead: Journey Continues | P3: Market Mechanics |
-| 372 | 3-QUOTE | Quote | "Trust Your Preparation" | P4: Psychology |
-| 373 | 4-CHRON | Chronicle | The Patience of the Cartographer | P5: Chronicle |
-| 374 | 5-EDU | Education | Wyckoff Accumulation Schematic | P3: Market Mechanics |
-| 375 | 6-PROD | Product | Janus Atlas + Plutus Flow Combo | P2: Indicator Truth |
-| 376 | 7-DOCS | Docs | Backtesting in TradingView | P3: Market Mechanics |
-| 377 | 8-EDU | Education | Trading Burnout: Signs and Solutions | P4: Psychology |
-| 378 | 9-MKTG | Marketing | Education Hub Depth | P2: Indicator Truth |
-| 379 | 1-BLOG | Blog | The Myth of Trading Secrets | P4: Psychology |
-| 380 | 2-EDU | Education | Wyckoff Distribution Schematic | P3: Market Mechanics |
-| 381 | 3-QUOTE | Quote | "Complexity vs Simplicity" | P4: Psychology |
-| 382 | 4-CHRON | Chronicle | The Arbiter's Balance | P5: Chronicle |
-| 383 | 5-EDU | Education | Market Structure Shift (MSS) | P3: Market Mechanics |
-| 384 | 6-PROD | Product | Volume Oracle Regime Detection | P2: Indicator Truth |
-| 385 | 7-DOCS | Docs | Alert Configuration | P3: Market Mechanics |
-| 386 | 8-EDU | Education | ICT Concepts Overview | P3: Market Mechanics |
-| 387 | 9-MKTG | Marketing | Indicator Integration | P2: Indicator Truth |
-| 388 | 1-BLOG | Blog | Building Trading Systems | P3: Market Mechanics |
-| 389 | 2-EDU | Education | Change of Character (ChOCH) | P3: Market Mechanics |
-| 390 | 3-QUOTE | Quote | "Market Rewards Alignment" | P4: Psychology |
-| 391 | 4-CHRON | Chronicle | The Prophet's Silence | P5: Chronicle |
-| 392 | 5-EDU | Education | Liquidity Concepts | P3: Market Mechanics |
-| 393 | 6-PROD | Product | Pentarch + Harmonic Oscillator Combo | P2: Indicator Truth |
-| 394 | 7-DOCS | Docs | Timeframe Selection Guide | P3: Market Mechanics |
-| 395 | 8-EDU | Education | The Cost of Perfectionism | P4: Psychology |
-| 396 | 9-MKTG | Marketing | Free Education Access | P2: Indicator Truth |
-| 397 | 1-BLOG | Blog | The Psychology of Waiting | P4: Psychology |
-| 398 | 2-EDU | Education | Break of Structure (BOS) | P3: Market Mechanics |
-| 399 | 3-QUOTE | Quote | "Confidence from Preparation" | P4: Psychology |
-| 400 | 4-CHRON | Chronicle | The Commander's Burden | P5: Chronicle |
-| 401 | 5-EDU | Education | Order Flow Basics | P3: Market Mechanics |
-| 402 | 6-PROD | Product | Janus Atlas Multi-Timeframe Demo | P2: Indicator Truth |
-| 403 | 7-DOCS | Docs | Indicator Settings Overview | P2: Indicator Truth |
-| 404 | 8-EDU | Education | Position Sizing Psychology | P4: Psychology |
-| 405 | 9-MKTG | Marketing | 7-Day Money Back Guarantee | P1: Liquidity Lie |
-
----
-
-## Posts 406-450
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 406 | 1-BLOG | Blog | When To Break Your Rules | P4: Psychology |
-| 407 | 2-EDU | Education | Imbalance & Fair Value Gaps | P3: Market Mechanics |
-| 408 | 3-QUOTE | Quote | "Risk Management = Survival" | P4: Psychology |
-| 409 | 4-CHRON | Chronicle | The Scales of Truth | P5: Chronicle |
-| 410 | 5-EDU | Education | Inducement & Trap Setups | P3: Market Mechanics |
-| 411 | 6-PROD | Product | Augury Grid Scanner Demo | P2: Indicator Truth |
-| 412 | 7-DOCS | Docs | Troubleshooting Common Issues | P2: Indicator Truth |
-| 413 | 8-EDU | Education | Premium & Discount Zones | P3: Market Mechanics |
-| 414 | 9-MKTG | Marketing | Cancel Anytime | P1: Liquidity Lie |
-| 415 | 1-BLOG | Blog | Recovery After a Losing Streak | P4: Psychology |
-| 416 | 2-EDU | Education | Wyckoff Accumulation Schematic | P3: Market Mechanics |
-| 417 | 3-QUOTE | Quote | "Being Wrong Better" | P4: Psychology |
-| 418 | 4-CHRON | Chronicle | The Cartographer's Map | P5: Chronicle |
-| 419 | 5-EDU | Education | Mitigation Blocks | P3: Market Mechanics |
-| 420 | 6-PROD | Product | Plutus Flow Divergence Demo | P2: Indicator Truth |
-| 421 | 7-DOCS | Docs | Multi-Chart Layouts | P2: Indicator Truth |
-| 422 | 8-EDU | Education | The Danger of Hindsight Analysis | P4: Psychology |
-| 423 | 9-MKTG | Marketing | Lifetime Access Option | P1: Liquidity Lie |
-| 424 | 1-BLOG | Blog | Building a Pre-Trade Checklist | P4: Psychology |
-| 425 | 2-EDU | Education | Wyckoff Distribution Schematic | P3: Market Mechanics |
-| 426 | 3-QUOTE | Quote | "Market is a Mirror" | P4: Psychology |
-| 427 | 4-CHRON | Chronicle | The Sovereign's Cycle | P5: Chronicle |
-| 428 | 5-EDU | Education | Inverse Fair Value Gaps | P3: Market Mechanics |
-| 429 | 6-PROD | Product | OmniDeck Confluence Score Demo | P2: Indicator Truth |
-| 430 | 7-DOCS | Docs | Keyboard Shortcuts Guide | P2: Indicator Truth |
-| 431 | 8-EDU | Education | The 3 Types of Trading Edges | P4: Psychology |
-| 432 | 9-MKTG | Marketing | Education-First Philosophy | P1: Liquidity Lie |
-| 433 | 1-BLOG | Blog | Analysis Paralysis | P4: Psychology |
-| 434 | 2-EDU | Education | Liquidity Sweeps vs. Grabs | P3: Market Mechanics |
-| 435 | 3-QUOTE | Quote | "Trade the Chart in Front of You" | P4: Psychology |
-| 436 | 4-CHRON | Chronicle | The Watchman's Vigil | P5: Chronicle |
-| 437 | 5-EDU | Education | Order Blocks Deep Dive | P3: Market Mechanics |
-| 438 | 6-PROD | Product | Harmonic Oscillator Exhaustion Signals | P2: Indicator Truth |
-| 439 | 7-DOCS | Docs | Mobile Access Guide | P2: Indicator Truth |
-| 440 | 8-EDU | Education | Time-Based Liquidity Concepts | P3: Market Mechanics |
-| 441 | 9-MKTG | Marketing | Community & Support | P1: Liquidity Lie |
-| 442 | 1-BLOG | Blog | Why Demo Trading Isn't Enough | P4: Psychology |
-| 443 | 2-EDU | Education | Killzones & High-Probability Windows | P3: Market Mechanics |
-| 444 | 3-QUOTE | Quote | "Process Defines Next Trade" | P4: Psychology |
-| 445 | 4-CHRON | Chronicle | The Council of Seven | P5: Chronicle |
-| 446 | 5-EDU | Education | Institutional Order Flow Concepts | P3: Market Mechanics |
-| 447 | 6-PROD | Product | Full Suite Integration Demo | P2: Indicator Truth |
-| 448 | 7-DOCS | Docs | Performance Optimization | P2: Indicator Truth |
-| 449 | 8-EDU | Education | Asian Range Strategy Concepts | P3: Market Mechanics |
-| 450 | 9-MKTG | Marketing | Transparent Pricing | P1: Liquidity Lie |
-
----
-
-## Posts 451-495
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 451 | 1-BLOG | Blog | The Myth of the Holy Grail Indicator | P4: Psychology |
-| 452 | 2-EDU | Education | Power of Three (AMD) | P3: Market Mechanics |
-| 453 | 3-QUOTE | Quote | "Chart Shows Possibilities" | P4: Psychology |
-| 454 | 4-CHRON | Chronicle | Origins of the Elite Seven | P5: Chronicle |
-| 455 | 5-EDU | Education | ICT Judas Swing Concept | P3: Market Mechanics |
-| 456 | 6-PROD | Product | Pentarch Cycle Phase Transitions | P2: Indicator Truth |
-| 457 | 7-DOCS | Docs | API & Webhook Integration | P2: Indicator Truth |
-| 458 | 8-EDU | Education | Market Maker Models | P3: Market Mechanics |
-| 459 | 9-MKTG | Marketing | 500th Post Milestone | P1: Liquidity Lie |
-| 460 | 1-BLOG | Blog | Building Trading Confidence | P4: Psychology |
-| 461 | 2-EDU | Education | Quarterly Theory Basics | P3: Market Mechanics |
-| 462 | 3-QUOTE | Quote | "Losses Are Tuition" | P4: Psychology |
-| 463 | 4-CHRON | Chronicle | The Eternal Dance | P5: Chronicle |
-| 464 | 5-EDU | Education | Algorithmic vs. Discretionary | P3: Market Mechanics |
-| 465 | 6-PROD | Product | Volume Oracle + Janus Atlas Combo | P2: Indicator Truth |
-| 466 | 7-DOCS | Docs | Frequently Asked Questions | P2: Indicator Truth |
-| 467 | 8-EDU | Education | Why Most Trading Education Fails | P4: Psychology |
-| 468 | 9-MKTG | Marketing | Built by Traders, For Traders | P1: Liquidity Lie |
-| 469 | 1-BLOG | Blog | The Art of Doing Nothing | P4: Psychology |
-| 470 | 2-EDU | Education | Building Your Trading System | P3: Market Mechanics |
-| 471 | 3-QUOTE | Quote | "Respond Not Predict" | P4: Psychology |
-| 472 | 4-CHRON | Chronicle | The Prophet's Warning | P5: Chronicle |
-| 473 | 5-EDU | Education | Backtesting Fundamentals | P3: Market Mechanics |
-| 474 | 6-PROD | Product | Plutus Flow Accumulation Detection | P2: Indicator Truth |
-| 475 | 7-DOCS | Docs | Update History & Changelog | P2: Indicator Truth |
-| 476 | 8-EDU | Education | The Cost of Impatience | P4: Psychology |
-| 477 | 9-MKTG | Marketing | Join 10,000+ Traders | P1: Liquidity Lie |
-| 478 | 1-BLOG | Blog | The Loneliness of Trading | P4: Psychology |
-| 479 | 2-EDU | Education | Correlation in Trading | P3: Market Mechanics |
-| 480 | 3-QUOTE | Quote | "Small Loss = Successful Trade" | P4: Psychology |
-| 481 | 4-CHRON | Chronicle | The Cartographer's Journey | P5: Chronicle |
-| 482 | 5-EDU | Education | Forward Testing Protocol | P3: Market Mechanics |
-| 483 | 6-PROD | Product | Harmonic Oscillator Multi-Component | P2: Indicator Truth |
-| 484 | 7-DOCS | Docs | Contact & Support | P2: Indicator Truth |
-| 485 | 8-EDU | Education | Managing Expectations vs Reality | P4: Psychology |
-| 486 | 9-MKTG | Marketing | 7-Day Free Education Challenge | P1: Liquidity Lie |
-| 487 | 1-BLOG | Blog | When to Take a Break | P4: Psychology |
-| 488 | 2-EDU | Education | Volatility Cycles | P3: Market Mechanics |
-| 489 | 3-QUOTE | Quote | "Patience vs. Prediction" | P4: Psychology |
-| 490 | 4-CHRON | Chronicle | The Seven Virtues | P5: Chronicle |
-| 491 | 5-EDU | Education | Risk-Adjusted Returns | P3: Market Mechanics |
-| 492 | 6-PROD | Product | Janus Atlas Historical Level Strength | P2: Indicator Truth |
-| 493 | 7-DOCS | Docs | Best Practices Guide | P2: Indicator Truth |
-| 494 | 8-EDU | Education | Trend Strength Assessment | P3: Market Mechanics |
-| 495 | 9-MKTG | Marketing | Compare Us to Alternatives | P1: Liquidity Lie |
-
----
-
-## Posts 496-540
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 496 | 1-BLOG | Blog | Conviction vs. Stubbornness | P4: Psychology |
-| 497 | 2-EDU | Education | Support Becomes Resistance | P3: Market Mechanics |
-| 498 | 3-QUOTE | Quote | "Beginners Who Didn't Quit" | P4: Psychology |
-| 499 | 4-CHRON | Chronicle | The Arbiter's Judgment | P5: Chronicle |
-| 500 | 5-EDU | Education | Multi-Timeframe Confirmation | P3: Market Mechanics |
-| 501 | 6-PROD | Product | Augury Grid Watchlist Prioritization | P2: Indicator Truth |
-| 502 | 7-DOCS | Docs | Video Tutorial Library | P2: Indicator Truth |
-| 503 | 8-EDU | Education | Mean Reversion Basics | P3: Market Mechanics |
-| 504 | 9-MKTG | Marketing | Results Over Promises | P1: Liquidity Lie |
-| 505 | 1-BLOG | Blog | Trade Smaller Than You Think | P4: Psychology |
-| 506 | 2-EDU | Education | Scaling Into Positions | P3: Market Mechanics |
-| 507 | 3-QUOTE | Quote | "Missed vs. Forced Trades" | P4: Psychology |
-| 508 | 4-CHRON | Chronicle | The Complete Picture | P5: Chronicle |
-| 509 | 5-EDU | Education | False Breakout Recognition | P3: Market Mechanics |
-| 510 | 6-PROD | Product | OmniDeck Daily Routine Demo | P2: Indicator Truth |
-| 511 | 7-DOCS | Docs | Glossary of Terms | P2: Indicator Truth |
-| 512 | 8-EDU | Education | Scaling Out of Positions | P3: Market Mechanics |
-| 513 | 9-MKTG | Marketing | Start Free Today | P1: Liquidity Lie |
-| 514 | 1-BLOG | Blog | Importance of Sleep for Trading | P4: Psychology |
-| 515 | 2-EDU | Education | Gap Trading Basics | P3: Market Mechanics |
-| 516 | 3-QUOTE | Quote | "Consistency Definition" | P4: Psychology |
-| 517 | 4-CHRON | Chronicle | Epilogue — The Trader's Path | P5: Chronicle |
-| 518 | 5-EDU | Education | Trade Review Process | P3: Market Mechanics |
-| 519 | 6-PROD | Product | Volume Oracle Regime Shifts | P2: Indicator Truth |
-| 520 | 7-DOCS | Docs | System Requirements | P2: Indicator Truth |
-| 521 | 8-EDU | Education | Candlestick Psychology | P3: Market Mechanics |
-| 522 | 9-MKTG | Marketing | The Signal Pilot Promise | P1: Liquidity Lie |
-| 523 | 1-BLOG | Blog | Handling Winning Streaks | P4: Psychology |
-| 524 | 2-EDU | Education | Volume Confirmation Basics | P3: Market Mechanics |
-| 525 | 3-QUOTE | Quote | "Entry Price Irrelevance" | P4: Psychology |
-| 526 | 4-CHRON | Chronicle | Recap: Lessons from Seven | P5: Chronicle |
-| 527 | 5-EDU | Education | Divergence Trading Fundamentals | P3: Market Mechanics |
-| 528 | 6-PROD | Product | Pentarch Full Cycle | P2: Indicator Truth |
-| 529 | 7-DOCS | Docs | Feedback & Feature Requests | P2: Indicator Truth |
-| 530 | 8-EDU | Education | Trading as a Business | P4: Psychology |
-| 531 | 9-MKTG | Marketing | Thank You for 600+ Posts | P1: Liquidity Lie |
-| 532 | 1-BLOG | Blog | Trading and Relationships | P4: Psychology |
-| 533 | 2-EDU | Education | Trend Reversal Patterns | P3: Market Mechanics |
-| 534 | 3-QUOTE | Quote | "System Execution" | P4: Psychology |
-| 535 | 4-CHRON | Chronicle | Final Chronicle Message | P5: Chronicle |
-| 536 | 5-EDU | Education | Risk-to-Reward Optimization | P3: Market Mechanics |
-| 537 | 6-PROD | Product | Complete Suite Overview | P2: Indicator Truth |
-| 538 | 7-DOCS | Docs | Quick Start Guide | P2: Indicator Truth |
-| 539 | 8-EDU | Education | Confluence Zones | P3: Market Mechanics |
-| 540 | 9-MKTG | Marketing | Final Push — 49 to Go | P1: Liquidity Lie |
-
----
-
-## Posts 541-585
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 541 | 1-BLOG | Blog | First Hour Trading Trap | P4: Psychology |
-| 542 | 2-EDU | Education | Trading Session Characteristics | P3: Market Mechanics |
-| 543 | 3-QUOTE | Quote | "Market Teacher" | P4: Psychology |
-| 544 | 4-CHRON | Chronicle | The Signal Pilot Vision | P5: Chronicle |
-| 545 | 5-EDU | Education | Position Management Principles | P3: Market Mechanics |
-| 546 | 6-PROD | Product | Settings Deep Dive | P2: Indicator Truth |
-| 547 | 7-DOCS | Docs | Upgrade Path Options | P2: Indicator Truth |
-| 548 | 8-EDU | Education | Common Beginner Mistakes | P3: Market Mechanics |
-| 549 | 9-MKTG | Marketing | Your Journey Starts Here | P1: Liquidity Lie |
-| 550 | 1-BLOG | Blog | Why Most Traders Quit | P4: Psychology |
-| 551 | 2-EDU | Education | Stop Loss Placement | P3: Market Mechanics |
-| 552 | 3-QUOTE | Quote | "Discipline (Now vs Most)" | P4: Psychology |
-| 553 | 4-CHRON | Chronicle | Elite Seven Summary | P5: Chronicle |
-| 554 | 5-EDU | Education | Building Trading Habits | P3: Market Mechanics |
-| 555 | 6-PROD | Product | Volume Oracle Regimes | P2: Indicator Truth |
-| 556 | 7-DOCS | Docs | Multi-Asset FAQ | P2: Indicator Truth |
-| 557 | 8-EDU | Education | Weekend Review Ritual | P4: Psychology |
-| 558 | 9-MKTG | Marketing | 621 Progress Update | P1: Liquidity Lie |
-| 559 | 1-BLOG | Blog | Spread and Slippage | P4: Psychology |
-| 560 | 2-EDU | Education | Price Action vs Indicators | P3: Market Mechanics |
-| 561 | 3-QUOTE | Quote | "Be Right vs Be Profitable" | P4: Psychology |
-| 562 | 4-CHRON | Chronicle | Three Guardian Lessons | P5: Chronicle |
-| 563 | 5-EDU | Education | Understanding Market Hours | P3: Market Mechanics |
-| 564 | 6-PROD | Product | Janus Atlas Levels | P2: Indicator Truth |
-| 565 | 7-DOCS | Docs | Getting Started Guide | P2: Indicator Truth |
-| 566 | 8-EDU | Education | Confluence Basics | P3: Market Mechanics |
-| 567 | 9-MKTG | Marketing | 631 Progress Update | P1: Liquidity Lie |
-| 568 | 1-BLOG | Blog | Dealing with FOMO | P4: Psychology |
-| 569 | 2-EDU | Education | Reading Wicks | P3: Market Mechanics |
-| 570 | 3-QUOTE | Quote | "Plan the Trade" | P4: Psychology |
-| 571 | 4-CHRON | Chronicle | Final Three Guardians | P5: Chronicle |
-| 572 | 5-EDU | Education | Importance of Doing Nothing | P3: Market Mechanics |
-| 573 | 6-PROD | Product | Plutus Flow | P2: Indicator Truth |
-| 574 | 7-DOCS | Docs | Troubleshooting Guide | P2: Indicator Truth |
-| 575 | 8-EDU | Education | Risk-Reward Ratios | P3: Market Mechanics |
-| 576 | 9-MKTG | Marketing | 641 Progress (9 to go) | P1: Liquidity Lie |
-| 577 | 1-BLOG | Blog | Surviving First Drawdown | P4: Psychology |
-| 578 | 2-EDU | Education | Understanding Liquidity | P3: Market Mechanics |
-| 579 | 3-QUOTE | Quote | "Warren Buffett (Patience)" | P4: Psychology |
-| 580 | 4-CHRON | Chronicle | The Signal Within | P5: Chronicle |
-| 581 | 5-EDU | Education | Building a Watchlist | P3: Market Mechanics |
-| 582 | 6-PROD | Product | OmniDeck | P2: Indicator Truth |
-| 583 | 7-DOCS | Docs | Documentation Overview | P2: Indicator Truth |
-| 584 | 8-EDU | Education | Compound Effect in Trading | P3: Market Mechanics |
-| 585 | 9-MKTG | Marketing | 649 (One to Go) | P1: Liquidity Lie |
-
----
-
-## Posts 586-650 (FINAL STRETCH)
-
-| Post | Grid Pos | Type | Topic | Pillar |
-|------|----------|------|-------|--------|
-| 586 | 1-BLOG | Blog | Year One Expectations | P4: Psychology |
-| 587 | 2-EDU | Education | Advanced Confluence | P3: Market Mechanics |
-| 588 | 3-QUOTE | Quote | "Sunk Cost Fallacy" | P4: Psychology |
-| 589 | 4-CHRON | Chronicle | Mastery and Beyond | P5: Chronicle |
-| 590 | 5-EDU | Education | Building Trading Systems | P3: Market Mechanics |
-| 591 | 6-PROD | Product | Complete Suite Demo | P2: Indicator Truth |
-| 592 | 7-DOCS | Docs | Final Documentation | P2: Indicator Truth |
-| 593 | 8-EDU | Education | When to Walk Away | P3: Market Mechanics |
-| 594 | 9-MKTG | Marketing | Complete Celebration | P1: Liquidity Lie |
-| 595 | 1-BLOG | Blog | Trading Plan Essentials | P4: Psychology |
-| 596 | 2-EDU | Education | Entry Trigger Types | P3: Market Mechanics |
-| 597 | 3-QUOTE | Quote | "Accepting Losses" | P4: Psychology |
-| 598 | 4-CHRON | Chronicle | Welcome to Signal Pilot | P5: Chronicle |
-| 599 | 5-EDU | Education | 80/20 Rule in Trading | P3: Market Mechanics |
-| 600 | 6-PROD | Product | Complete Suite Overview | P2: Indicator Truth |
-| 601 | 7-DOCS | Docs | Quick Start Guide | P2: Indicator Truth |
-| 602 | 8-EDU | Education | Common Beginner Mistakes | P3: Market Mechanics |
-| 603 | 9-MKTG | Marketing | Why Most Traders Fail | P1: Liquidity Lie |
-| 604 | 1-BLOG | Blog | Trading Journal Best Practices | P4: Psychology |
-| 605 | 2-EDU | Education | Reading Order Flow Simply | P3: Market Mechanics |
-| 606 | 3-QUOTE | Quote | "Finding Your Trading Style" | P4: Psychology |
-| 607 | 4-CHRON | Chronicle | Importance of Liquidity | P5: Chronicle |
-| 608 | 5-EDU | Education | Understanding Trends | P3: Market Mechanics |
-| 609 | 6-PROD | Product | Volume Oracle Final | P2: Indicator Truth |
-| 610 | 7-DOCS | Docs | Feedback & Feature Requests | P2: Indicator Truth |
-| 611 | 8-EDU | Education | Market Profile | P3: Market Mechanics |
-| 612 | 9-MKTG | Marketing | Journey Complete | P1: Liquidity Lie |
-| 613 | 1-BLOG | Blog | Volume Basics | P3: Market Mechanics |
-| 614 | 2-EDU | Education | Psychology of Round Numbers | P4: Psychology |
-| 615 | 3-QUOTE | Quote | "Discipline (Now vs Most)" | P4: Psychology |
-| 616 | 4-CHRON | Chronicle | Elite Seven Summary | P5: Chronicle |
-| 617 | 5-EDU | Education | Confluence Basics | P3: Market Mechanics |
-| 618 | 6-PROD | Product | Volume Oracle Regimes | P2: Indicator Truth |
-| 619 | 7-DOCS | Docs | Multi-Asset FAQ | P2: Indicator Truth |
-| 620 | 8-EDU | Education | Journaling What to Track | P4: Psychology |
-| 621 | 9-MKTG | Marketing | 621 Progress Update | P1: Liquidity Lie |
-| 622 | 1-BLOG | Blog | Understanding Trends | P3: Market Mechanics |
-| 623 | 2-EDU | Education | Risk-Reward Ratios | P3: Market Mechanics |
-| 624 | 3-QUOTE | Quote | "Be Right vs Be Profitable" | P4: Psychology |
-| 625 | 4-CHRON | Chronicle | Three Guardian Lessons | P5: Chronicle |
-| 626 | 5-EDU | Education | Reading Wicks | P3: Market Mechanics |
-| 627 | 6-PROD | Product | Janus Atlas Levels | P2: Indicator Truth |
-| 628 | 7-DOCS | Docs | Getting Started Guide | P2: Indicator Truth |
-| 629 | 8-EDU | Education | Advanced Confluence | P3: Market Mechanics |
-| 630 | 9-MKTG | Marketing | 631 Progress Update | P1: Liquidity Lie |
-| 631 | 1-BLOG | Blog | Importance of Doing Nothing | P3: Market Mechanics |
-| 632 | 2-EDU | Education | Building a Watchlist | P3: Market Mechanics |
-| 633 | 3-QUOTE | Quote | "Plan the Trade" | P4: Psychology |
-| 634 | 4-CHRON | Chronicle | Final Three Guardians | P5: Chronicle |
-| 635 | 5-EDU | Education | Understanding Liquidity | P3: Market Mechanics |
-| 636 | 6-PROD | Product | Plutus Flow | P2: Indicator Truth |
-| 637 | 7-DOCS | Docs | Troubleshooting Guide | P2: Indicator Truth |
-| 638 | 8-EDU | Education | Compound Effect in Trading | P3: Market Mechanics |
-| 639 | 9-MKTG | Marketing | 641 Progress (9 to go) | P1: Liquidity Lie |
-| 640 | 1-BLOG | Blog | When to Walk Away | P4: Psychology |
-| 641 | 2-EDU | Education | Building Trading Systems | P3: Market Mechanics |
-| 642 | 3-QUOTE | Quote | "Warren Buffett (Patience)" | P4: Psychology |
-| 643 | 4-CHRON | Chronicle | The Signal Within | P5: Chronicle |
-| 644 | 5-EDU | Education | Mastery and Beyond | P3: Market Mechanics |
-| 645 | 6-PROD | Product | OmniDeck Complete | P2: Indicator Truth |
-| 646 | 7-DOCS | Docs | Documentation Overview | P2: Indicator Truth |
-| 647 | 8-EDU | Education | Why Most Traders Fail | P3: Market Mechanics |
-| 648 | 9-MKTG | Marketing | 649 (One to Go) | P1: Liquidity Lie |
-| 649 | 1-BLOG | Blog | Final Wisdom | P4: Psychology |
-| **650** | **2-EDU** | **Education** | **Welcome to Signal Pilot - Complete** | **FINALE** |
-
----
-
-# CANVA WORKFLOW
-
-## Your Current Position: Post 37
-
-**Post 37 = Grid Position 1 = BLOG (Left Column, Teal Tones)**
-
-### Posts 37-39 (Your Next 3 Posts):
-
-| Post | Grid | Type | Topic | Canva Template |
-|------|------|------|-------|----------------|
-| **37** | 1 | BLOG | The Confirmation Trap | Teal Blog Template |
-| **38** | 2 | EDU | Position Sizing | Neutral Education Template |
-| **39** | 3 | QUOTE | "Entries vs Exits" | Orange Quote Template |
-
-### Canva Template Assignments:
-
-| Grid Position | Type | Template Color | Visual Style |
-|---------------|------|----------------|--------------|
-| 1 | BLOG | Teal (#008080) | Text-heavy, article preview |
-| 2 | EDU | Neutral (#1a1a1a) | Diagram/chart education |
-| 3 | QUOTE | Orange (#ff6b35) | Bold quote, centered text |
-| 4 | CHRON | Teal (#008080) | Artistic, lore imagery |
-| 5 | EDU | Neutral (#1a1a1a) | Lesson format |
-| 6 | PROD | Orange (#ff6b35) | Screenshot, product demo |
-| 7 | DOCS | Teal (#008080) | Cheatsheet, reference |
-| 8 | EDU | Neutral (#1a1a1a) | Educational graphic |
-| 9 | MKTG | Orange (#ff6b35) | CTA, promotional |
-
----
-
-# QUICK REFERENCE: Grid Position Formula
-
-```
-Post Number | Position | Type
------------+----------+------
-N % 9 = 1  | 1        | BLOG
-N % 9 = 2  | 2        | EDU
-N % 9 = 3  | 3        | QUOTE
-N % 9 = 4  | 4        | CHRON
-N % 9 = 5  | 5        | EDU
-N % 9 = 6  | 6        | PROD
-N % 9 = 7  | 7        | DOCS
-N % 9 = 8  | 8        | EDU
-N % 9 = 0  | 9        | MKTG
-```
-
----
-
-# CONTENT TYPE COUNTS (650 Posts)
-
-| Type | Grid Positions | Total Posts |
-|------|----------------|-------------|
-| BLOG | 1 | 73 posts |
-| EDU | 2, 5, 8 | 217 posts |
-| QUOTE | 3 | 73 posts |
-| CHRON | 4 | 72 posts |
-| PROD | 6 | 72 posts |
-| DOCS | 7 | 72 posts |
-| MKTG | 9 | 72 posts |
-
-**Center column = 33% of all content = ALWAYS Education**
-
----
-
-# POSTING CHECKLIST
-
-For each post, verify:
-
-1. [ ] Post number matches grid position
-2. [ ] Content type matches grid assignment
-3. [ ] Canva template matches column color
-4. [ ] Content pillar is appropriate
-
-Example for Post 37:
-- 37 % 9 = 1 → Grid Position 1 → BLOG → Teal Template ✓
-
----
-
-*Generated from CONTENT_PLAN_PART1.md and CONTENT_PLAN_PART2.md*
-*Remapped to 9-Grid System: LEFT (Blog/Chron/Docs) | CENTER (Edu) | RIGHT (Quote/Prod/Mktg)*
+### 📋 COMPLETE POSTING SCHEDULE (Posts 40-650)
+
+| Row | Post Order | Orange | Neutral | Teal |
+|-----|------------|--------|---------|------|
+| 14 | 40-42 | 041 | 039 | 043 |
+| 15 | 43-45 | 044 | 042 | 047 |
+| 16 | 46-48 | 045 | 046 | 048 |
+| 17 | 49-51 | 051 | 049 | 050 |
+| 18 | 52-54 | 054 | 052 | 053 |
+| 19 | 55-57 | 055 | 056 | 057 |
+| 20 | 58-60 | 061 | 059 | 058 |
+| 21 | 61-63 | 064 | 062 | 060 |
+| 22 | 64-66 | 065 | 066 | 063 |
+| 23 | 67-69 | 071 | 069 | 067 |
+| 24 | 70-72 | 074 | 072 | 068 |
+| 25 | 73-75 | 075 | 076 | 070 |
+| 26 | 76-78 | 081 | 079 | 073 |
+| 27 | 79-81 | 084 | 082 | 077 |
+| 28 | 82-84 | 085 | 086 | 078 |
+| 29 | 85-87 | 091 | 089 | 080 |
+| 30 | 88-90 | 094 | 092 | 083 |
+| 31 | 91-93 | 095 | 096 | 087 |
+| 32 | 94-96 | 101 | 099 | 088 |
+| 33 | 97-99 | 104 | 102 | 090 |
+| 34 | 100-102 | 105 | 106 | 093 |
+| 35 | 103-105 | 111 | 109 | 097 |
+| 36 | 106-108 | 114 | 112 | 098 |
+| 37 | 109-111 | 115 | 116 | 100 |
+| 38 | 112-114 | 121 | 119 | 103 |
+| 39 | 115-117 | 124 | 122 | 107 |
+| 40 | 118-120 | 125 | 126 | 108 |
+| 41 | 121-123 | 131 | 129 | 110 |
+| 42 | 124-126 | 134 | 132 | 113 |
+| 43 | 127-129 | 135 | 136 | 117 |
+| 44 | 130-132 | 141 | 139 | 118 |
+| 45 | 133-135 | 144 | 142 | 120 |
+| 46 | 136-138 | 145 | 146 | 123 |
+| 47 | 139-141 | 151 | 149 | 127 |
+| 48 | 142-144 | 154 | 152 | 128 |
+| 49 | 145-147 | 155 | 156 | 130 |
+| 50 | 148-150 | 161 | 159 | 133 |
+| 51 | 151-153 | 164 | 162 | 137 |
+| 52 | 154-156 | 165 | 166 | 138 |
+| 53 | 157-159 | 171 | 169 | 140 |
+| 54 | 160-162 | 174 | 172 | 143 |
+| 55 | 163-165 | 175 | 176 | 147 |
+| 56 | 166-168 | 184 | 179 | 148 |
+| 57 | 169-171 | 185 | 182 | 150 |
+| 58 | 172-174 | 191 | 186 | 153 |
+| 59 | 175-177 | 194 | 189 | 157 |
+| 60 | 178-180 | 195 | 192 | 158 |
+| 61 | 181-183 | 201 | 196 | 160 |
+| 62 | 184-186 | 204 | 199 | 163 |
+| 63 | 187-189 | 205 | 202 | 167 |
+| 64 | 190-192 | 211 | 206 | 168 |
+| 65 | 193-195 | 214 | 209 | 170 |
+| 66 | 196-198 | 215 | 212 | 173 |
+| 67 | 199-201 | 221 | 216 | 177 |
+| 68 | 202-204 | 224 | 219 | 178 |
+| 69 | 205-207 | 225 | 222 | 180 |
+| 70 | 208-210 | 231 | 226 | 181 |
+| 71 | 211-213 | 234 | 229 | 183 |
+| 72 | 214-216 | 235 | 232 | 187 |
+| 73 | 217-219 | 241 | 236 | 188 |
+| 74 | 220-222 | 244 | 239 | 190 |
+| 75 | 223-225 | 245 | 242 | 193 |
+| 76 | 226-228 | 251 | 246 | 197 |
+| 77 | 229-231 | 254 | 249 | 198 |
+| 78 | 232-234 | 255 | 252 | 200 |
+| 79 | 235-237 | 261 | 256 | 203 |
+| 80 | 238-240 | 264 | 259 | 207 |
+| 81 | 241-243 | 265 | 262 | 208 |
+| 82 | 244-246 | 271 | 266 | 210 |
+| 83 | 247-249 | 274 | 269 | 213 |
+| 84 | 250-252 | 275 | 272 | 217 |
+| 85 | 253-255 | 281 | 276 | 218 |
+| 86 | 256-258 | 284 | 279 | 220 |
+| 87 | 259-261 | 285 | 282 | 223 |
+| 88 | 262-264 | 291 | 286 | 227 |
+| 89 | 265-267 | 294 | 289 | 228 |
+| 90 | 268-270 | 295 | 292 | 230 |
+| 91 | 271-273 | 300 | 296 | 233 |
+| 92 | 274-276 | 304 | 299 | 237 |
+| 93 | 277-279 | 305 | 302 | 238 |
+| 94 | 280-282 | 311 | 306 | 240 |
+| 95 | 283-285 | 314 | 309 | 243 |
+| 96 | 286-288 | 315 | 312 | 247 |
+| 97 | 289-291 | 321 | 316 | 248 |
+| 98 | 292-294 | 324 | 319 | 250 |
+| 99 | 295-297 | 325 | 322 | 253 |
+| 100 | 298-300 | 331 | 326 | 257 |
+| 101 | 301-303 | 334 | 329 | 258 |
+| 102 | 304-306 | 335 | 332 | 260 |
+| 103 | 307-309 | 341 | 336 | 263 |
+| 104 | 310-312 | 344 | 339 | 267 |
+| 105 | 313-315 | 345 | 342 | 268 |
+| 106 | 316-318 | 351 | 346 | 270 |
+| 107 | 319-321 | 354 | 349 | 273 |
+| 108 | 322-324 | 355 | 352 | 277 |
+| 109 | 325-327 | 361 | 356 | 278 |
+| 110 | 328-330 | 364 | 359 | 280 |
+| 111 | 331-333 | 365 | 362 | 283 |
+| 112 | 334-336 | 371 | 366 | 287 |
+| 113 | 337-339 | 374 | 369 | 288 |
+| 114 | 340-342 | 375 | 372 | 290 |
+| 115 | 343-345 | 381 | 376 | 293 |
+| 116 | 346-348 | 384 | 379 | 297 |
+| 117 | 349-351 | 385 | 382 | 298 |
+| 118 | 352-354 | 391 | 386 | 301 |
+| 119 | 355-357 | 394 | 389 | 303 |
+| 120 | 358-360 | 395 | 392 | 307 |
+| 121 | 361-363 | 400 | 396 | 308 |
+| 122 | 364-366 | 404 | 401 | 310 |
+| 123 | 367-369 | 405 | 402 | 313 |
+| 124 | 370-372 | 411 | 406 | 317 |
+| 125 | 373-375 | 414 | 409 | 318 |
+| 126 | 376-378 | 415 | 412 | 320 |
+| 127 | 379-381 | 421 | 416 | 323 |
+| 128 | 382-384 | 424 | 419 | 327 |
+| 129 | 385-387 | 425 | 422 | 328 |
+| 130 | 388-390 | 431 | 426 | 330 |
+| 131 | 391-393 | 434 | 429 | 333 |
+| 132 | 394-396 | 435 | 432 | 337 |
+| 133 | 397-399 | 441 | 436 | 338 |
+| 134 | 400-402 | 444 | 439 | 340 |
+| 135 | 403-405 | 445 | 442 | 343 |
+| 136 | 406-408 | 451 | 446 | 347 |
+| 137 | 409-411 | 454 | 449 | 348 |
+| 138 | 412-414 | 455 | 452 | 350 |
+| 139 | 415-417 | 461 | 456 | 353 |
+| 140 | 418-420 | 464 | 459 | 357 |
+| 141 | 421-423 | 465 | 462 | 358 |
+| 142 | 424-426 | 471 | 466 | 360 |
+| 143 | 427-429 | 474 | 469 | 363 |
+| 144 | 430-432 | 475 | 472 | 367 |
+| 145 | 433-435 | 481 | 476 | 368 |
+| 146 | 436-438 | 484 | 479 | 370 |
+| 147 | 439-441 | 485 | 482 | 373 |
+| 148 | 442-444 | 491 | 486 | 377 |
+| 149 | 445-447 | 494 | 489 | 378 |
+| 150 | 448-450 | 495 | 492 | 380 |
+| 151 | 451-453 | 500 | 496 | 383 |
+| 152 | 454-456 | 504 | 499 | 387 |
+| 153 | 457-459 | 505 | 502 | 388 |
+| 154 | 460-462 | 511 | 506 | 390 |
+| 155 | 463-465 | 514 | 509 | 393 |
+| 156 | 466-468 | 515 | 512 | 397 |
+| 157 | 469-471 | 521 | 516 | 398 |
+| 158 | 472-474 | 524 | 519 | 399 |
+| 159 | 475-477 | 525 | 522 | 403 |
+| 160 | 478-480 | 531 | 526 | 407 |
+| 161 | 481-483 | 534 | 529 | 408 |
+| 162 | 484-486 | 535 | 532 | 410 |
+| 163 | 487-489 | 541 | 536 | 413 |
+| 164 | 490-492 | 544 | 539 | 417 |
+| 165 | 493-495 | 545 | 542 | 418 |
+| 166 | 496-498 | 551 | 546 | 420 |
+| 167 | 499-501 | 554 | 549 | 423 |
+| 168 | 502-504 | 555 | 552 | 427 |
+| 169 | 505-507 | 561 | 556 | 428 |
+| 170 | 508-510 | 564 | 559 | 430 |
+| 171 | 511-513 | 565 | 562 | 433 |
+| 172 | 514-516 | 571 | 566 | 437 |
+| 173 | 517-519 | 574 | 569 | 438 |
+| 174 | 520-522 | 581 | 572 | 440 |
+| 175 | 523-525 | 584 | 576 | 443 |
+| 176 | 526-528 | 591 | 579 | 447 |
+| 177 | 529-531 | 594 | 582 | 448 |
+| 178 | 532-534 | 601 | 586 | 450 |
+| 179 | 535-537 | 604 | 589 | 453 |
+| 180 | 538-540 | 614 | 592 | 457 |
+| 181 | 541-543 | 615 | 596 | 458 |
+| 182 | 544-546 | 621 | 599 | 460 |
+| 183 | 547-549 | 624 | 602 | 463 |
+| 184 | 550-552 | 625 | 606 | 467 |
+| 185 | 553-555 | 631 | 609 | 468 |
+| 186 | 556-558 | 634 | 612 | 470 |
+| 187 | 559-561 | 635 | 616 | 473 |
+| 188 | 562-564 | 641 | 619 | 477 |
+| 189 | 565-567 | 644 | 622 | 478 |
+| 190 | 568-570 | 645 | 626 | 480 |
+| 191 | 571-573 | 649 | 629 | 483 |
+| 192 | 574-576 | 487* | 632 | 488 |
+| 193 | 577-579 | 490* | 636 | 493 |
+| 194 | 580-582 | 497* | 639 | 498 |
+| 195 | 583-585 | 501* | 642 | 503 |
+| 196 | 586-588 | 507* | 646 | 508 |
+| 197 | 589-591 | 510* | 513* | 517 |
+| 198 | 592-594 | 518* | 520* | 523 |
+| 199 | 595-597 | 527* | 528* | 530 |
+| 200 | 598-600 | 533* | 537* | 538 |
+| 201 | 601-603 | 540* | 543* | 547 |
+| 202 | 604-606 | 548* | 550* | 553 |
+| 203 | 607-609 | 557* | 558* | 560 |
+| 204 | 610-612 | 563* | 567* | 568 |
+| 205 | 613-615 | 570* | 573* | 577 |
+| 206 | 616-618 | 578* | 580* | 583 |
+| 207 | 619-621 | 587* | 588* | 590 |
+| 208 | 622-624 | 593* | 597* | 598 |
+| 209 | 625-627 | 600* | 603* | 607 |
+| 210 | 628-630 | 610* | 613* | 617 |
+| 211 | 631-633 | 618* | 620* | 623 |
+| 212 | 634-636 | 627* | 628* | 630 |
+| 213 | 637-639 | 633* | 637* | 638 |
+| 214 | 640-642 | 640* | 643* | 647 |
+| 215 | 643-645 | 648* | 650* | 650 |
+
+*\* = Borrowed from Teal to fill Orange/Neutral gap*


### PR DESCRIPTION
- Cleaned up POST_MAPPING.md to remove wrong grid position mappings
- Kept only correct content: posting order (Orange→Neutral→Teal), posted tracker, Canva items, rows 10-13, and complete 40-650 schedule
- File now shows correct ORIGINAL content plan post numbers

https://claude.ai/code/session_01Jd52RJSkDPPcV8sbQkg2a2