### PR TITLE
Fix TradingView username validation: reject fake usernames, fail closed

### DIFF
--- a/api/validate-tv-username.js
+++ b/api/validate-tv-username.js
@@ -33,38 +33,60 @@ export default async function handler(req, res) {
   const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
   try {
-    // Check if the TradingView profile page exists
+    // Use GET with redirect following — HEAD is unreliable with CDNs (Cloudflare
+    // returns 200 for all HEAD requests regardless of whether the user exists).
     const tvResponse = await fetch(`https://www.tradingview.com/u/${encodeURIComponent(trimmed)}/`, {
-      method: 'HEAD',
-      headers: { 'User-Agent': UA, 'Accept': 'text/html' },
-      redirect: 'manual',
+      method: 'GET',
+      headers: {
+        'User-Agent': UA,
+        'Accept': 'text/html,application/xhtml+xml',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+      redirect: 'follow',
     });
 
-    // TradingView returns 2xx for existing profiles, 302/404 for non-existing
-    if (tvResponse.status >= 200 && tvResponse.status < 300) {
-      return res.status(200).json({ valid: true, username: trimmed });
-    }
-
-    // Fall back to GET if HEAD doesn't return 2xx
-    if (tvResponse.status !== 404) {
-      const getResponse = await fetch(`https://www.tradingview.com/u/${encodeURIComponent(trimmed)}/`, {
-        method: 'GET',
-        headers: { 'User-Agent': UA, 'Accept': 'text/html' },
-        redirect: 'manual',
-      });
-
-      if (getResponse.status >= 200 && getResponse.status < 300) {
-        return res.status(200).json({ valid: true, username: trimmed });
-      }
-
+    // TradingView returns 404 for non-existent profiles
+    if (tvResponse.status === 404) {
       return res.status(200).json({ valid: false, reason: 'not_found' });
     }
 
-    return res.status(200).json({ valid: false, reason: 'not_found' });
+    // Any non-2xx response means the profile doesn't exist or something went wrong
+    if (tvResponse.status < 200 || tvResponse.status >= 300) {
+      return res.status(200).json({ valid: false, reason: 'not_found' });
+    }
+
+    // Got 200 — read the body to verify this is a real profile page,
+    // not a Cloudflare challenge, soft-404, or generic error page
+    const body = await tvResponse.text();
+    const lowerBody = body.toLowerCase();
+
+    // Check for "not found" indicators (soft 404 pages that return HTTP 200)
+    const isNotFound =
+      lowerBody.includes('page not found') ||
+      lowerBody.includes('page_not_found') ||
+      lowerBody.includes('"error":404') ||
+      tvResponse.url.includes('/error');
+
+    if (isNotFound) {
+      return res.status(200).json({ valid: false, reason: 'not_found' });
+    }
+
+    // Verify the page actually contains profile-specific content for this user
+    const hasProfile =
+      body.includes(`/u/${trimmed}/`) ||
+      body.includes(`"username":"${trimmed}"`) ||
+      body.includes(`@${trimmed}`);
+
+    if (hasProfile) {
+      return res.status(200).json({ valid: true, username: trimmed });
+    }
+
+    // If we got 200 but can't confirm profile content, fail closed
+    return res.status(200).json({ valid: false, reason: 'unverifiable' });
 
   } catch (error) {
     console.error('TradingView validation error:', error.message);
-    // On network error, allow the submission (fail open) but flag it
-    return res.status(200).json({ valid: true, uncertain: true, error: 'validation_unavailable' });
+    // Fail closed — do not mark as valid when we cannot verify
+    return res.status(200).json({ valid: false, uncertain: true, error: 'validation_unavailable' });
   }
 }

--- a/ar/index.html
+++ b/ar/index.html
@@ -8069,19 +8069,24 @@ if ('serviceWorker' in navigator) {
       try {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Username verified on TradingView');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + value);
           }
         }
       } catch (e) {
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true';
+          setTvFieldState(input, errorEl, 'error', 'Could not verify username. Please check your connection and try again.');
         }
       }
     }, 600);
@@ -8206,7 +8211,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/de/index.html
+++ b/de/index.html
@@ -8519,19 +8519,24 @@ if ('serviceWorker' in navigator) {
       try {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Username verified on TradingView');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + value);
           }
         }
       } catch (e) {
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true';
+          setTvFieldState(input, errorEl, 'error', 'Could not verify username. Please check your connection and try again.');
         }
       }
     }, 600);
