### PR TITLE
Fix IGAAM token refresh and add Instagram checks to diagnose endpoint

### DIFF
--- a/api/social/diagnose.js
+++ b/api/social/diagnose.js
@@ -1,10 +1,11 @@
 // GET /api/social/diagnose
-// Full system health check — tests Redis, Twitter API, queue state, and next post validity
+// Full system health check — tests Redis, Twitter API, Instagram API, queue state, and next post validity
 // Hit this endpoint to see EXACTLY why posts aren't going through
 
 import { getStatus, getPostingLog, getErrorLog, isPaused, getNextPostOrder, shouldSkipPost, getRetryCount, wasRecentlyPosted } from '../../lib/social/queue-manager.js';
-import { getPostNumber } from '../../lib/social/posting-schedule.js';
+import { getPostNumber, getInstagramColumn } from '../../lib/social/posting-schedule.js';
 import { verifyCredentials } from '../../lib/social/twitter-client.js';
+import { verifyToken, detectTokenType } from '../../lib/social/instagram-client.js';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
@@ -28,6 +29,10 @@ export default async function handler(req, res) {
 
   // ── 1. Environment Variables ──────────────────────────────────────
   const envChecks = {
+    INSTAGRAM_ACCESS_TOKEN: !!process.env.INSTAGRAM_ACCESS_TOKEN,
+    INSTAGRAM_BUSINESS_ACCOUNT_ID: !!process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID,
+    FACEBOOK_APP_ID: !!process.env.FACEBOOK_APP_ID,
+    FACEBOOK_APP_SECRET: !!process.env.FACEBOOK_APP_SECRET,
     TWITTER_API_KEY: !!process.env.TWITTER_API_KEY,
     TWITTER_API_SECRET: !!process.env.TWITTER_API_SECRET,
     TWITTER_ACCESS_TOKEN: !!process.env.TWITTER_ACCESS_TOKEN,
@@ -72,25 +77,72 @@ export default async function handler(req, res) {
     report.errors.push(`Twitter API failed: ${err.message}`);
   }
 
+  // ── 3b. Instagram API Credentials ──────────────────────────────────
+  try {
+    const tokenType = detectTokenType();
+    const igCreds = await verifyToken();
+    report.checks.instagramApi = {
+      status: 'PASS',
+      tokenType,
+      userId: igCreds.userId,
+      name: igCreds.name,
+      tokenExpiresAt: igCreds.expiresAt,
+      accountId: process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID ? `...${process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID.slice(-6)}` : 'NOT SET',
+    };
+    // Warn if token expires within 7 days
+    if (igCreds.expiresAt && igCreds.expiresAt !== 'unknown') {
+      const daysUntilExpiry = (new Date(igCreds.expiresAt) - new Date()) / (1000 * 60 * 60 * 24);
+      if (daysUntilExpiry < 7) {
+        report.checks.instagramApi.status = 'WARN';
+        report.errors.push(`Instagram token expires in ${Math.round(daysUntilExpiry)} day(s) — refresh ASAP`);
+      }
+    }
+  } catch (err) {
+    report.checks.instagramApi = { status: 'FAIL', error: err.message };
+    report.errors.push(`Instagram API failed: ${err.message}`);
+  }
+
   // ── 4. Queue State (paused? stuck? idempotency?) ──────────────────
   try {
     const paused = await isPaused();
-    const recentlyPosted = await wasRecentlyPosted('twitter', 300000);
-    const nextOrder = await getNextPostOrder('twitter');
-    const retries = await getRetryCount('twitter', nextOrder);
-    const shouldSkip = await shouldSkipPost('twitter', nextOrder);
+
+    // Twitter queue state
+    const twRecentlyPosted = await wasRecentlyPosted('twitter', 300000);
+    const twNextOrder = await getNextPostOrder('twitter');
+    const twRetries = await getRetryCount('twitter', twNextOrder);
+    const twShouldSkip = await shouldSkipPost('twitter', twNextOrder);
+
+    // Instagram queue state
+    const igRecentlyPosted = await wasRecentlyPosted('instagram', 300000);
+    const igNextOrder = await getNextPostOrder('instagram');
+    const igRetries = await getRetryCount('instagram', igNextOrder);
+    const igShouldSkip = await shouldSkipPost('instagram', igNextOrder);
+    const igPostNumber = getPostNumber('instagram', igNextOrder);
+    const igColumn = getInstagramColumn(igNextOrder);
 
     report.checks.queueState = {
-      status: (paused || shouldSkip) ? 'BLOCKED' : 'PASS',
+      status: (paused || twShouldSkip || igShouldSkip) ? 'BLOCKED' : 'PASS',
       paused,
-      recentlyPosted,
-      nextPostOrder: nextOrder,
-      retriesOnNextPost: retries,
-      wouldSkipNextPost: shouldSkip,
+      twitter: {
+        recentlyPosted: twRecentlyPosted,
+        nextPostOrder: twNextOrder,
+        retriesOnNextPost: twRetries,
+        wouldSkipNextPost: twShouldSkip,
+      },
+      instagram: {
+        recentlyPosted: igRecentlyPosted,
+        nextPostOrder: igNextOrder,
+        nextPostNumber: igPostNumber,
+        nextColumn: igColumn,
+        retriesOnNextPost: igRetries,
+        wouldSkipNextPost: igShouldSkip,
+      },
     };
     if (paused) report.errors.push('Queue is PAUSED — posts will not fire');
-    if (shouldSkip) report.errors.push(`Post order ${nextOrder} hit max retries (${retries}) — will be skipped`);
-    if (recentlyPosted) report.errors.push('Idempotency guard active — posted within last 5 minutes');
+    if (twShouldSkip) report.errors.push(`Twitter post order ${twNextOrder} hit max retries (${twRetries}) — will be skipped`);
+    if (igShouldSkip) report.errors.push(`Instagram post order ${igNextOrder} hit max retries (${igRetries}) — will be skipped`);
+    if (twRecentlyPosted) report.errors.push('Twitter idempotency guard active — posted within last 5 minutes');
+    if (igRecentlyPosted) report.errors.push('Instagram idempotency guard active — posted within last 5 minutes');
   } catch (err) {
     report.checks.queueState = { status: 'FAIL', error: err.message };
     report.errors.push(`Queue state check failed: ${err.message}`);
@@ -108,6 +160,8 @@ export default async function handler(req, res) {
         status: 'PASS',
         totalPosts: posts.length,
         postsWithTwitter: posts.filter(p => p.twitter && p.twitter.tweets && p.twitter.tweets.length > 0).length,
+        postsWithInstagram: posts.filter(p => p.instagram && p.instagram.caption).length,
+        postsWithSlides: posts.filter(p => p.instagram && p.instagram.slideCount >= 2).length,
       };
     }
   } catch (err) {
@@ -115,7 +169,7 @@ export default async function handler(req, res) {
     report.errors.push(`Content queue error: ${err.message}`);
   }
 
-  // ── 6. Next Post Validation ───────────────────────────────────────
+  // ── 6. Next Post Validation (Twitter) ────────────────────────────
   try {
     const nextOrder = await getNextPostOrder('twitter');
     const postNumber = getPostNumber('twitter', nextOrder);
@@ -124,12 +178,12 @@ export default async function handler(req, res) {
     const post = posts.find(p => p.postNumber === postNumber);
 
     if (!post) {
-      report.checks.nextPost = { status: 'FAIL', postOrder: nextOrder, postNumber, error: 'Post not found in queue' };
-      report.errors.push(`Next post #${postNumber} (order ${nextOrder}) not found in content-queue.json`);
+      report.checks.nextTwitterPost = { status: 'FAIL', postOrder: nextOrder, postNumber, error: 'Post not found in queue' };
+      report.errors.push(`Next Twitter post #${postNumber} (order ${nextOrder}) not found in content-queue.json`);
     } else {
       const tweets = post.twitter?.tweets || [];
       const longTweets = tweets.filter(t => t.length > 280);
-      report.checks.nextPost = {
+      report.checks.nextTwitterPost = {
         status: longTweets.length > 0 ? 'WARN' : 'PASS',
         postOrder: nextOrder,
         postNumber,
@@ -139,11 +193,49 @@ export default async function handler(req, res) {
         longTweets: longTweets.map((t, i) => ({ index: tweets.indexOf(t), length: t.length, preview: t.substring(0, 60) + '...' })),
       };
       if (longTweets.length > 0) {
-        report.errors.push(`Next post has ${longTweets.length} tweet(s) over 280 chars — will fail Twitter API`);
+        report.errors.push(`Next Twitter post has ${longTweets.length} tweet(s) over 280 chars — will fail Twitter API`);
       }
     }
   } catch (err) {
-    report.checks.nextPost = { status: 'FAIL', error: err.message };
+    report.checks.nextTwitterPost = { status: 'FAIL', error: err.message };
+  }
+
+  // ── 6b. Next Post Validation (Instagram) ───────────────────────────
+  try {
+    const igNextOrder = await getNextPostOrder('instagram');
+    const igPostNumber = getPostNumber('instagram', igNextOrder);
+    const igColumn = getInstagramColumn(igNextOrder);
+    const filePath = join(process.cwd(), 'data', 'social', 'content-queue.json');
+    const posts = JSON.parse(readFileSync(filePath, 'utf-8'));
+    const post = posts.find(p => p.postNumber === igPostNumber);
+
+    if (!post) {
+      report.checks.nextInstagramPost = { status: 'FAIL', postOrder: igNextOrder, postNumber: igPostNumber, column: igColumn, error: 'Post not found in queue' };
+      report.errors.push(`Next Instagram post #${igPostNumber} (order ${igNextOrder}, ${igColumn}) not found in content-queue.json`);
+    } else {
+      const caption = post.instagram?.caption;
+      const slideCount = post.instagram?.slideCount || 0;
+      const issues = [];
+      if (!caption) issues.push('No caption');
+      if (slideCount < 2) issues.push(`Only ${slideCount} slide(s) — need 2+`);
+
+      report.checks.nextInstagramPost = {
+        status: issues.length > 0 ? 'FAIL' : 'PASS',
+        postOrder: igNextOrder,
+        postNumber: igPostNumber,
+        column: igColumn,
+        title: post.title,
+        slideCount,
+        hasCaption: !!caption,
+        captionLength: caption ? caption.length : 0,
+        issues,
+      };
+      if (issues.length > 0) {
+        report.errors.push(`Next Instagram post #${igPostNumber}: ${issues.join(', ')}`);
+      }
+    }
+  } catch (err) {
+    report.checks.nextInstagramPost = { status: 'FAIL', error: err.message };
   }
 
   // ── 7. Recent Error Log ───────────────────────────────────────────

--- a/api/social/refresh-ig-token.js
+++ b/api/social/refresh-ig-token.js
@@ -35,6 +35,7 @@ export default async function handler(req, res) {
     return res.status(200).json({
       success: true,
       message: 'Token refreshed. Update INSTAGRAM_ACCESS_TOKEN in Vercel env vars with the new token.',
+      tokenType: result.token_type,
       newToken: result.access_token,
       expiresInDays: Math.round(result.expires_in / 86400),
     });

--- a/lib/social/instagram-client.js
+++ b/lib/social/instagram-client.js
@@ -184,26 +184,53 @@ async function postCarousel(postNumber, slideCount, caption) {
 }
 
 /**
+ * Detect whether the token is from Instagram Login (IGAAM) or Facebook Login (EAA)
+ * @returns {'instagram' | 'facebook'} Token type
+ */
+function detectTokenType() {
+  const { accessToken } = getConfig();
+  if (accessToken.startsWith('IGAAM') || accessToken.startsWith('IGQVJ')) {
+    return 'instagram';
+  }
+  return 'facebook';
+}
+
+/**
  * Refresh a long-lived token (they expire every 60 days)
  * Should be called weekly via cron to keep the token fresh
- * @returns {{ access_token: string, expires_in: number }}
+ *
+ * Supports both token types:
+ * - IGAAM tokens (Instagram Login): uses grant_type=ig_refresh_token
+ * - EAA tokens (Facebook Login): uses grant_type=fb_exchange_token
+ *
+ * @returns {{ access_token: string, expires_in: number, token_type: string }}
  */
 async function refreshLongLivedToken() {
   const { accessToken } = getConfig();
-  const url = `${GRAPH_API_BASE}/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.FACEBOOK_APP_ID}&client_secret=${process.env.FACEBOOK_APP_SECRET}&fb_exchange_token=${accessToken}`;
+  const tokenType = detectTokenType();
+
+  let url;
+  if (tokenType === 'instagram') {
+    // Instagram Login tokens use ig_refresh_token — no app secret needed
+    url = `${GRAPH_API_BASE}/refresh_access_token?grant_type=ig_refresh_token&access_token=${accessToken}`;
+  } else {
+    // Facebook Login tokens use fb_exchange_token
+    url = `${GRAPH_API_BASE}/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.FACEBOOK_APP_ID}&client_secret=${process.env.FACEBOOK_APP_SECRET}&fb_exchange_token=${accessToken}`;
+  }
 
   const response = await fetch(url);
   const data = await response.json();
 
   if (data.error) {
     throw new Error(
-      `Token refresh failed: ${data.error.message} (code: ${data.error.code})`
+      `Token refresh failed (${tokenType} flow): ${data.error.message} (code: ${data.error.code})`
     );
   }
 
   return {
     access_token: data.access_token,
     expires_in: data.expires_in,
+    token_type: tokenType,
   };
 }
 
@@ -240,6 +267,7 @@ export {
   getSlideUrl,
   refreshLongLivedToken,
   verifyToken,
+  detectTokenType,
   checkContainerStatus,
   SITE_URL,
 };


### PR DESCRIPTION
The token refresh was hardcoded to use fb_exchange_token (Facebook Login flow) which fails for IGAAM tokens (Instagram Login flow). Now auto-detects token type by prefix and uses the correct refresh grant_type (ig_refresh_token vs fb_exchange_token).

The diagnose endpoint was completely blind to Instagram — no env var checks, no API token verification, no IG queue state, no next-post validation. Added full Instagram diagnostics: token type detection, expiry warnings, queue state for both platforms, and next Instagram post validation (caption + slide count).

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6