### PR TITLE
Fix TradingView username validation rejecting valid users

### DIFF
--- a/api/validate-tv-username.js
+++ b/api/validate-tv-username.js
@@ -71,18 +71,24 @@ export default async function handler(req, res) {
       return res.status(200).json({ valid: false, reason: 'not_found' });
     }
 
-    // Verify the page actually contains profile-specific content for this user
+    // Verify the page actually contains profile-specific content for this user.
+    // Use case-insensitive matching: TradingView usernames are case-insensitive
+    // but the stored casing may differ from what the user typed (e.g. "axlmob"
+    // vs "AxlMoB"), so a case-sensitive check would incorrectly reject valid users.
+    const lowerTrimmed = trimmed.toLowerCase();
     const hasProfile =
-      body.includes(`/u/${trimmed}/`) ||
-      body.includes(`"username":"${trimmed}"`) ||
-      body.includes(`@${trimmed}`);
+      lowerBody.includes(`/u/${lowerTrimmed}/`) ||
+      lowerBody.includes(`"username":"${lowerTrimmed}"`) ||
+      lowerBody.includes(`@${lowerTrimmed}`);
 
     if (hasProfile) {
       return res.status(200).json({ valid: true, username: trimmed });
     }
 
-    // If we got 200 but can't confirm profile content, fail closed
-    return res.status(200).json({ valid: false, reason: 'unverifiable' });
+    // If we got 200 but can't confirm profile content (e.g. Cloudflare
+    // challenge page), flag as uncertain so the frontend can show a softer
+    // message and still allow the user to proceed after confirmation.
+    return res.status(200).json({ valid: false, uncertain: true, reason: 'unverifiable' });
 
   } catch (error) {
     console.error('TradingView validation error:', error.message);

--- a/ar/index.html
+++ b/ar/index.html
@@ -8022,6 +8022,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'Checking TradingView username...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8057,6 +8062,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Please check your username at tradingview.com/u/' + value);
       }
@@ -8078,7 +8085,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
+            setTvFieldState(input, errorEl, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + value);
           }
@@ -8194,13 +8201,15 @@ if ('serviceWorker' in navigator) {
         return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
             submitting = false;
@@ -8209,13 +8218,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/de/index.html
+++ b/de/index.html
@@ -8472,6 +8472,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'Checking TradingView username...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8507,6 +8512,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Please check your username at tradingview.com/u/' + value);
       }
@@ -8528,7 +8535,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
+            setTvFieldState(input, errorEl, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + value);
           }
@@ -8643,13 +8650,15 @@ if ('serviceWorker' in navigator) {
         return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
             submitting = false;
@@ -8658,13 +8667,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/es/index.html
+++ b/es/index.html
@@ -8482,6 +8482,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'Checking TradingView username...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8505,7 +8510,9 @@ if ('serviceWorker' in navigator) {
     var cached = tvValidationCache[value.toLowerCase()];
     if (cached) {
       if (cached.valid) { setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView'); }
-      else { setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Please check your username at tradingview.com/u/' + value); }
+      else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
+      } else { setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Please check your username at tradingview.com/u/' + value); }
       return;
     }
     setTvFieldState(input, errorEl, 'loading', 'Checking TradingView username...');
@@ -8517,7 +8524,7 @@ if ('serviceWorker' in navigator) {
         if (!data.uncertain) { tvValidationCache[value.toLowerCase()] = data; }
         if (input.value.trim().toLowerCase() === value.toLowerCase()) {
           if (data.valid && !data.uncertain) { setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView'); }
-          else if (data.uncertain) { setTvFieldState(input, errorEl, 'error', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value); }
+          else if (data.uncertain) { setTvFieldState(input, errorEl, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value); }
           else { setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + value); }
         }
       } catch (e) {
@@ -8588,24 +8595,42 @@ if ('serviceWorker' in navigator) {
         submitting = false; submitBtn.disabled = false; submitBtn.textContent = originalText; tvField.focus(); return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
-            submitting = false; submitBtn.disabled = false; submitBtn.textContent = originalText; tvField.focus(); return;
+            submitting = false;
+            submitBtn.disabled = false;
+            submitBtn.textContent = originalText;
+            tvField.focus();
+            return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/fr/index.html
+++ b/fr/index.html
@@ -8889,6 +8889,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'Vérification du nom d\'utilisateur TradingView...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8927,6 +8932,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Nom d\'utilisateur vérifié sur TradingView');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'Ce nom d\'utilisateur n\'existe pas sur TradingView. Vérifiez votre nom d\'utilisateur sur tradingview.com/u/' + value);
       }
@@ -8952,7 +8959,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Nom d\'utilisateur vérifié sur TradingView');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Impossible de vérifier ce nom d\'utilisateur pour le moment. Vérifiez sur tradingview.com/u/' + value);
+            setTvFieldState(input, errorEl, 'warn', 'Impossible de vérifier ce nom d\'utilisateur pour le moment. Vérifiez sur tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Ce nom d\'utilisateur n\'existe pas sur TradingView. Vérifiez votre profil sur tradingview.com/u/' + value);
           }
