### PR TITLE
Fix IGAAM token account ID: resolve Instagram user ID via /me instead…

### DIFF
--- a/api/social/diagnose.js
+++ b/api/social/diagnose.js
@@ -5,7 +5,7 @@
 import { getStatus, getPostingLog, getErrorLog, isPaused, getNextPostOrder, shouldSkipPost, getRetryCount, wasRecentlyPosted } from '../../lib/social/queue-manager.js';
 import { getPostNumber, getInstagramColumn } from '../../lib/social/posting-schedule.js';
 import { verifyCredentials } from '../../lib/social/twitter-client.js';
-import { verifyToken, detectTokenType } from '../../lib/social/instagram-client.js';
+import { verifyToken, detectTokenType, resolveAccountId } from '../../lib/social/instagram-client.js';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
@@ -81,13 +81,15 @@ export default async function handler(req, res) {
   try {
     const tokenType = detectTokenType();
     const igCreds = await verifyToken();
+    const resolvedId = await resolveAccountId().catch(() => null);
     report.checks.instagramApi = {
       status: 'PASS',
       tokenType,
       userId: igCreds.userId,
       name: igCreds.name,
       tokenExpiresAt: igCreds.expiresAt,
-      accountId: process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID ? `...${process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID.slice(-6)}` : 'NOT SET',
+      envAccountId: process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID ? `...${process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID.slice(-6)}` : 'NOT SET',
+      resolvedAccountId: resolvedId ? `...${resolvedId.slice(-6)}` : 'FAILED',
     };
     // Warn if token expires within 7 days
     if (igCreds.expiresAt && igCreds.expiresAt !== 'unknown') {

--- a/api/social/post-instagram.js
+++ b/api/social/post-instagram.js
@@ -71,7 +71,10 @@ export default async function handler(req, res) {
       return res.status(200).json({ success: true, skipped: true, reason: 'No more posts in queue' });
     }
 
-    // Check retry limit
+    // Check retry limit (force=true clears retries so manual posts always attempt)
+    if (force) {
+      await clearRetryCount('instagram', postOrder);
+    }
     if (await shouldSkipPost('instagram', postOrder)) {
       await setLastPosted('instagram', postOrder);
       await logError({

--- a/lib/social/instagram-client.js
+++ b/lib/social/instagram-client.js
@@ -27,6 +27,39 @@ function getConfig() {
 }
 
 /**
+ * Resolve the correct account ID for the current token type.
+ * - IGAAM tokens (Instagram Login) → use the Instagram user ID from /me
+ *   (INSTAGRAM_BUSINESS_ACCOUNT_ID is typically a Facebook Page ID which
+ *    doesn't work on graph.instagram.com)
+ * - EAA tokens (Facebook Login) → use INSTAGRAM_BUSINESS_ACCOUNT_ID as-is
+ *
+ * Result is cached for the lifetime of the serverless invocation.
+ */
+let _resolvedAccountId = null;
+
+async function resolveAccountId() {
+  if (_resolvedAccountId) return _resolvedAccountId;
+
+  const { accessToken, accountId } = getConfig();
+  const tokenType = detectTokenType();
+
+  if (tokenType === 'instagram') {
+    // For IGAAM tokens, query /me on graph.instagram.com to get the real IG user ID
+    const url = `${INSTAGRAM_GRAPH_BASE}/me?fields=id&access_token=${accessToken}`;
+    const response = await fetch(url);
+    const data = await response.json();
+    if (data.error) {
+      throw new Error(`Failed to resolve Instagram account ID: ${data.error.message}`);
+    }
+    _resolvedAccountId = data.id;
+  } else {
+    _resolvedAccountId = accountId;
+  }
+
+  return _resolvedAccountId;
+}
+
+/**
  * Get the correct Graph API base URL for the current token type
  * IGAAM tokens (Instagram Login) → graph.instagram.com
  * EAA tokens (Facebook Login) → graph.facebook.com
@@ -86,7 +119,7 @@ function getSlideUrl(postNumber, slideNumber) {
  * @returns {string} Container ID
  */
 async function createImageContainer(imageUrl) {
-  const { accountId } = getConfig();
+  const accountId = await resolveAccountId();
   const data = await graphRequest(`/${accountId}/media`, {
     image_url: imageUrl,
     is_carousel_item: 'true',
@@ -101,7 +134,7 @@ async function createImageContainer(imageUrl) {
  * @returns {string} Carousel container ID
  */
 async function createCarouselContainer(childIds, caption) {
-  const { accountId } = getConfig();
+  const accountId = await resolveAccountId();
   const data = await graphRequest(`/${accountId}/media`, {
     media_type: 'CAROUSEL',
     children: childIds.join(','),
@@ -116,7 +149,7 @@ async function createCarouselContainer(childIds, caption) {
  * @returns {{ id: string }} Published media ID
  */
 async function publishMedia(containerId) {
-  const { accountId } = getConfig();
+  const accountId = await resolveAccountId();
   const data = await graphRequest(`/${accountId}/media_publish`, {
     creation_id: containerId,
   });
@@ -282,6 +315,7 @@ export {
   refreshLongLivedToken,
   verifyToken,
   detectTokenType,
+  resolveAccountId,
   getGraphBase,
   checkContainerStatus,
   SITE_URL,


### PR DESCRIPTION
… of using Facebook Page ID

For Instagram Login (IGAAM) tokens, the INSTAGRAM_BUSINESS_ACCOUNT_ID env var contains a Facebook Page ID which doesn't exist on graph.instagram.com. Now auto-resolves the correct Instagram user ID by querying /me, with caching per serverless invocation. Also makes force=true clear retry count so manual posts always attempt.

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6