### PR TITLE
Fix schedule duplicates and slideCount mismatches across 22+ posts

### DIFF
--- a/data/social/content-queue.json
+++ b/data/social/content-queue.json
@@ -1913,7 +1913,7 @@
     },
     "instagram": {
       "caption": "One complete Bitcoin cycle. Five Pentarch signals. 🔮\n\nHere's what each signal historically indicated:\n\n🟢 TD (TouchDown)\n→ Early-cycle reversal on selling exhaustion\n\n🔵 IGN (Ignition)\n→ Breakout confirmation with conviction\n\n🟡 WRN (Warning)\n→ Early weakness in uptrends\n\n🟠 CAP (Climax)\n→ Late-cycle exhaustion with volume spikes\n\n🔴 BDN (BreakDown)\n→ Bearish structure break\n\nThe Sovereign observes the full cycle.\n\nHistorical patterns. Educational purposes only.",
-      "slideCount": 6
+      "slideCount": 7
     },
     "hashtags": [
       "#Pentarch",
@@ -2065,7 +2065,7 @@
     },
     "instagram": {
       "caption": "Janus Atlas Timeframe Guide 🗺️\n\nHIGHER TIMEFRAMES (Weekly, Daily)\n• Stronger levels\n• More significant reactions\n• Best for swing trading\n\nMEDIUM TIMEFRAMES (4H, 1H)\n• Balance of strength and speed\n• Good for day trading\n• Confirm with higher TF\n\nLOWER TIMEFRAMES (15m, 5m)\n• More levels, more noise\n• Best for scalping\n• Use higher TF for direction\n\nThe Cartographer maps all timeframes.\n\nFull docs in bio 🔗\n\n#SignalPilot #Documentation #TradingSetup #TradingView #IndicatorGuide #JanusAtlas #AutoLevels",
-      "slideCount": 6
+      "slideCount": 5
     },
     "hashtags": [
       "#JanusAtlas",
@@ -2074,7 +2074,7 @@
       "#SignalPilot",
       "#TradingView"
     ],
-    "slideCount": 6
+    "slideCount": 5
   },
   {
     "postNumber": 71,
@@ -2095,7 +2095,7 @@
     },
     "instagram": {
       "caption": "82 free trading lessons 📚\n\nNo paywall. No \"pay for advanced.\" Just free.\n\nBEGINNER (20 lessons)\n• Psychology, risk, basic patterns\n\nINTERMEDIATE (27 lessons)\n• Structure, volume, indicators\n\nADVANCED (27 lessons)\n• Multi-timeframe, confluence, optimization\n\nPROFESSIONAL (8 lessons)\n• Portfolio management, edge refinement\n\nEducated traders make better decisions. That's why we give this away.\n\nStart learning in bio 🔗\n\n#SignalPilot #TradingTools #TradingView #TradingCommunity #LearnTrading #RiskManagement",
-      "slideCount": 1
+      "slideCount": 5
     },
     "hashtags": [
       "#SignalPilot",
@@ -2104,7 +2104,7 @@
       "#LearnTrading",
       "#TradingLessons"
     ],