@@ -8655,7 +8660,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/es/index.html
+++ b/es/index.html
@@ -8513,13 +8513,16 @@ if ('serviceWorker' in navigator) {
       try {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) { tvValidationCache[value.toLowerCase()] = data; }
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) { setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Username verified on TradingView'); }
+          if (data.valid && !data.uncertain) { setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView'); }
+          else if (data.uncertain) { setTvFieldState(input, errorEl, 'error', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value); }
           else { setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + value); }
         }
       } catch (e) {
-        if (input.value.trim().toLowerCase() === value.toLowerCase()) { setTvFieldState(input, errorEl, 'clear', ''); input.dataset.tvValid = 'true'; }
+        // Network error — fail closed, don't mark as valid
+        if (input.value.trim().toLowerCase() === value.toLowerCase()) { setTvFieldState(input, errorEl, 'error', 'Could not verify username. Please check your connection and try again.'); }
       }
     }, 600);
   }
@@ -8597,7 +8600,14 @@ if ('serviceWorker' in navigator) {
             submitting = false; submitBtn.disabled = false; submitBtn.textContent = originalText; tvField.focus(); return;
           }
           setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
-        } catch (e) { /* fail open */ }
+        } catch (e) {
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
+        }
       }
 
       if (!tvConfirmed) {

--- a/fr/index.html
+++ b/fr/index.html
@@ -8942,22 +8942,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Nom d\'utilisateur vérifié sur TradingView');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Nom d\'utilisateur vérifié sur TradingView');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Impossible de vérifier ce nom d\'utilisateur pour le moment. Vérifiez sur tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Ce nom d\'utilisateur n\'existe pas sur TradingView. Vérifiez votre profil sur tradingview.com/u/' + value);
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'Impossible de vérifier le nom d\'utilisateur. Vérifiez votre connexion et réessayez.');
         }
       }
     }, 600);
@@ -9092,7 +9095,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Nom d\'utilisateur vérifié sur TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/hu/index.html
+++ b/hu/index.html
@@ -8389,22 +8389,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Felhasználónév megerősítve a TradingView-on');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Felhasználónév megerősítve a TradingView-on');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'A felhasználónév jelenleg nem ellenőrizhető. Ellenőrizd a tradingview.com/u/' + value + ' oldalon');
           } else {
             setTvFieldState(input, errorEl, 'error', 'Ez a felhasználónév nem létezik a TradingView-on. Ellenőrizd a profilod a tradingview.com/u/' + value + ' oldalon');
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'A felhasználónév nem ellenőrizhető. Ellenőrizd a kapcsolatot és próbáld újra.');
         }
       }
     }, 600);
@@ -8531,7 +8534,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/index.html
+++ b/index.html
@@ -7906,22 +7906,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Username verified on TradingView');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + value);
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'Could not verify username. Please check your connection and try again.');
         }
       }
     }, 600);
@@ -8056,7 +8059,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/it/index.html
+++ b/it/index.html
@@ -7966,22 +7966,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Username verificato su TradingView');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Username verificato su TradingView');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Impossibile verificare questo username al momento. Controlla su tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Questo username non esiste su TradingView. Controlla il tuo profilo su tradingview.com/u/' + value);
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'Impossibile verificare l\'username. Controlla la connessione e riprova.');
         }
       }
     }, 600);
@@ -8108,7 +8111,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -8197,22 +8197,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'TradingViewでユーザー名が確認されました');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'TradingViewでユーザー名が確認されました');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', '現在ユーザー名を確認できません。tradingview.com/u/' + value + ' でご確認ください');
           } else {
             setTvFieldState(input, errorEl, 'error', 'このユーザー名はTradingViewに存在しません。tradingview.com/u/' + value + ' でご確認ください');
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'ユーザー名を確認できませんでした。接続を確認して再試行してください。');
         }
       }
     }, 600);
