### PR TITLE
Fix content parser: handle ## TWITTER/X section headers with direct c…

### DIFF
--- a/data/social/content-queue.json
+++ b/data/social/content-queue.json
@@ -116,7 +116,7 @@
     "source": "",
     "twitter": {
       "tweets": [
-        "\"The edge isn't seeing more.\n\nIt's seeing what matters.\"\n\n— Signal Pilot\n\n#TradingWisdom #TradingMindset #SignalPilot"
+        "\"The edge isn't seeing more.\n\nIt's seeing what matters.\"\n\n— Signal Pilot"
       ]
     },
     "instagram": {
@@ -143,7 +143,7 @@
     "source": "https://docs.signalpilot.io/pentarch-v10/",
     "twitter": {
       "tweets": [
-        "TD appears when selling exhausts.\n\nNot a buy signal. Not financial advice.\n\nA structural observation: the downtrend may be losing steam.\n\nWhat happens next depends on confluence.\n\nPentarch docs ↓\nhttps://docs.signalpilot.io/pentarch-v10/\n\n#Pentarch #TradingView #SignalPilot #TechnicalAnalysis"
+        "TD appears when selling exhausts.\n\nNot a buy signal. Not financial advice.\n\nA structural observation: the downtrend may be losing steam.\n\nWhat happens next depends on confluence.\n\nPentarch docs ↓\nhttps://docs.signalpilot.io/pentarch-v10/"
       ]
     },
     "instagram": {
@@ -250,7 +250,7 @@
     "source": "",
     "twitter": {
       "tweets": [
-        "\"Support doesn't hold.\n\nIt's broken to harvest your stops.\"\n\n— Signal Pilot\n\n#Liquidity #SmartMoney #TradingWisdom #SignalPilot"
+        "\"Support doesn't hold.\n\nIt's broken to harvest your stops.\"\n\n— Signal Pilot"
       ]
     },
     "instagram": {
@@ -274,7 +274,7 @@
     "source": "https://signalpilot.io",
     "twitter": {
       "tweets": [
-        "82 free lessons.\n7 non-repainting indicators.\n7-day money-back guarantee.\n\nNo alerts pinging your phone.\nNo signals telling you what to do.\n\nJust a system you learn once and keep forever.\n\nThis is Signal Pilot ↓\nhttps://signalpilot.io\n\n#SignalPilot #TradingTools #TradingView #TradingEducation"
+        "82 free lessons.\n7 non-repainting indicators.\n7-day money-back guarantee.\n\nNo alerts pinging your phone.\nNo signals telling you what to do.\n\nJust a system you learn once and keep forever.\n\nThis is Signal Pilot ↓\nhttps://signalpilot.io"
       ]
     },
     "instagram": {
@@ -298,7 +298,7 @@
     "source": "https://docs.signalpilot.io/ref-cheatsheets-pentarch/",
     "twitter": {
       "tweets": [
-        "Five signals. Five phases. One complete cycle.\n\nTD → Selling exhaustion\nIGN → Breakout confirmation\nWRN → Early weakness\nCAP → Late-cycle exhaustion\nBDN → Structure break\n\nThe Pentarch cheatsheet. Print it. Pin it. Use it ↓\nhttps://docs.signalpilot.io/ref-cheatsheets-pentarch/\n\n#Pentarch #Cheatsheet #TradingEducation #SignalPilot"
+        "Five signals. Five phases. One complete cycle.\n\nTD → Selling exhaustion\nIGN → Breakout confirmation\nWRN → Early weakness\nCAP → Late-cycle exhaustion\nBDN → Structure break\n\nThe Pentarch cheatsheet. Print it. Pin it. Use it ↓\nhttps://docs.signalpilot.io/ref-cheatsheets-pentarch/"
       ]
     },
     "instagram": {
@@ -355,7 +355,7 @@
     "source": "https://docs.signalpilot.io/volume-oracle-v10/",
     "twitter": {
       "tweets": [
-        "Volume Oracle shows:\n\n• Accumulation/Distribution phase\n• Health status\n• Structure alignment\n• Market regime\n\nAll in one panel. All without repainting.\n\nDocs ↓\nhttps://docs.signalpilot.io/volume-oracle-v10/\n\n#VolumeOracle #TradingView #SignalPilot #VolumeAnalysis"
+        "Volume Oracle shows:\n\n• Accumulation/Distribution phase\n• Health status\n• Structure alignment\n• Market regime\n\nAll in one panel. All without repainting.\n\nDocs ↓\nhttps://docs.signalpilot.io/volume-oracle-v10/"
       ]
     },
     "instagram": {
@@ -409,7 +409,7 @@
     "source": "",
     "twitter": {
       "tweets": [
-        "\"You stop chasing signals.\nYou stop stacking indicators.\nYou stop depending on strangers.\"\n\n— Signal Pilot\n\n#TradingMindset #Independence #TradingWisdom #SignalPilot"
+        "\"You stop chasing signals.\nYou stop stacking indicators.\nYou stop depending on strangers.\"\n\n— Signal Pilot"
       ]
     },
     "instagram": {
@@ -513,7 +513,7 @@
     "source": "https://signalpilot.io/#pricing",
     "twitter": {
       "tweets": [
-        "The free trial math:\n\n$69/month with 7-day money-back guarantee.\n\nFull access to all 7 indicators, all 82 lessons, all documentation for a week.\n\nIf it's not for you, full refund. No questions.\n\nStart learning ↓\nhttps://signalpilot.io/#pricing\n\n#SignalPilot #FreeTrial #TradingTools #TradingView"
+        "The free trial math:\n\n$69/month with 7-day money-back guarantee.\n\nFull access to all 7 indicators, all 82 lessons, all documentation for a week.\n\nIf it's not for you, full refund. No questions.\n\nStart learning ↓\nhttps://signalpilot.io/#pricing"
       ]
     },
     "instagram": {
@@ -593,7 +593,7 @@
     "source": "",
     "twitter": {
       "tweets": [
-        "\"Prepare for transitions.\n\nDon't chase them.\"\n\n— Signal Pilot\n\n#TradingWisdom #Patience #TradingMindset #SignalPilot"
+        "\"Prepare for transitions.\n\nDon't chase them.\"\n\n— Signal Pilot"
       ]
     },
     "instagram": {
@@ -618,7 +618,7 @@
     "source": "https://docs.signalpilot.io/janus-atlas-v10/",
     "twitter": {
       "tweets": [
-        "Most support/resistance tools make you draw lines manually.\n\nJanus Atlas calculates them automatically across multiple timeframes.\n\nThen shows you which levels matter most.\n\nSame chart. Different timeframes. One unified view ↓\nhttps://docs.signalpilot.io/janus-atlas-v10/\n\n#JanusAtlas #SupportResistance #TradingView #SignalPilot"
+        "Most support/resistance tools make you draw lines manually.\n\nJanus Atlas calculates them automatically across multiple timeframes.\n\nThen shows you which levels matter most.\n\nSame chart. Different timeframes. One unified view ↓\nhttps://docs.signalpilot.io/janus-atlas-v10/"
       ]
     },
     "instagram": {
@@ -671,7 +671,7 @@
     "source": "",
     "twitter": {
       "tweets": [
-        "\"We could send alerts.\nPing your phone.\nTell you what to buy.\n\nBut then you'd need us forever.\"\n\n— Signal Pilot\n\n#TradingEducation #Independence #SignalPilot #TradingWisdom"
+        "\"We could send alerts.\nPing your phone.\nTell you what to buy.\n\nBut then you'd need us forever.\"\n\n— Signal Pilot"
       ]
     },
     "instagram": {
@@ -776,7 +776,7 @@
     "source": "https://docs.signalpilot.io/harmonic-oscillator-v10/",
     "twitter": {
       "tweets": [
-        "Harmonic Oscillator combines 7 momentum components:\n\n• RSI\n• Stochastic RSI\n• MACD\n• Momentum\n• EMA Trend\n• Volume\n• Divergence Zone\n\nOne unified score. Divergences highlighted automatically.\n\nDocs ↓\nhttps://docs.signalpilot.io/harmonic-oscillator-v10/\n\n#HarmonicOscillator #Momentum #TradingView #SignalPilot"
+        "Harmonic Oscillator combines 7 momentum components:\n\n• RSI\n• Stochastic RSI\n• MACD\n• Momentum\n• EMA Trend\n• Volume\n• Divergence Zone\n\nOne unified score. Divergences highlighted automatically.\n\nDocs ↓\nhttps://docs.signalpilot.io/harmonic-oscillator-v10/"
       ]
     },
     "instagram": {
@@ -827,7 +827,7 @@
     "source": "https://docs.signalpilot.io/start-quick/",
     "twitter": {
       "tweets": [
-        "New to Signal Pilot?\n\nThe Quick Start guide gets you from zero to charting in 10 minutes.\n\nInstallation. Configuration. First signals.\n\nEverything you need to begin ↓\nhttps://docs.signalpilot.io/start-quick/\n\n#GettingStarted #SignalPilot #TradingView #Documentation"
+        "New to Signal Pilot?\n\nThe Quick Start guide gets you from zero to charting in 10 minutes.\n\nInstallation. Configuration. First signals.\n\nEverything you need to begin ↓\nhttps://docs.signalpilot.io/start-quick/"
       ]
     },
     "instagram": {
@@ -934,7 +934,7 @@
     "source": "",
     "twitter": {
       "tweets": [
-        "\"The goal isn't to be right. The goal is to be profitable.\"\n\nYou can win 40% of your trades and still make money.\nYou can win 80% and still lose it all.\n\nIt's never about accuracy. It's about expectancy.\n\n— Signal Pilot\n\n#TradingQuotes #TradingMindset #SignalPilot #RiskReward"
+        "\"The goal isn't to be right. The goal is to be profitable.\"\n\nYou can win 40% of your trades and still make money.\nYou can win 80% and still lose it all.\n\nIt's never about accuracy. It's about expectancy.\n\n— Signal Pilot"
       ]
     },
     "instagram": {
@@ -958,7 +958,7 @@
     "source": "https://docs.signalpilot.io/plutus-flow-v10",
     "twitter": {
       "tweets": [
-        "Volume bars lie. Cumulative flow doesn't.\n\nPlutus Flow (The Scales) shows where money may actually be moving—not just how much traded.\n\nGreen volume on a red candle? That's absorption.\nThe Scales weighs what matters.\n\n#VolumeAnalysis #PlutusFlow #SignalPilot #TradingIndicators"
+        "Volume bars lie. Cumulative flow doesn't.\n\nPlutus Flow (The Scales) shows where money may actually be moving—not just how much traded.\n\nGreen volume on a red candle? That's absorption.\nThe Scales weighs what matters."
       ]
     },
     "instagram": {
@@ -1038,7 +1038,7 @@
     "source": "https://signalpilot.io/chronicle/the-scales/",
     "twitter": {
       "tweets": [
-        "\"Price is opinion. Flow is fact.\"\n— Plutus, The Scales\n\nWhile others debate direction, The Scales simply weighs the evidence.\n\nWhere is money actually moving? The answer is in the flow.\n\n#SignalPilot #Chronicle #PlutusFlow #TheScales"
+        "\"Price is opinion. Flow is fact.\"\n— Plutus, The Scales\n\nWhile others debate direction, The Scales simply weighs the evidence.\n\nWhere is money actually moving? The answer is in the flow."
       ]
     },
     "instagram": {
@@ -1089,7 +1089,7 @@
     "source": "https://docs.signalpilot.io/ref-cheatsheets-plutus",
     "twitter": {
       "tweets": [
-        "Plutus Flow Cheatsheet:\n\n📈 Flow rising + Price rising = Trend may be confirmed\n📈 Flow rising + Price falling = Possible accumulation\n📉 Flow falling + Price rising = Possible distribution\n📉 Flow falling + Price falling = Trend may be confirmed\n\nDivergence is the signal.\n\n#PlutusFlow #Cheatsheet #TradingIndicators #SignalPilot"
+        "Plutus Flow Cheatsheet:\n\n📈 Flow rising + Price rising = Trend may be confirmed\n📈 Flow rising + Price falling = Possible accumulation\n📉 Flow falling + Price rising = Possible distribution\n📉 Flow falling + Price falling = Trend may be confirmed\n\nDivergence is the signal."
       ]
     },
     "instagram": {
@@ -1112,7 +1112,7 @@
     "source": "https://signalpilot.io/",
     "twitter": {
       "tweets": [
-        "7 indicators. 82 free lessons. 1 platform.\n\n👑 The Sovereign (Pentarch) — Cycles\n🔮 The Prophet (Volume Oracle) — Regimes\n🗺️ The Cartographer (Janus Atlas) — Levels\n⚖️ The Scales (Plutus Flow) — Flow\n⚔️ The Arbiter (Harmonic Oscillator) — Momentum\n👁️ The Watchman (Augury Grid) — Scanner\n🎯 The Commander (OmniDeck) — Unified\n\nSignal Pilot. Education first.\n\n#SignalPilot #EliteSeven #TradingIndicators #TradingView #TradingEducation"
+        "7 indicators. 82 free lessons. 1 platform.\n\n👑 The Sovereign (Pentarch) — Cycles\n🔮 The Prophet (Volume Oracle) — Regimes\n🗺️ The Cartographer (Janus Atlas) — Levels\n⚖️ The Scales (Plutus Flow) — Flow\n⚔️ The Arbiter (Harmonic Oscillator) — Momentum\n👁️ The Watchman (Augury Grid) — Scanner\n🎯 The Commander (OmniDeck) — Unified\n\nSignal Pilot. Education first."
       ]
     },
     "instagram": {
@@ -1189,7 +1189,7 @@
     "source": "",
     "twitter": {
       "tweets": [
-        "\"Amateur traders focus on entries. Professional traders focus on exits.\"\n\nYour entry doesn't determine your profit.\nYour exit does.\n\nPlan the exit before you enter.\n\n— Signal Pilot\n\n#TradingQuotes #ExitStrategy #TradingWisdom #SignalPilot"
+        "\"Amateur traders focus on entries. Professional traders focus on exits.\"\n\nYour entry doesn't determine your profit.\nYour exit does.\n\nPlan the exit before you enter.\n\n— Signal Pilot"
       ]
     },
     "instagram": {
@@ -1213,7 +1213,7 @@
     "source": "https://docs.signalpilot.io/augury-grid-v10",
     "twitter": {
       "tweets": [
-        "One chart. Multiple symbols. Real-time scanning.\n\nAugury Grid (The Watchman) monitors your entire watchlist without switching tabs.\n\nSee which assets may be setting up. All at once.\n\nStop missing moves while watching one chart.\n\n#AuguryGrid #Scanner #TradingIndicators #SignalPilot #TradingView"
+        "One chart. Multiple symbols. Real-time scanning.\n\nAugury Grid (The Watchman) monitors your entire watchlist without switching tabs.\n\nSee which assets may be setting up. All at once.\n\nStop missing moves while watching one chart."
       ]
     },
     "instagram": {
@@ -1292,7 +1292,7 @@
     "source": "https://signalpilot.io/chronicle/the-arbiter/",
     "twitter": {
       "tweets": [
-        "\"Momentum without context is noise. Context without momentum is hesitation.\"\n— The Arbiter\n\nThe Harmonic Oscillator doesn't just measure speed.\nIt measures agreement between forces.\n\nWhen they align, movement follows.\n\n#SignalPilot #Chronicle #HarmonicOscillator #TheArbiter"
+        "\"Momentum without context is noise. Context without momentum is hesitation.\"\n— The Arbiter\n\nThe Harmonic Oscillator doesn't just measure speed.\nIt measures agreement between forces.\n\nWhen they align, movement follows."
       ]
     },
     "instagram": {
@@ -1342,7 +1342,7 @@
     "source": "https://docs.signalpilot.io/start-quick",
     "twitter": {
       "tweets": [
-        "Signal Pilot Quick Start:\n\n1. Add indicators to TradingView\n2. Start with Pentarch (cycles) or Volume Oracle (regimes)\n3. Complete beginner lessons (free)\n4. Paper trade first\n5. Graduate to live when consistent\n\nEducation before execution.\n\n#SignalPilot #GettingStarted #TradingEducation #TradingView"
+        "Signal Pilot Quick Start:\n\n1. Add indicators to TradingView\n2. Start with Pentarch (cycles) or Volume Oracle (regimes)\n3. Complete beginner lessons (free)\n4. Paper trade first\n5. Graduate to live when consistent\n\nEducation before execution."
       ]
     },
     "instagram": {
@@ -1366,7 +1366,7 @@
     "source": "https://signalpilot.io/",
     "twitter": {
       "tweets": [
-        "Not sure if Signal Pilot is right for you?\n\n7-day money-back guarantee. No questions asked.\n\nTry the indicators. Go through the lessons. Test it yourself.\n\nIf it's not for you, full refund. Simple.\n\n#SignalPilot #MoneyBackGuarantee #TradingIndicators #RiskFree #TradingView"
+        "Not sure if Signal Pilot is right for you?\n\n7-day money-back guarantee. No questions asked.\n\nTry the indicators. Go through the lessons. Test it yourself.\n\nIf it's not for you, full refund. Simple."
       ]
     },
     "instagram": {
@@ -1441,7 +1441,7 @@
     "source": "",
     "twitter": {
       "tweets": [
-        "\"The market is a device for transferring money from the impatient to the patient.\"\n\nEvery panic sell funds someone's accumulation.\nEvery FOMO buy funds someone's distribution.\n\nWhich side are you on?\n\n— Signal Pilot\n\n#TradingQuotes #Patience #TradingWisdom #SignalPilot"
+        "\"The market is a device for transferring money from the impatient to the patient.\"\n\nEvery panic sell funds someone's accumulation.\nEvery FOMO buy funds someone's distribution.\n\nWhich side are you on?\n\n— Signal Pilot"
       ]
     },
     "instagram": {
@@ -1465,7 +1465,7 @@
     "source": "https://docs.signalpilot.io/omnideck-v10",
     "twitter": {
       "tweets": [
-        "Too many indicators cluttering your chart?\n\nOmniDeck (The Commander) unifies everything into one clean overlay.\n\nCycles, levels, momentum, flow—all coordinated.\n\nOne indicator to command them all.\n\n#OmniDeck #TradingIndicators #SignalPilot #TradingView #CleanCharts"
+        "Too many indicators cluttering your chart?\n\nOmniDeck (The Commander) unifies everything into one clean overlay.\n\nCycles, levels, momentum, flow—all coordinated.\n\nOne indicator to command them all."
       ]
     },
     "instagram": {
@@ -1542,7 +1542,7 @@
     "source": "https://signalpilot.io/chronicle/the-watchman/",
     "twitter": {
       "tweets": [
-        "\"While you watch one, I watch all.\"\n— The Watchman\n\nAugury Grid doesn't sleep. It scans.\n\nOpportunities don't wait. Neither should you.\n\n#SignalPilot #Chronicle #AuguryGrid #TheWatchman"
+        "\"While you watch one, I watch all.\"\n— The Watchman\n\nAugury Grid doesn't sleep. It scans.\n\nOpportunities don't wait. Neither should you."
       ]
     },
     "instagram": {
@@ -1593,7 +1593,7 @@
     "source": "https://docs.signalpilot.io/harmonic-oscillator-v10",
     "twitter": {
       "tweets": [
-        "Harmonic Oscillator settings guide:\n\nDefault: Balanced for most markets\nFaster: More signals, more noise\nSlower: Fewer signals, more reliable\n\nMatch your settings to your timeframe and style.\n\nNo single setting works for everything.\n\n#HarmonicOscillator #IndicatorSettings #SignalPilot #TradingView"
+        "Harmonic Oscillator settings guide:\n\nDefault: Balanced for most markets\nFaster: More signals, more noise\nSlower: Fewer signals, more reliable\n\nMatch your settings to your timeframe and style.\n\nNo single setting works for everything."
       ]
     },
     "instagram": {

--- a/lib/social/content-parser.js
+++ b/lib/social/content-parser.js
@@ -39,6 +39,15 @@ function parsePart1Post(block) {
     }
   }
 
+  // Format 3: "## TWITTER/X — ..." section header with direct code block
+  if (tweets.length === 0) {
+    const sectionMatch = block.match(/^#{2,3}\s+TWITTER\/X[^\n]*\n+```\n([\s\S]*?)```/m);
+    if (sectionMatch) {
+      const text = sectionMatch[1].trim();
+      if (text) tweets.push(text);
+    }
+  }
+
   // Extract Instagram caption - try multiple formats
   let instagramCaption = '';
 


### PR DESCRIPTION
…ode blocks

The parser only matched ### Tweet N: and ### Twitter/X Copy formats, missing 27 posts that use ## TWITTER/X — Single Tweet with a code block directly under the section header. The build regenerates content-queue.json, so the previous hand-backfill was overwritten on every deploy.

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6