### PR TITLE
Fix color/label mismatches in 26 carousel HTML files

### DIFF
--- a/INSTAGRAM_CONTENT_HUB/social/post-000/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-000/carousel.html
@@ -385,7 +385,7 @@
           </video>
         </div>
         <div class="slide-content">
-          <div class="cine-label">Insight</div>
+          <div class="cine-label">Quote</div>
           <div class="hook-main">To The 3AM Version of You</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">A letter to the trader who's still here</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-027/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-027/carousel.html
@@ -530,7 +530,7 @@
     <!-- Slide 1: Cinematic Hook (ORANGE - Marketing/START YOUR JOURNEY) -->
     <div class="slide-wrapper slide-1">
       <div class="slide-content">
-        <div class="cine-label">Start Your Journey</div>
+        <div class="cine-label">Indicator</div>
         <div class="hook-main">Your Indicators Aren't Broken</div>
         <div class="cine-divider"></div>
         <p class="hook-sub">Same tool. Wrong context. Failure guaranteed.</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-030/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-030/carousel.html
@@ -387,7 +387,7 @@
     <!-- Slide 1: Cinematic Hook (ORANGE - Docs/START YOUR JOURNEY) -->
     <div class="slide-wrapper slide-1">
       <div class="slide-content">
-        <div class="cine-label">Start Your Journey</div>
+        <div class="cine-label">Product</div>
         <div class="hook-main">Zero to Charting in 10 Minutes</div>
         <div class="cine-divider"></div>
         <p class="hook-sub">Installation. Configuration. First signals. No confusion.</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-036/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-036/carousel.html
@@ -493,7 +493,7 @@
       <span class="slide-label">Slide 1 — Cinematic Hook</span>
       <div class="slide slide-1">
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Indicator</div>
           <div class="hook-main">When Everyone Panics...</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">What if that volume is buyers absorbing the selling?</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-037/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-037/carousel.html
@@ -502,7 +502,7 @@
           </video>
         </div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Insight</div>
           <div class="hook-main">Your Analysis Is<br>Probably Biased</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">You found 5 reasons to enter the trade.<br>You ignored the 3 reasons not to.</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-039/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-039/carousel.html
@@ -466,7 +466,7 @@
         <source src="../../video/starfield.mp4" type="video/mp4">
       </video>
       <div class="slide-content">
-        <div class="cine-label">Learn</div>
+        <div class="cine-label">Indicator</div>
         <div class="hook-main">The Survival Formula</div>
         <div class="cine-divider"></div>
         <p class="hook-sub">Your position size is your risk management.<br>Calculate before you click.</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-042/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-042/carousel.html
@@ -483,7 +483,7 @@
         <source src="../../video/starfield.mp4" type="video/mp4">
       </video>
       <div class="slide-content">
-        <div class="cine-label">Learn</div>
+        <div class="cine-label">Indicator</div>
         <div class="hook-main">Win Rate Is Overrated</div>
         <div class="cine-divider"></div>
         <p class="hook-sub">Risk-reward isn't about greed.<br>It's about math.</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-066/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-066/carousel.html
@@ -585,7 +585,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Indicator</div>
           <div class="hook-main">Fibonacci Retracements</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">The self-fulfilling prophecy</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-132/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-132/carousel.html
@@ -417,7 +417,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Indicator</div>
           <div class="hook-main">The Art of Scalping</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">Quick profits, precise execution</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-156/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-156/carousel.html
@@ -466,7 +466,7 @@
           </video>
         </div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Indicator</div>
           <div class="hook-main">Trend Exhaustion</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">Recognize when trends are dying</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-157/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-157/carousel.html
@@ -449,7 +449,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Insight</div>
           <div class="hook-main">News Event<br>Volatility</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">Navigate high-impact releases</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-159/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-159/carousel.html
@@ -476,7 +476,7 @@
             <div class="slide slide-1">
                 <video class="video-bg" autoplay muted loop playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video>
                 <div class="slide-content">
-                    <div class="cine-label">Learn</div>
+                    <div class="cine-label">Indicator</div>
                     <div class="hook-main">Fibonacci<br>Extensions</div>
                     <div class="cine-divider"></div>
                     <p class="hook-sub">Project your profit targets</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-160/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-160/carousel.html
@@ -447,7 +447,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Insight</div>
           <div class="hook-main">Mobile<br>Trading</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">Trade anywhere, anytime</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-162/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-162/carousel.html
@@ -439,7 +439,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Indicator</div>
           <div class="hook-main">Breakout<br>Confirmation</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">Avoid the fakeouts</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-163/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-163/carousel.html
@@ -448,7 +448,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Insight</div>
           <div class="hook-main">Trading<br>Journal</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">Your path to consistent improvement</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-181/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-181/carousel.html