@@ -9078,13 +9085,15 @@ if ('serviceWorker' in navigator) {
       }
 
       // If not yet validated (e.g. user typed too fast), validate now
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Vérification du nom d\'utilisateur...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'Ce nom d\'utilisateur n\'existe pas sur TradingView. Vérifiez votre profil sur tradingview.com/u/' + tvUsername);
             alert('Le nom d\'utilisateur TradingView "' + tvUsername + '" n\'existe pas.\n\nVeuillez entrer votre vrai nom d\'utilisateur TradingView.');
             submitting = false;
@@ -9093,13 +9102,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Nom d\'utilisateur vérifié sur TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Nom d\'utilisateur vérifié sur TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/hu/index.html
+++ b/hu/index.html
@@ -8336,6 +8336,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'TradingView felhasználónév ellenőrzése...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8374,6 +8379,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Felhasználónév megerősítve a TradingView-on');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'Ez a felhasználónév nem létezik a TradingView-on. Kérjük, ellenőrizd a felhasználóneved a tradingview.com/u/' + value + ' oldalon');
       }
@@ -8399,7 +8406,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Felhasználónév megerősítve a TradingView-on');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'A felhasználónév jelenleg nem ellenőrizhető. Ellenőrizd a tradingview.com/u/' + value + ' oldalon');
+            setTvFieldState(input, errorEl, 'warn', 'A felhasználónév jelenleg nem ellenőrizhető. Ellenőrizd a tradingview.com/u/' + value + ' oldalon');
           } else {
             setTvFieldState(input, errorEl, 'error', 'Ez a felhasználónév nem létezik a TradingView-on. Ellenőrizd a profilod a tradingview.com/u/' + value + ' oldalon');
           }
@@ -8517,13 +8524,15 @@ if ('serviceWorker' in navigator) {
         return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
             submitting = false;
@@ -8532,13 +8541,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/index.html
+++ b/index.html
@@ -7853,6 +7853,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'Checking TradingView username...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -7891,6 +7896,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Please check your username at tradingview.com/u/' + value);
       }
@@ -7916,7 +7923,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Username verified on TradingView');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
+            setTvFieldState(input, errorEl, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + value);
           }
@@ -8042,13 +8049,15 @@ if ('serviceWorker' in navigator) {
       }
 
       // If not yet validated (e.g. user typed too fast), validate now
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
             submitting = false;
@@ -8057,13 +8066,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/it/index.html
+++ b/it/index.html
@@ -7913,6 +7913,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'Verifica username TradingView in corso...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -7951,6 +7956,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Username verificato su TradingView');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'Questo username non esiste su TradingView. Controlla il tuo username su tradingview.com/u/' + value);
       }
@@ -7976,7 +7983,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Username verificato su TradingView');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Impossibile verificare questo username al momento. Controlla su tradingview.com/u/' + value);
+            setTvFieldState(input, errorEl, 'warn', 'Impossibile verificare questo username al momento. Controlla su tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Questo username non esiste su TradingView. Controlla il tuo profilo su tradingview.com/u/' + value);
           }
@@ -8094,13 +8101,15 @@ if ('serviceWorker' in navigator) {
         return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
             submitting = false;
@@ -8109,13 +8118,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/ja/index.html
+++ b/ja/index.html
@@ -8144,6 +8144,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'TradingViewユーザー名を確認中...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8182,6 +8187,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'TradingViewでユーザー名が確認されました');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'このユーザー名はTradingViewに存在しません。tradingview.com/u/' + value + ' でご確認ください');
       }
@@ -8207,7 +8214,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'TradingViewでユーザー名が確認されました');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', '現在ユーザー名を確認できません。tradingview.com/u/' + value + ' でご確認ください');
+            setTvFieldState(input, errorEl, 'warn', '現在ユーザー名を確認できません。tradingview.com/u/' + value + ' でご確認ください');
           } else {
             setTvFieldState(input, errorEl, 'error', 'このユーザー名はTradingViewに存在しません。tradingview.com/u/' + value + ' でご確認ください');
           }
@@ -8333,13 +8340,15 @@ if ('serviceWorker' in navigator) {
       }
 
       // If not yet validated (e.g. user typed too fast), validate now
-      if (tvField.dataset.tvValid !== 'true') {
-        submitBtn.textContent = 'ユーザー名を確認中...';
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
+        submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'このユーザー名はTradingViewに存在しません。tradingview.com/u/' + tvUsername + ' でご確認ください');
             alert('TradingViewユーザー名 "' + tvUsername + '" は存在しません。\n\n正しいTradingViewユーザー名を入力してください。');
             submitting = false;
