### PR TITLE
fix: consolidate cron schedules to comma-separated hours per path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -300,27 +300,11 @@
   "crons": [
     {
       "path": "/api/social/post-twitter/",
-      "schedule": "0 8 * * *"
-    },
-    {
-      "path": "/api/social/post-twitter/",
-      "schedule": "0 14 * * *"
-    },
-    {
-      "path": "/api/social/post-twitter/",
-      "schedule": "0 20 * * *"
+      "schedule": "0 8,14,20 * * *"
     },
     {
       "path": "/api/social/post-instagram/",
-      "schedule": "0 10 * * *"
-    },
-    {
-      "path": "/api/social/post-instagram/",
-      "schedule": "0 16 * * *"
-    },
-    {
-      "path": "/api/social/post-instagram/",
-      "schedule": "0 19 * * *"
+      "schedule": "0 10,16,19 * * *"
     },
     {
       "path": "/api/social/refresh-ig-token/",


### PR DESCRIPTION
Vercel was only firing the LAST cron entry for each path, causing:
- Instagram: only 7PM firing (not 10AM or 4PM)
- Twitter: inconsistent firing

Root cause: Vercel doesn't support multiple entries for the same path.
Solution: Use comma-separated hours in a single cron expression.

Before:
- 3x entries for /api/social/post-instagram/ (only last fired)
- 3x entries for /api/social/post-twitter/ (inconsistent)

After:
- 1x entry: "0 10,16,19 * * *" (10AM, 4PM, 7PM UTC)
- 1x entry: "0 8,14,20 * * *" (8AM, 2PM, 8PM UTC)

This ensures all Instagram posts (morning, afternoon, evening) will fire correctly.

https://claude.ai/code/session_01JdAyDtW3X2RhJAyPJGnP6R