### PR TITLE
Add Elite Seven Strategy v1 — all 7 Signal Pilot indicators combined

### DIFF
--- a/strategy-lab/pinescripts/elite_seven_strategy_v1.pine
+++ b/strategy-lab/pinescripts/elite_seven_strategy_v1.pine
@@ -1,0 +1,189 @@
+//@version=6
+strategy("Signal Pilot — Elite Seven Strategy", overlay=true,
+     default_qty_type=strategy.percent_of_equity, default_qty_value=5,
+     commission_type=strategy.commission.percent, commission_value=0.055,
+     slippage=2, initial_capital=500, margin_long=0, margin_short=0)
+
+// ══════════════════════════════════════════════════════════════════════
+// SIGNAL PILOT — ELITE SEVEN CONFLUENCE STRATEGY v1
+//
+// Distills the core signal from each of the 7 Signal Pilot indicators:
+//   1. Pentarch       → Regime (Pilot Line + EMA stack + slope voting)
+//   2. OmniDeck       → SuperTrend consensus (3 ATR levels)
+//   3. Volume Oracle   → Directional volume flow
+//   4. Plutus Flow     → OBV trend vs basis
+//   5. Janus Atlas     → Market structure (HH/HL vs LH/LL)
+//   6. Augury Grid     → MACD + major trend + trend strength
+//   7. Harmonic Osc    → Composite oscillator direction
+//
+// Entry: Score freshly crosses threshold (N+ of 7 agree)
+// Exit:  ATR-based stop-loss and take-profit, or opposing confluence
+//
+// Test on: BYBIT:BTCUSDT.P (or any perp), H4 timeframe recommended
+// ══════════════════════════════════════════════════════════════════════
+
+// ── Inputs ────────────────────────────────────────────────────────────
+int   MIN_SCORE = input.int(5, "Min Score to Enter (of 7)", minval=3, maxval=7, group="Strategy")
+float ATR_SL    = input.float(1.5, "ATR Stop-Loss Multiplier", step=0.1, group="Risk")
+float ATR_TP    = input.float(3.0, "ATR Take-Profit Multiplier", step=0.1, group="Risk")
+int   ATR_LEN   = input.int(14, "ATR Period", group="Risk")
+
+// ── Shared ────────────────────────────────────────────────────────────
+float atrVal = ta.atr(ATR_LEN)
+
+// ══════════════════════════════════════════════════════════════════════
+// VOTE 1: PENTARCH — Cycle regime via Pilot Line
+// 3-factor vote: EMA alignment, price vs pilot line, pilot slope
+// ══════════════════════════════════════════════════════════════════════
+float ema34   = ta.ema(close, 34)
+float ema55   = ta.ema(close, 55)
+float pilot   = ta.ema(ema34, 3)
+float plSlope = pilot - pilot[1]
+float eps     = atrVal * 0.02
+int   pUp     = (ema34 > ema55 ? 1 : 0) + (close > pilot ? 1 : 0) + (plSlope > eps ? 1 : 0)
+int   pDn     = (ema34 < ema55 ? 1 : 0) + (close < pilot ? 1 : 0) + (plSlope < -eps ? 1 : 0)
+bool  v1_bull = pUp >= 2
+bool  v1_bear = pDn >= 2
+
+// ══════════════════════════════════════════════════════════════════════
+// VOTE 2: OMNIDECK — Multi-ATR SuperTrend consensus
+// 3 SuperTrend levels (tight/medium/wide), 2+ agree = confirmed trend
+// ══════════════════════════════════════════════════════════════════════
+[_s1, d1] = ta.supertrend(2.0, 10)
+[_s2, d2] = ta.supertrend(3.0, 10)
+[_s3, d3] = ta.supertrend(4.0, 10)
+int  stUp    = (d1 == -1 ? 1 : 0) + (d2 == -1 ? 1 : 0) + (d3 == -1 ? 1 : 0)
+bool v2_bull = stUp >= 2
+bool v2_bear = stUp <= 1
+
+// ══════════════════════════════════════════════════════════════════════
+// VOTE 3: VOLUME ORACLE — Directional volume flow
+// Track bull vs bear volume on above-average bars
+// ══════════════════════════════════════════════════════════════════════
+float volSma = ta.sma(volume, 20)
+float bVol   = close > open and volume > volSma ? volume : 0.0
+float sVol   = close < open and volume > volSma ? volume : 0.0
+float bFlow  = ta.sma(bVol, 10)
+float sFlow  = ta.sma(sVol, 10)
+bool  v3_bull = bFlow > sFlow * 1.1
+bool  v3_bear = sFlow > bFlow * 1.1
+
+// ══════════════════════════════════════════════════════════════════════
+// VOTE 4: PLUTUS FLOW — OBV trend vs basis
+// OBV above its 20-bar SMA = volume accumulation
+// ══════════════════════════════════════════════════════════════════════
+float obvVal   = ta.obv
+float obvBasis = ta.sma(obvVal, 20)
+bool  v4_bull  = obvVal > obvBasis
+bool  v4_bear  = obvVal < obvBasis
+
+// ══════════════════════════════════════════════════════════════════════
+// VOTE 5: JANUS ATLAS — Market structure direction
+// Compare recent 10-bar range vs prior — HH+HL = bull, LH+LL = bear
+// ══════════════════════════════════════════════════════════════════════
+float hiNow  = ta.highest(high, 10)
+float hiPrev = ta.highest(high[10], 10)
+float loNow  = ta.lowest(low, 10)
+float loPrev = ta.lowest(low[10], 10)
+bool  v5_bull = hiNow > hiPrev and loNow > loPrev
+bool  v5_bear = hiNow < hiPrev and loNow < loPrev
+
+// ══════════════════════════════════════════════════════════════════════
+// VOTE 6: AUGURY GRID — MACD momentum + major trend + strength
+// MACD histogram + price vs EMA200 + ADX trending
+// ══════════════════════════════════════════════════════════════════════
+[_m, _sg, hist] = ta.macd(close, 12, 26, 9)
+float ema200     = ta.ema(close, 200)
+[diP, diM, adx]  = ta.dmi(14, 14)
+bool  v6_bull    = hist > 0 and close > ema200 and adx > 20
+bool  v6_bear    = hist < 0 and close < ema200 and adx > 20
+
+// ══════════════════════════════════════════════════════════════════════
+// VOTE 7: HARMONIC OSCILLATOR — Composite oscillator direction
+// Normalized RSI + StochRSI blend, smoothed, vs signal line
+// ══════════════════════════════════════════════════════════════════════
+float rsiVal   = ta.rsi(close, 14)
+float srsiK    = ta.sma(ta.stoch(rsiVal, rsiVal, rsiVal, 14), 3)
+float comp     = (rsiVal + srsiK) / 2.0
+float compEma  = ta.ema(comp, 7)
+float compSig  = ta.ema(compEma, 3)
+bool  v7_bull  = compEma > compSig and compEma > 50
+bool  v7_bear  = compEma < compSig and compEma < 50
+
+// ══════════════════════════════════════════════════════════════════════
+// COMPOSITE SCORING
+// ══════════════════════════════════════════════════════════════════════
+int bullScore = (v1_bull ? 1 : 0) + (v2_bull ? 1 : 0) + (v3_bull ? 1 : 0) + (v4_bull ? 1 : 0) + (v5_bull ? 1 : 0) + (v6_bull ? 1 : 0) + (v7_bull ? 1 : 0)
+int bearScore = (v1_bear ? 1 : 0) + (v2_bear ? 1 : 0) + (v3_bear ? 1 : 0) + (v4_bear ? 1 : 0) + (v5_bear ? 1 : 0) + (v6_bear ? 1 : 0) + (v7_bear ? 1 : 0)
+
+// ── Entry: fresh score crossing threshold ────────────────────────────
+bool longCond  = bullScore >= MIN_SCORE and bullScore[1] < MIN_SCORE
+bool shortCond = bearScore >= MIN_SCORE and bearScore[1] < MIN_SCORE
+
+if longCond and strategy.position_size == 0
+    float sl = close - ATR_SL * atrVal
+    float tp = close + ATR_TP * atrVal
+    strategy.entry("Long", strategy.long)
+    strategy.exit("Long X", "Long", stop=sl, limit=tp)
+
+if shortCond and strategy.position_size == 0
+    float sl = close + ATR_SL * atrVal
+    float tp = close - ATR_TP * atrVal
+    strategy.entry("Short", strategy.short)
+    strategy.exit("Short X", "Short", stop=sl, limit=tp)
+
+// ── Protective exit: opposing confluence ──────────────────────────────
+if bearScore >= MIN_SCORE and strategy.position_size > 0
+    strategy.close("Long", comment="Bear confluence")
+if bullScore >= MIN_SCORE and strategy.position_size < 0
+    strategy.close("Short", comment="Bull confluence")
+
+// ══════════════════════════════════════════════════════════════════════
+// VISUAL OUTPUT
+// ══════════════════════════════════════════════════════════════════════
+plot(pilot, "Pilot Line", color=v1_bull ? color.green : v1_bear ? color.red : color.gray, linewidth=2)
+plot(ema200, "EMA 200", color=color.new(color.blue, 60), linewidth=1)
+
+plotshape(longCond and strategy.position_size == 0, "Long", shape.triangleup, location.belowbar, color.green, size=size.small)
+plotshape(shortCond and strategy.position_size == 0, "Short", shape.triangledown, location.abovebar, color.red, size=size.small)
+
+bgcolor(bullScore >= MIN_SCORE ? color.new(color.green, 93) : bearScore >= MIN_SCORE ? color.new(color.red, 93) : na)
+
+// ── Score panel ──────────────────────────────────────────────────────
+var table panel = table.new(position.top_right, 3, 9, bgcolor=color.new(color.black, 85), border_width=1, border_color=color.gray)
+if barstate.islast
+    table.cell(panel, 0, 0, "ELITE 7", text_color=color.white, text_size=size.small, bgcolor=color.new(color.blue, 60))
+    table.cell(panel, 1, 0, "BULL", text_color=color.green, text_size=size.tiny, bgcolor=color.new(color.blue, 60))
+    table.cell(panel, 2, 0, "BEAR", text_color=color.red, text_size=size.tiny, bgcolor=color.new(color.blue, 60))
+
+    table.cell(panel, 0, 1, "Pentarch", text_color=color.gray, text_size=size.tiny)
+    table.cell(panel, 1, 1, v1_bull ? "●" : "○", text_color=v1_bull ? color.green : color.gray, text_size=size.tiny)
+    table.cell(panel, 2, 1, v1_bear ? "●" : "○", text_color=v1_bear ? color.red : color.gray, text_size=size.tiny)
+
+    table.cell(panel, 0, 2, "OmniDeck", text_color=color.gray, text_size=size.tiny)
+    table.cell(panel, 1, 2, v2_bull ? "●" : "○", text_color=v2_bull ? color.green : color.gray, text_size=size.tiny)
+    table.cell(panel, 2, 2, v2_bear ? "●" : "○", text_color=v2_bear ? color.red : color.gray, text_size=size.tiny)
+
+    table.cell(panel, 0, 3, "Vol Oracle", text_color=color.gray, text_size=size.tiny)
+    table.cell(panel, 1, 3, v3_bull ? "●" : "○", text_color=v3_bull ? color.green : color.gray, text_size=size.tiny)
+    table.cell(panel, 2, 3, v3_bear ? "●" : "○", text_color=v3_bear ? color.red : color.gray, text_size=size.tiny)
+
+    table.cell(panel, 0, 4, "Plutus", text_color=color.gray, text_size=size.tiny)
+    table.cell(panel, 1, 4, v4_bull ? "●" : "○", text_color=v4_bull ? color.green : color.gray, text_size=size.tiny)
+    table.cell(panel, 2, 4, v4_bear ? "●" : "○", text_color=v4_bear ? color.red : color.gray, text_size=size.tiny)
+
+    table.cell(panel, 0, 5, "Janus", text_color=color.gray, text_size=size.tiny)
+    table.cell(panel, 1, 5, v5_bull ? "●" : "○", text_color=v5_bull ? color.green : color.gray, text_size=size.tiny)
+    table.cell(panel, 2, 5, v5_bear ? "●" : "○", text_color=v5_bear ? color.red : color.gray, text_size=size.tiny)
+
+    table.cell(panel, 0, 6, "Augury", text_color=color.gray, text_size=size.tiny)
+    table.cell(panel, 1, 6, v6_bull ? "●" : "○", text_color=v6_bull ? color.green : color.gray, text_size=size.tiny)
+    table.cell(panel, 2, 6, v6_bear ? "●" : "○", text_color=v6_bear ? color.red : color.gray, text_size=size.tiny)
+
+    table.cell(panel, 0, 7, "Harmonic", text_color=color.gray, text_size=size.tiny)
+    table.cell(panel, 1, 7, v7_bull ? "●" : "○", text_color=v7_bull ? color.green : color.gray, text_size=size.tiny)
+    table.cell(panel, 2, 7, v7_bear ? "●" : "○", text_color=v7_bear ? color.red : color.gray, text_size=size.tiny)
+
+    table.cell(panel, 0, 8, "TOTAL", text_color=color.white, text_size=size.small, bgcolor=color.new(color.gray, 70))
+    table.cell(panel, 1, 8, str.tostring(bullScore) + "/7", text_color=bullScore >= MIN_SCORE ? color.green : color.gray, text_size=size.small, bgcolor=color.new(color.gray, 70))
+    table.cell(panel, 2, 8, str.tostring(bearScore) + "/7", text_color=bearScore >= MIN_SCORE ? color.red : color.gray, text_size=size.small, bgcolor=color.new(color.gray, 70))


### PR DESCRIPTION
Pine Script v6 strategy that distills each of the 7 Signal Pilot indicators into a single bull/bear vote, then uses a scoring system (default 5/7 required) for entry. Built for direct TradingView testing on Bybit perps (BTCUSDT.P H4 recommended).

Votes:
1. Pentarch    → Pilot Line regime (EMA + slope + price voting)
2. OmniDeck    → Multi-ATR SuperTrend consensus (3 levels)
3. Volume Oracle → Directional volume flow tracking
4. Plutus Flow  → OBV above/below basis
5. Janus Atlas  → Market structure (HH/HL vs LH/LL)
6. Augury Grid  → MACD + EMA200 + ADX
7. Harmonic Osc → Composite RSI+StochRSI oscillator

Includes score panel overlay showing each indicator's current vote.

https://claude.ai/code/session_0113hVivxiMx2T3Lv9SPvi2k