@@ -8348,13 +8357,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'TradingViewでユーザー名が確認されました');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'TradingViewでユーザー名が確認されました');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/nl/index.html
+++ b/nl/index.html
@@ -7816,6 +7816,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'TradingView gebruikersnaam controleren...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -7854,6 +7859,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Gebruikersnaam geverifieerd op TradingView');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'Deze gebruikersnaam bestaat niet op TradingView. Controleer je gebruikersnaam op tradingview.com/u/' + value);
       }
@@ -7879,7 +7886,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Gebruikersnaam geverifieerd op TradingView');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Kan deze gebruikersnaam momenteel niet verifiëren. Controleer op tradingview.com/u/' + value);
+            setTvFieldState(input, errorEl, 'warn', 'Kan deze gebruikersnaam momenteel niet verifiëren. Controleer op tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Deze gebruikersnaam bestaat niet op TradingView. Controleer je profiel op tradingview.com/u/' + value);
           }
@@ -7997,13 +8004,15 @@ if ('serviceWorker' in navigator) {
         return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'This username does not exist on TradingView. Check your profile at tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
             submitting = false;
@@ -8012,13 +8021,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Username verified on TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/pt/index.html
+++ b/pt/index.html
@@ -8200,6 +8200,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'Verificando nome de usuário TradingView...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8238,6 +8243,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Nome de usuário verificado no TradingView');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'Este nome de usuário não existe no TradingView. Verifique seu nome de usuário em tradingview.com/u/' + value);
       }
@@ -8263,7 +8270,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Nome de usuário verificado no TradingView');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Não foi possível verificar este nome de usuário no momento. Verifique em tradingview.com/u/' + value);
+            setTvFieldState(input, errorEl, 'warn', 'Não foi possível verificar este nome de usuário no momento. Verifique em tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Este nome de usuário não existe no TradingView. Verifique seu perfil em tradingview.com/u/' + value);
           }
@@ -8381,13 +8388,15 @@ if ('serviceWorker' in navigator) {
         return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'Este nome de usuário não existe no TradingView. Verifique seu perfil em tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
             submitting = false;
@@ -8396,13 +8405,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Nome de usuário verificado no TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Nome de usuário verificado no TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/ru/index.html
+++ b/ru/index.html
@@ -8076,6 +8076,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'Проверка имени пользователя TradingView...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8114,6 +8119,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'Имя пользователя подтверждено на TradingView');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'Это имя пользователя не существует на TradingView. Проверьте своё имя пользователя на tradingview.com/u/' + value);
       }
@@ -8139,7 +8146,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'Имя пользователя подтверждено на TradingView');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Не удалось проверить имя пользователя. Проверьте на tradingview.com/u/' + value);
+            setTvFieldState(input, errorEl, 'warn', 'Не удалось проверить имя пользователя. Проверьте на tradingview.com/u/' + value);
           } else {
             setTvFieldState(input, errorEl, 'error', 'Это имя пользователя не существует на TradingView. Проверьте свой профиль на tradingview.com/u/' + value);
           }
@@ -8257,13 +8264,15 @@ if ('serviceWorker' in navigator) {
         return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
         submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'Это имя пользователя не существует на TradingView. Проверьте свой профиль на tradingview.com/u/' + tvUsername);
             alert('The TradingView username "' + tvUsername + '" does not exist.\n\nPlease enter your real TradingView username.');
             submitting = false;
@@ -8272,13 +8281,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'Имя пользователя подтверждено на TradingView');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'Имя пользователя подтверждено на TradingView');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }

--- a/tr/index.html
+++ b/tr/index.html
@@ -8152,6 +8152,11 @@ if ('serviceWorker' in navigator) {
       input.style.borderColor = '#3ed598';
       input.classList.add('valid');
       input.dataset.tvValid = 'true';
+    } else if (state === 'warn') {
+      if (errorEl) { errorEl.textContent = message || ''; errorEl.style.display = message ? 'block' : 'none'; errorEl.style.color = '#ffaa00'; }
+      input.style.borderColor = '#ffaa00';
+      input.classList.remove('valid');
+      input.dataset.tvValid = 'uncertain';
     } else if (state === 'loading') {
       if (errorEl) { errorEl.textContent = message || 'TradingView kullanıcı adı doğrulanıyor...'; errorEl.style.display = 'block'; errorEl.style.color = '#ffaa00'; }
       input.style.borderColor = '#ffaa00';
@@ -8190,6 +8195,8 @@ if ('serviceWorker' in navigator) {
     if (cached) {
       if (cached.valid) {
         setTvFieldState(input, errorEl, 'valid', 'TradingView\'da kullanıcı adı doğrulandı');
+      } else if (cached.uncertain) {
+        setTvFieldState(input, errorEl, 'warn', 'Could not verify this username. Please double-check it at tradingview.com/u/' + value);
       } else {
         setTvFieldState(input, errorEl, 'error', 'Bu kullanıcı adı TradingView\'da mevcut değil. tradingview.com/u/' + value + ' adresinden kontrol edin');
       }
@@ -8215,7 +8222,7 @@ if ('serviceWorker' in navigator) {
           if (data.valid && !data.uncertain) {
             setTvFieldState(input, errorEl, 'valid', 'TradingView\'da kullanıcı adı doğrulandı');
           } else if (data.uncertain) {
-            setTvFieldState(input, errorEl, 'error', 'Bu kullanıcı adı şu anda doğrulanamıyor. tradingview.com/u/' + value + ' adresinden kontrol edin');
+            setTvFieldState(input, errorEl, 'warn', 'Bu kullanıcı adı şu anda doğrulanamıyor. tradingview.com/u/' + value + ' adresinden kontrol edin');
           } else {
             setTvFieldState(input, errorEl, 'error', 'Bu kullanıcı adı TradingView\'da mevcut değil. tradingview.com/u/' + value + ' adresinden kontrol edin');
           }
@@ -8334,13 +8341,15 @@ if ('serviceWorker' in navigator) {
         return;
       }
 
-      if (tvField.dataset.tvValid !== 'true') {
-        submitBtn.textContent = 'Kullanıcı adı doğrulanıyor...';
+      if (tvField.dataset.tvValid !== 'true' && tvField.dataset.tvValid !== 'uncertain') {
+        submitBtn.textContent = 'Verifying username...';
         try {
           var vResp = await fetch('/api/validate-tv-username?username=' + encodeURIComponent(tvUsername));
           var vData = await vResp.json();
-          tvValidationCache[tvUsername.toLowerCase()] = vData;
-          if (!vData.valid) {
+          if (!vData.uncertain) {
+            tvValidationCache[tvUsername.toLowerCase()] = vData;
+          }
+          if (!vData.valid && !vData.uncertain) {
             setTvFieldState(tvField, tvError, 'error', 'Bu kullanıcı adı TradingView\'da mevcut değil. tradingview.com/u/' + tvUsername + ' adresinden kontrol edin');
             alert('"' + tvUsername + '" TradingView kullanıcı adı mevcut değil.\n\nLütfen gerçek TradingView kullanıcı adınızı girin.');
             submitting = false;
@@ -8349,13 +8358,25 @@ if ('serviceWorker' in navigator) {
             tvField.focus();
             return;
           }
-          setTvFieldState(tvField, tvError, 'valid', 'TradingView\'da kullanıcı adı doğrulandı');
+          if (vData.uncertain) {
+            setTvFieldState(tvField, tvError, 'warn', 'Could not verify this username right now. Please double-check it at tradingview.com/u/' + tvUsername);
+          } else {
+            setTvFieldState(tvField, tvError, 'valid', 'TradingView\'da kullanıcı adı doğrulandı');
+          }
         } catch (e) {
-          // Fail closed — don't allow submission without verification
-          alert('Could not verify your TradingView username. Please check your connection and try again.');
+          // Network error — allow submission with confirmation
+          setTvFieldState(tvField, tvError, 'warn', 'Could not verify username. Please double-check it at tradingview.com/u/' + tvUsername);
+        }
+      }
+
+      // If username could not be verified, let user confirm and proceed
+      if (tvField.dataset.tvValid === 'uncertain') {
+        var proceed = confirm('We could not automatically verify "' + tvUsername + '" on TradingView.\n\nPlease make sure this is your exact TradingView username.\nCheck at: tradingview.com/u/' + tvUsername + '\n\nClick OK if the username is correct, or Cancel to fix it.');
+        if (!proceed) {
           submitting = false;
           submitBtn.disabled = false;
           submitBtn.textContent = originalText;
+          tvField.focus();
           return;
         }
       }


### PR DESCRIPTION
Two issues caused valid usernames (e.g. "AxlMoB") to be incorrectly rejected:

1. Case-sensitive profile check: body.includes() matched the exact casing the user typed, but TradingView may store a different casing. Now uses case-insensitive matching via lowerBody/lowerTrimmed.

2. Cloudflare blocking treated as "not found": When Vercel's servers get a Cloudflare challenge instead of the real profile page, the API returned { valid: false, reason: 'unverifiable' } without uncertain:true. The frontend showed "does not exist" instead of allowing the user to proceed. Now returns uncertain:true and the frontend shows a warning with a confirmation dialog, letting users submit after verifying their username.

Changes across all 12 locale files + main index.html + backend API.

https://claude.ai/code/session_015BSFv5htUQ4wGMv5MXZHtD