### PR TITLE
Add affiliate outreach email templates and prospect tracker

### DIFF
--- a/affiliate-outreach/OUTREACH-EMAILS.md
+++ b/affiliate-outreach/OUTREACH-EMAILS.md
@@ -1,0 +1,490 @@
+# Signal Pilot — Affiliate Outreach Emails
+
+> 15 personalized emails for trading educator prospects.
+> Replace `[Your Name]` with your name before sending.
+> Emails marked with `[CONTACT FORM]` have no public email — use the listed contact method instead.
+
+---
+
+## 1. Mind Math Money
+
+**To:** mindmathmoney@gmail.com
+**Subject:** Your Order Flow guide + our cycle detection — could be a strong pairing
+
+Hi,
+
+Your "Ultimate Order Flow Trading Course" nailed something most TradingView content misses — the idea that you need to see the battle that happened inside each candle, not just where price ended up. That framing stuck with me.
+
+I'm reaching out from Signal Pilot. We build a suite of 7 non-repainting TradingView indicators. Two of them, I think, would genuinely interest you:
+
+- **Pentarch** — maps complete market cycles through 5 phases (Touchdown → Ignition → Warning → Capitulation → Breakdown). It answers "where am I in the cycle?" before you even look at order flow.
+- **Volume Oracle** — institutional accumulation/distribution detection with regime classification. It sits in the same territory as your order flow content but approaches it from the indicator side.
+
+I'd love to give you full access to test all 7 indicators. No strings, no timeline. Just send me your TradingView username and I'll activate everything within 24 hours.
+
+If they resonate with your audience, we have an affiliate program (15-30% recurring). But honestly, I'd just value your take on them first — your 300K+ audience trusts your indicator reviews because you test everything properly.
+
+We also back the non-repaint claim with a **$100 bounty** if anyone can prove otherwise. Every signal finalizes on candle close, audited for lookahead bias.
+
+Quick links:
+- Website: https://www.signalpilot.io
+- Docs: https://docs.signalpilot.io
+- Education (82 free lessons): https://education.signalpilot.io
+
+Happy to jump on a call if you'd prefer.
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 2. Zen & The Art of Trading (Matthew Slabosz)
+
+**To:** [CONTACT FORM] — zenandtheartoftrading.com/contact
+**Subject:** From one Pine Script builder to another — free access to test our suite
+
+Hi Matt,
+
+I've been following your Pine Script content for a while — the ZenLibrary v10 update to Pine v6 is the kind of contribution that makes the entire TradingView ecosystem better. Your point about backtesting being "the most under-utilized secret weapon in trading" is something we've built our entire product philosophy around.
+
+I'm reaching out from Signal Pilot. We've built 7 non-repainting TradingView indicators, and as a Pine Script developer, I think you'd appreciate looking under the hood:
+
+- **Harmonic Oscillator** — a 7-component voting system (RSI, StochRSI, MACD, EMA Trend, Momentum, Volume, Divergence Zone). Each component votes independently — the architecture is what I think you'd find most interesting.
+- **Augury Grid** — scans 8 tickers across 3 timeframes simultaneously (21 parallel scans) with quality scoring and conviction ranking.
+
+Every indicator uses a 4-layer confirmation system: Regime Classification → Pilot Line Distance → NanoFlow Momentum → Bar Close confirmation. No mid-bar repainting, ever. We back it with a $100 bounty.
+
+I'd love to give you lifetime access to the full suite — no strings attached. If you're interested, just send me your TradingView username and I'll activate all 7 within 24 hours.
+
+Your audience consists entirely of TradingView power users who care about how indicators actually work. If the tools hold up to your standards, I think there's a natural fit. We have an affiliate program (15-30% recurring), but your honest assessment matters more to us than a quick partnership.
+
+Quick links:
+- Website: https://www.signalpilot.io
+- Full docs: https://docs.signalpilot.io
+- 82 free education lessons: https://education.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 3. The Chart Guys
+
+**To:** info@thechartguys.com
+**Subject:** OmniDeck vs. SuperStack — thought you'd want to compare
+
+Hi Dan,
+
+I've watched how you've built The Chart Guys around education first, indicators second — the fact that your community is known for teaching rather than chasing tickers is rare and something we respect.
+
+Your SuperStack (multi-timeframe RSI scanning across 9 timeframes) and BackBurner (catching first pullbacks in fear/FOMO conditions) tackle real problems traders face. We've built tools that approach similar problems from a different angle, and I'd love to get your honest comparison:
+
+- **OmniDeck** — a single overlay combining 10 systems (SuperTrend, Squeeze Detector, Confluence Score Panel, supply/demand zones, and more). It's the "one indicator to rule them all" concept — similar philosophy to how you've unified your suite.
+- **Augury Grid** — multi-symbol, multi-timeframe scanner with quality scoring. Directly parallels your SuperStack concept but adds conviction ranking and 15+ confluence filters.
+
+All 7 of our indicators are 100% non-repainting (audited, $100 bounty if anyone proves otherwise). Signals finalize on candle close.
+
+Send me your TradingView username and I'll activate the full Elite Seven suite on your account — take as long as you want to test against your own indicators. No cost, no commitment.
+
+If they complement what you're already offering your community, we have an affiliate program (15-30% recurring). But I'd genuinely value your comparison first — your audience trusts you because you've been TradingView-exclusive since 2016.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 4. Kivanc Ozbilgic (AlgoWorld)
+
+**To:** [TELEGRAM DM] — t.me/AlgoRhytm (or TradingView DM to @KivancOzbilgic)
+**Subject:** What a Pine Script Wizard thinks of our 4-layer confirmation system
+
+Hi Kivanc,
+
+Your AlphaTrend solved a real problem — minimizing stop losses in sideways conditions by combining momentum, trend, volatility, trailing stops, and volume into a single line. The fact that you publish everything open source because "sharing knowledge helps the trading community grow" is a philosophy we deeply respect.
+
+I'm reaching out from Signal Pilot. We've built 7 non-repainting TradingView indicators, and I'm specifically curious what a Pine Script Wizard would think of the architecture:
+
+- **Pentarch** — approaches the same sideways-market problem from the cycle-detection angle. Instead of filtering sideways noise, it maps where you are in the complete market cycle (5 phases: Touchdown → Ignition → Warning → Capitulation → Breakdown). If you're in a consolidation phase, you know to stand aside.
+- **Harmonic Oscillator** — 7-component voting system with a multi-factor algorithmic design that I think aligns with your approach of combining multiple indicator categories into one coherent tool.
+
+Every signal runs through a 4-layer confirmation: Regime Classification → Pilot Line Distance → NanoFlow Momentum → Bar Close. No mid-bar repainting. We back it with a $100 bounty.
+
+I'd love to give you full access to the entire suite. Send me your TradingView username and I'll activate all 7 indicators within 24 hours. No strings, no timeline — just interested in your expert feedback.
+
+Website: https://www.signalpilot.io
+Full technical docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 5. Trading Strategy Guides (Casey Stubbs)
+
+**To:** casey@tradingstrategyguides.com
+**Subject:** The anti-strategy-hopping indicator — could be a good "How to Trade It" episode
+
+Hi Casey,
+
+Your point about "the negative impact of strategy hopping on traders" really resonated with me. It's exactly why we built what we built.
+
+I'm reaching out from Signal Pilot. We make 7 non-repainting TradingView indicators, and two of them were specifically designed to solve the strategy-hopping problem:
+
+- **OmniDeck** — a single overlay with 10 integrated systems (SuperTrend, Squeeze Detector, supply/demand zones, Confluence Score Panel, and more). One indicator instead of ten. One coherent system your listeners can execute consistently, not another tool to add to the pile.
+- **Volume Oracle** — institutional flow detection with a built-in Position Management System (Stop Loss, Target 1, Target 2, Trailing Stop, Breakeven). It's a complete trading system in one indicator — entry, management, and exit.
+
+All 7 indicators are 100% non-repainting. We audit every one for lookahead bias and back it with a $100 bounty.
+
+I'd love to give you and your team full access to test the complete suite. Just send me your TradingView username and I'll activate everything within 24 hours.
+
+If they hold up, I think this could make a strong episode on "How to Trade It" — the idea of a unified system that eliminates indicator chaos is a topic your audience would connect with. We also have an affiliate program (15-30% recurring) if you'd want to share them with your community.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+82 free education lessons: https://education.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 6. Liberated Stock Trader (Barry D. Moore, CFTe)
+
+**To:** [CONTACT FORM] — liberatedstocktrader.com/contact (site was down during research; try LinkedIn: linkedin.com/in/barrydmoore)
+**Subject:** Submitting Pentarch for your indicator testing methodology
+
+Hi Barry,
+
+Your "I Tested 103 Free TradingView Indicators" article is exactly the kind of rigor the TradingView community needs. Most indicator reviews are surface-level — yours actually backtest and verify. That's rare and valuable.
+
+I'm reaching out from Signal Pilot to do something unusual: I want to submit our flagship indicator, **Pentarch**, for your testing methodology.
+
+Here's why I think it's worth your time:
+
+- **Pentarch** maps complete market cycles through 5 phases (TD → IGN → WRN → CAP → BDN) using a 4-layer confirmation system. It's non-repainting — audited, signals finalize on candle close. We back it with a **$100 bounty** if anyone can prove otherwise.
+- Given your experience building MOSES in Pine Script (which also focuses on cycle timing for broad market ETFs), I think you'd find the architecture interesting from a builder's perspective.
+- We have 6 additional indicators in the suite covering volume regime detection, multi-timeframe levels, momentum voting systems, and more.
+
+I'd love to give you full access to the complete Elite Seven suite — all 7 indicators, no cost, no timeline. Your audience trusts your verdict more than any marketing claim we could make, and we'd rather earn a genuine review than buy a sponsored one.
+
+Send me your TradingView username and I'll activate everything within 24 hours.
+
+If they pass your testing standards, we have an affiliate program (15-30% recurring). But your honest assessment is what matters.
+
+Website: https://www.signalpilot.io
+Technical docs: https://docs.signalpilot.io
+Education (82 free lessons): https://education.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 7. Crypto Jebb (Jebb McAfee)
+
+**To:** [CHECK YOUTUBE ABOUT PAGE for business email] — alternatively DM on Instagram @cryptojebb or X @CryptoJebb
+**Subject:** Pentarch answers "Is Bitcoin overextended?" — automatically
+
+Hi Jebb,
+
+Your very first video back in 2017 asked "Is Bitcoin Overextended?" — and 2,600+ videos later, that question is still the heart of everything you teach. Where are we in the cycle? Is this the bottom? Is this the top?
+
+I'm reaching out from Signal Pilot. We've built an indicator called **Pentarch** that answers that exact question automatically — it maps complete market cycles through 5 phases:
+
+- **Touchdown (TD)** — selling exhaustion at the low
+- **Ignition (IGN)** — breakout confirmation
+- **Warning (WRN)** — momentum divergence
+- **Capitulation (CAP)** — buying exhaustion at the high
+- **Breakdown (BDN)** — trend reversal confirmed
+
+It's non-repainting (audited, $100 bounty), works on all timeframes (your preferred 4H swing setups included), and adapts automatically to Bitcoin, altcoins, stocks, forex — anything on TradingView.
+
+I'd love to give you access to the full suite (7 indicators total) so you can test it on your daily Bitcoin analysis. Send me your TradingView username and I'll activate everything within 24 hours. No cost, no strings.
+
+Your CT2A students are already learning "How to Spot a Winning Indicator" — I'd love for Pentarch to be on that list if it earns it.
+
+We also have an affiliate program (15-30% recurring) if you'd want to share with your audience, but your honest take comes first.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 8. askSlim (Steve "Slim" Miller)
+
+**To:** slim@askslim.com (or matt@askslim.com for general inquiries)
+**Subject:** Pentarch — the digital evolution of what you pioneered by hand in 1980
+
+Hi Slim,
+
+I've been studying your cycle analysis work — the Principle of Summation, how dominant and minor cycle patterns interact, how cycle shapes and translations create the chart patterns traders see. The fact that you were doing this by hand since 1980, with 47+ years of experience on the CBOE floor, gives your perspective a depth that's hard to find anywhere else.
+
+I'm reaching out from Signal Pilot because I think Pentarch — our flagship indicator — is the automated evolution of what you pioneered manually:
+
+- **Pentarch** maps 5 cycle phases: Touchdown (cycle low) → Ignition (breakout) → Warning (momentum divergence) → Capitulation (cycle high) → Breakdown (reversal). It detects these transitions automatically using a 4-layer confirmation system.
+- **Augury Grid** — scans 8 tickers across 3 timeframes simultaneously, similar to how your Market Condition Monitor scans multiple timeframes in real-time.
+
+Your tagline — "unbiased insights in price, time, and direction" — is exactly what these tools deliver. Non-repainting, audited, signals finalize on candle close. We back it with a $100 bounty.
+
+I'd love to give you full access to our complete suite (7 indicators). Send me your TradingView username and I'll activate everything within 24 hours. I'd be genuinely curious how Pentarch's automated cycle mapping compares to your decades of manual cycle analysis.
+
+If you see value in them for your Market Week LIVE audience or your Cycle Analysis Workshop students, we have an affiliate program (15-30% recurring). But your expert assessment is what I'm really after.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 9. ClayTrader (Clay Huber)
+
+**To:** [CONTACT FORM] — claytrader.com/contact
+**Subject:** "Terminate Your Emotions" — we built an indicator that does exactly that
+
+Hi Clay,
+
+Your "Robotic Trading" philosophy — that emotional decisions lead to irrational decisions, which lead to losing money — is one of the most honest frameworks in trading education. The fact that your chatroom deliberately issues no alerts, forcing members to think through setups individually, tells me you care more about building real traders than collecting followers.
+
+I'm reaching out from Signal Pilot. We've built two indicators that are, essentially, the technical embodiment of "terminate your emotions":
+
+- **Harmonic Oscillator** — a 7-component voting system (RSI, StochRSI, MACD, EMA Trend, Momentum, Volume, Divergence). It doesn't give you a "BUY NOW" signal. It gives you a vote count (e.g., 6/7 STRONG BULL) and lets you make the decision. Robotic consensus, human execution.
+- **OmniDeck** — 10 systems unified in a single overlay, eliminating the indicator chaos that leads to analysis paralysis and emotional decisions.
+
+Both are 100% non-repainting (audited, $100 bounty). Signals finalize on candle close — no mid-bar flickering that triggers impulsive entries.
+
+Send me your TradingView username and I'll activate the full suite (7 indicators) on your account. No cost, no timeline, no pitch. Test them in your own trading first.
+
+If they align with what you teach your 639K+ community, we have an affiliate program (15-30% recurring). But I'd rather earn your endorsement than buy it — your audience trusts you because you've never taken shortcuts.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 10. TRADEPRO Academy (George Papazov)
+
+**To:** george@tradeproacademy.com
+**Subject:** "Order flow reveals, it doesn't predict" — we built indicators with that same philosophy
+
+Hi George,
+
+Your point on Mind Over Markets that "candlesticks show where price moved, the footprint chart shows how it moved" captures a gap that most retail traders don't even know exists. Coming from 7 years on the Scotia Capital desk, you understand institutional flow in a way most educators can't teach.
+
+I'm reaching out from Signal Pilot. Three of our indicators were built around the same "reveal, don't predict" philosophy:
+
+- **Volume Oracle** — detects institutional accumulation/distribution with regime classification (Accumulation, Markup, Distribution, Markdown). It surfaces what retail can't see in standard volume bars.
+- **Plutus Flow** — buying/selling pressure ribbon with divergence detection. Maps the delta between buyers and sellers — the same concept as your footprint chart delta analysis, visualized as a continuous ribbon.
+- **Janus Atlas** — auto-maps 60+ level types across multiple timeframes, including session boundaries, VWAP anchors, and confluence zones. It's the "value area and point of control" concept from your volume profile teaching, automated.
+
+All non-repainting (audited, $100 bounty). Every signal finalizes on candle close.
+
+I'd love to give you full access to all 7 indicators. Send me your TradingView username and I'll activate everything within 24 hours. Test them during your 9AM morning sessions on ES and CL.
+
+Your founding motivation — combating "poor education, excessive leverage, and traders relying on systems they didn't truly understand" — aligns with ours. If the tools hold up, we have an affiliate program (15-30% recurring) and I think your audience would connect with the transparency.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+82 free education lessons: https://education.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 11. Brian Shannon (Alpha Trends)
+
+**To:** support@alphatrends.net
+**Subject:** "The perfect combination of Price, Time & Volume" — our Elite Seven unite all three
+
+Hi Brian,
+
+Your November ASFX VWAP Deep Dive reinforced something your work has consistently shown: that anchored VWAP reveals where the average buyer and seller is positioned from any meaningful point, on any timeframe. The emphasis on humility over prediction is a philosophy we share.
+
+I'm reaching out from Signal Pilot. Two of our 7 indicators were designed around the same intersection of price, time, and volume that you've championed since 2003:
+
+- **Janus Atlas** — auto-maps 60+ level types across multiple timeframes, including VWAP anchors, session boundaries, and confluence zones (where 3+ levels cluster). It extends the AVWAP concept by mapping all the critical levels simultaneously — "The map exists before the journey begins."
+- **Volume Oracle** — institutional positioning detection with regime classification. It answers "where are the buyers and sellers in control?" — the same question AVWAP answers, approached from the volume-regime side.
+
+All 7 indicators are 100% non-repainting. Signals finalize on candle close, audited for lookahead bias. We back it with a $100 bounty.
+
+I'd love to give you full access to the complete suite. Send me your TradingView username and I'll activate everything within 24 hours. No cost, no strings — just genuinely curious how they complement your AVWAP workflow.
+
+If they add value for your Alpha Trends community, we have an affiliate program (15-30% recurring). But your assessment matters more than any partnership.
+
+Your book subtitle says it all: "The Perfect Combination of Price, Time & Volume." That's what we've tried to build.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 12. Rayner Teo (TradingwithRayner)
+
+**To:** support@tradingwithrayner.com
+**Subject:** Automating the "M" in your MAEE Formula
+
+Hi Rayner,
+
+Your MAEE Formula — Market structure, Area of value, Entry trigger, Exit trigger — is one of the cleanest trading frameworks out there. The first step, reading market structure, is also the hardest for your students to learn.
+
+I'm reaching out from Signal Pilot. We've built an indicator called **Pentarch** that automates that first step:
+
+It maps complete market cycles through 5 phases — Touchdown (selling exhaustion), Ignition (breakout), Warning (momentum divergence), Capitulation (buying exhaustion), Breakdown (reversal). Instead of your students guessing "are we in an uptrend or a range?", Pentarch tells them exactly where they are in the cycle with a 4-layer confirmation system.
+
+I know you teach that "price is the leading indicator" and that traditional indicators lag. Pentarch was designed differently — it doesn't lag because it maps cycle phases (structural, not oscillating). And it's 100% non-repainting (audited, $100 bounty).
+
+We also built **OmniDeck** with 16 candlestick pattern recognition and supply/demand zone detection — tools that complement rather than replace your price action approach.
+
+I'd love to give you full access to all 7 indicators. Send me your TradingView username and I'll activate everything within 24 hours. No cost, no timeline.
+
+Your 18M+ subscribers trust your judgment. If these tools genuinely help your students apply MAEE more effectively, we have an affiliate program (15-30% recurring). But your honest take comes first.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 13. The Trading Channel (Steven Hart)
+
+**To:** support@thetradingchannel.net (or stevenkieth2014@gmail.com for press)
+**Subject:** "Extreme Analytical Precision" — automated into a TradingView indicator
+
+Hi Steven,
+
+Your EAP Training Program name says everything about your philosophy: Extreme Analytical Precision. That same precision — especially your Fibonacci and level-based approach — is what we've tried to automate.
+
+I'm reaching out from Signal Pilot. Our indicator **Janus Atlas** was built for traders who think exactly the way you teach:
+
+- Auto-maps **60+ level types** across multiple timeframes — Fibonacci levels, session levels, VWAP anchors, pivot zones, and confluence zones (where 3+ levels cluster into a single high-probability area)
+- Your students are learning to draw these levels by hand with extreme precision. Janus Atlas gives them the institutional-grade level map automatically, so they can focus on execution rather than line-drawing.
+
+We also built **Volume Oracle** with a Position Management System (1.5x ATR stop, 2.0x ATR T1, 3.5x ATR T2) that directly supports your 2% rule — precise risk management built into the indicator itself.
+
+All 7 indicators are 100% non-repainting (audited, $100 bounty). Signals finalize on candle close.
+
+Send me your TradingView username and I'll activate the full suite within 24 hours. No cost, no strings. Test them on your forex setups.
+
+If they meet your standards for "extreme analytical precision," we have an affiliate program (15-30% recurring). Your 2.38M subscribers trust your judgment — we'd rather earn a genuine recommendation than buy a sponsored one.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 14. Adam Khoo (Piranha Profits)
+
+**To:** support@piranhaprofits.com
+**Subject:** Your indicator-stacking philosophy — we automated it into one tool
+
+Hi Adam,
+
+Your principle that "no one indicator works on its own — you need to cross-reference indicators with other indicators" is something most traders learn the hard way. Your Bounce System and Value Momentum Investing framework both demonstrate what systematic cross-referencing looks like in practice.
+
+I'm reaching out from Signal Pilot. We've built an indicator that is literally the automated version of what you teach:
+
+**Harmonic Oscillator** — a 7-component voting system running RSI, StochRSI, MACD, EMA Trend, Momentum, Volume, and Divergence Zone in parallel. Each component votes independently, and the indicator outputs a clear conviction count (e.g., "6/7 STRONG BULL"). It includes Conservative, Balanced, and Aggressive signal modes for different risk profiles.
+
+It's the cross-referencing process your students do manually — systematized into a single non-repainting indicator. Every signal finalizes on candle close. We back the non-repaint claim with a $100 bounty.
+
+We also built **Augury Grid** — a multi-symbol scanner that ranks 7 symbols across 3 timeframes with quality scoring. For your students scanning for stock setups across markets, it surfaces the highest-conviction opportunities automatically.
+
+I'd love to give you full access to all 7 indicators. Send me your TradingView username and I'll activate everything within 24 hours.
+
+If they complement your Piranha Profits curriculum, we have an affiliate program (15-30% recurring). Your 1M+ subscriber audience already believes in indicator stacking — Harmonic Oscillator is that belief, automated.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+82 free lessons: https://education.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## 15. Warrior Trading (Ross Cameron)
+
+**To:** ross@warriortrading.com
+**Subject:** A TradingView-native momentum scanner — built for the Gap and Go workflow
+
+Hi Ross,
+
+Your $583 to $12.5M challenge is one of the most documented, audited track records in trading education. The fact that you publish broker statements and independent accountant reports sets a transparency standard most educators won't touch.
+
+I'm reaching out from Signal Pilot because our **Augury Grid** indicator was built around the same "scanner-first" workflow you teach:
+
+- Scans **8 tickers across 3 timeframes simultaneously** (21 parallel scans)
+- Detects MACD histogram crossovers with **15+ confluence filters** (ADX, trend, EMA200, RSI, volume, momentum)
+- Ranks opportunities by **quality score** with star ratings and "time since signal" — so your students know which setups have the highest conviction before the bell rings
+
+It's a momentum scanner built directly into TradingView. No external software needed.
+
+We also built **OmniDeck** with a Squeeze Detector (Bollinger vs. Keltner compression) and Liquidity Sweep detection — tools that surface the volatility breakouts and stop-hunt traps your small-cap momentum students are looking for.
+
+All 7 indicators are 100% non-repainting (audited, $100 bounty). Signals finalize on candle close.
+
+Send me your TradingView username and I'll activate the full suite within 24 hours. No cost, no timeline. Test Augury Grid in your premarket routine and see if it complements your existing scanner workflow.
+
+If it adds value for your Warrior Trading community, we have an affiliate program (15-30% recurring). But the product has to earn it first.
+
+Website: https://www.signalpilot.io
+Docs: https://docs.signalpilot.io
+
+Best,
+[Your Name]
+Signal Pilot Labs
+
+---
+
+## Quick Reference — Contact Summary
+
+| # | Prospect | Email | Method |
+|---|---------|-------|--------|
+| 1 | Mind Math Money | mindmathmoney@gmail.com | Direct email |
+| 2 | Zen & The Art of Trading | — | Contact form: zenandtheartoftrading.com/contact |
+| 3 | The Chart Guys | info@thechartguys.com | Direct email |
+| 4 | Kivanc Ozbilgic | — | Telegram: t.me/AlgoRhytm or TradingView DM |
+| 5 | Trading Strategy Guides | casey@tradingstrategyguides.com | Direct email |
+| 6 | Liberated Stock Trader | — | Contact form or LinkedIn: linkedin.com/in/barrydmoore |
+| 7 | Crypto Jebb | — | YouTube About page / Instagram DM @cryptojebb |
+| 8 | askSlim | slim@askslim.com / matt@askslim.com | Direct email |
+| 9 | ClayTrader | — | Contact form: claytrader.com/contact |
+| 10 | TRADEPRO Academy | george@tradeproacademy.com | Direct email |
+| 11 | Brian Shannon | support@alphatrends.net | Direct email |
+| 12 | Rayner Teo | support@tradingwithrayner.com | Direct email |
+| 13 | The Trading Channel | support@thetradingchannel.net | Direct email |
+| 14 | Adam Khoo | support@piranhaprofits.com | Direct email |
+| 15 | Warrior Trading | ross@warriortrading.com | Direct email |

