### PR TITLE
Fix IGAAM token support: use graph.instagram.com for Instagram Login …

### DIFF
--- a/lib/social/instagram-client.js
+++ b/lib/social/instagram-client.js
@@ -9,7 +9,8 @@
 // Images are served from the Vercel deployment at:
 // https://www.signalpilot.io/assets/social/post-XXX/slide-N.png
 
-const GRAPH_API_BASE = 'https://graph.facebook.com/v21.0';
+const FACEBOOK_GRAPH_BASE = 'https://graph.facebook.com/v21.0';
+const INSTAGRAM_GRAPH_BASE = 'https://graph.instagram.com/v21.0';
 const SITE_URL = 'https://www.signalpilot.io';
 
 function getConfig() {
@@ -26,11 +27,24 @@ function getConfig() {
 }
 
 /**
+ * Get the correct Graph API base URL for the current token type
+ * IGAAM tokens (Instagram Login) → graph.instagram.com
+ * EAA tokens (Facebook Login) → graph.facebook.com
+ */
+function getGraphBase() {
+  const { accessToken } = getConfig();
+  if (accessToken.startsWith('IGAAM') || accessToken.startsWith('IGQVJ')) {
+    return INSTAGRAM_GRAPH_BASE;
+  }
+  return FACEBOOK_GRAPH_BASE;
+}
+
+/**
  * Make a Graph API request with error handling
  */
 async function graphRequest(endpoint, params = {}, method = 'POST') {
   const { accessToken } = getConfig();
-  const url = `${GRAPH_API_BASE}${endpoint}`;
+  const url = `${getGraphBase()}${endpoint}`;
 
   const body = new URLSearchParams({
     access_token: accessToken,
@@ -116,7 +130,7 @@ async function publishMedia(containerId) {
  */
 async function checkContainerStatus(containerId) {
   const { accessToken } = getConfig();
-  const url = `${GRAPH_API_BASE}/${containerId}?fields=status,status_code&access_token=${accessToken}`;
+  const url = `${getGraphBase()}/${containerId}?fields=status,status_code&access_token=${accessToken}`;
   const response = await fetch(url);
   return response.json();
 }
@@ -212,10 +226,10 @@ async function refreshLongLivedToken() {
   let url;
   if (tokenType === 'instagram') {
     // Instagram Login tokens use ig_refresh_token — no app secret needed
-    url = `${GRAPH_API_BASE}/refresh_access_token?grant_type=ig_refresh_token&access_token=${accessToken}`;
+    url = `${INSTAGRAM_GRAPH_BASE}/refresh_access_token?grant_type=ig_refresh_token&access_token=${accessToken}`;
   } else {
     // Facebook Login tokens use fb_exchange_token
-    url = `${GRAPH_API_BASE}/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.FACEBOOK_APP_ID}&client_secret=${process.env.FACEBOOK_APP_SECRET}&fb_exchange_token=${accessToken}`;
+    url = `${FACEBOOK_GRAPH_BASE}/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.FACEBOOK_APP_ID}&client_secret=${process.env.FACEBOOK_APP_SECRET}&fb_exchange_token=${accessToken}`;
   }
 
   const response = await fetch(url);
@@ -240,7 +254,7 @@ async function refreshLongLivedToken() {
  */
 async function verifyToken() {
   const { accessToken } = getConfig();
-  const url = `${GRAPH_API_BASE}/me?fields=id,name&access_token=${accessToken}`;
+  const url = `${getGraphBase()}/me?fields=id,name&access_token=${accessToken}`;
   const response = await fetch(url);
   const data = await response.json();
 
@@ -249,7 +263,7 @@ async function verifyToken() {
   }
 
   // Also check token expiry
-  const debugUrl = `${GRAPH_API_BASE}/debug_token?input_token=${accessToken}&access_token=${accessToken}`;
+  const debugUrl = `${getGraphBase()}/debug_token?input_token=${accessToken}&access_token=${accessToken}`;
   const debugResponse = await fetch(debugUrl);
   const debugData = await debugResponse.json();
 
@@ -268,6 +282,7 @@ export {
   refreshLongLivedToken,
   verifyToken,
   detectTokenType,
+  getGraphBase,
   checkContainerStatus,
   SITE_URL,
 };


### PR DESCRIPTION
…tokens

IGAAM tokens from Instagram Login only work with graph.instagram.com, not graph.facebook.com. Detect token type and route to correct API host.

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6