### PR TITLE
fix(post-050): change Signal Pilot logo from grey to teal

### DIFF
--- a/INSTAGRAM_CONTENT_HUB/social/post-050/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-050/carousel.html
@@ -325,7 +325,7 @@
       font-size: clamp(0.4rem, 1.2cqw, 0.625rem);
       letter-spacing: 0.3em;
       text-transform: uppercase;
-      color: rgba(255,255,255,0.25);
+      color: rgba(94,234,212,0.4);
       z-index: 2;
       white-space: nowrap;
     }
@@ -339,7 +339,7 @@
       font-size: clamp(0.4rem, 1.2cqw, 0.625rem);
       letter-spacing: 0.3em;
       text-transform: uppercase;
-      color: rgba(255,255,255,0.25);
+      color: rgba(94,234,212,0.4);
       z-index: 2;
       white-space: nowrap;
     }


### PR DESCRIPTION
Teal posts should have teal-colored logos rgba(94,234,212,0.4) matching the post's accent color, not neutral white.

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6