### PR TITLE
Fix Twitter search query syntax in engagement config

### DIFF
--- a/data/social/engagement-config.json
+++ b/data/social/engagement-config.json
@@ -57,11 +57,11 @@
     "likeDaily": 75,
     "replyDaily": 15,
     "searchQueries": [
-      "trading tips lang:en -filter:retweets",
-      "stock market analysis -filter:retweets",
-      "technical analysis -filter:retweets",
-      "day trading strategy -filter:retweets",
-      "market insights -filter:retweets"
+      "trading tips lang:en -is:retweet",
+      "stock market analysis -is:retweet",
+      "technical analysis -is:retweet",
+      "day trading strategy -is:retweet",
+      "market insights -is:retweet"
     ],
     "targetAccounts": [
       {


### PR DESCRIPTION
Changed -filter:retweets to -is:retweet for Twitter API v2 compatibility. The -filter:retweets syntax is not valid in Twitter API v2 and caused 400 Bad Request errors. Now engagement can properly search for tweets.

https://claude.ai/code/session_01CTTG9WrGEtF4ZSqGLQRbKv