### PR TITLE
Sync posting schedule rows 13-22 with 9-grid and add repost endpoint

### DIFF
--- a/api/social/repost.js
+++ b/api/social/repost.js
@@ -1,0 +1,93 @@
+// POST /api/social/repost?token=<ADMIN_TOKEN>&post=33
+// Manually repost a specific post to Instagram without advancing the queue
+// Use this to re-publish posts that were deleted or need to be reposted
+//
+// Query params:
+//   token  - SOCIAL_ADMIN_TOKEN for auth
+//   post   - Post number to repost (e.g. 33)
+
+import { logPosting, logError } from '../../lib/social/queue-manager.js';
+import { postCarousel } from '../../lib/social/instagram-client.js';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+let contentCache = null;
+
+function loadContent() {
+  if (!contentCache) {
+    const filePath = join(process.cwd(), 'data', 'social', 'content-queue.json');
+    contentCache = JSON.parse(readFileSync(filePath, 'utf-8'));
+  }
+  return contentCache;
+}
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Cache-Control', 'no-cache');
+
+  // Auth check
+  const adminToken = req.query.token;
+  if (!adminToken || adminToken !== process.env.SOCIAL_ADMIN_TOKEN) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const postNumber = parseInt(req.query.post, 10);
+  if (!postNumber || isNaN(postNumber)) {
+    return res.status(400).json({ error: 'Missing or invalid ?post= parameter' });
+  }
+
+  try {
+    const posts = loadContent();
+    const post = posts.find(p => p.postNumber === postNumber);
+
+    if (!post) {
+      return res.status(404).json({ error: `Post ${postNumber} not found in content-queue.json` });
+    }
+
+    const caption = post.instagram?.caption;
+    if (!caption) {
+      return res.status(400).json({ error: `Post ${postNumber} has no Instagram caption` });
+    }
+
+    const slideCount = post.instagram?.slideCount || 0;
+    if (slideCount < 2) {
+      return res.status(400).json({ error: `Post ${postNumber} has ${slideCount} slide(s) (need 2+)` });
+    }
+
+    // Post carousel to Instagram via Graph API
+    const result = await postCarousel(postNumber, slideCount, caption);
+
+    // Log it (but do NOT advance queue position)
+    await logPosting({
+      platform: 'instagram',
+      postNumber,
+      title: post.title,
+      type: post.type,
+      slideCount: result.slideCount,
+      mediaId: result.mediaId,
+      action: 'reposted',
+      note: 'Manual repost via /api/social/repost',
+    });
+
+    return res.status(200).json({
+      success: true,
+      reposted: {
+        postNumber,
+        title: post.title,
+        slideCount: result.slideCount,
+        mediaId: result.mediaId,
+      },
+    });
+  } catch (error) {
+    console.error('Repost error:', error.message);
+
+    await logError({
+      platform: 'instagram',
+      postNumber,
+      action: 'repost_error',
+      reason: error.message,
+    });
+
+    return res.status(500).json({ success: false, error: error.message });
+  }
+}

--- a/lib/social/posting-schedule.js
+++ b/lib/social/posting-schedule.js
@@ -58,16 +58,17 @@ const ALREADY_POSTED = [
 // Then rows 14-215 from COMPLETE POSTING SCHEDULE table
 // Format per row: [Orange, Neutral, Teal] = 3 post orders
 const NINE_GRID_ROWS = [
-  [35, 36, 33],
-  [40, 42, 43],
-  [41, 46, 47],
-  [44, 49, 48],
-  [45, 52, 50],
-  [51, 56, 53],
-  [54, 59, 57],
-  [55, 62, 58],
-  [60, 66, 63],
-  [61, 69, 67],
+  // Row 13-22: synced with 9GRID_COMPLETE_PART1.md (2026-02-16)
+  [35, 36, 40],   // Row 13: 035 Product | 036 EDU | 040 Docs
+  [41, 39, 43],   // Row 14: 041 Marketing | 039 EDU | 043 Blog
+  [44, 42, 47],   // Row 15: 044 Quote | 042 EDU | 047 Blog
+  [45, 46, 48],   // Row 16: 045 Product | 046 EDU | 048 Chronicle
+  [51, 49, 50],   // Row 17: 051 Marketing | 049 EDU | 050 Docs
+  [54, 52, 53],   // Row 18: 054 Quote | 052 EDU | 053 Blog
+  [55, 56, 57],   // Row 19: 055 Product | 056 EDU | 057 Blog
+  [65, 59, 60],   // Row 20: 065 Product | 059 EDU | 060 Docs
+  [61, 62, 63],   // Row 21: 061 Marketing | 062 EDU | 063 Blog
+  [64, 66, 58],   // Row 22: 064 Quote | 066 EDU | 058 Chronicle
   [64, 72, 68],
   [65, 76, 70],
   [71, 79, 73],


### PR DESCRIPTION
- Update NINE_GRID_ROWS[0-9] in posting-schedule.js to match 9GRID_COMPLETE_PART1.md remaps (all 10 rows were out of sync)
- Add /api/social/repost endpoint for manual reposting of specific posts without advancing the queue (POST ?token=&post=33)

https://claude.ai/code/session_011c39rV3HugQjQHFNWVfikw