### PR TITLE
fix: update Post 51 slideCount from 4 to 6

### DIFF
--- a/data/social/content-queue.json
+++ b/data/social/content-queue.json
@@ -1604,7 +1604,7 @@
     },
     "instagram": {
       "caption": "Still on the fence? 🤔\n\nWe get it. That's why we offer:\n\n🛡️ 7-DAY MONEY-BACK GUARANTEE\n\n→ Full access to all 7 indicators\n→ Full access to 82 lessons\n→ Full access to docs & support\n\nTry everything. Test the setups. Go through the education.\n\nNot for you? Full refund. No questions.\n\nLink in bio 🔗\n\n#signalpilot #moneybackguarantee #riskfree #tradingview #trading",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#signalpilot",


### PR DESCRIPTION
The HTML carousel template for Post 051 (7-Day Money-Back Guarantee) has 6 slides but content-queue.json incorrectly declared slideCount: 4, causing only 4 of 6 slides to be uploaded to Instagram.

https://claude.ai/code/session_01JdAyDtW3X2RhJAyPJGnP6R