### PR TITLE
Add cache-busting query param to slide image URLs for Instagram

### DIFF
--- a/lib/social/instagram-client.js
+++ b/lib/social/instagram-client.js
@@ -110,7 +110,7 @@ async function graphRequest(endpoint, params = {}, method = 'POST') {
  */
 function getSlideUrl(postNumber, slideNumber) {
   const paddedNum = String(postNumber).padStart(3, '0');
-  return `${SITE_URL}/assets/social/post-${paddedNum}/slide-${slideNumber}.png`;
+  return `${SITE_URL}/assets/social/post-${paddedNum}/slide-${slideNumber}.png?v=${Date.now()}`;
 }
 
 /**


### PR DESCRIPTION
Prevents Vercel CDN and Instagram from serving stale cached PNGs when slides are re-rendered.

https://claude.ai/code/session_011gVZZQoetPmCJjDwuDyeN6