--- a/affiliate-outreach/PROSPECT-TRACKER.md
+++ b/affiliate-outreach/PROSPECT-TRACKER.md
@@ -1,0 +1,35 @@
+# Affiliate Outreach — Prospect Tracker
+
+> Track outreach status for each prospect. Update as you send emails and receive responses.
+
+| # | Prospect | Email/Method | Tier | Status | Date Sent | Response | Notes |
+|---|---------|-------------|------|--------|-----------|----------|-------|
+| 1 | Mind Math Money | mindmathmoney@gmail.com | 1 | Not sent | | | TradingView indicator reviews, 300K+ subs |
+| 2 | Zen & The Art of Trading | Contact form | 1 | Not sent | | | Pine Script educator, systematic trading |
+| 3 | The Chart Guys | info@thechartguys.com | 1 | Not sent | | | Own TradingView indicators, education-first |
+| 4 | Kivanc Ozbilgic | Telegram/TV DM | 1 | Not sent | | | Pine Script Wizard, AlphaTrend creator |
+| 5 | Trading Strategy Guides | casey@tradingstrategyguides.com | 1 | Not sent | | | Podcast host, reviews premium indicators |
+| 6 | Liberated Stock Trader | Contact form/LinkedIn | 1 | Not sent | | | Backtested 103 indicators, CFTe |
+| 7 | Crypto Jebb | YouTube About/IG DM | 2 | Not sent | | | Crypto TA, 224K+ subs, CT2A course |
+| 8 | askSlim | slim@askslim.com | 2 | Not sent | | | Cycle analysis pioneer, 47+ years |
+| 9 | ClayTrader | Contact form | 2 | Not sent | | | "Robotic Trading", 639K subs |
+| 10 | TRADEPRO Academy | george@tradeproacademy.com | 2 | Not sent | | | Ex-Scotia Capital, volume profile |
+| 11 | Brian Shannon | support@alphatrends.net | 2 | Not sent | | | Anchored VWAP pioneer, CMT, 35+ years |
+| 12 | Rayner Teo | support@tradingwithrayner.com | 3 | Not sent | | | 18.3M subs, MAEE Formula |
+| 13 | The Trading Channel | support@thetradingchannel.net | 3 | Not sent | | | 2.38M subs, EAP program |
+| 14 | Adam Khoo | support@piranhaprofits.com | 3 | Not sent | | | 1M+ subs, indicator stacking |
+| 15 | Warrior Trading | ross@warriortrading.com | 3 | Not sent | | | $583→$12.5M, momentum scanning |
+
+## Status Key
+- **Not sent** — Email not yet sent
+- **Sent** — Email sent, awaiting response
+- **Replied** — Received response
+- **TV activated** — Sent TradingView username, indicators activated
+- **Affiliate signed** — Joined affiliate program
+- **Declined** — Not interested
+- **No response** — No reply after follow-up
+
+## Follow-up Schedule
+- **Day 0:** Send initial email
+- **Day 5:** If no response, send brief follow-up
+- **Day 14:** Final follow-up, then move to "No response"


