### PR TITLE
Upgrade all 6 Pine Script strategies from v5 to v6

### DIFF
--- a/strategy-lab/pinescripts/meta_confluence_v1_bonk.pine
+++ b/strategy-lab/pinescripts/meta_confluence_v1_bonk.pine
@@ -1,5 +1,5 @@
-//@version=5
-strategy("Meta Confluence v1 — BONK H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500)
+//@version=6
+strategy("Meta Confluence v1 — BONK H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500, margin_long=0, margin_short=0)
 
 // ══════════════════════════════════════════════════════════════════════
 // Meta Confluence v1: 6 independent systems score, need 4+ to agree

--- a/strategy-lab/pinescripts/mtf_trend_v2_ada.pine
+++ b/strategy-lab/pinescripts/mtf_trend_v2_ada.pine
@@ -1,5 +1,5 @@
-//@version=5
-strategy("MTF Trend v2 — ADA H1", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500)
+//@version=6
+strategy("MTF Trend v2 — ADA H1", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500, margin_long=0, margin_short=0)
 
 // ══════════════════════════════════════════════════════════════════════
 // MTF Trend v2: Hull MA H4 trend + StochRSI H1 timing + MACD confirm

--- a/strategy-lab/pinescripts/rsi_divergence_v1_ltc.pine
+++ b/strategy-lab/pinescripts/rsi_divergence_v1_ltc.pine
@@ -1,5 +1,5 @@
-//@version=5
-strategy("RSI Divergence v1 — LTC H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500)
+//@version=6
+strategy("RSI Divergence v1 — LTC H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500, margin_long=0, margin_short=0)
 
 // ══════════════════════════════════════════════════════════════════════
 // RSI Divergence v1: Price vs RSI divergence with pivot detection

--- a/strategy-lab/pinescripts/rsi_divergence_v1_stx.pine
+++ b/strategy-lab/pinescripts/rsi_divergence_v1_stx.pine
@@ -1,5 +1,5 @@
-//@version=5
-strategy("RSI Divergence v1 — STX H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500)
+//@version=6
+strategy("RSI Divergence v1 — STX H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500, margin_long=0, margin_short=0)
 
 // ══════════════════════════════════════════════════════════════════════
 // RSI Divergence v1: Price vs RSI divergence with pivot detection

--- a/strategy-lab/pinescripts/stochrsi_momentum_v1_arb.pine
+++ b/strategy-lab/pinescripts/stochrsi_momentum_v1_arb.pine
@@ -1,5 +1,5 @@
-//@version=5
-strategy("StochRSI Momentum v1 — ARB H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500)
+//@version=6
+strategy("StochRSI Momentum v1 — ARB H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500, margin_long=0, margin_short=0)
 
 // ══════════════════════════════════════════════════════════════════════
 // StochRSI Momentum v1: Pullback entries in established trends

--- a/strategy-lab/pinescripts/volume_breakout_v1_mana.pine
+++ b/strategy-lab/pinescripts/volume_breakout_v1_mana.pine
@@ -1,5 +1,5 @@
-//@version=5
-strategy("Volume Breakout v1 — MANA H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500)
+//@version=6
+strategy("Volume Breakout v1 — MANA H4", overlay=true, default_qty_type=strategy.percent_of_equity, default_qty_value=5, commission_type=strategy.commission.percent, commission_value=0.055, slippage=2, initial_capital=500, margin_long=0, margin_short=0)
 
 // ══════════════════════════════════════════════════════════════════════
 // Volume Breakout v1: Volume spike + price breakout entries


### PR DESCRIPTION
- Version tag: //@version=5 → //@version=6
- Add margin_long=0, margin_short=0 to strategy() to preserve v5 position sizing behavior (v6 changed default from 0 to 100)
- All indicator calls already at global scope, safe from v6 lazy evaluation breaking change

https://claude.ai/code/session_0113hVivxiMx2T3Lv9SPvi2k