### PR TITLE
Add server-side trial form proxy to hide Make.com webhook URL

### DIFF
--- a/api/submit-trial.js
+++ b/api/submit-trial.js
@@ -1,0 +1,69 @@
+// Vercel Serverless Function: Trial Form Submission Proxy
+// Endpoint: POST /api/submit-trial
+//
+// Validates form data server-side, then forwards to Make.com webhook.
+// This keeps the webhook URL hidden from the frontend and blocks
+// bots that POST empty/garbage data directly.
+
+const WEBHOOK_URL = process.env.MAKE_WEBHOOK_URL || 'https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz';
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const body = req.body || {};
+  const email = (body.email || '').trim();
+  const tvUsername = (body.tradingview_username || '').trim();
+  const consent = !!body.consent;
+  const timestamp = body.timestamp || new Date().toISOString();
+  const source = body.source || 'website_trial_form';
+
+  // --- Server-side validation (mirrors frontend checks) ---
+
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return res.status(400).json({ error: 'Invalid email format' });
+  }
+
+  if (!tvUsername) {
+    return res.status(400).json({ error: 'TradingView username is required' });
+  }
+  if (tvUsername.length < 2 || tvUsername.length > 50) {
+    return res.status(400).json({ error: 'Invalid TradingView username length' });
+  }
+  if (/\s/.test(tvUsername) || /@/.test(tvUsername)) {
+    return res.status(400).json({ error: 'Invalid TradingView username format' });
+  }
+
+  // --- Forward to Make.com ---
+
+  try {
+    const response = await fetch(WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email,
+        tradingview_username: tvUsername,
+        consent,
+        timestamp,
+        source
+      })
+    });
+
+    if (response.ok) {
+      return res.status(200).json({ success: true });
+    } else {
+      console.error('Make.com webhook error:', response.status);
+      return res.status(502).json({ error: 'Submission failed' });
+    }
+  } catch (error) {
+    console.error('Webhook network error:', error.message);
+    return res.status(502).json({ error: 'Submission failed' });
+  }
+}

--- a/ar/index.html
+++ b/ar/index.html
@@ -8235,7 +8235,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/de/index.html
+++ b/de/index.html
@@ -8684,7 +8684,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/es/index.html
+++ b/es/index.html
@@ -8612,7 +8612,7 @@ if ('serviceWorker' in navigator) {
       const formData = { email: email, tradingview_username: tvUsername, consent: document.getElementById('trialConsent').checked, timestamp: new Date().toISOString(), source: 'website_trial_form' };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(formData), keepalive: true
         });
         if (response.ok) { window.location.href = '/es/trial-thanks.html'; }

--- a/fr/index.html
+++ b/fr/index.html
@@ -9124,8 +9124,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        // Send webhook with keepalive so it completes even during redirect
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/hu/index.html
+++ b/hu/index.html
@@ -8560,7 +8560,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/index.html
+++ b/index.html
@@ -8088,8 +8088,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        // Send webhook with keepalive so it completes even during redirect
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/it/index.html
+++ b/it/index.html
@@ -8137,7 +8137,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/ja/index.html
+++ b/ja/index.html
@@ -8379,8 +8379,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        // Send webhook with keepalive so it completes even during redirect
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/nl/index.html
+++ b/nl/index.html
@@ -8040,7 +8040,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/pt/index.html
+++ b/pt/index.html
@@ -8424,7 +8424,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/ru/index.html
+++ b/ru/index.html
@@ -8300,7 +8300,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/tr/index.html
+++ b/tr/index.html
@@ -8377,7 +8377,7 @@ if ('serviceWorker' in navigator) {
       };
 
       try {
-        const response = await fetch('https://hook.eu1.make.com/7klx329gnfpknko32nubiu43nadwoouz', {
+        const response = await fetch('/api/submit-trial', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
Bot attacked the trial form by POSTing directly to the Make.com webhook (URL was exposed in frontend source). This adds a Vercel serverless proxy (/api/submit-trial) that:
- Hides the webhook URL server-side
- Validates email + TV username before forwarding
- Rejects empty/garbage submissions that crash Make.com

All 12 language HTML files now POST to /api/submit-trial instead of the raw Make.com URL.

https://claude.ai/code/session_015BSFv5htUQ4wGMv5MXZHtD