### PR TITLE
Make conduit video full-width so energy beam is actually visible

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5041,20 +5041,20 @@ html[lang="ar"] [style*="text-align:center"] {
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/de/index.html
+++ b/de/index.html
@@ -5038,20 +5038,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/es/index.html
+++ b/es/index.html
@@ -5251,20 +5251,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/fr/index.html
+++ b/fr/index.html
@@ -5434,20 +5434,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/hu/index.html
+++ b/hu/index.html
@@ -4985,20 +4985,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/index.html
+++ b/index.html
@@ -4105,20 +4105,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/it/index.html
+++ b/it/index.html
@@ -4950,20 +4950,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/ja/index.html
+++ b/ja/index.html
@@ -5299,20 +5299,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/nl/index.html
+++ b/nl/index.html
@@ -4977,20 +4977,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/pt/index.html
+++ b/pt/index.html
@@ -5231,20 +5231,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/ru/index.html
+++ b/ru/index.html
@@ -5179,20 +5179,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >

--- a/tr/index.html
+++ b/tr/index.html
@@ -5253,20 +5253,20 @@
         style="
           position: absolute;
           top: -140px;
-          left: 10%;
+          left: 0;
           height: calc(100% + 210px);
-          width: auto;
+          width: 100%;
           pointer-events: none;
           z-index: 0;
           object-fit: cover;
-          object-position: left 30%;
+          object-position: center 30%;
           opacity: 0.9;
           transform: translateZ(0) scaleX(-1);
           mix-blend-mode: screen;
           filter: brightness(0.7) saturate(1.4) hue-rotate(10deg);
-          -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          -webkit-mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           -webkit-mask-composite: source-in;
-          mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+          mask-image: linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%), linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
           mask-composite: intersect;
         "
       >


### PR DESCRIPTION
Previous approach just shifted the container position but the video element was still width:auto (narrow). Now the video spans the full hero section width with centered content, making the energy beam effect visible across the page instead of a thin strip on the edge.

Changes across all 12 pages:
- width: auto → width: 100%
- left: 10% → left: 0
- object-position: left 30% → center 30%
- Mask gradients updated to fade both edges

https://claude.ai/code/session_01M1DPRvqBzNL6BXq94zr1VK