### PR TITLE
Move 3rd Instagram post from 22:00 UTC to 19:00 UTC

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -320,7 +320,7 @@
     },
     {
       "path": "/api/social/post-instagram/",
-      "schedule": "0 22 * * *"
+      "schedule": "0 19 * * *"
     },
     {
       "path": "/api/social/refresh-ig-token/",


### PR DESCRIPTION
22:00 UTC (11PM CET) is too late for European audience. 19:00 UTC (8PM CET / 2PM EST) hits prime evening scroll time.

New schedule: 10:00, 16:00, 19:00 UTC

https://claude.ai/code/session_011c39rV3HugQjQHFNWVfikw