### PR TITLE
Fix post-033 carousel rendering — slides were invisible

### DIFF
--- a/INSTAGRAM_CONTENT_HUB/social/post-033/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-033/carousel.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
     <style>
         :root {
-            --bg-dark: #0a0a0f;
+            --bg-dark: #0A1A1A;
             --bg-card: rgba(255, 255, 255, 0.02);
             --border-subtle: rgba(255, 255, 255, 0.06);
             --text-primary: #e8e6e3;
@@ -131,6 +131,7 @@
             aspect-ratio: 4 / 5;
             border-radius: 12px;
             overflow: hidden;
+            background: var(--bg-dark);
             box-shadow:
                 0 4px 24px rgba(0, 0, 0, 0.4),
                 0 0 0 1px var(--border-subtle);
@@ -149,18 +150,15 @@
         }
 
         .slide-content {
-            position: relative;
-            z-index: 1;
+            position: absolute;
+            top: 0;
+            left: 0;
             width: 100%;
             height: 100%;
+            z-index: 2;
             display: flex;
             flex-direction: column;
             padding: clamp(36px, 6.67cqw, 72px);
-            background: linear-gradient(
-                145deg,
-                rgba(10, 10, 15, 0.97) 0%,
-                rgba(10, 10, 15, 0.92) 100%
-            );
         }
 
         .slide-header {
@@ -349,6 +347,9 @@
             background: linear-gradient(90deg, var(--cine-teal), var(--cine-teal-glow));
             border-radius: 2px;
         }
+
+        /* Slide 1 content above pseudo-elements */
+        .slide-1 .slide-content { z-index: 3; }
 
         /* Slide 1 - Cinematic TEAL (Concept 03) */
         .slide.slide-1::before {


### PR DESCRIPTION
- Add background: var(--bg-dark) to .slide (was transparent)
- Change .slide-content from position:relative to position:absolute
- Remove dark gradient overlay that obscured content
- Fix z-index stacking: content (z:2/3) above pseudo-elements (z:1/2)
- Fix --bg-dark to teal value #0A1A1A (was #0a0a0f)

https://claude.ai/code/session_015r5gXFZiS4zHeKaYHwdo7h