### PR TITLE
Fix: reset tvConfirmed on username input change across all 12 languages

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -8089,6 +8089,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/de/index.html
+++ b/de/index.html
@@ -8539,6 +8539,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/es/index.html
+++ b/es/index.html
@@ -8525,7 +8525,7 @@ if ('serviceWorker' in navigator) {
   }
 
   if (tvInput && tvError) {
-    tvInput.addEventListener('input', function() { validateTvUsernameApi(tvInput, tvError); });
+    tvInput.addEventListener('input', function() { tvConfirmed = false; validateTvUsernameApi(tvInput, tvError); });
     tvInput.addEventListener('paste', function(e) { setTimeout(function() { tvInput.value = tvInput.value.replace(/\s+/g, ''); tvInput.dispatchEvent(new Event('input')); }, 0); });
     tvInput.addEventListener('keydown', function(e) { if (e.key === ' ') e.preventDefault(); });
   }

--- a/fr/index.html
+++ b/fr/index.html
@@ -8965,6 +8965,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -8412,6 +8412,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/index.html
+++ b/index.html
@@ -7929,6 +7929,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/it/index.html
+++ b/it/index.html
@@ -7989,6 +7989,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -8220,6 +8220,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -7892,6 +7892,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -8276,6 +8276,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -8152,6 +8152,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -8228,6 +8228,7 @@ if ('serviceWorker' in navigator) {
 
   if (tvInput && tvError) {
     tvInput.addEventListener('input', function() {
+      tvConfirmed = false;
       validateTvUsernameApi(tvInput, tvError);
     });
 


### PR DESCRIPTION
When the user modified their TradingView username after verification, the tvConfirmed flag stayed true, skipping the confirmation dialog on the next submit. Now any keystroke in the username field resets tvConfirmed = false so the user is always re-prompted to confirm.

https://claude.ai/code/session_015BSFv5htUQ4wGMv5MXZHtD