### PR TITLE
Set permanent Twitter cron schedule: 08:00, 14:00, 20:00 UTC

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -265,15 +265,15 @@
   "crons": [
     {
       "path": "/api/social/post-twitter",
-      "schedule": "45 12 * * *"
+      "schedule": "0 8 * * *"
     },
     {
       "path": "/api/social/post-twitter",
-      "schedule": "0 17 * * *"
+      "schedule": "0 14 * * *"
     },
     {
       "path": "/api/social/post-twitter",
-      "schedule": "0 22 * * *"
+      "schedule": "0 20 * * *"
     },
     {
       "path": "/api/social/post-instagram",


### PR DESCRIPTION
Optimized for global audience coverage:
- 08:00 UTC: EU morning + Asia afternoon
- 14:00 UTC: EU afternoon + US morning (peak engagement)
- 20:00 UTC: US afternoon + EU evening

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6