@@ -8347,7 +8350,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'TradingViewでユーザー名が確認されました');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -7869,22 +7869,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Gebruikersnaam geverifieerd op TradingView');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Gebruikersnaam geverifieerd op TradingView');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Kan deze gebruikersnaam momenteel niet verifiëren. Controleer op tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Deze gebruikersnaam bestaat niet op TradingView. Controleer je profiel op tradingview.com/u/' + value);
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'Kan gebruikersnaam niet verifiëren. Controleer je verbinding en probeer opnieuw.');
         }
       }
     }, 600);
@@ -8011,7 +8014,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/pt/index.html
+++ b/pt/index.html
@@ -8253,22 +8253,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Nome de usuário verificado no TradingView');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Nome de usuário verificado no TradingView');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Não foi possível verificar este nome de usuário no momento. Verifique em tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Este nome de usuário não existe no TradingView. Verifique seu perfil em tradingview.com/u/' + value);
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'Não foi possível verificar o nome de usuário. Verifique sua conexão e tente novamente.');
         }
       }
     }, 600);
@@ -8395,7 +8398,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Nome de usuário verificado no TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -8129,22 +8129,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'Имя пользователя подтверждено на TradingView');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'Имя пользователя подтверждено на TradingView');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Не удалось проверить имя пользователя. Проверьте на tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Это имя пользователя не существует на TradingView. Проверьте свой профиль на tradingview.com/u/' + value);
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'Не удалось проверить имя пользователя. Проверьте подключение и попробуйте снова.');
         }
       }
     }, 600);
@@ -8271,7 +8274,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'Имя пользователя подтверждено на TradingView');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 

--- a/tr/index.html
+++ b/tr/index.html
@@ -8205,22 +8205,25 @@ if ('serviceWorker' in navigator) {
         var resp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(value));
         var data = await resp.json();
 
-        // Cache the result
-        tvValidationCache[value.toLowerCase()] = data;
+        // Only cache definitive results (not uncertain ones)
+        if (!data.uncertain) {
+          tvValidationCache[value.toLowerCase()] = data;
+        }
 
         // Only update if the input value hasn't changed during the request
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          if (data.valid) {
-            setTvFieldState(input, errorEl, 'valid', data.uncertain ? '' : 'TradingView\'da kullanıcı adı doğrulandı');
+          if (data.valid && !data.uncertain) {
+            setTvFieldState(input, errorEl, 'valid', 'TradingView\'da kullanıcı adı doğrulandı');
+          } else if (data.uncertain) {
+            setTvFieldState(input, errorEl, 'error', 'Bu kullanıcı adı şu anda doğrulanamıyor. tradingview.com/u/' + value + ' adresinden kontrol edin');
           } else {
             setTvFieldState(input, errorEl, 'error', 'Bu kullanıcı adı TradingView\'da mevcut değil. tradingview.com/u/' + value + ' adresinden kontrol edin');
           }
         }
       } catch (e) {
-        // Network error — fail open but don't show as verified
+        // Network error — fail closed, don't mark as valid
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
-          setTvFieldState(input, errorEl, 'clear', '');
-          input.dataset.tvValid = 'true'; // fail open
+          setTvFieldState(input, errorEl, 'error', 'Kullanıcı adı doğrulanamadı. Bağlantınızı kontrol edip tekrar deneyin.');
         }
       }
     }, 600);
@@ -8348,7 +8351,12 @@ if ('serviceWorker' in navigator) {
           }
           setTvFieldState(tvField, tvError, 'valid', 'TradingView\'da kullanıcı adı doğrulandı');
         } catch (e) {
-          // Fail open on network error
+          // Fail closed — don't allow submission without verification
+          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          submitting = false;
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+          return;
         }
       }
 


### PR DESCRIPTION
The validation was accepting ANY username as "verified" because:

1. Backend used HEAD requests which Cloudflare returns 200 for regardless of whether the user exists. Switched to GET with redirect following and added response body verification to confirm profile content.

2. Backend catch block returned valid:true on network errors (fail open). Changed to valid:false so unverifiable usernames are rejected.

3. Frontend catch blocks set tvValid='true' on network errors (fail open). Changed to show error messages and block form submission.

4. Frontend cached uncertain API responses, causing stale false-positives. Now only caches definitive results.

Applied across all 12 language versions (en, ar, de, es, fr, hu, it, ja, nl, pt, ru, tr) and the backend API.

https://claude.ai/code/session_015BSFv5htUQ4wGMv5MXZHtD