@@ -550,7 +550,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Insight</div>
           <div class="hook-main">82 Lessons<br>100% Free</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">Your complete trading education</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-186/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-186/carousel.html
@@ -640,7 +640,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Indicator</div>
           <div class="hook-main">Wyckoff<br>Distribution</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">The blueprint of market tops</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-187/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-187/carousel.html
@@ -640,7 +640,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Insight</div>
           <div class="hook-main">Trading As<br>A Business</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">The mindset that separates winners from losers</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-189/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-189/carousel.html
@@ -561,7 +561,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Indicator</div>
           <div class="hook-main">Market<br>Profile</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">See price and time together</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-192/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-192/carousel.html
@@ -578,7 +578,7 @@
       <div class="slide slide-1">
         <div class="slide-bg"><video autoplay loop muted playsinline><source src="../../videos/starfield-bg.mp4" type="video/mp4"></video></div>
         <div class="slide-content">
-          <div class="cine-label">Learn</div>
+          <div class="cine-label">Indicator</div>
           <div class="hook-main">Auction<br>Market Theory</div>
           <div class="cine-divider"></div>
           <p class="hook-sub">Markets exist to facilitate trade</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-193/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-193/carousel.html
@@ -513,7 +513,7 @@
                 </video>
                 <div class="slide-content">
                     <div class="content-area" style="text-align: center;">
-                        <div class="cine-label">Learn</div>
+                        <div class="cine-label">Insight</div>
                         <div class="hook-main">The Power of<br>NO</div>
                         <div class="cine-divider"></div>
                         <p class="hook-sub">Trading discipline starts with saying no</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-216/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-216/carousel.html
@@ -695,7 +695,7 @@
                     </video>
                 </div>
                 <div class="slide-content">
-                    <div class="cine-label">Learn</div>
+                    <div class="cine-label">Indicator</div>
                     <div class="hook-main">Breaker<br>Blocks</div>
                     <div class="cine-divider"></div>
                     <p class="hook-sub">When Order Blocks Fail and Flip</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-217/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-217/carousel.html
@@ -701,7 +701,7 @@
                     </video>
                 </div>
                 <div class="slide-content">
-                    <div class="cine-label">Learn</div>
+                    <div class="cine-label">Insight</div>
                     <div class="hook-main">The Cost of<br>Overtrading</div>
                     <div class="cine-divider"></div>
                     <p class="hook-sub">The Hidden Drain on Your Account</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-219/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-219/carousel.html
@@ -692,7 +692,7 @@
                     </video>
                 </div>
                 <div class="slide-content">
-                    <div class="cine-label">Learn</div>
+                    <div class="cine-label">Indicator</div>
                     <div class="hook-main">Mitigation<br>Blocks</div>
                     <div class="cine-divider"></div>
                     <p class="hook-sub">Where Institutions Fix Their Losses</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-222/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-222/carousel.html
@@ -639,7 +639,7 @@
                     </video>
                 </div>
                 <div class="slide-content">
-                    <div class="cine-label">Learn</div>
+                    <div class="cine-label">Indicator</div>
                     <div class="hook-main">Kill Zones<br>When Setups Actually Work</div>
                     <div class="cine-divider"></div>
                     <p class="hook-sub">London Open · NY Open · London Close</p>

--- a/INSTAGRAM_CONTENT_HUB/social/post-223/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-223/carousel.html
@@ -690,7 +690,7 @@
                     </video>
                 </div>
                 <div class="slide-content">
-                    <div class="cine-label">Learn</div>
+                    <div class="cine-label">Insight</div>
                     <div class="hook-main">Social Media Dangers<br>The Traps Every Trader Falls Into</div>
                     <div class="cine-divider"></div>
                     <p class="hook-sub">Blind calls · Comparison · FOMO · Fake gurus</p>


### PR DESCRIPTION
TEAL posts changed "Learn" to "Insight" (9 files):
- post-037, post-157, post-160, post-163, post-181
- post-187, post-193, post-217, post-223

ORANGE posts changed "Learn" to "Indicator" (14 files):
- post-036, post-039, post-042, post-066, post-132
- post-156, post-159, post-162, post-186, post-189
- post-192, post-216, post-219, post-222

Special cases:
- post-000: "Insight" → "Quote" (manifesto)
- post-027: "Start Your Journey" → "Indicator"
- post-030: "Start Your Journey" → "Product"

Rules applied:
- TEAL = Insight, Reference, or Chronicle
- NEUTRAL = Learn
- ORANGE = Product, Quote, Indicator

https://claude.ai/code/session_01Jd52RJSkDPPcV8sbQkg2a2