-    "slideCount": 6
+    "slideCount": 5
   },
   {
     "postNumber": 72,
@@ -2249,7 +2249,7 @@
     },
     "instagram": {
       "caption": "Backtesting 101 📈\n\nWHY BACKTEST?\n• Test ideas without risking capital\n• Find actual edge (or lack of it)\n• Build confidence in your system\n\nKEY METRICS TO TRACK:\n• Win Rate — % of winning trades\n• Avg R:R — Average risk to reward\n• Expectancy — Expected $ per trade\n• Max Drawdown — Worst losing streak\n• Sample Size — Need 100+ trades minimum\n\nRULES:\n• Be honest, no cherry-picking\n• Include commissions/fees\n• Test across different market conditions\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingEducation #PriceAction #TradingSkills #TechnicalAnalysis #RiskManagement",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#Backtesting",
@@ -2279,7 +2279,7 @@
     },
     "instagram": {
       "caption": "Why your stops keep getting hit 🎯\n\nLIQUIDITY = Where orders cluster\n\nWHERE IT SITS:\n• Below swing lows (everyone's stop losses)\n• Above swing highs (everyone's stop losses)\n• At obvious round numbers\n• At \"textbook\" pattern stops\n\nWHAT HAPPENS:\nPrice sweeps these levels → Triggers stops → Reverses\n\nWHY?\nLarge players need liquidity to fill orders. Your stops = their entries.\n\nTHE FIX:\nPlace stops at less obvious levels. Give room for the hunt.\n\nFull article in bio 🔗\n\n#SignalPilot #TradingInsights #TradingPsychology #MarketMindset #SmartTrading",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#Liquidity",
@@ -2308,7 +2308,7 @@
     },
     "instagram": {
       "caption": "THE PROPHET 🔮\n\n\"I do not see the future. I see the conditions that create it.\"\n\nAmong the Elite Seven, The Prophet reads what others cannot.\n\nVolume Oracle sees:\n• Volatility regimes\n• Volume patterns\n• Market phase transitions\n• The environment, not the outcome\n\nThe future isn't predicted. It's prepared for.\n\nMeet The Prophet in bio 🔗\n\n#SignalPilot #Chronicle #TheSeven #TradingLore #MarketWisdom #VolumeOracle #VolumeAnalysis",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#SignalPilot",
@@ -2338,7 +2338,7 @@
     },
     "instagram": {
       "caption": "Paper Trading 101 📝\n\nWHAT IT IS:\nSimulated trading with no real money at risk\n\nWHY DO IT:\n• Test strategies before going live\n• Build discipline and process\n• Make mistakes for free\n• Build confidence in your system\n\nRULES FOR EFFECTIVE PAPER TRADING:\n• Treat it like real money\n• Use realistic position sizes\n• Journal every trade\n• Don't skip the boring parts\n\nGraduate to live when consistently profitable.\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingTips #MarketAnalysis #TradingCommunity #LearnTrading #RiskManagement",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#PaperTrading",
@@ -2368,7 +2368,7 @@
     },
     "instagram": {
       "caption": "Pentarch Signal Reference Guide 👑\n\n🟢 TD (TouchDown)\n→ Early-cycle reversal on selling exhaustion\n\n🔵 IGN (Ignition)\n→ Breakout confirmation with conviction\n\n🟡 WRN (Warning)\n→ Early weakness in uptrends\n\n🟠 CAP (Climax)\n→ Late-cycle exhaustion with volume spikes\n\n🔴 BDN (BreakDown)\n→ Bearish structure break\n\nSave this reference 📌\n\nFull docs in bio 🔗\n\n#SignalPilot #TradingGuide #HowTo #TradingView #IndicatorSetup #Pentarch #CycleDetection",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#Pentarch",
@@ -2396,7 +2396,7 @@
     },
     "instagram": {
       "caption": "The math on annual vs monthly 🧮\n\nMONTHLY PLAN\n$69 × 12 months = $828/year\n\nANNUAL PLAN\n$399 one-time = $399/year\n\nYOU SAVE: $429 💰\n\nThat's 52% off.\n\nSame access:\n✅ All 7 indicators\n✅ All 82 lessons\n✅ All updates\n✅ Full support\n\nJust smarter commitment.\n\nLink in bio 🔗\n\n#SignalPilot #TradingTools #TradingView #TradingCommunity #LearnTrading #SupportResistance",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#SignalPilot",
@@ -2427,7 +2427,7 @@
     },
     "instagram": {
       "caption": "Ready to go live? Checklist ✅\n\nBEFORE YOU GO LIVE:\n☐ Profitable in paper trading (3+ months)\n☐ Strategy backtested (100+ trades)\n☐ Risk management defined\n☐ Journal system ready\n☐ Emotionally prepared for losses\n\nWHEN YOU GO LIVE:\n• Start with SMALLEST position size\n• Focus on PROCESS, not profit\n• Expect emotions to hit different\n• Scale up SLOWLY as you prove yourself\n\nLive trading is a different game. Respect it.\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingEducation #LearnTrading #TradingTips #TechnicalAnalysis #RiskManagement",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#GoingLive",
@@ -2458,7 +2458,7 @@
     },
     "instagram": {
       "caption": "The Wyckoff Method simplified 📊\n\nPHASE 1: ACCUMULATION\n• Price ranges sideways\n• Smart money quietly accumulates\n• Public sees \"boring\" price action\n\nPHASE 2: MARKUP\n• Price breaks out and trends up\n• Public starts buying\n• Media turns bullish\n\nPHASE 3: DISTRIBUTION\n• Price ranges at highs\n• Smart money quietly sells\n• Public sees \"consolidation\"\n\nPHASE 4: MARKDOWN\n• Price breaks down and trends lower\n• Public panic sells\n• Cycle resets\n\nFull article in bio 🔗\n\n#SignalPilot #TradingBlog #TradingTips #MarketWisdom #TradingCommunity #Pentarch #CycleDetection",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#Wyckoff",
@@ -2488,7 +2488,7 @@
     },
     "instagram": {
       "caption": "📚 THE MOST EXPENSIVE EDUCATION\n\n\"The market will teach you.\n\nThe tuition is your losses.\n\nPay attention or keep paying.\"\n\nEvery loss contains information:\n\n✦ Was the setup valid?\n✦ Did you follow your rules?\n✦ What would you do differently?\n\nTraders who improve:\n✅ Journal every loss\n✅ Look for patterns in mistakes\n✅ Adjust and adapt\n\nTraders who don't:\n❌ Blame the market\n❌ Repeat the same errors\n❌ Wonder why nothing changes\n\nYou're going to pay tuition either way.\n\nMight as well learn something.\n\nSave this 📌\n\nMore in bio 🔗\n\n#SignalPilot #TradingQuote #TradingTruth #MarketWisdom #SmartTrading #TradingJournal",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#TradingWisdom",
@@ -2519,7 +2519,7 @@
     },
     "instagram": {
       "caption": "Confluence is where the magic happens ✨\n\nWHAT IS CONFLUENCE?\nMultiple levels/signals agreeing at the same zone\n\nJANUS ATLAS CONFLUENCE:\n• Daily level at $50,000\n• 4H level at $50,100\n• 1H level at $49,950\n→ All pointing to same zone = STRONG level\n\nWHY IT MATTERS:\n• More traders watching = More reaction\n• Higher probability zone\n• Better risk:reward entries\n\nThe Cartographer maps them all.\n\nDemo in bio 🔗\n\n#SignalPilot #TradingIndicators #TradingView #TradingTools #TechnicalAnalysis #JanusAtlas #AutoLevels",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#JanusAtlas",
@@ -2551,7 +2551,7 @@
     },
     "instagram": {
       "caption": "Market Structure 101 🦴\n\nBULLISH STRUCTURE\n• Higher Highs (HH)\n• Higher Lows (HL)\n• Buyers in control\n\nBEARISH STRUCTURE\n• Lower Highs (LH)\n• Lower Lows (LL)\n• Sellers in control\n\nBREAK OF STRUCTURE (BOS)\n• Pattern breaks\n• Potential trend reversal\n• Wait for confirmation\n\nCHANGE OF CHARACTER (CHoCH)\n• First sign of shift\n• Structure starting to change\n• Be alert\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingEducation #PriceAction #TradingSkills #TechnicalAnalysis #OrderBlocks #SMC",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#MarketStructure",
@@ -2581,7 +2581,7 @@
     },
     "instagram": {
       "caption": "Order Blocks explained 📦\n\nWHAT IS AN ORDER BLOCK?\nThe last candle before a strong impulse move\n\nBULLISH ORDER BLOCK\n• Last down candle before strong up move\n• Marks potential institutional buying\n• Price often returns to test it\n\nBEARISH ORDER BLOCK\n• Last up candle before strong down move\n• Marks potential institutional selling\n• Price often returns to test it\n\nHOW TO USE:\n• Mark the zone (body of the candle)\n• Wait for price to return\n• Look for reaction + confirmation\n\nFull article in bio 🔗\n\n#SignalPilot #TradingBlog #MarketInsights #TradingMindset #TradingLife #OrderBlocks #SMC",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#OrderBlocks",
@@ -2611,7 +2611,7 @@
     },
     "instagram": {
       "caption": "THE BIRTH OF THE ELITE SEVEN ⚔️\n\nBefore them, there was chaos.\n\n• Indicators that repainted\n• Signals that contradicted\n• Noise mistaken for insight\n• Traders lost in confusion\n\nThen came the Seven.\n\nEach forged with a single purpose:\n👑 The Sovereign — Cycles\n🔮 The Prophet — Regimes\n🗺️ The Cartographer — Levels\n⚖️ The Scales — Flow\n⚔️ The Arbiter — Momentum\n👁️ The Watchman — Scanning\n🎯 The Commander — Unity\n\nClarity from chaos.\n\nRead the full origin in bio 🔗\n\n#SignalPilot #TheChronicle #TradingWisdom #TheSeven #MarketStory",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#SignalPilot",
@@ -2643,7 +2643,7 @@
     },
     "instagram": {
       "caption": "Supply & Demand Zones 📊\n\nDEMAND ZONE (Bullish)\n• Where buyers overwhelmed sellers\n• Strong rally originated here\n• Price often returns to \"refill\"\n\nSUPPLY ZONE (Bearish)\n• Where sellers overwhelmed buyers\n• Strong drop originated here\n• Price often returns to test\n\nHOW TO DRAW:\n• Find impulse move\n• Mark the base before the move\n• Zone = range of that consolidation\n\nKEY CONCEPT:\nFresh zones > Tested zones\nClean departure > Messy departure\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingTips #MarketAnalysis #TradingCommunity #LearnTrading #SupportResistance",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#SupplyAndDemand",
@@ -2672,7 +2672,7 @@
     },
     "instagram": {
       "caption": "Volume Oracle Settings Guide 🔮\n\nSENSITIVITY SETTING\n• Higher = Detects more regime changes\n• Lower = Fewer, more significant changes\n• Choppy market? Increase sensitivity\n• Trending market? Decrease sensitivity\n\nSMOOTHING SETTING\n• Higher = Cleaner signals, more lag\n• Lower = Faster signals, more noise\n• Swing trading? More smoothing\n• Day trading? Less smoothing\n\nDEFAULT:\nBalanced for most conditions. Start here.\n\nFull docs in bio 🔗\n\n#SignalPilot #TradingDocs #HowTo #TradingView #TradingIndicators #VolumeOracle #VolumeAnalysis",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#VolumeOracle",
@@ -2702,7 +2702,7 @@
     },
     "instagram": {
       "caption": "Why non-repainting matters 🔒\n\nREPAINTING INDICATORS:\n❌ Change past signals\n❌ Look perfect in hindsight\n❌ Fail in real-time\n❌ Can't be trusted\n\nSIGNAL PILOT INDICATORS:\n✅ What you see is what happened\n✅ No retroactive changes\n✅ Same signal live and in history\n✅ Trustworthy in real-time\n\nIf you can't trust the signal, what's the point?\n\nAll 7 indicators. Non-repainting. Guaranteed.\n\nLink in bio 🔗\n\n#SignalPilot #TradingIndicators #TradingView #FreeEducation #TradingTools",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#NonRepainting",
@@ -2732,7 +2732,7 @@
     },
     "instagram": {
       "caption": "Fair Value Gaps explained 📊\n\nWHAT IS AN FVG?\nA gap between candle wicks caused by aggressive buying/selling\n\nHOW TO IDENTIFY:\n• 3-candle formation\n• Middle candle moves aggressively\n• Gap between Candle 1 high and Candle 3 low (bullish)\n• Or Candle 1 low and Candle 3 high (bearish)\n\nWHY IT MATTERS:\n• Represents imbalance\n• Price often returns to \"fill\" the gap\n• Can act as support/resistance\n\nNOT A GUARANTEE:\nPrice doesn't always fill. Use with confluence.\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingTips #MarketAnalysis #TradingCommunity #LearnTrading #SupportResistance",
-      "slideCount": 8
+      "slideCount": 6
     },
     "hashtags": [
       "#FVG",
@@ -2762,7 +2762,7 @@
     },
     "instagram": {
       "caption": "The problem isn't indicators. It's how you use them. 🔧\n\nCOMMON MISTAKES:\n\n❌ EXPECTING PREDICTION\nIndicators show what happened, not what will\n\n❌ USING LAGGING FOR ENTRIES\nMAs confirm trends, they don't call bottoms\n\n❌ IGNORING CONTEXT\nRSI oversold in a downtrend ≠ buy signal\n\n❌ TOO MANY INDICATORS\n10 indicators saying different things = confusion\n\nTHE FIX:\n• Understand what each indicator actually does\n• Use them for context, not signals\n• Less is more\n\nFull article in bio 🔗\n\n#SignalPilot #TradingInsights #MarketAnalysis #TradingJourney #SmartTrading",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#TradingIndicators",
@@ -2791,7 +2791,7 @@
     },
     "instagram": {
       "caption": "This is what discipline really means 👇\n\n\"Discipline is choosing between what you want now and what you want most.\"\n\nRIGHT NOW you want to:\n• Revenge trade that loss\n• FOMO into that pump\n• Skip the journal entry\n• Size up \"just this once\"\n\nMOST you want to:\n• Be consistently profitable\n• Build real wealth\n• Trade for years to come\n\nEvery impulsive decision is a vote against your future.\n\nSave this. 🔖\n\nFull guide in bio 🔗\n\n#SignalPilot #TradingQuotes #TradingWisdom #MarketMindset #TradingMotivation #TradingJournal",
-      "slideCount": 4
+      "slideCount": 5
     },
     "hashtags": [
       "#TradingQuotes",
@@ -2821,7 +2821,7 @@
     },
     "instagram": {
       "caption": "Divergence explained ⚔️\n\nWHAT IS DIVERGENCE?\nPrice and indicator moving in opposite directions\n\nBEARISH DIVERGENCE\n• Price: Higher high\n• Oscillator: Lower high\n• = Momentum weakening\n\nBULLISH DIVERGENCE\n• Price: Lower low\n• Oscillator: Higher low\n• = Selling pressure weakening\n\nIMPORTANT:\nDivergence ≠ Immediate reversal\nIt's a WARNING, not a signal\n\nThe Arbiter sees when forces disagree.\n\nDemo in bio 🔗\n\n#SignalPilot #TradingIndicators #TradingView #ChartAnalysis #TradingTools #Pentarch #CycleDetection",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#HarmonicOscillator",
@@ -2852,7 +2852,7 @@
     },
     "instagram": {
       "caption": "Inducement explained 🪤\n\nWHAT IS INDUCEMENT?\nA trap designed to trigger stops before the real move\n\nHOW IT WORKS:\n1️⃣ Price approaches key level\n2️⃣ Breaks slightly beyond (triggers stops)\n3️⃣ Grabs liquidity (stop losses = market orders)\n4️⃣ Reverses in intended direction\n\nWHY IT HAPPENS:\n• Large players need liquidity to fill orders\n• Your stop loss = their entry\n• \"Obvious\" breakouts are often traps\n\nTHE LESSON:\nDon't place stops at obvious levels. Give room for the sweep.\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingTips #MarketAnalysis #TradingCommunity #LearnTrading",
-      "slideCount": 8
+      "slideCount": 6
     },
     "hashtags": [
       "#Inducement",
@@ -2883,7 +2883,7 @@
     },
     "instagram": {
       "caption": "The most profitable thing you can do is... nothing 🧘\n\nDO NOTHING WHEN:\n• No clear setup exists\n• You're unsure about direction\n• You're emotional (angry, fearful, greedy)\n• Market is choppy/unclear\n• You're trying to \"make back\" losses\n\nTHE TRUTH:\nMost losses come from trades that shouldn't have happened.\n\nPATIENCE IS A POSITION.\nCash is a position.\nWaiting is a strategy.\n\nThe best traders know when NOT to trade.\n\nFull article in bio 🔗\n\n#SignalPilot #TradingInsights #MarketAnalysis #TradingJourney #SmartTrading",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#TradingDiscipline",
@@ -2913,7 +2913,7 @@
     },
     "instagram": {
       "caption": "THE COUNCIL ASSEMBLES 👑\n\nWhen the Elite Seven gather, the full picture emerges.\n\n👑 The Sovereign speaks of cycles\n🔮 The Prophet reads the regime\n🗺️ The Cartographer maps the levels\n⚖️ The Scales weighs the flow\n⚔️ The Arbiter judges momentum\n👁️ The Watchman scans the field\n🎯 The Commander unifies all\n\nAlone, powerful. Together, unstoppable.\n\nWhen they align—that's confluence.\n\nRead the full chronicle in bio 🔗\n\n#SignalPilot #TheChronicle #TradingStory #MarketWisdom #TradingMythology #RiskManagement",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#SignalPilot",
@@ -2942,7 +2942,7 @@
     },
     "instagram": {
       "caption": "Trend Continuation Patterns 🚩\n\nFLAG PATTERN\n• Sharp move (flagpole)\n• Tight consolidation against trend\n• Breakout continues original direction\n\nPENNANT PATTERN\n• Sharp move (pole)\n• Symmetrical triangle consolidation\n• Typically breaks in trend direction\n\nWEDGE PATTERN\n• Consolidation with converging lines\n• Rising wedge = often bearish\n• Falling wedge = often bullish\n\nKEY INSIGHT:\nThese are PAUSES, not reversals. Trade with the trend.\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingLessons #ChartAnalysis #TradingStrategy #LearnToTrade",
-      "slideCount": 8
+      "slideCount": 6
     },
     "hashtags": [
       "#ContinuationPatterns",
@@ -2973,7 +2973,7 @@
     },
     "instagram": {
       "caption": "New to Signal Pilot? Follow this workflow 🛤️\n\nSTEP 1: SETUP\nAdd indicators to TradingView\n\nSTEP 2: START SIMPLE\nBegin with Pentarch OR Volume Oracle (not both)\n\nSTEP 3: LEARN\nComplete Beginner lessons (20 free)\n\nSTEP 4: PRACTICE\nPaper trade until consistent\n\nSTEP 5: EXPAND\nAdd second indicator, learn its purpose\n\nSTEP 6: GRADUATE\nGo live with small size when ready\n\nMaster one before adding another.\n\nFull workflow in bio 🔗\n\n#SignalPilot #Documentation #TradingSetup #TradingView #IndicatorGuide #Pentarch #CycleDetection",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#SignalPilot",
@@ -3000,7 +3000,7 @@
     },
     "instagram": {
       "caption": "100 POSTS 🎉\n\n100 pieces of free trading education.\n\nWe've covered:\n✅ Trading psychology\n✅ Risk management\n✅ Technical analysis\n✅ Indicator deep dives\n✅ The Chronicle lore\n✅ Strategy breakdowns\n\nAnd we're just getting started.\n\n500+ more posts planned.\n\nThank you for being here. Thank you for learning.\n\nThe journey continues 🚀\n\nLink in bio 🔗\n\n#SignalPilot #TradingIndicators #TradingView #FreeEducation #TradingTools #Pentarch #CycleDetection",
-      "slideCount": 4
+      "slideCount": 6
     },
     "hashtags": [
       "#SignalPilot",
@@ -3030,7 +3030,7 @@
     },
     "instagram": {
       "caption": "Liquidity Pools explained 🧲\n\nWHAT ARE LIQUIDITY POOLS?\nClusters of stop losses and pending orders at predictable levels\n\nWHERE THEY FORM:\n• Above equal highs (buy stops)\n• Below equal lows (sell stops)\n• At obvious support/resistance\n• At round numbers\n\nWHY PRICE HUNTS THEM:\n• Large players need liquidity to fill orders\n• Your stops = their entries\n• Price gravitates toward order clusters\n\nTHE INSIGHT:\nPrice often sweeps liquidity BEFORE the real move.\n\nFull lesson in bio 🔗\n\n#SignalPilot #TradingEducation #SmartTrading #TechnicalAnalysis #TradingKnowledge #SupportResistance",
-      "slideCount": 8
+      "slideCount": 6
     },
     "hashtags": [
       "#Liquidity",

--- a/lib/social/posting-schedule.js
+++ b/lib/social/posting-schedule.js
@@ -59,7 +59,7 @@ const ALREADY_POSTED = [
 // Format per row: [Orange, Neutral, Teal] = 3 post orders
 const NINE_GRID_ROWS = [
   [35, 36, 40],   // Row 13: 035 Product | 036 EDU | 040 Docs
-  [41, 39, 43],   // Row 14: 041 Marketing | 039 EDU | 043 Blog
+  [41, 42, 43],   // Row 14: 041 Marketing | 042 EDU | 043 Blog
   [44, 46, 47],   // Row 15: 044 Quote | 046 EDU | 047 Blog
   [45, 49, 48],   // Row 16: 045 Product | 049 EDU | 048 Chronicle
   [51, 52, 50],   // Row 17: 051 Marketing | 052 EDU | 050 Docs
@@ -68,8 +68,8 @@ const NINE_GRID_ROWS = [
   [65, 62, 60],   // Row 20: 065 Product | 062 EDU | 060 Docs
   [61, 66, 63],   // Row 21: 061 Marketing | 066 EDU | 063 Blog
   [64, 72, 58],   // Row 22: 064 Quote | 072 EDU | 058 Chronicle
-  [64, 76, 68],
-  [65, 79, 70],
+  [67, 76, 68],   // Row 23: 067 Blog | 076 EDU | 068 Chronicle
+  [69, 79, 70],   // Row 24: 069 EDU | 079 EDU | 070 Docs
   [71, 82, 73],
   [74, 86, 77],
   [75, 89, 78],


### PR DESCRIPTION
Schedule fixes (posting-schedule.js):
- Row 14: post 39 (dup from ALREADY_POSTED) → post 42 (neutral)
- Row 23: post 64 (dup from row 22) → post 67 (orange)
- Row 24: post 65 (dup from row 20) → post 69 (orange)

SlideCount fixes (content-queue.json):
- Synced instagram.slideCount to actual slide PNG count on disk
- Fixed 17 under-counted posts (076-091 had slideCount:4 but 5-6 slides)
- Fixed 5 over-counted posts (070,092,096,099,102 claimed more than exist)
- Fixed post 071 from slideCount:1 → 5 (was blocking carousel posting)

https://claude.ai/code/session_01RKLH6giKDAmv7x8a2m3cpL