### PR TITLE
Fix Vercel auto-update: add missing 'type' field to env var request

### DIFF
--- a/api/social/refresh-ig-token.js
+++ b/api/social/refresh-ig-token.js
@@ -35,6 +35,7 @@ async function updateVercelEnvVar(newToken) {
         key: 'INSTAGRAM_ACCESS_TOKEN',
         value: newToken,
         target: ['production', 'preview', 'development'],
+        type: 'secret',
       }),
     });
 


### PR DESCRIPTION
The Vercel API v10 requires a 'type' field when updating environment variables. Setting type to 'secret' since INSTAGRAM_ACCESS_TOKEN is a sensitive credential.

https://claude.ai/code/session_01CTTG9WrGEtF4ZSqGLQRbKv