### PR TITLE
Fix Vercel auto-update: use plaintext instead of secret type

### DIFF
--- a/api/social/refresh-ig-token.js
+++ b/api/social/refresh-ig-token.js
@@ -35,7 +35,7 @@ async function updateVercelEnvVar(newToken) {
         key: 'INSTAGRAM_ACCESS_TOKEN',
         value: newToken,
         target: ['production', 'preview', 'development'],
-        type: 'secret',
+        type: 'plaintext',
       }),
     });
 


### PR DESCRIPTION
Vercel API no longer allows type 'secret' for environment variables. Use 'plaintext' type instead for INSTAGRAM_ACCESS_TOKEN update.

https://claude.ai/code/session_01CTTG9WrGEtF4ZSqGLQRbKv