### PR TITLE
Remove redundant cache-busting across all 12 languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -31,10 +31,6 @@
   </script>
 
   <meta charset="utf-8" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
@@ -7501,11 +7497,10 @@ html[lang="ar"] [style*="text-align:center"] {
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/de/index.html
+++ b/de/index.html
@@ -32,10 +32,6 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -7951,11 +7947,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/es/index.html
+++ b/es/index.html
@@ -31,11 +31,6 @@
   </script>
 
   <meta charset="utf-8" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
-
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
   <!-- Tailwind CSS -->
@@ -7962,11 +7957,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/fr/index.html
+++ b/fr/index.html
@@ -31,11 +31,6 @@
   </script>
 
   <meta charset="utf-8" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
-
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
   <!-- Tailwind CSS -->
@@ -8369,11 +8364,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/hu/index.html
+++ b/hu/index.html
@@ -32,10 +32,6 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -7815,11 +7811,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/index.html
+++ b/index.html
@@ -52,10 +52,6 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <!-- Detect Chrome for CTA animation fallback -->
   <script>
@@ -7368,10 +7364,8 @@
   }
 
   // Load in sequence: device-capability -> themes
-  // Cache-busting: Added timestamp to force reload of updated scripts
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js');
     // DISABLED: particles.js replaced by starfield video background
     // DISABLED: theme-switcher.js - using default theme only for professional look
   });

--- a/it/index.html
+++ b/it/index.html
@@ -32,10 +32,6 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -7392,11 +7388,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/ja/index.html
+++ b/ja/index.html
@@ -31,10 +31,6 @@
   </script>
 
   <meta charset="utf-8" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
@@ -7620,11 +7616,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/nl/index.html
+++ b/nl/index.html
@@ -32,10 +32,6 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -7292,11 +7288,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/pt/index.html
+++ b/pt/index.html
@@ -31,10 +31,6 @@
   </script>
 
   <meta charset="utf-8" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
@@ -7676,11 +7672,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/ru/index.html
+++ b/ru/index.html
@@ -32,10 +32,6 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -7552,11 +7548,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });

--- a/tr/index.html
+++ b/tr/index.html
@@ -31,11 +31,6 @@
   </script>
 
   <meta charset="utf-8" />
-  <!-- Cache bust v2 - force reload after mobile fixes -->
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-  <meta http-equiv="Pragma" content="no-cache" />
-  <meta http-equiv="Expires" content="0" />
-
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
   <!-- Tailwind CSS -->
@@ -7629,11 +7624,10 @@
   }
 
   // Load in sequence: device-capability -> themes -> particles -> theme-switcher
-  const cacheBust = '?v=' + Date.now();
-  loadScript('assets/device-capability.js' + cacheBust, function() {
-    loadScript('assets/themes.js' + cacheBust, function() {
-      loadScript('assets/particles.js' + cacheBust, function() {
-        loadScript('assets/theme-switcher.js' + cacheBust);
+  loadScript('assets/device-capability.js', function() {
+    loadScript('assets/themes.js', function() {
+      loadScript('assets/particles.js', function() {
+        loadScript('assets/theme-switcher.js');
       });
     });
   });


### PR DESCRIPTION
- Remove useless <meta http-equiv="Cache-Control"> and <meta http-equiv="Pragma"> tags (ignored by browsers, Vercel headers handle this)
- Remove Date.now() cache-busting on script loads (forced re-download on every visit, defeating browser cache)
- Vercel CDN already invalidates caches on deploy, so no manual version bumping needed

https://claude.ai/code/session_015BSFv5htUQ4wGMv5MXZHtD