### PR DESCRIPTION
## Summary
Add comprehensive affiliate outreach materials for Signal Pilot's trading educator partnership program, including 15 personalized email templates and a prospect tracking spreadsheet.

## Changes
- **OUTREACH-EMAILS.md** — 15 personalized email templates targeting trading educators and content creators
  - Each email is customized to the prospect's specific teaching philosophy, audience size, and content focus
  - Includes direct product positioning (Pentarch, Harmonic Oscillator, Volume Oracle, OmniDeck, Augury Grid, etc.)
  - Consistent value proposition: free access to full indicator suite, 15-30% recurring affiliate commission, $100 non-repaint bounty
  - Contact methods documented (direct email, contact forms, social DMs, Telegram)
  - Quick reference contact summary table at end

- **PROSPECT-TRACKER.md** — Spreadsheet template for managing outreach workflow
  - Tracks 15 prospects across 3 tiers (by audience size/influence)
  - Status tracking: Not sent → Sent → Replied → TV activated → Affiliate signed
  - Columns for date sent, response, and notes
  - Follow-up schedule guidance (Day 0, 5, 14)

## Notable Details
- Prospects range from 224K to 18.3M+ subscribers across crypto, stocks, forex, and options trading
- Email personalization includes specific references to each prospect's signature indicators, courses, or philosophies (e.g., MAEE Formula for Rayner Teo, AlphaTrend for Kivanc, AVWAP for Brian Shannon)
- All emails emphasize non-repainting verification and $100 bounty as key differentiator
- Consistent CTA: request TradingView username for 24-hour activation, no strings attached
- Affiliate program details (15-30% recurring) positioned as secondary benefit after product testing

https://claude.ai/code/session_01VsLB4SWwupRnTA7ujduwgY