### PR TITLE
Bump all export-mode font sizes by ~15% for Instagram readability

### DIFF
--- a/scripts/render-carousels.js
+++ b/scripts/render-carousels.js
@@ -89,7 +89,7 @@ async function renderCarousel(page, postDir, postNumber) {
         text-align: center !important;
         width: 100% !important;
         height: 100% !important;
-        padding: 6% 8% !important;
+        padding: 5% 6% !important;
         box-sizing: border-box !important;
       }
 
@@ -97,25 +97,25 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Titles — big and centered */
       .slide-title, .header, .hook-main, .hook-title {
-        font-size: clamp(36px, 8cqw, 56px) !important;
+        font-size: clamp(41px, 9.2cqw, 64px) !important;
         margin-bottom: 4% !important;
         text-align: center !important;
         width: 100% !important;
       }
       .slide-title.large {
-        font-size: clamp(40px, 9cqw, 64px) !important;
+        font-size: clamp(46px, 10.3cqw, 74px) !important;
       }
 
       /* Section titles (h2/h3 inside slide-content) */
       .slide-content h2, .slide-content h3,
       .section-title {
-        font-size: clamp(32px, 8cqw, 52px) !important;
+        font-size: clamp(37px, 9.2cqw, 60px) !important;
         text-align: center !important;
       }
 
       /* Body text — boosted for Instagram readability */
       .slide-body, .text {
-        font-size: clamp(30px, 7.5cqw, 44px) !important;
+        font-size: clamp(35px, 8.6cqw, 51px) !important;
         line-height: 1.65 !important;
         max-width: 95% !important;
         text-align: center !important;
@@ -124,7 +124,7 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Subtitles — boosted for Instagram readability */
       .slide-subtitle, .hook-sub {
-        font-size: clamp(32px, 7.5cqw, 46px) !important;
+        font-size: clamp(37px, 8.6cqw, 53px) !important;
         letter-spacing: 3px !important;
         text-align: center !important;
         color: rgba(255,255,255,0.88) !important;
@@ -132,56 +132,56 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Paragraphs and lists inside slide-content */
       .slide-content p {
-        font-size: clamp(28px, 6.5cqw, 40px) !important;
+        font-size: clamp(32px, 7.5cqw, 46px) !important;
         text-align: center !important;
         color: rgba(255,255,255,0.85) !important;
       }
       .slide-content ul, .slide-content ol {
-        font-size: clamp(28px, 6.5cqw, 40px) !important;
+        font-size: clamp(32px, 7.5cqw, 46px) !important;
         max-width: 95% !important;
         color: rgba(255,255,255,0.85) !important;
       }
 
       /* Combo titles and descriptions */
       .combo-title {
-        font-size: clamp(28px, 7cqw, 44px) !important;
+        font-size: clamp(32px, 8cqw, 51px) !important;
         font-weight: 700 !important;
       }
       .combo-desc {
-        font-size: clamp(26px, 6.5cqw, 38px) !important;
+        font-size: clamp(30px, 7.5cqw, 44px) !important;
         line-height: 1.5 !important;
         color: rgba(255,255,255,0.85) !important;
       }
       .combo-arrows, .combo-emojis {
-        font-size: clamp(40px, 10cqw, 64px) !important;
+        font-size: clamp(46px, 11.5cqw, 74px) !important;
       }
 
       /* Signal items */
       .signal-item .label, .signal-item .name {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .signal-item .arrow, .signal-item .icon {
-        font-size: clamp(32px, 8cqw, 48px) !important;
+        font-size: clamp(37px, 9.2cqw, 55px) !important;
       }
 
       /* Divergence boxes */
       .divergence-title, .divergence-label {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         font-weight: 700 !important;
       }
       .divergence-desc {
-        font-size: clamp(20px, 5.5cqw, 32px) !important;
+        font-size: clamp(23px, 6.3cqw, 37px) !important;
       }
 
       /* Icons */
       .slide-icon, .icon {
-        font-size: clamp(48px, 14cqw, 72px) !important;
+        font-size: clamp(55px, 16.1cqw, 83px) !important;
         text-align: center !important;
       }
 
       /* Checklists */
       .checklist {
-        font-size: clamp(26px, 6.5cqw, 38px) !important;
+        font-size: clamp(30px, 7.5cqw, 44px) !important;
         line-height: 1.8 !important;
         text-align: left !important;
         max-width: 95% !important;
@@ -194,25 +194,25 @@ async function renderCarousel(page, postDir, postNumber) {
       /* CTA elements */
       .cta-link, .cta-button {
         padding: 4% 8% !important;
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
         font-weight: 600 !important;
         letter-spacing: 1px !important;
       }
       .cta-text, .cta-title {
-        font-size: clamp(30px, 8cqw, 48px) !important;
+        font-size: clamp(35px, 9.2cqw, 55px) !important;
         font-family: 'Cormorant Garamond', serif !important;
         font-weight: 600 !important;
         text-align: center !important;
       }
       .link-hint {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
         margin-top: 3% !important;
         text-align: center !important;
       }
 
       /* Feature cards (grid items like "Wait for Confluence") */
       .feature-text {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         color: rgba(255,255,255,0.9) !important;
       }
       .feature-card {
@@ -222,7 +222,7 @@ async function renderCarousel(page, postDir, postNumber) {
       /* Brand mark — Gugi font, centered at bottom, themed per column */
       .brand-mark, .logo, .cine-logo, .slide-logo {
         font-family: 'Gugi', sans-serif !important;
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
         letter-spacing: 4px !important;
         text-transform: uppercase !important;
       }
@@ -281,7 +281,7 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Arrow lists */
       .arrow-list {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         line-height: 1.6 !important;
         max-width: 95% !important;
         text-align: left !important;
@@ -301,11 +301,11 @@ async function renderCarousel(page, postDir, postNumber) {
         padding: 5% 6% !important;
       }
       .callout-box .callout-title {
-        font-size: clamp(28px, 7cqw, 44px) !important;
+        font-size: clamp(32px, 8cqw, 51px) !important;
         font-weight: 600 !important;
       }
       .callout-box .callout-text {
-        font-size: clamp(26px, 6.5cqw, 40px) !important;
+        font-size: clamp(30px, 7.5cqw, 46px) !important;
         line-height: 1.6 !important;
       }
 
@@ -315,14 +315,14 @@ async function renderCarousel(page, postDir, postNumber) {
         padding: 5% 6% !important;
       }
       .concept-card .card-label {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .concept-card .card-title {
-        font-size: clamp(28px, 7cqw, 44px) !important;
+        font-size: clamp(32px, 8cqw, 51px) !important;
         font-weight: 600 !important;
       }
       .concept-card .card-desc {
-        font-size: clamp(26px, 6.5cqw, 40px) !important;
+        font-size: clamp(30px, 7.5cqw, 46px) !important;
         line-height: 1.5 !important;
       }
 
@@ -331,25 +331,25 @@ async function renderCarousel(page, postDir, postNumber) {
         max-width: 95% !important;
       }
       .data-item .item-icon {
-        font-size: clamp(32px, 8cqw, 48px) !important;
+        font-size: clamp(37px, 9.2cqw, 55px) !important;
       }
       .data-item .item-value {
-        font-size: clamp(28px, 7cqw, 44px) !important;
+        font-size: clamp(32px, 8cqw, 51px) !important;
         font-weight: 600 !important;
       }
       .data-item .item-label {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
         line-height: 1.4 !important;
       }
 
       /* Quote blocks */
       .quote-block {
-        font-size: clamp(32px, 8cqw, 52px) !important;
+        font-size: clamp(37px, 9.2cqw, 60px) !important;
         line-height: 1.5 !important;
         max-width: 90% !important;
       }
       .quote-attr {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
 
       /* Step flows */
@@ -357,21 +357,21 @@ async function renderCarousel(page, postDir, postNumber) {
         max-width: 95% !important;
       }
       .step-num {
-        font-size: clamp(32px, 8cqw, 52px) !important;
+        font-size: clamp(37px, 9.2cqw, 60px) !important;
         font-weight: 600 !important;
       }
       .step-text {
-        font-size: clamp(26px, 6.5cqw, 40px) !important;
+        font-size: clamp(30px, 7.5cqw, 46px) !important;
         line-height: 1.5 !important;
       }
 
       /* Stat values */
       .stat-value {
-        font-size: clamp(36px, 9cqw, 56px) !important;
+        font-size: clamp(41px, 10.3cqw, 64px) !important;
         font-weight: 600 !important;
       }
       .stat-label {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
 
       /* Compare grids */
@@ -379,16 +379,16 @@ async function renderCarousel(page, postDir, postNumber) {
         max-width: 95% !important;
       }
       .compare-item .compare-label {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .compare-item .compare-text {
-        font-size: clamp(26px, 6.5cqw, 40px) !important;
+        font-size: clamp(30px, 7.5cqw, 46px) !important;
         line-height: 1.5 !important;
       }
 
       /* Indicator pills */
       .indicator-pill {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         padding: 2% 5% !important;
       }
 
@@ -396,43 +396,43 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Section tags & labels (mono uppercase) */
       .hook-tag, .sec-tag, .lesson-tag, .cta-badge {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
         letter-spacing: 3px !important;
       }
 
       /* Section titles (.sec-title is the gold standard equivalent of .section-title) */
       .sec-title {
-        font-size: clamp(32px, 8cqw, 52px) !important;
+        font-size: clamp(37px, 9.2cqw, 60px) !important;
         text-align: center !important;
       }
 
       /* --- Definition cards --- */
       .def-label {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
         letter-spacing: 2px !important;
       }
       .def-quote {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
       }
       .def-text {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.45 !important;
       }
 
       /* --- Factor / feature cards (2x2 / 2x3 grids) --- */
       .factor-card .fc-name {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
       }
       .factor-card .fc-desc {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
         line-height: 1.45 !important;
       }
       .factor-card .fc-tag {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         padding: 4px 12px !important;
       }
       .factor-card .fc-let {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
       }
       .factor-card .fc-icon {
         width: clamp(32px, 6cqw, 48px) !important;
@@ -441,40 +441,40 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Comparison cards --- */
       .compare-card .cc-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .compare-card .cc-quote {
-        font-size: clamp(22px, 5.5cqw, 32px) !important;
+        font-size: clamp(25px, 6.3cqw, 37px) !important;
       }
       .compare-card .cc-desc {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
         line-height: 1.5 !important;
       }
 
       /* --- Truth cards --- */
       .truth-card .tc-title {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
       }
       .truth-card .tc-desc {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
         line-height: 1.45 !important;
       }
       .truth-quote {
-        font-size: clamp(26px, 6.5cqw, 38px) !important;
+        font-size: clamp(30px, 7.5cqw, 44px) !important;
         line-height: 1.5 !important;
       }
 
       /* --- Step flow --- */
       .step-name {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
       }
       .step-desc {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         line-height: 1.45 !important;
       }
       .step-ring .s-num {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
       }
       .step-ring {
         width: clamp(36px, 7cqw, 52px) !important;
@@ -487,16 +487,16 @@ async function renderCarousel(page, postDir, postNumber) {
         height: clamp(42px, 8cqw, 64px) !important;
       }
       .icon-circle .ic-letter {
-        font-size: clamp(20px, 5cqw, 32px) !important;
+        font-size: clamp(23px, 5.8cqw, 37px) !important;
       }
 
       /* --- Warning / Alert / Insight boxes --- */
       .warn-label, .alert-label, .insight-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .warn-text, .alert-text, .insight-text {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
 
@@ -508,64 +508,64 @@ async function renderCarousel(page, postDir, postNumber) {
         padding: clamp(14px, 3cqw, 22px) !important;
       }
       .info-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         letter-spacing: 2px !important;
         color: rgba(94,234,212,0.9) !important;
       }
       .info-text {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
         color: var(--txt) !important;
       }
 
       /* --- Stack / layer visualization --- */
       .stack-bar {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         height: clamp(28px, 5.5cqw, 42px) !important;
       }
       .stack-result {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         height: clamp(32px, 6cqw, 48px) !important;
       }
       .stack-arrow {
-        font-size: clamp(14px, 3cqw, 20px) !important;
+        font-size: clamp(16px, 3.4cqw, 23px) !important;
       }
 
       /* --- CTA slide elements --- */
       .cta-sub {
-        font-size: clamp(26px, 6.5cqw, 38px) !important;
+        font-size: clamp(30px, 7.5cqw, 44px) !important;
         line-height: 1.5 !important;
       }
       .stat-cell .sv {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .stat-cell .sl {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
       }
       .pill {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         padding: 5px 14px !important;
       }
       .cta-url {
-        font-size: clamp(22px, 5.5cqw, 30px) !important;
+        font-size: clamp(25px, 6.3cqw, 35px) !important;
       }
       .cta-hint {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
       }
       .cta-url-main {
-        font-size: clamp(22px, 5.5cqw, 30px) !important;
+        font-size: clamp(25px, 6.3cqw, 35px) !important;
       }
       .cta-badge-pill {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         padding: 5px 14px !important;
       }
 
       /* --- Divergence visual elements --- */
       .da-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .diverge-vs {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
       }
       .diverge-arrow .da-line {
         height: clamp(24px, 5cqw, 40px) !important;
@@ -574,13 +574,13 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Volume bar / flow ribbon labels --- */
       .flow-ribbon-labels {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .flow-ribbon {
         height: clamp(22px, 4.5cqw, 36px) !important;
       }
       .vol-bar-dot {
-        font-size: clamp(8px, 2cqw, 14px) !important;
+        font-size: clamp(9px, 2.3cqw, 16px) !important;
       }
 
       /* --- Progress bars (make thicker) --- */
@@ -590,12 +590,12 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Orb / orb-sm letter --- */
       .orb-sm .orb-letter {
-        font-size: clamp(28px, 7cqw, 44px) !important;
+        font-size: clamp(32px, 8cqw, 51px) !important;
       }
 
       /* --- Scales labels inside orb --- */
       .scales-label {
-        font-size: clamp(8px, 1.6cqw, 12px) !important;
+        font-size: clamp(9px, 1.8cqw, 14px) !important;
       }
 
       /* --- Slide-1 column line (thicker for grid visibility) --- */
@@ -616,23 +616,23 @@ async function renderCarousel(page, postDir, postNumber) {
       .signal-card .signal-icon {
         width: clamp(24px, 4.5cqw, 38px) !important;
         height: clamp(24px, 4.5cqw, 38px) !important;
-        font-size: clamp(10px, 2cqw, 16px) !important;
+        font-size: clamp(12px, 2.3cqw, 18px) !important;
         margin: 0 auto clamp(2px, 0.5cqw, 6px) !important;
       }
       .signal-card .signal-name {
-        font-size: clamp(12px, 2.5cqw, 18px) !important;
+        font-size: clamp(14px, 2.9cqw, 21px) !important;
         margin-bottom: 0.5% !important;
       }
       .signal-card .signal-full {
-        font-size: clamp(14px, 2.8cqw, 20px) !important;
+        font-size: clamp(16px, 3.2cqw, 23px) !important;
         margin-bottom: 1% !important;
       }
       .signal-card .signal-desc {
-        font-size: clamp(11px, 2.2cqw, 16px) !important;
+        font-size: clamp(13px, 2.5cqw, 18px) !important;
         line-height: 1.35 !important;
       }
       .signal-card .signal-detail {
-        font-size: clamp(8px, 1.6cqw, 12px) !important;
+        font-size: clamp(9px, 1.8cqw, 14px) !important;
         margin-top: 0.5% !important;
       }
 
@@ -645,14 +645,14 @@ async function renderCarousel(page, postDir, postNumber) {
       .feature-benefit .benefit-icon {
         width: clamp(16px, 3cqw, 24px) !important;
         height: clamp(16px, 3cqw, 24px) !important;
-        font-size: clamp(10px, 2cqw, 16px) !important;
+        font-size: clamp(12px, 2.3cqw, 18px) !important;
       }
       .feature-benefit .benefit-title {
-        font-size: clamp(11px, 2.2cqw, 16px) !important;
+        font-size: clamp(13px, 2.5cqw, 18px) !important;
         margin-bottom: 0.5% !important;
       }
       .feature-benefit .benefit-desc {
-        font-size: clamp(10px, 1.8cqw, 14px) !important;
+        font-size: clamp(12px, 2.1cqw, 16px) !important;
         line-height: 1.3 !important;
       }
 
@@ -662,10 +662,10 @@ async function renderCarousel(page, postDir, postNumber) {
         margin-bottom: 1% !important;
       }
       .premium-feature .premium-feature-title {
-        font-size: clamp(10px, 2cqw, 14px) !important;
+        font-size: clamp(12px, 2.3cqw, 16px) !important;
       }
       .premium-feature .premium-feature-desc {
-        font-size: clamp(9px, 1.8cqw, 13px) !important;
+        font-size: clamp(10px, 2.1cqw, 15px) !important;
         line-height: 1.3 !important;
       }
 
@@ -675,10 +675,10 @@ async function renderCarousel(page, postDir, postNumber) {
         margin-bottom: clamp(3px, 0.6cqw, 6px) !important;
       }
       .cycle-row .cycle-label {
-        font-size: clamp(11px, 2.2cqw, 16px) !important;
+        font-size: clamp(13px, 2.5cqw, 18px) !important;
       }
       .cycle-row .cycle-meaning {
-        font-size: clamp(11px, 2.2cqw, 16px) !important;
+        font-size: clamp(13px, 2.5cqw, 18px) !important;
       }
 
       /* Feat cards (post-065 slide 6 pattern) */
@@ -690,30 +690,30 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Answer cards (post-033 pattern) --- */
       .answer-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .answer-title {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .answer-desc {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
 
       /* --- Risk scenario cards --- */
       .risk-pct {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
       }
       .risk-remain {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
       }
       .risk-desc {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
         line-height: 1.5 !important;
       }
       .risk-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         letter-spacing: 1px !important;
       }
       .risk-bar {
@@ -722,11 +722,11 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Scenario cards (post-044 pattern) --- */
       .scenario-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .scenario-desc {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
         color: var(--txt2) !important;
       }
@@ -734,20 +734,20 @@ async function renderCarousel(page, postDir, postNumber) {
         color: var(--txt) !important;
       }
       .scenario-badge {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         padding: clamp(4px, 0.8cqw, 7px) clamp(8px, 1.6cqw, 14px) !important;
       }
       .scenario-insight-text {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
 
       /* --- Excuse items --- */
       .excuse-x {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
       }
       .excuse-text {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
       }
       .excuse-item {
         padding: clamp(12px, 2.5cqw, 20px) !important;
@@ -756,18 +756,18 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Formula / Example cards --- */
       .formula-label, .example-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .formula-exp {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
         line-height: 1.7 !important;
       }
       .ex-key {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .ex-val {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .example-row {
         padding: clamp(5px, 1cqw, 10px) 0 !important;
@@ -775,10 +775,10 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- VP chart elements (post-043 pattern) --- */
       .vp-tick {
-        font-size: clamp(10px, 2cqw, 16px) !important;
+        font-size: clamp(12px, 2.3cqw, 18px) !important;
       }
       .vp-pointer {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
       }
       .vp-bar {
         height: clamp(8px, 1.5cqw, 14px) !important;
@@ -786,66 +786,66 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Zone cards (HVN / LVN pattern) --- */
       .zone-name {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .zone-full {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
       }
       .zone-desc {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
       .zone-insight {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
       .zone-badge {
         width: clamp(48px, 9cqw, 72px) !important;
         height: clamp(48px, 9cqw, 72px) !important;
-        font-size: clamp(22px, 5cqw, 36px) !important;
+        font-size: clamp(25px, 5.8cqw, 41px) !important;
       }
 
       /* --- Legend / Annotation labels --- */
       .legend-text {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .legend-dot {
         width: clamp(10px, 2cqw, 16px) !important;
         height: clamp(10px, 2cqw, 16px) !important;
       }
       .ann-tag {
-        font-size: clamp(10px, 2cqw, 16px) !important;
+        font-size: clamp(12px, 2.3cqw, 18px) !important;
       }
 
       /* --- Indicator cards (post-040/045/050/055 patterns) --- */
       .indicator-desc {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
         line-height: 1.5 !important;
       }
       .indicator-codename {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .section-sub {
-        font-size: clamp(26px, 6.5cqw, 40px) !important;
+        font-size: clamp(30px, 7.5cqw, 46px) !important;
         line-height: 1.5 !important;
       }
       .truth-card-title {
-        font-size: clamp(22px, 5.5cqw, 34px) !important;
+        font-size: clamp(25px, 6.3cqw, 39px) !important;
       }
       .cta-stat-text {
-        font-size: clamp(16px, 4cqw, 26px) !important;
+        font-size: clamp(18px, 4.6cqw, 30px) !important;
       }
 
       /* --- Risk-Reward Display (post-042 pattern) --- */
       .rr-box .rr-num {
-        font-size: clamp(36px, 9cqw, 56px) !important;
+        font-size: clamp(41px, 10.3cqw, 64px) !important;
       }
       .rr-box .rr-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .rr-colon {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
       }
       .rr-display {
         gap: clamp(12px, 2.5cqw, 24px) !important;
@@ -858,17 +858,17 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Winrate Section (post-042 pattern) --- */
       .winrate-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         letter-spacing: 2px !important;
       }
       .winrate-value {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .winrate-desc {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
       }
       .winrate-insight {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
       .winrate-insight em {
@@ -883,17 +883,17 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Compare Table (post-042 pattern) --- */
       .ct-header span {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         letter-spacing: 2px !important;
       }
       .ct-cell .ct-ratio {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
       }
       .ct-cell .ct-val {
-        font-size: clamp(22px, 5.5cqw, 32px) !important;
+        font-size: clamp(25px, 6.3cqw, 37px) !important;
       }
       .ct-cell .ct-tag {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         padding: 4px 10px !important;
       }
       .ct-row {
@@ -905,99 +905,99 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Status Display (post-048 pattern) --- */
       .status-box .sb-val {
-        font-size: clamp(32px, 8cqw, 48px) !important;
+        font-size: clamp(37px, 9.2cqw, 55px) !important;
       }
       .status-box .sb-lbl {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .status-vs {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
       }
       .status-tag {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         padding: 4px 12px !important;
       }
 
       /* --- Merge Flow (post-048 pattern) --- */
       .merge-chip {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         padding: clamp(8px, 1.5cqw, 14px) clamp(12px, 2.5cqw, 20px) !important;
       }
       .merge-arrow {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .merge-result {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
         padding: clamp(18px, 3.5cqw, 30px) clamp(12px, 2.5cqw, 20px) !important;
       }
 
       /* --- Alignment arrows (post-048 pattern) --- */
       .align-arrows {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
       }
       .align-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .align-desc {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
 
       /* --- Philosophy quote (post-048 pattern) --- */
       .phil-quote {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
         line-height: 1.4 !important;
       }
       .phil-desc {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         line-height: 1.5 !important;
       }
 
       /* --- Reveal badge (post-048 pattern) --- */
       .reveal-badge {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
         padding: clamp(10px, 2cqw, 16px) clamp(20px, 4cqw, 36px) !important;
       }
 
       /* --- Truth Box (teal/gold bordered quote) --- */
       .truth-box .tb-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         letter-spacing: 2px !important;
       }
       .truth-box .tb-text {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         line-height: 1.5 !important;
       }
 
       /* --- Orb halves labels --- */
       .half-side .half-icon {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .half-side .half-lbl {
-        font-size: clamp(10px, 2cqw, 14px) !important;
+        font-size: clamp(12px, 2.3cqw, 16px) !important;
       }
 
       /* --- Concept description (post-047 pattern) --- */
       .cd-main {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         line-height: 1.5 !important;
       }
       .cd-note {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
 
       /* --- Step Flow (post-047 pattern) --- */
       .step-name {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
       }
       .step-desc {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         line-height: 1.45 !important;
       }
       .step-ring .s-num {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
       }
       .step-row {
         padding: clamp(14px, 2.8cqw, 24px) clamp(12px, 2.5cqw, 20px) !important;
@@ -1005,61 +1005,61 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Zone Card (post-047 pattern) --- */
       .zone-card .zc-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         letter-spacing: 2px !important;
       }
       .zone-card .zc-title {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .zone-card .zc-desc {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
 
       /* --- Stop loss elements (post-046 pattern) --- */
       .stop-desc {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         line-height: 1.5 !important;
       }
       .stop-detail {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .stop-type-tag {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 3px !important;
       }
       .big-stat {
-        font-size: clamp(48px, 12cqw, 72px) !important;
+        font-size: clamp(55px, 13.8cqw, 83px) !important;
       }
 
       /* --- Param / settings grid (post-060 pattern) --- */
       .param-key, .param-val {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
       }
       .section-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .row-setting-name {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
       }
       .row-cell {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .card-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
       }
 
       /* --- Swing Ladder (post-049 pattern) --- */
       .swing-hilo {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         padding: clamp(6px, 1.2cqw, 12px) clamp(10px, 2cqw, 18px) !important;
       }
       .swing-arrow {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
       }
       .swing-label {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .swing-step {
         padding: clamp(14px, 2.8cqw, 24px) clamp(16px, 3.2cqw, 28px) !important;
@@ -1067,69 +1067,69 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Range Zone (post-049 pattern) --- */
       .zone-icon {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
       }
       .zone-label-text {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .zone-arrows {
-        font-size: clamp(40px, 10cqw, 60px) !important;
+        font-size: clamp(46px, 11.5cqw, 69px) !important;
       }
       .zone-text {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
 
       /* --- S/R Zone (post-052 pattern) --- */
       .sr-zone-badge {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
         padding: clamp(6px, 1.2cqw, 10px) clamp(16px, 3.2cqw, 28px) !important;
       }
       .sr-action-label {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .sr-action-arrow {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .sr-zone-repeat {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .sr-zone-desc {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .sr-zone-arrows {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
       }
       .sr-zone-arrows-mid {
-        font-size: clamp(36px, 9cqw, 56px) !important;
+        font-size: clamp(41px, 10.3cqw, 64px) !important;
       }
       .sr-zone-mid-text {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
 
       /* --- Fail Visual (post-053 pattern) --- */
       .fail-stat-value {
-        font-size: clamp(36px, 9cqw, 56px) !important;
+        font-size: clamp(41px, 10.3cqw, 64px) !important;
       }
       .fail-stat-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .fail-verdict-text {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .fail-verdict-icon {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .fail-balance-label {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
       }
       .fail-balance-value {
-        font-size: clamp(28px, 7cqw, 42px) !important;
+        font-size: clamp(32px, 8cqw, 48px) !important;
       }
       .fail-balance-vs {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .fail-tl-text {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .fail-tl-dot {
         width: clamp(16px, 3cqw, 24px) !important;
@@ -1138,27 +1138,27 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* --- Cross Diagram (post-059 pattern) --- */
       .ma-name {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
       }
       .ma-desc {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .ma-cross-icon {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
       }
       .cross-meaning-text {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
 
       /* --- Lag Timeline (post-059 pattern) --- */
       .lag-tl-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .lag-tl-desc {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .lag-tl-zone-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
 
       /* ===== Gold Standard Architecture — layout overrides ===== */
@@ -1223,39 +1223,39 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Slide counter */
       .slide-counter {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
         letter-spacing: 2px !important;
       }
 
       /* Hook elements */
       .blog-badge, .chronicle-badge {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
         letter-spacing: 3px !important;
         padding: 6px 18px !important;
       }
       .hook-indicator, .char-indicator {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
         letter-spacing: 3px !important;
       }
       .hook-quote, .char-quote {
-        font-size: clamp(24px, 6cqw, 34px) !important;
+        font-size: clamp(28px, 6.9cqw, 39px) !important;
         line-height: 1.45 !important;
       }
 
       /* Pillar / Vision grid cards */
       .pillar-name, .vision-name {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .pillar-desc, .vision-desc {
-        font-size: clamp(15px, 3.7cqw, 21px) !important;
+        font-size: clamp(17px, 4.3cqw, 24px) !important;
         line-height: 1.4 !important;
       }
       .pillar-label, .vision-label {
-        font-size: clamp(10px, 2.4cqw, 14px) !important;
+        font-size: clamp(12px, 2.8cqw, 16px) !important;
         letter-spacing: 1px !important;
       }
       .pillar-icon, .vision-icon {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .pillar-ring, .vision-ring {
         width: clamp(40px, 8cqw, 60px) !important;
@@ -1267,18 +1267,18 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Dive / Power cards (horizontal layout) */
       .dive-name, .power-name {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .dive-desc, .power-desc {
-        font-size: clamp(15px, 3.7cqw, 21px) !important;
+        font-size: clamp(17px, 4.3cqw, 24px) !important;
         line-height: 1.35 !important;
       }
       .dive-label, .power-label {
-        font-size: clamp(10px, 2.4cqw, 14px) !important;
+        font-size: clamp(12px, 2.8cqw, 16px) !important;
         letter-spacing: 1px !important;
       }
       .dive-icon-sym, .power-icon-sym {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .dive-icon-circle, .power-icon-circle {
         width: clamp(42px, 8.5cqw, 64px) !important;
@@ -1290,45 +1290,45 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Cycle / Reading flow steps */
       .cycle-label, .reading-label {
-        font-size: clamp(11px, 2.8cqw, 16px) !important;
+        font-size: clamp(13px, 3.2cqw, 18px) !important;
         letter-spacing: 2px !important;
       }
       .cycle-text, .reading-text {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .cycle-desc, .reading-desc {
-        font-size: clamp(13px, 3.2cqw, 18px) !important;
+        font-size: clamp(15px, 3.7cqw, 21px) !important;
         line-height: 1.35 !important;
       }
       .cycle-num, .reading-num {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .cycle-ring, .reading-ring {
         width: clamp(38px, 7.5cqw, 56px) !important;
         height: clamp(38px, 7.5cqw, 56px) !important;
       }
       .cycle-arrow, .reading-arrow {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .cycle-truth, .reading-truth {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
         line-height: 1.4 !important;
       }
 
       /* Strategy grid cards */
       .strat-name {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
       }
       .strat-desc {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         line-height: 1.5 !important;
       }
       .strat-label {
-        font-size: clamp(12px, 3cqw, 16px) !important;
+        font-size: clamp(14px, 3.4cqw, 18px) !important;
         letter-spacing: 1px !important;
       }
       .strat-icon {
-        font-size: clamp(22px, 5.5cqw, 36px) !important;
+        font-size: clamp(25px, 6.3cqw, 41px) !important;
       }
       .strat-ring {
         width: clamp(52px, 10cqw, 80px) !important;
@@ -1340,23 +1340,23 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Strategy warning box */
       .strat-warn-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         letter-spacing: 2px !important;
       }
       .strat-warn-text {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
         line-height: 1.55 !important;
       }
 
       /* CTA stat recap (teal gold standard) */
       .stat-recap .stat-num, .stat-card .stat-num {
-        font-size: clamp(22px, 5.5cqw, 34px) !important;
+        font-size: clamp(25px, 6.3cqw, 39px) !important;
       }
       .stat-recap .stat-name, .stat-card .stat-name {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
       }
       .stat-recap .stat-val, .stat-card .stat-val {
-        font-size: clamp(12px, 3cqw, 16px) !important;
+        font-size: clamp(14px, 3.4cqw, 18px) !important;
       }
       .stat-ring {
         width: clamp(38px, 7.5cqw, 56px) !important;
@@ -1365,29 +1365,29 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* CTA elements (teal gold standard) */
       .cta-glow-icon {
-        font-size: clamp(28px, 7cqw, 44px) !important;
+        font-size: clamp(32px, 8cqw, 51px) !important;
       }
       .cta-tagline {
-        font-size: clamp(32px, 8cqw, 52px) !important;
+        font-size: clamp(37px, 9.2cqw, 60px) !important;
       }
       .cta-desc {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
         line-height: 1.5 !important;
       }
       .cta-pill {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         padding: 6px 14px !important;
       }
       .cta-box-text {
-        font-size: clamp(22px, 5.5cqw, 32px) !important;
+        font-size: clamp(25px, 6.3cqw, 37px) !important;
       }
       .cta-link {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
       }
 
       /* Slide logo */
       .slide-logo {
-        font-size: clamp(10px, 2.5cqw, 14px) !important;
+        font-size: clamp(12px, 2.9cqw, 16px) !important;
         letter-spacing: 3px !important;
         padding-bottom: 1.5cqw !important;
         margin-top: auto !important;
@@ -1405,15 +1405,15 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* S1 hook elements */
       .s1-prod-label {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
         letter-spacing: 4px !important;
         padding: clamp(6px, 1.2cqw, 12px) clamp(16px, 3cqw, 28px) !important;
       }
       .s1-hook {
-        font-size: clamp(36px, 8cqw, 56px) !important;
+        font-size: clamp(41px, 9.2cqw, 64px) !important;
       }
       .s1-sub {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         letter-spacing: 3px !important;
       }
       .s1-divider {
@@ -1423,192 +1423,192 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* Obsession block (post-044 v2 — slide 2) */
       .obsess-label {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
         letter-spacing: 3px !important;
       }
       .obsess-text {
-        font-size: clamp(24px, 5.5cqw, 38px) !important;
+        font-size: clamp(28px, 6.3cqw, 44px) !important;
         line-height: 1.4 !important;
       }
       .obsess-verdict-text {
-        font-size: clamp(22px, 5.5cqw, 34px) !important;
+        font-size: clamp(25px, 6.3cqw, 39px) !important;
         line-height: 1.4 !important;
       }
 
       /* Graveyard cards (post-044 v2 — slide 3) */
       .grave-pair {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .grave-result {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
         padding: clamp(4px, 0.8cqw, 7px) clamp(8px, 1.6cqw, 14px) !important;
       }
       .grave-story {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         line-height: 1.45 !important;
       }
       .grave-cause {
-        font-size: clamp(13px, 3cqw, 18px) !important;
+        font-size: clamp(15px, 3.4cqw, 21px) !important;
         letter-spacing: 2px !important;
       }
       .grave-truth-text {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.4 !important;
       }
 
       /* Scale visual (post-044 v2 — slide 4) */
       .scale-pan-label {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         letter-spacing: 3px !important;
       }
       .scale-pan-symbol {
-        font-size: clamp(22px, 5cqw, 34px) !important;
+        font-size: clamp(25px, 5.8cqw, 39px) !important;
       }
       .scale-pan-icon {
         width: clamp(50px, 10cqw, 80px) !important;
         height: clamp(50px, 10cqw, 80px) !important;
       }
       .scale-item {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         line-height: 1.4 !important;
       }
       .scale-insight {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
         line-height: 1.5 !important;
       }
 
       /* Shift columns (post-044 v2 — slide 5) */
       .shift-col-header {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         letter-spacing: 3px !important;
       }
       .shift-item-text {
-        font-size: clamp(15px, 3.5cqw, 22px) !important;
+        font-size: clamp(17px, 4cqw, 25px) !important;
         line-height: 1.4 !important;
       }
       .shift-truth-text {
-        font-size: clamp(22px, 5.5cqw, 34px) !important;
+        font-size: clamp(25px, 6.3cqw, 39px) !important;
         line-height: 1.4 !important;
       }
 
       /* Post-085 warm architecture classes */
       .cat-name {
-        font-size: clamp(16px, 3.5cqw, 24px) !important;
+        font-size: clamp(18px, 4cqw, 28px) !important;
       }
       .cat-desc {
-        font-size: clamp(12px, 2.5cqw, 18px) !important;
+        font-size: clamp(14px, 2.9cqw, 21px) !important;
       }
       .cat-icon-symbol {
-        font-size: clamp(18px, 4cqw, 30px) !important;
+        font-size: clamp(21px, 4.6cqw, 35px) !important;
       }
       .conf-text {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .conf-desc {
-        font-size: clamp(14px, 3cqw, 20px) !important;
+        font-size: clamp(16px, 3.4cqw, 23px) !important;
         line-height: 1.4 !important;
       }
       .conf-step-label {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
         letter-spacing: 2px !important;
       }
       .conf-num {
-        font-size: clamp(22px, 5cqw, 34px) !important;
+        font-size: clamp(25px, 5.8cqw, 39px) !important;
       }
       .conf-demo-label {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .conf-demo-desc {
-        font-size: clamp(14px, 3cqw, 20px) !important;
+        font-size: clamp(16px, 3.4cqw, 23px) !important;
       }
       .s2-total-text {
-        font-size: clamp(18px, 4cqw, 26px) !important;
+        font-size: clamp(21px, 4.6cqw, 30px) !important;
       }
       .feat-card-title {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .feat-card-desc {
-        font-size: clamp(14px, 3cqw, 20px) !important;
+        font-size: clamp(16px, 3.4cqw, 23px) !important;
         line-height: 1.4 !important;
       }
       .feat-bar-label {
-        font-size: clamp(11px, 2.5cqw, 16px) !important;
+        font-size: clamp(13px, 2.9cqw, 18px) !important;
       }
       .feat-icon-letter {
-        font-size: clamp(18px, 4cqw, 28px) !important;
+        font-size: clamp(21px, 4.6cqw, 32px) !important;
       }
       .stat-ring-val {
-        font-size: clamp(22px, 5cqw, 34px) !important;
+        font-size: clamp(25px, 5.8cqw, 39px) !important;
       }
       .stat-ring-label {
-        font-size: clamp(14px, 3cqw, 20px) !important;
+        font-size: clamp(16px, 3.4cqw, 23px) !important;
       }
       .stat-ring-sub {
-        font-size: clamp(11px, 2.5cqw, 16px) !important;
+        font-size: clamp(13px, 2.9cqw, 18px) !important;
       }
       .nr-badge {
-        font-size: clamp(14px, 3cqw, 20px) !important;
+        font-size: clamp(16px, 3.4cqw, 23px) !important;
       }
 
       /* Warm architecture stat recap / CTA */
       .stat-recap-num {
-        font-size: clamp(18px, 4cqw, 28px) !important;
+        font-size: clamp(21px, 4.6cqw, 32px) !important;
       }
       .stat-recap-label {
-        font-size: clamp(14px, 3cqw, 20px) !important;
+        font-size: clamp(16px, 3.4cqw, 23px) !important;
       }
       .stat-recap-val {
-        font-size: clamp(12px, 2.5cqw, 16px) !important;
+        font-size: clamp(14px, 2.9cqw, 18px) !important;
       }
       .stat-recap-ring {
         width: clamp(44px, 8.5cqw, 68px) !important;
         height: clamp(44px, 8.5cqw, 68px) !important;
       }
       .cta-glow-icon {
-        font-size: clamp(28px, 6cqw, 48px) !important;
+        font-size: clamp(32px, 6.9cqw, 55px) !important;
       }
       .cta-tagline {
-        font-size: clamp(32px, 8cqw, 52px) !important;
+        font-size: clamp(37px, 9.2cqw, 60px) !important;
       }
       .cta-desc {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
         line-height: 1.5 !important;
       }
       .cta-pill {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
         padding: 5px 14px !important;
       }
       .cta-box-text {
-        font-size: clamp(20px, 5cqw, 30px) !important;
+        font-size: clamp(23px, 5.8cqw, 35px) !important;
       }
       .cta-link {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
       }
 
       /* --- Doji Anatomy (post-056 pattern) --- */
       .da-part {
-        font-size: clamp(18px, 4.5cqw, 28px) !important;
+        font-size: clamp(21px, 5.2cqw, 32px) !important;
       }
       .da-meaning {
-        font-size: clamp(14px, 3.5cqw, 22px) !important;
+        font-size: clamp(16px, 4cqw, 25px) !important;
       }
       .type-badge {
-        font-size: clamp(12px, 3cqw, 18px) !important;
+        font-size: clamp(14px, 3.4cqw, 21px) !important;
       }
       .confirm-step {
-        font-size: clamp(16px, 4cqw, 24px) !important;
+        font-size: clamp(18px, 4.6cqw, 28px) !important;
       }
       .confirm-arrow {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
       }
 
       /* ===== Old Architecture — feature cards (post-045/050) ===== */
       .feature-text {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
         font-weight: 600 !important;
       }
       .feature-desc {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         line-height: 1.45 !important;
       }
       .feature-ic, .fic-letter {
@@ -1616,10 +1616,10 @@ async function renderCarousel(page, postDir, postNumber) {
         min-height: clamp(32px, 6cqw, 44px) !important;
       }
       .fic-letter {
-        font-size: clamp(18px, 4.5cqw, 26px) !important;
+        font-size: clamp(21px, 5.2cqw, 30px) !important;
       }
       .inner-heading {
-        font-size: clamp(32px, 7cqw, 48px) !important;
+        font-size: clamp(37px, 8cqw, 55px) !important;
       }
       .indicator-bar {
         height: clamp(5px, 1cqw, 8px) !important;
@@ -1627,25 +1627,25 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* ===== Old Architecture — definition cards (post-045/050 slide 2/3) ===== */
       .def-name {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
         font-weight: 600 !important;
       }
       .def-tag {
-        font-size: clamp(13px, 3.2cqw, 18px) !important;
+        font-size: clamp(15px, 3.7cqw, 21px) !important;
         letter-spacing: 2px !important;
       }
       .def-desc {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         line-height: 1.45 !important;
       }
 
       /* ===== Old Architecture — access cards (post-051) ===== */
       .access-name {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
         font-weight: 600 !important;
       }
       .access-desc {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         line-height: 1.45 !important;
       }
       .access-bar {
@@ -1654,32 +1654,32 @@ async function renderCarousel(page, postDir, postNumber) {
 
       /* ===== Old Architecture — promise / philosophy (post-051) ===== */
       .promise-card-title {
-        font-size: clamp(20px, 5cqw, 28px) !important;
+        font-size: clamp(23px, 5.8cqw, 32px) !important;
         font-weight: 600 !important;
       }
       .promise-card-text {
-        font-size: clamp(16px, 4cqw, 22px) !important;
+        font-size: clamp(18px, 4.6cqw, 25px) !important;
         line-height: 1.45 !important;
       }
       .philosophy-text {
-        font-size: clamp(22px, 5.5cqw, 32px) !important;
+        font-size: clamp(25px, 6.3cqw, 37px) !important;
         line-height: 1.5 !important;
       }
 
       /* ===== Old Architecture — stat pills ===== */
       .stat-pill .stat-val {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         font-weight: 600 !important;
       }
       .stat-pill .stat-label {
-        font-size: clamp(14px, 3.5cqw, 20px) !important;
+        font-size: clamp(16px, 4cqw, 23px) !important;
       }
       .cta-stat-val {
-        font-size: clamp(24px, 6cqw, 36px) !important;
+        font-size: clamp(28px, 6.9cqw, 41px) !important;
         font-weight: 600 !important;
       }
       .cta-stat-label {
-        font-size: clamp(13px, 3.2cqw, 18px) !important;
+        font-size: clamp(15px, 3.7cqw, 21px) !important;
       }
     </style>
   `;


### PR DESCRIPTION
All clamp() font-size values scaled by 1.15x and slide padding reduced from 6%/8% to 5%/6% to give more room for the larger text.

https://claude.ai/code/session_01T5rMz6MU922jzr7v8dwCKB