### PR TITLE
resilience: 3-strike auth system, per-platform pause, auto-recovery

### DIFF
--- a/api/social/post-instagram.js
+++ b/api/social/post-instagram.js
@@ -10,7 +10,12 @@
 // 5. Queue advances to post order 38
 
 import {
-  isPaused,
+  isPlatformPaused,
+  setPlatformPaused,
+  incrementAuthStrikes,
+  clearAuthStrikes,
+  getAuthStrikes,
+  AUTH_STRIKES_BEFORE_PAUSE,
   getNextPostOrder,
   setLastPosted,
   logPosting,
@@ -19,7 +24,6 @@ import {
   shouldSkipPost,
   incrementRetryCount,
   clearRetryCount,
-  setPaused,
 } from '../../lib/social/queue-manager.js';
 import { getPostNumber, getInstagramColumn } from '../../lib/social/posting-schedule.js';
 import { postCarousel, verifyToken } from '../../lib/social/instagram-client.js';
@@ -61,36 +65,85 @@ export default async function handler(req, res) {
   log(`✓ Authorized (cron: ${!!cronSecret}, token: ${!!adminToken})`);
 
   try {
-    // Check if paused
-    const paused = await isPaused();
-    log(`isPaused() → ${paused}`);
+    // Check if paused (per-platform + global)
+    const { paused, reason: pauseReason } = await isPlatformPaused('instagram');
+    log(`isPlatformPaused('instagram') → ${paused} (reason: ${pauseReason})`);
+
     if (paused) {
-      log(`⏸ SKIP: Queue is paused — returning 200`);
-      return res.status(200).json({ success: true, skipped: true, reason: 'Queue is paused' });
+      // If paused due to auth issues, try to auto-recover
+      if (pauseReason === 'platform') {
+        log(`⚡ Auto-recovery: Instagram paused, trying token verification...`);
+        try {
+          const tokenInfo = await verifyToken();
+          log(`✓ Token valid again! userId=${tokenInfo.userId} — auto-unpausing Instagram`);
+          await setPlatformPaused('instagram', false);
+          await clearAuthStrikes('instagram');
+          await logPosting({
+            platform: 'instagram',
+            action: 'auto_recovered',
+            reason: `Token verified OK, auto-unpaused after auth pause`,
+          });
+          // Continue with the rest of the handler (don't return)
+        } catch (recoveryError) {
+          log(`⏸ Auto-recovery FAILED: ${recoveryError.message} — staying paused`);
+          return res.status(200).json({ success: true, skipped: true, reason: 'Instagram paused (auth), auto-recovery failed' });
+        }
+      } else {
+        // Global pause (admin-set) — respect it
+        log(`⏸ SKIP: Queue is globally paused — returning 200`);
+        return res.status(200).json({ success: true, skipped: true, reason: 'Queue is paused' });
+      }
     }
 
-    // Pre-flight token validation (prevent wasted retries)
+    // Pre-flight token validation
     try {
       log(`Verifying token...`);
       const tokenInfo = await verifyToken();
       log(`✓ Token valid — userId=${tokenInfo.userId}, expires=${tokenInfo.expiresAt} (${Date.now() - startTime}ms elapsed)`);
+      // Token works — clear any accumulated strikes
+      const prevStrikes = await getAuthStrikes('instagram');
+      if (prevStrikes > 0) {
+        await clearAuthStrikes('instagram');
+        log(`Cleared ${prevStrikes} auth strike(s) — token is healthy`);
+      }
     } catch (tokenError) {
       const errorMsg = tokenError.message || 'Unknown token error';
       log(`✗ Token verification FAILED: ${errorMsg}`);
-      // On auth failures, pause the queue immediately
-      if (errorMsg.includes('OAuthException') || errorMsg.includes('Token') || errorMsg.includes('Unauthorized')) {
-        await setPaused(true);
+
+      const isAuthError = errorMsg.includes('OAuthException') ||
+                          errorMsg.includes('Token') ||
+                          errorMsg.includes('Unauthorized') ||
+                          errorMsg.includes('blocked');
+
+      if (isAuthError) {
+        const strikes = await incrementAuthStrikes('instagram');
+        log(`Auth strike ${strikes}/${AUTH_STRIKES_BEFORE_PAUSE} for Instagram`);
+
         await logError({
           platform: 'instagram',
-          action: 'critical_auth_failure',
-          reason: `Token invalid, queue paused. ${errorMsg}`,
+          action: 'auth_failure',
+          strikes,
+          maxStrikes: AUTH_STRIKES_BEFORE_PAUSE,
+          reason: `Auth strike ${strikes}/${AUTH_STRIKES_BEFORE_PAUSE}: ${errorMsg}`,
         });
-        log(`⛔ AUTH FAILURE — queue paused, returning 200`);
+
+        if (strikes >= AUTH_STRIKES_BEFORE_PAUSE) {
+          await setPlatformPaused('instagram', true);
+          log(`⛔ ${strikes} consecutive auth failures — INSTAGRAM paused (Twitter unaffected)`);
+          return res.status(200).json({
+            success: false,
+            error: `Token failed ${strikes}x — Instagram paused`,
+            detail: errorMsg,
+            action: 'WILL_AUTO_RETRY_NEXT_CRON',
+          });
+        }
+
+        // Below threshold — skip this run but don't pause
+        log(`⏭ Auth failed but only strike ${strikes}/${AUTH_STRIKES_BEFORE_PAUSE} — skipping this run`);
         return res.status(200).json({
           success: false,
-          error: 'Token validation failed - queue paused',
-          detail: errorMsg,
-          action: 'MANUAL_INTERVENTION_REQUIRED',
+          skipped: true,
+          reason: `Auth strike ${strikes}/${AUTH_STRIKES_BEFORE_PAUSE}: ${errorMsg}`,
         });
       }
       // Non-auth errors, allow retry
@@ -205,37 +258,14 @@ export default async function handler(req, res) {
     try {
       const postOrder = await getNextPostOrder('instagram');
       const retryCount = await incrementRetryCount('instagram', postOrder);
-      const isAuthError = error.message.includes('OAuthException') ||
-                          error.message.includes('Unauthorized') ||
-                          error.message.includes('Invalid');
 
-      log(`Error details: postOrder=${postOrder}, retryCount=${retryCount}, isAuthError=${isAuthError}`);
-
-      // For auth errors, pause queue after 2 retries
-      if (isAuthError && retryCount >= 2) {
-        await setPaused(true);
-        await logError({
-          platform: 'instagram',
-          postOrder,
-          action: 'critical_auth_failure',
-          retryCount,
-          reason: `Auth error (${retryCount} retries), queue paused. ${error.message}`,
-        });
-        log(`⛔ AUTH FAILURE after ${retryCount} retries — queue paused, returning 200`);
-        return res.status(200).json({
-          success: false,
-          error: 'Auth error - queue paused',
-          detail: error.message,
-          action: 'MANUAL_INTERVENTION_REQUIRED',
-        });
-      }
+      log(`Error details: postOrder=${postOrder}, retryCount=${retryCount}`);
 
       await logError({
         platform: 'instagram',
         postOrder,
         action: 'error',
         retryCount,
-        isAuthError,
         reason: error.message,
       });
     } catch (logErr) {

--- a/api/social/post-twitter.js
+++ b/api/social/post-twitter.js
@@ -3,7 +3,7 @@
 // Schedule: 3x daily at 8AM, 2PM, 8PM UTC (3AM, 9AM, 3PM EST)
 
 import {
-  isPaused,
+  isPlatformPaused,
   getNextPostOrder,
   setLastPosted,
   logPosting,
@@ -53,12 +53,12 @@ export default async function handler(req, res) {
   log(`✓ Authorized (cron: ${!!cronSecret}, token: ${!!adminToken})`);
 
   try {
-    // Check if paused
-    const paused = await isPaused();
-    log(`isPaused() → ${paused}`);
+    // Check if paused (per-platform + global)
+    const { paused, reason: pauseReason } = await isPlatformPaused('twitter');
+    log(`isPlatformPaused('twitter') → ${paused} (reason: ${pauseReason})`);
     if (paused) {
-      log(`⏸ SKIP: Queue is paused — returning 200`);
-      return res.status(200).json({ success: true, skipped: true, reason: 'Queue is paused' });
+      log(`⏸ SKIP: Queue is paused (${pauseReason}) — returning 200`);
+      return res.status(200).json({ success: true, skipped: true, reason: `Queue is paused (${pauseReason})` });
     }
 
     // Idempotency: skip if already posted recently (within 5 minutes)

--- a/lib/social/queue-manager.js
+++ b/lib/social/queue-manager.js
@@ -22,6 +22,8 @@ const KEYS = {
   instagramLastPosted: 'social:instagram:last_posted',
   instagramLastPostedAt: 'social:instagram:last_posted_at',
   paused: 'social:queue:paused',
+  platformPaused: (platform) => `social:${platform}:paused`,
+  authStrikes: (platform) => `social:auth_strikes:${platform}`,
   postingLog: 'social:posting:log',
   errorLog: 'social:errors:log',
   retryCount: (platform, postOrder) => `social:retry:${platform}:${postOrder}`,
@@ -31,6 +33,7 @@ const KEYS = {
 
 const MAX_LOG_ENTRIES = 100;
 const MAX_RETRIES = 3;
+const AUTH_STRIKES_BEFORE_PAUSE = 3; // consecutive auth failures before pausing
 
 // Exponential backoff wait times (ms) between retries
 const RETRY_WAIT_MS = [3000, 10000, 30000]; // 3s, 10s, 30s for retries 1, 2, 3
@@ -46,6 +49,50 @@ async function isPaused() {
 async function setPaused(paused) {
   const kv = getKV();
   await kv.set(KEYS.paused, paused);
+}
+
+/**
+ * Check if a specific platform is paused (global OR platform-specific)
+ */
+async function isPlatformPaused(platform) {
+  const kv = getKV();
+  const globalPaused = await isPaused();
+  if (globalPaused) return { paused: true, reason: 'global' };
+  const val = await kv.get(KEYS.platformPaused(platform));
+  if (val === true || val === 'true') return { paused: true, reason: 'platform' };
+  return { paused: false, reason: null };
+}
+
+/**
+ * Pause/unpause a specific platform (doesn't affect other platforms)
+ */
+async function setPlatformPaused(platform, paused) {
+  const kv = getKV();
+  await kv.set(KEYS.platformPaused(platform), paused);
+}
+
+// --- Auth Strike System ---
+// Tracks consecutive auth failures per platform.
+// Only pauses after AUTH_STRIKES_BEFORE_PAUSE consecutive failures.
+// Resets on any successful auth or post.
+
+async function incrementAuthStrikes(platform) {
+  const kv = getKV();
+  const key = KEYS.authStrikes(platform);
+  const current = (await kv.get(key)) || 0;
+  const newCount = current + 1;
+  await kv.set(key, newCount, { ex: 86400 }); // expire in 24h
+  return newCount;
+}
+
+async function getAuthStrikes(platform) {
+  const kv = getKV();
+  return (await kv.get(KEYS.authStrikes(platform))) || 0;
+}
+
+async function clearAuthStrikes(platform) {
+  const kv = getKV();
+  await kv.del(KEYS.authStrikes(platform));
 }
 
 async function getLastPosted(platform) {
@@ -224,6 +271,12 @@ async function getStatus() {
 export {
   isPaused,
   setPaused,
+  isPlatformPaused,
+  setPlatformPaused,
+  incrementAuthStrikes,
+  getAuthStrikes,
+  clearAuthStrikes,
+  AUTH_STRIKES_BEFORE_PAUSE,
   getLastPosted,
   setLastPosted,
   getNextPostOrder,


### PR DESCRIPTION
Before: ONE transient Instagram API error paused BOTH platforms for the entire day until manual intervention.

After:
- Auth failures use a 3-strike system (skip the cron run, don't pause)
- Only pauses after 3 CONSECUTIVE auth failures
- Pauses are per-platform (Instagram issues don't block Twitter)
- Auto-recovery: when paused, each cron fire re-checks the token. If it works, auto-unpauses and posts in the same run.
- Global admin pause still works and is always respected.

With today's scenario (1 transient "API access blocked"):
  Before: lost 2 IG posts + 1 Twitter post
  After:  lost 0 Twitter, at most 1 IG (the one that hit the error)

https://claude.ai/code/session_01JdAyDtW3X2RhJAyPJGnP6R