### PR TITLE
Fix post-060 slide 1 centering: remove margin-top:auto from oscillato…

### DIFF
--- a/INSTAGRAM_CONTENT_HUB/social/post-060/carousel.html
+++ b/INSTAGRAM_CONTENT_HUB/social/post-060/carousel.html
@@ -81,7 +81,6 @@
       letter-spacing: 0.3em;
       text-transform: uppercase;
       margin-bottom: clamp(1rem, 4cqw, 2.5rem);
-      margin-top: clamp(1.5rem, 6cqw, 4rem);
     }
     .slide-1 .hook-question {
       font-family: var(--font-serif);
@@ -109,8 +108,8 @@
       color: rgba(94,234,212,0.9);
     }
     .slide-1 .oscillator-preview {
-      margin-top: auto;
-      margin-bottom: clamp(1.5rem, 5cqw, 3rem);
+      margin-top: clamp(1.5rem, 4cqw, 2.5rem);
+      margin-bottom: 0;
       height: clamp(2rem, 7cqw, 4rem);
       width: 100%;
       position: relative;


### PR DESCRIPTION
…r-preview

The oscillator-preview had margin-top:auto which absorbed all free space above it in the flex container, pushing the hook text to the top instead of centering. Also removed extra margin-top from hook-label.

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6