### PR TITLE
Update post-066 slideCount from 10 to 6 to match PNG renders

### DIFF
--- a/data/social/content-queue.json
+++ b/data/social/content-queue.json
@@ -1945,7 +1945,7 @@
     },
     "instagram": {
       "caption": "Fibonacci Retracements explained 📐\n\nKEY LEVELS:\n◾ 23.6% — Shallow pullback\n◾ 38.2% — Common retracement\n◾ 50% — Halfway (not technically Fib)\n◾ 61.8% — Golden ratio, deep pullback\n◾ 78.6% — Very deep, trend may be weakening\n\nWHY THEY WORK:\nSelf-fulfilling prophecy. Millions watch them.\n\nHOW TO USE:\n◾ Draw from swing low to swing high (uptrend)\n◾ Or swing high to swing low (downtrend)\n◾ Look for confluence with other levels\n\nZones, not exact lines.\n\nFull lesson in bio 🔗",
-      "slideCount": 10
+      "slideCount": 6
     },
     "hashtags": [
       "#Fibonacci",
@@ -1954,7 +1954,7 @@
       "#TradingEducation",
       "#SignalPilot"
     ],
-    "slideCount": 10
+    "slideCount": 6
   },
   {
     "postNumber": 67,


### PR DESCRIPTION
Updated both instagram.slideCount and slideCount for post 066 (FIBONACCI RETRACEMENTS). Currently have 6 PNG renders ready for this post.

https://claude.ai/code/session_01CTTG9WrGEtF4ZSqGLQRbKv