### PR TITLE
Replace trader-type cycling animation with static headline, add trial…

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1170,8 +1170,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1221,8 +1219,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1243,12 +1239,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -1869,8 +1859,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1920,8 +1908,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1942,12 +1928,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -4861,7 +4841,7 @@ html[lang="ar"] [style*="text-align:center"] {
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;min-height:3.5rem;white-space:nowrap">
-            كشف الدورات • 7 مؤشرات متميزة لـ <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">المتداولين الجادين</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            كشف الدورات • 7 مؤشرات متميزة لـ <span style="color:var(--brand);font-weight:600">كل متداول</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8449,18 +8429,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['متداولي الفوركس','متداولي الأسهم','متداولي اليوم','متداولي السوينغ','المضاربين','متداولي الكريبتو','متداولي العقود الآجلة','جميع المتداولين'];
     var propWords = ['جميع الأسواق','جميع الأطر الزمنية','7 أيام تجربة مجانية','82 درس مجاني','7 أيام ضمان استرداد','مؤشرات TradingView'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8494,15 +8472,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/de/index.html
+++ b/de/index.html
@@ -1134,8 +1134,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1185,8 +1183,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1207,12 +1203,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -1798,8 +1788,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1849,8 +1837,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1871,12 +1857,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -4858,7 +4838,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Zyklus-Erkennung • 7 Premium-Indikatoren für <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">ernsthafte Trader</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Zyklus-Erkennung • 7 Premium-Indikatoren für <span style="color:var(--brand);font-weight:600">jeden Trader</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8898,18 +8878,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['Forex Trader','Aktien Trader','Day Trader','Swing Trader','Scalper','Krypto Trader','Futures Trader','alle Trader'];
     var propWords = ['Alle Märkte','Alle Zeitrahmen','7 Tage Kostenlos Testen','82 Kostenlose Lektionen','7-Tage Geld-zurück-Garantie','TradingView Indikatoren'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8943,15 +8921,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/es/index.html
+++ b/es/index.html
@@ -1237,8 +1237,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1288,8 +1286,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1310,12 +1306,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -2002,8 +1992,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -2053,8 +2041,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -2075,12 +2061,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -5072,7 +5052,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Detección de ciclos • 7 indicadores premium para <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">traders profesionales</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Detección de ciclos • 7 indicadores premium para <span style="color:var(--brand);font-weight:600">cada trader</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8910,18 +8890,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['traders de forex','traders de acciones','traders intradía','traders de swing','scalpers','traders de cripto','traders de futuros','todos los traders'];
     var propWords = ['Todos los mercados','Todos los timeframes','7 Días Prueba Gratis','82 Lecciones Gratuitas','7 Días Garantía de Devolución','Indicadores TradingView'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8955,15 +8933,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/fr/index.html
+++ b/fr/index.html
@@ -1422,8 +1422,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1473,8 +1471,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1495,12 +1491,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -2373,8 +2363,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -2424,8 +2412,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -2446,12 +2432,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -5255,7 +5235,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Détection de cycles • 7 indicateurs premium pour <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">traders sérieux</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Détection de cycles • 7 indicateurs premium pour <span style="color:var(--brand);font-weight:600">chaque trader</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -9317,18 +9297,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['traders forex','traders actions','day traders','swing traders','scalpers','traders crypto','traders futures','tous les traders'];
     var propWords = ['Tous les marchés','Tous les timeframes','7 Jours Essai Gratuit','82 Leçons Gratuites','7 Jours Satisfait ou Remboursé','Indicateurs TradingView'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -9362,15 +9340,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/hu/index.html
+++ b/hu/index.html
@@ -1175,8 +1175,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1227,8 +1225,6 @@
     @media (prefers-reduced-motion: reduce){
 
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1249,12 +1245,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
 
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
@@ -1882,8 +1872,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1934,8 +1922,6 @@
     @media (prefers-reduced-motion: reduce){
 
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1956,12 +1942,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
 
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
@@ -4805,7 +4785,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Ciklusérzékelés • 7 prémium indikátor <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">komoly kereskedőknek</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Ciklusérzékelés • 7 prémium indikátor <span style="color:var(--brand);font-weight:600">minden kereskedőnek</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8763,18 +8743,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['forex kereskedőknek','részvény kereskedőknek','napi kereskedőknek','swing kereskedőknek','scalpereknek','kripto kereskedőknek','futures kereskedőknek','minden kereskedőnek'];
     var propWords = ['Minden piac','Minden időkeret','7 Nap Ingyenes Próba','82 Ingyenes Lecke','7 Nap Pénzvisszafizetési Garancia','TradingView Indikátorok'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8808,15 +8786,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/index.html
+++ b/index.html
@@ -1145,8 +1145,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Optimize button press for touch */
       .btn:active{transform:translateY(2px) scale(0.99)}
@@ -1165,8 +1163,6 @@
 
 
     @media (prefers-reduced-motion: reduce){
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -3791,7 +3787,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Cycle detection • 7 premium indicators for <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">serious traders</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Cycle detection • 7 premium indicators for <span style="color:var(--brand);font-weight:600">every trader</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8210,18 +8206,16 @@ if ('serviceWorker' in navigator) {
     initTypingEffect();
   }
 
-  // Staggered hero animations - trader types and value props alternate (only one scrambles at a time)
+  // Hero value props cycling animation (only one scrambles at a time)
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['forex traders','stock traders','day traders','swing traders','scalpers','crypto traders','futures traders','all traders'];
     var propWords = ['All Markets','All Timeframes','7-Day Free Trial','82 Free Lessons','7-Day Money-Back Guarantee','TradingView Indicators'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8255,20 +8249,13 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      // Decode props (trader text holds still)
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
-
-      // Decode trader type (props text holds still)
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-
       cycle();
     }
 

--- a/it/index.html
+++ b/it/index.html
@@ -1141,8 +1141,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1192,8 +1190,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1214,12 +1210,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -1812,8 +1802,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1863,8 +1851,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1885,12 +1871,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -4770,7 +4750,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Rilevamento cicli • 7 indicatori premium per <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">trader professionisti</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Rilevamento cicli • 7 indicatori premium per <span style="color:var(--brand);font-weight:600">ogni trader</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8340,18 +8320,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['trader forex','trader azionari','day trader','swing trader','scalper','trader crypto','trader futures','tutti i trader'];
     var propWords = ['Tutti i mercati','Tutti i timeframe','7 Giorni Prova Gratuita','82 Lezioni Gratuite','7 Giorni Rimborso Garantito','Indicatori TradingView'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8385,15 +8363,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/ja/index.html
+++ b/ja/index.html
@@ -1232,8 +1232,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Fix signal legend items wrapping on mobile */
       div[style*="white-space:nowrap"]{white-space:normal !important;word-wrap:break-word;overflow-wrap:break-word}
@@ -1324,8 +1322,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1346,12 +1342,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -2037,8 +2027,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Fix signal legend items wrapping on mobile */
       div[style*="white-space:nowrap"]{white-space:normal !important;word-wrap:break-word;overflow-wrap:break-word}
@@ -2129,8 +2117,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -2151,12 +2137,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -5119,7 +5099,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            サイクル検出 • プレミアム7種類のインジケーター <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">本格的なトレーダー向け</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            サイクル検出 • プレミアム7種類のインジケーター <span style="color:var(--brand);font-weight:600">すべてのトレーダー向け</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8571,18 +8551,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['FXトレーダー向け','株式トレーダー向け','デイトレーダー向け','スイングトレーダー向け','スキャルパー向け','仮想通貨トレーダー向け','先物トレーダー向け','すべてのトレーダー向け'];
     var propWords = ['全市場','全時間足','7日間 無料お試し','82 無料レッスン','7日間 返金保証','TradingView インジケーター'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8616,15 +8594,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/nl/index.html
+++ b/nl/index.html
@@ -1165,8 +1165,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1217,8 +1215,6 @@
     @media (prefers-reduced-motion: reduce){
 
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1239,12 +1235,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -1864,8 +1854,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1916,8 +1904,6 @@
     @media (prefers-reduced-motion: reduce){
 
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1938,12 +1924,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -4797,7 +4777,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Cyclusdetectie • 7 premium indicatoren voor <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">serieuze traders</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Cyclusdetectie • 7 premium indicatoren voor <span style="color:var(--brand);font-weight:600">elke trader</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8244,18 +8224,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['forex traders','aandelen traders','daytraders','swingtraders','scalpers','crypto traders','futures traders','alle traders'];
     var propWords = ['Alle markten','Alle timeframes','7 Dagen Gratis Proberen','82 Gratis Lessen','7 Dagen Geld-Terug-Garantie','TradingView Indicatoren'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8289,15 +8267,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/pt/index.html
+++ b/pt/index.html
@@ -1164,8 +1164,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile - with fixes for mobile browsers */
       .scroll-progress{
@@ -1222,8 +1220,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1244,12 +1240,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -1887,8 +1877,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile - with fixes for mobile browsers */
       .scroll-progress{
@@ -1945,8 +1933,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1967,12 +1953,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -5052,7 +5032,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Detecção de ciclos • 7 indicadores premium para <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">traders sérios</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Detecção de ciclos • 7 indicadores premium para <span style="color:var(--brand);font-weight:600">todos os traders</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8627,18 +8607,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['traders forex','traders de ações','day traders','swing traders','scalpers','traders crypto','traders de futuros','todos os traders'];
     var propWords = ['Todos os mercados','Todos os timeframes','7 Dias Teste Grátis','82 Lições Gratuitas','7 Dias Garantia de Reembolso','Indicadores TradingView'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8672,15 +8650,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/ru/index.html
+++ b/ru/index.html
@@ -1391,8 +1391,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1443,8 +1441,6 @@
     @media (prefers-reduced-motion: reduce){
 
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1465,12 +1461,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -2316,8 +2306,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -2368,8 +2356,6 @@
     @media (prefers-reduced-motion: reduce){
 
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -2390,12 +2376,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
-
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
         position: fixed !important;
@@ -4999,7 +4979,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.05rem;line-height:1.6;max-width:900px;margin:1.5rem auto 0;white-space:nowrap">
-            Определение циклов • 7 премиальных индикаторов для <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">серьёзных трейдеров</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span>
+            Определение циклов • 7 премиальных индикаторов для <span style="color:var(--brand);font-weight:600">каждого трейдера</span>
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8504,18 +8484,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['форекс-трейдеров','фондовых трейдеров','дневных трейдеров','свинг-трейдеров','скальперов','крипто-трейдеров','фьючерсных трейдеров','всех трейдеров'];
     var propWords = ['Все рынки','Все таймфреймы','7 Дней Бесплатно','82 Бесплатных Урока','7 Дней Гарантия Возврата','Индикаторы TradingView'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8549,15 +8527,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }

--- a/tr/index.html
+++ b/tr/index.html
@@ -1437,8 +1437,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -1488,8 +1486,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -1510,12 +1506,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
 
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
@@ -2407,8 +2397,6 @@
       /* Allow hero text to wrap on mobile */
       #hero-description{white-space:normal !important;font-size:1rem !important;padding:0 1rem;max-width:100%;overflow-wrap:break-word;word-break:break-word;min-height:3.2rem}
 
-      /* Reduce typing text on mobile */
-      #typed-text{font-size:0.95rem !important}
 
       /* Smaller progress bar on mobile */
       .scroll-progress{height:2px}
@@ -2458,8 +2446,6 @@
 
     @media (prefers-reduced-motion: reduce){
 
-      #typing-cursor{animation:none;opacity:1}
-
       /* Disable all animations for users who prefer reduced motion */
       .success-check,.spinner{animation:none !important}
 
@@ -2480,12 +2466,6 @@
     /* bg-aurora capability rules REMOVED - using video background instead */
 
     @media (max-width: 1024px) {
-
-      /* Disable harsh blinking cursor on mobile */
-      #typing-cursor {
-        animation: none !important;
-        opacity: 1 !important;
-      }
 
       /* Constellations should stay in background (default z-index:-2) - removed forced z-index:1 */
       .sp-constellations, #constellations {
@@ -5074,7 +5054,7 @@
           </h1>
 
           <p id="hero-description" style="color:var(--muted);font-size:1.15rem;line-height:1.6;max-width:700px;margin:1.5rem auto 0;white-space:nowrap">
-            Döngü tespiti • <span id="typed-text" class="signal-decode" style="color:var(--brand);font-weight:600">ciddi yatırımcılar</span><span id="typing-cursor" style="color:var(--brand);font-weight:300;animation:blink 1s step-end infinite">|</span> için 7 premium gösterge
+            Döngü tespiti • <span style="color:var(--brand);font-weight:600">her trader</span> için 7 premium gösterge
           </p>
 
           <!-- Value Props - Animated Cycling -->
@@ -8580,18 +8560,16 @@ if ('serviceWorker' in navigator) {
     setTimeout(updateProgress, 100);
   }
 
-  // Staggered hero animations - trader types and value props alternate
+  // Hero value props cycling animation
   function initTypingEffect() {
-    var typedEl = document.getElementById('typed-text');
     var propsEl = document.getElementById('hero-props-text');
     var propsLinkEl = document.getElementById('hero-props-link');
-    if (!typedEl && !propsEl) return;
+    if (!propsEl) return;
 
-    var traderWords = ['forex traderları','hisse traderları','günlük traderlar','swing traderlar','scalperlar','kripto traderları','vadeli işlem traderları','tüm traderlar'];
     var propWords = ['Tüm piyasalar','Tüm zaman dilimleri','7 Gün Ücretsiz Deneme','82 Ücretsiz Ders','7 Gün Para İade Garantisi','TradingView Göstergeleri'];
-    var propLinks = ['','','','https://education.signalpilot.io/','','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
+    var propLinks = ['','','#trial','https://education.signalpilot.io/','refund.html','https://www.tradingview.com/u/SignalPilotLabs/#published-scripts'];
     var chars = '!<>-_\\/[]{}—=+*^?#@$%&ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    var tIdx = 0, pIdx = 0;
+    var pIdx = 0;
 
     function decode(el, newText) {
       return new Promise(function(resolve) {
@@ -8625,15 +8603,12 @@ if ('serviceWorker' in navigator) {
     }
 
     async function cycle() {
-      if (propsEl) await decode(propsEl, propWords[pIdx]);
+      await decode(propsEl, propWords[pIdx]);
       if (propsLinkEl) {
         if (propLinks[pIdx]) { propsLinkEl.href = propLinks[pIdx]; propsLinkEl.style.pointerEvents = ''; }
         else { propsLinkEl.removeAttribute('href'); propsLinkEl.style.pointerEvents = 'none'; }
       }
       pIdx = (pIdx + 1) % propWords.length;
-      await new Promise(function(r) { setTimeout(r, 1400); });
-      if (typedEl) await decode(typedEl, traderWords[tIdx]);
-      tIdx = (tIdx + 1) % traderWords.length;
       await new Promise(function(r) { setTimeout(r, 1400); });
       cycle();
     }


### PR DESCRIPTION
… and refund links

- Remove animated trader-type text (scalpers, day traders, etc.) from hero
- Replace with static localized "every trader" text across all 12 languages
- Keep props-only cycling animation for value propositions
- Add #trial link to 7-Day Free Trial prop
- Add refund.html link to Money-Back Guarantee prop
- Clean up unused traderWords, tIdx, #typed-text and #typing-cursor CSS

https://claude.ai/code/session_015BSFv5htUQ4wGMv5MXZHtD