### PR TITLE
Fix slide count: use HTTP HEAD probes instead of filesystem reads

### DIFF
--- a/api/social/post-instagram.js
+++ b/api/social/post-instagram.js
@@ -21,8 +21,8 @@ import {
   clearRetryCount,
 } from '../../lib/social/queue-manager.js';
 import { getPostNumber, getInstagramColumn } from '../../lib/social/posting-schedule.js';
-import { postCarousel } from '../../lib/social/instagram-client.js';
-import { readFileSync, readdirSync, existsSync } from 'fs';
+import { postCarousel, SITE_URL } from '../../lib/social/instagram-client.js';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 
 let contentCache = null;
@@ -36,14 +36,26 @@ function loadContent() {
 }
 
 /**
- * Count how many slide PNGs exist for a post
+ * Count how many slide PNGs exist for a post by probing public URLs.
+ * Vercel serves static assets via CDN but doesn't include them in the
+ * serverless function bundle, so filesystem reads fail. HEAD requests
+ * against the public URL are reliable and also validate that Instagram
+ * can actually fetch the images.
  */
-function getSlideCount(postNumber) {
+async function getSlideCount(postNumber) {
   const paddedNum = String(postNumber).padStart(3, '0');
-  const dir = join(process.cwd(), 'assets', 'social', `post-${paddedNum}`);
-  if (!existsSync(dir)) return 0;
-  const files = readdirSync(dir).filter(f => f.startsWith('slide-') && f.endsWith('.png'));
-  return files.length;
+  let count = 0;
+  for (let i = 1; i <= 10; i++) {
+    const url = `${SITE_URL}/assets/social/post-${paddedNum}/slide-${i}.png`;
+    try {
+      const res = await fetch(url, { method: 'HEAD' });
+      if (res.ok) count++;
+      else break;
+    } catch {
+      break;
+    }
+  }
+  return count;
 }
 
 export default async function handler(req, res) {
@@ -102,22 +114,20 @@ export default async function handler(req, res) {
 
     if (!post) {
       await logError({ platform: 'instagram', postOrder, postNumber, action: 'error', reason: 'Post not found' });
-      await setLastPosted('instagram', postOrder);
       return res.status(200).json({ success: false, error: `Post ${postNumber} not found` });
     }
 
     const caption = post.instagram?.caption;
     if (!caption) {
       await logError({ platform: 'instagram', postOrder, postNumber, column, action: 'error', reason: 'No caption' });
-      await setLastPosted('instagram', postOrder);
       return res.status(200).json({ success: false, error: `Post ${postNumber} has no caption` });
     }
 
-    // Count actual slides (posts have 4-10 slides, not always 10)
-    const slideCount = getSlideCount(postNumber);
+    // Count actual slides via public URL (Vercel doesn't expose static assets to functions)
+    const slideCount = await getSlideCount(postNumber);
     if (slideCount < 2) {
+      await incrementRetryCount('instagram', postOrder);
       await logError({ platform: 'instagram', postOrder, postNumber, column, action: 'error', reason: `Only ${slideCount} slide(s) (need 2+)` });
-      await setLastPosted('instagram', postOrder);
       return res.status(200).json({ success: false, error: `Post ${postNumber} has ${slideCount} slide(s) (need 2+)` });
     }
 


### PR DESCRIPTION
Vercel serves static assets via CDN but doesn't include them in the serverless function bundle. Also stop advancing queue on errors (missing slides/caption/post) so posts retry instead of being skipped.

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6