### PR TITLE
Add comprehensive platform listing guide for SignalPilot

### DIFF
--- a/WHOP-ALTERNATIVES-LISTING-GUIDE.md
+++ b/WHOP-ALTERNATIVES-LISTING-GUIDE.md
@@ -1,0 +1,1089 @@
+# SignalPilot.io — Complete Platform Listing Guide
+
+> **Goal:** List SignalPilot on every relevant marketplace, directory, and community to maximize discovery, backlinks, and sales.
+>
+> **What is SignalPilot?** A suite of 7 non-repainting TradingView indicators powered by the Pentarch™ cycle detection system. Pricing: $69/mo | $399/yr | $999 Lifetime. Sold via Gumroad.
+
+---
+
+## Table of Contents
+
+1. [Pre-Written Copy (Use Everywhere)](#1-pre-written-copy-use-everywhere)
+2. [Category A: Trading-Specific Marketplaces](#2-category-a-trading-specific-marketplaces)
+3. [Category B: Digital Product Marketplaces (Direct Whop Alternatives)](#3-category-b-digital-product-marketplaces-direct-whop-alternatives)
+4. [Category C: Lifetime Deal / SaaS Marketplaces](#4-category-c-lifetime-deal--saas-marketplaces)
+5. [Category D: Product Launch & Discovery Directories](#5-category-d-product-launch--discovery-directories)
+6. [Category E: Community & Social Channels](#6-category-e-community--social-channels)
+7. [Assets Checklist](#7-assets-checklist)
+8. [Launch Calendar](#8-launch-calendar)
+
+---
+
+## 1. Pre-Written Copy (Use Everywhere)
+
+Keep these ready on your clipboard. Most platforms ask for the same fields.
+
+### Product Name
+```
+Signal Pilot
+```
+
+### One-Liner / Tagline (under 60 chars)
+```
+7 non-repainting TradingView indicators for cycle trading
+```
+
+### Short Description (under 260 chars)
+```
+Signal Pilot is a suite of 7 non-repainting TradingView indicators built around the Pentarch™ five-phase cycle detection system. Map complete market cycles, spot reversals before they happen, and trade with institutional-grade tools — no repainting, ever.
+```
+
+### Medium Description (1 paragraph)
+```
+Signal Pilot gives traders 7 professional TradingView indicators that never repaint. The flagship Pentarch™ system identifies five-phase market reversal sequences (TD → IGN → WRN → CAP → BDN), helping you understand complete market cycles instead of relying on basic overbought/oversold signals. The suite includes OmniDeck (unified overlay), Volume Oracle (regime detection), Plutus Flow (statistical OBV), Janus Atlas (multi-timeframe levels), Augury Grid (watchlist scanner), and Harmonic Oscillator (momentum timing). All indicators come with real-time alerts, 200+ preset configurations, and a 7-day money-back guarantee.
+```
+
+### Long Description / Maker Story (for Product Hunt first comment, Indie Hackers, etc.)
+```
+Hey everyone! I built Signal Pilot because I was frustrated with TradingView indicators that repaint — they look perfect on historical charts but fail miserably in real-time. Every indicator in the suite is 100% audited non-repainting.
+
+The core of Signal Pilot is Pentarch™, a cycle detection system that maps five distinct phases of market reversals. Instead of just telling you "overbought" or "oversold," it shows you exactly where you are in a complete market cycle.
+
+The full suite includes 7 indicators:
+
+• SP — Pentarch: Five-phase cycle detection and reversal mapping
+• SP — OmniDeck: Unified overlay with 10+ detection mechanisms
+• SP — Volume Oracle: Volume regime detection and profiling
+• SP — Plutus Flow: Statistical OBV with divergence alerts
+• SP — Janus Atlas: Multi-timeframe key levels (50+ level types incl. VWAP, Fibonacci)
+• SP — Augury Grid: Watchlist scanner — 7 symbols across 3 timeframes
+• SP — Harmonic Oscillator: Consensus system combining 7 momentum components
+
+We also built a free education hub with 82 lessons (250,000+ words), full documentation, and a blog published in 12 languages.
+
+Pricing: $69/mo, $399/yr (52% savings), or $999 lifetime (limited to 100 founding members).
+
+All plans include every indicator, real-time alerts, presets, and support. 7-day money-back guarantee.
+
+Would love your feedback!
+```
+
+### Keywords / Tags (pick relevant ones per platform)
+```
+TradingView, trading indicators, technical analysis, non-repainting indicators, cycle trading, market cycles, stock trading, forex, crypto trading, algorithmic trading, Pine Script, trading tools, fintech, SaaS, trading signals, volume analysis, momentum trading, swing trading, day trading
+```
+
+### Key Links
+```
+Website:       https://www.signalpilot.io
+Education Hub: https://education.signalpilot.io
+Documentation: https://docs.signalpilot.io
+Blog:          https://blog.signalpilot.io
+Support:       support@signalpilot.io
+```
+
+### Categories to Select (varies by platform)
+```
+Primary:   Trading Tools / Financial Software / Fintech
+Secondary: SaaS / Developer Tools / Productivity
+Tertiary:  Education / Analytics / Data Visualization
+```
+
+---
+
+## 2. Category A: Trading-Specific Marketplaces
+
+These platforms have your **exact buyers** — traders looking for indicators.
+
+---
+
+### 2A-1. TradingView Community Scripts
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://www.tradingview.com/scripts/ |
+| **Cost** | Free |
+| **What to list** | Individual Pine Script indicators (publish as invite-only) |
+| **Audience** | Millions of active TradingView users |
+
+**How to submit:**
+1. Go to TradingView → Pine Editor → Open your script
+2. Click "Publish Script" in the editor toolbar
+3. Choose **"Invite-only"** (for paid indicators)
+4. Fill in:
+   - **Title:** `SP — Pentarch™ | Five-Phase Cycle Detection [SignalPilot]`
+   - **Short Description:** Use the short description from Section 1 above
+   - **Long Description:** Explain what the indicator does, include screenshots of it on charts, list key features in bullet points
+   - **Categories:** Select "Trend Analysis", "Oscillators", "Volume", etc. depending on the indicator
+   - **Tags:** `non-repainting`, `cycle-detection`, `reversal`, `signalpilot`, `pentarch`
+5. In the description, add: *"Get access: https://www.signalpilot.io"*
+6. Repeat for each of the 7 indicators
+
+**Tips:**
+- Publish a **free** lightweight version of one indicator to build trust and funnel users to the paid suite
+- Respond to every comment — TradingView's algorithm favors active scripts
+- Add chart screenshots showing the indicator working on multiple timeframes (1H, 4H, Daily)
+- Include a "How to use" section in the description
+
+---
+
+### 2A-2. PineIndicators.com
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://pineindicators.com/tradingview-script-marketplace/ |
+| **Cost** | Revenue share model |
+| **What to list** | TradingView indicator suite |
+| **Audience** | Traders specifically looking for premium TradingView indicators |
+
+**How to submit:**
+1. Visit the marketplace and look for "Submit" or "Sell Your Indicators"
+2. Create a seller account
+3. Fill in:
+   - **Product Name:** `Signal Pilot — 7 Non-Repainting TradingView Indicators`
+   - **Description:** Use the medium description from Section 1
+   - **Price:** Match your Gumroad pricing ($69/mo, $399/yr, $999 lifetime)
+   - **Screenshots:** Charts showing each indicator in action
+   - **Demo Video:** Screen recording of the indicators working in real-time
+4. Highlight "non-repainting" and "audited" prominently — this is a major selling point in this marketplace
+
+---
+
+### 2A-3. TradingIndicators.store
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://tradingindicators.store/ |
+| **Cost** | Varies |
+| **What to list** | TradingView buy/sell signal indicators |
+
+**How to submit:**
+1. Visit the site and look for seller/partner application
+2. Provide:
+   - Product details and pricing
+   - Screenshots and demo videos
+   - Proof of non-repainting (backtest vs. real-time comparison)
+
+---
+
+### 2A-4. MQL5 Market (if you port to MetaTrader)
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://www.mql5.com/en/market |
+| **Cost** | Revenue share (MQL5 keeps a percentage) |
+| **What to list** | MetaTrader 4/5 indicators (requires porting from Pine Script to MQL) |
+| **Audience** | Massive — the largest trading tools marketplace globally |
+
+**How to submit:**
+1. Register as a seller at https://www.mql5.com/en/market/seller
+2. You must provide real identity verification (ID, address)
+3. Port your indicators from Pine Script to MQL4/MQL5
+4. Submit each indicator separately
+5. Fill in:
+   - **Name:** `Signal Pilot — Pentarch Cycle Detection`
+   - **Description:** Detailed feature list, screenshots, and usage instructions
+   - **Price:** Set per indicator (typical range $30–$300)
+   - **Version:** Must pass MQL5's automated testing before approval
+   - **Screenshots:** At least 3-5 chart screenshots
+   - **Video:** Recommended
+6. All products go through a review process before listing
+
+**Note:** This requires significant development work to port Pine Script → MQL. Consider this a Phase 2 initiative if you want to tap the MetaTrader audience.
+
+---
+
+## 3. Category B: Digital Product Marketplaces (Direct Whop Alternatives)
+
+These are general platforms for selling subscriptions and digital products — direct replacements for Whop.
+
+---
+
+### 3B-1. Sellfy
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://sellfy.com |
+| **Submit URL** | https://sellfy.com/sell/trading-signals/ |
+| **Cost** | Plans from $22/mo, 0% transaction fees |
+| **What to list** | Your full indicator suite as subscription + one-time products |
+
+**How to set up:**
+1. Sign up at sellfy.com
+2. Choose a plan (Starter $22/mo is fine to start)
+3. Set up your store:
+   - **Store Name:** `Signal Pilot`
+   - **Store URL:** Choose `signalpilot.sellfy.com` or connect your custom domain
+   - **Logo:** Upload your SP logo (240×240 min)
+   - **Banner:** Upload a hero banner (1200×400 recommended)
+4. Add products:
+   - **Product 1:** "Signal Pilot Monthly" → Digital subscription → $69/mo
+   - **Product 2:** "Signal Pilot Yearly" → Digital subscription → $399/yr
+   - **Product 3:** "Signal Pilot Lifetime" → One-time digital product → $999
+5. For each product, add:
+   - **Title:** `Signal Pilot — 7 Non-Repainting TradingView Indicators (Monthly)`
+   - **Description:** Use the medium description
+   - **Images:** 3-5 chart screenshots + the indicator suite overview
+   - **Delivery:** Include TradingView invite link + setup guide PDF
+6. Enable Sellfy's built-in email marketing to collect leads
+
+**Why Sellfy over Gumroad:**
+- 0% transaction fees (vs Gumroad's 10%)
+- Built-in email marketing and discount codes
+- Cleaner storefront with custom branding
+
+---
+
+### 3B-2. Payhip
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://payhip.com |
+| **Cost** | Free plan with 5% transaction fee; Plus plan $29/mo with 2% fee |
+| **What to list** | Subscriptions + digital products |
+
+**How to set up:**
+1. Sign up at payhip.com (free)
+2. Create your store:
+   - **Store Name:** `Signal Pilot`
+   - **Store Description:** Use the short description from Section 1
+3. Add products:
+   - Click "Add Product" → "Membership" for subscription plans
+   - Click "Add Product" → "Digital Download" for lifetime plan
+   - **Title, Description, Price:** Same as Section 1
+   - **Cover Image:** 1280×720 recommended
+   - **Files:** Setup guide PDF, TradingView access instructions
+4. Set up payment via Stripe or PayPal
+5. Customize your store page colors and layout
+
+**Why consider Payhip:**
+- Completely free to start (0 monthly fee)
+- Simple checkout experience
+- Built-in affiliate program you can offer to trading influencers
+
+---
+
+### 3B-3. Podia
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://podia.com |
+| **Cost** | Free plan (10% fee) → Mover $33/mo (5% fee) |
+| **What to list** | Indicators + your 82-lesson education hub as a course |
+
+**How to set up:**
+1. Sign up at podia.com
+2. You get a full website + store. Set up:
+   - **Site Name:** Signal Pilot
+   - **Products:**
+     - Digital download: Indicator suite access
+     - Online course: Repackage your 82-lesson education hub as a paid course (or free lead magnet)
+     - Membership: Monthly/yearly subscription tiers
+   - **Description, pricing:** Same as Section 1
+3. Podia also gives you:
+   - Email marketing built-in
+   - Affiliate program
+   - Custom domain support
+
+**Why Podia:**
+- You can sell your education hub AS A COURSE alongside the indicators
+- All-in-one: products + courses + email + website
+- The free plan lets you test without commitment
+
+---
+
+### 3B-4. Patreon
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://patreon.com |
+| **Cost** | 8-12% of income + payment processing |
+| **What to list** | Membership tiers with indicator access + community |
+
+**How to set up:**
+1. Create a Patreon creator account
+2. Set up tiers:
+   - **Tier 1 — "Analyst" ($69/mo):** Access to all 7 indicators, real-time alerts, basic presets
+   - **Tier 2 — "Strategist" ($99/mo):** Everything in Tier 1 + 200 preset configurations + priority support
+   - **Tier 3 — "Founding Member" ($999 one-time via custom offer):** Lifetime access + private Discord
+3. Fill in:
+   - **Creator Name:** Signal Pilot
+   - **About:** Use the maker story from Section 1
+   - **What Patrons Get:** List indicator access, education content, community
+   - **Cover Image:** 1600×400 banner
+   - **Profile Image:** Your logo
+4. Create welcome posts and regular market analysis posts to retain members
+
+---
+
+### 3B-5. SuperProfile
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://superprofile.bio |
+| **Cost** | Free / premium plans available |
+| **What to list** | Digital products, courses, consultations |
+
+**How to set up:**
+1. Sign up and create your profile
+2. Add offerings:
+   - Digital product: Indicator suite
+   - Course: Education hub content
+   - Consultation: 1-on-1 trading mentorship sessions (if you want to offer this)
+3. Use the pre-written descriptions from Section 1
+
+---
+
+### 3B-6. ConvertKit Commerce (Kit)
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://kit.com |
+| **Cost** | Free → $29/mo |
+| **What to list** | Digital products + newsletter |
+
+**How to set up:**
+1. Sign up at kit.com
+2. Create a product:
+   - **Type:** Digital product or paid newsletter
+   - **Name, Description, Price:** Same as Section 1
+3. Best used as an **email-first strategy** — build a trading newsletter, then upsell the indicator suite to subscribers
+
+---
+
+## 4. Category C: Lifetime Deal / SaaS Marketplaces
+
+These generate **bursts of revenue and early adopters**. Ideal for your $999 Lifetime tier.
+
+---
+
+### 4C-1. AppSumo
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://sell.appsumo.com |
+| **Apply URL** | https://appsumo.com/partner-apply/ |
+| **Revenue split** | 70% AppSumo / 30% you (Select deals) or 30% AppSumo / 70% you (Marketplace) |
+| **Audience** | 1,000,000+ entrepreneurs and founders |
+
+**How to apply:**
+1. Go to https://appsumo.com/partner-apply/
+2. Fill in the partner application:
+   - **Product Name:** Signal Pilot
+   - **Website URL:** https://www.signalpilot.io
+   - **Product Description:** Use the medium description from Section 1
+   - **Category:** SaaS / Fintech / Trading Tools
+   - **Current Pricing:** $69/mo, $399/yr, $999 lifetime
+   - **Number of Active Users:** [your current number]
+   - **Monthly Revenue:** [your current revenue]
+3. Propose a deal structure:
+   - **Recommended deal:** Lifetime access for $99–$149 (one-time) — this is aggressive but drives massive volume
+   - OR: 1-year access for $49–$79
+4. AppSumo will review in 3-4 weeks
+5. If accepted as **Marketplace** (self-serve):
+   - You create the listing yourself
+   - 30% goes to AppSumo, 70% to you
+   - You handle all support
+6. If accepted as **Select**:
+   - AppSumo handles marketing, video production, sales pages
+   - 60% goes to AppSumo, 40% to you
+
+**What to prepare:**
+- High-quality product demo video (2-3 minutes)
+- Feature comparison chart vs. competitors (LuxAlgo, etc.)
+- Customer testimonials / reviews
+- A deal-specific landing page or redemption flow
+
+**Tips:**
+- "Sumo-lings" expect lifetime deals — position your $999 Lifetime tier as a special AppSumo price (e.g., $99 for lifetime)
+- Be VERY responsive to questions during your launch week — this dramatically affects reviews
+- Expect 500-2000 sales if you get featured
+
+---
+
+### 4C-2. PitchGround
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://pitchground.com |
+| **Apply URL** | https://partners.pitchground.com |
+| **Revenue split** | Featured: 60/40 (PG/you) — Marketplace: 30/70 (PG/you) |
+
+**How to apply:**
+1. Go to https://partners.pitchground.com
+2. Submit your application:
+   - **Product Name:** Signal Pilot
+   - **Website:** https://www.signalpilot.io
+   - **What it does:** Use medium description from Section 1
+   - **Current pricing and users**
+3. PitchGround's "Three P's" requirements:
+   - **People:** Be ready to personally engage in their community, answer every question
+   - **Product:** Must be 99.99% bug-free, all website links working, SSL on all pages
+   - **Pricing:** Recommended price points: $49, $97, $145, $197, $245, $397, $997
+
+**Website checklist before applying:**
+- [ ] All links working (no broken links)
+- [ ] SSL on all pages (HTTPS redirect)
+- [ ] "About Us" page with real team photos
+- [ ] "Contact Us" page with clear support info
+- [ ] Mission/vision statement visible
+- [ ] Knowledge base / documentation live (you have this at docs.signalpilot.io)
+- [ ] No typos or grammatical errors
+
+**Deal structure to propose:**
+- Tier 1: $49 → 1 year access, basic presets
+- Tier 2: $97 → Lifetime access, all presets
+- Tier 3: $197 → Lifetime access + private Discord + priority support
+
+**How their code system works:**
+PitchGround sells coupon codes → buyers redeem on your site → you fulfill access. You need to build a code redemption page on signalpilot.io.
+
+---
+
+### 4C-3. Other LTD Platforms
+
+Apply to these using the same materials:
+
+| Platform | Apply URL | Revenue Split | Notes |
+|----------|-----------|---------------|-------|
+| **DealMirror** | https://www.dealmirror.com/sell | Varies | Entrepreneurs & agencies |
+| **SaaSZilla** | https://www.saaszilla.com | Varies | Broad SaaS deal catalog |
+| **Dealify** | https://www.dealify.com | Varies | Growth hackers audience |
+| **SaaS Mantra** | https://www.saasmantra.com | Varies | Early-stage SaaS focus |
+| **RocketHub** | https://www.rockethub.com | Varies | Marketing/productivity |
+
+**What to write for all of them:**
+- **Product Name:** Signal Pilot
+- **Description:** Use medium description from Section 1
+- **Deal Proposed:** Lifetime access at a discounted price (e.g., $97-$149)
+- **Regular Price:** $999 lifetime (shows massive savings)
+- **What's Included:** All 7 indicators, alerts, presets, support, 82-lesson education hub access
+
+---
+
+## 5. Category D: Product Launch & Discovery Directories
+
+**Free listings** that drive awareness, backlinks, and organic traffic.
+
+---
+
+### 5D-1. Product Hunt
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://www.producthunt.com/posts/new |
+| **Prep URL** | https://www.producthunt.com/launch/preparing-for-launch |
+| **Cost** | Free |
+| **DR** | 91 |
+
+**Required fields:**
+
+| Field | What to Write | Limit |
+|-------|---------------|-------|
+| **Product URL** | `https://www.signalpilot.io` | No shortened/UTM links |
+| **Product Name** | `Signal Pilot` | No emojis or descriptions in name |
+| **Tagline** | `7 non-repainting TradingView indicators for cycle trading` | 60 chars max |
+| **Short Description** | Use the 260-char description from Section 1 | 260 chars max |
+| **Topics** | Select 3: `Fintech`, `Trading`, `SaaS` | Max 3 |
+| **Thumbnail** | Your SP logo, square | 240×240px |
+| **Gallery** | 3+ images showing indicators on charts | 1270×760px each, under 3MB |
+| **Makers** | Link your PH profile + any team members | Must have PH accounts |
+| **First Comment** | Use the Maker Story from Section 1 | No limit (keep under 500 words) |
+| **Promo Code** | Offer PH community a discount, e.g., `PRODUCTHUNT20` for 20% off | Optional but recommended |
+
+**Launch day strategy:**
+1. Schedule for Tuesday-Thursday, around 12:01 AM PST (launches reset at midnight PST)
+2. Post your First Comment immediately
+3. Share on your social media, Discord, email list — but do NOT ask for upvotes, just say "We launched on Product Hunt today!"
+4. Respond to every comment within minutes
+5. Offer a PH-exclusive deal (e.g., `PRODUCTHUNT` promo code for 20% off first month)
+
+**Tips:**
+- You can re-launch after 6 months + major feature update
+- Tuesday-Thursday perform best
+- The first comment by the maker is critical — 70% of winning products had one
+
+---
+
+### 5D-2. SaaS Hub
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://www.saashub.com/services/submit |
+| **Cost** | Free (paid featured options available) |
+| **DR** | 72 |
+| **Monthly Traffic** | 358K visitors |
+
+**How to submit:**
+1. Go to https://www.saashub.com/services/submit
+2. Create an account and verify
+3. Fill in:
+   - **Product Name:** `Signal Pilot`
+   - **Website URL:** `https://www.signalpilot.io`
+   - **Description:** Use the medium description from Section 1
+   - **Category:** Trading Tools / Fintech / Technical Analysis
+   - **Pricing:** List all three tiers ($69/mo, $399/yr, $999 lifetime)
+   - **Screenshots:** 3-5 chart screenshots showing the indicators
+   - **Competitors:** List competitors (LuxAlgo, TradingIndicators, etc.) — this helps with "alternative to" searches
+4. Verify your product from the management page
+5. Answer the Q&A section to improve your listing
+
+**Tips:**
+- List competitors generously — each competitor link creates an "alternative to X" page where you appear
+- Verified products get higher priority
+- Add screenshots, not just a logo
+
+---
+
+### 5D-3. Peerlist Launchpad
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://peerlist.io/projects |
+| **Cost** | Free |
+| **DR** | 64 |
+| **Monthly Traffic** | 199K visitors |
+
+**How to submit:**
+1. Create a Peerlist profile at peerlist.io
+2. Go to peerlist.io/projects → click "Launch Project" from the weekly Spotlight banner
+3. Fill in:
+   - **Project Name:** `Signal Pilot`
+   - **Tagline:** `7 non-repainting TradingView indicators for cycle trading` (4-6 words ideal)
+   - **Project URL:** `https://www.signalpilot.io`
+   - **Cover Image:** High-quality banner showing the indicator suite
+   - **Screenshots:** Fill ALL available screenshot slots (more = better)
+   - **Demo Video:** Screen recording of the indicators working (even a simple one works)
+   - **Description:** Use the long maker story from Section 1. Avoid AI-generated text.
+   - **Tags:** `tradingview`, `fintech`, `saas`, `trading`, `indicators`
+   - **Demo Access:** Provide a way for users to try (e.g., free trial link or video demo)
+
+**Launch timing:**
+- Launches happen on **Mondays** every week
+- Prepare your listing by Friday
+- You have a full week to collect votes (less stressful than Product Hunt)
+- You can submit a new project every week
+- All submitted projects get featured; ranking is randomized for the first 2 days
+
+**Tips:**
+- Engage with other projects — comment, upvote, appreciate
+- Don't ask for upvotes; ask for feedback and shares
+- Winners get featured in Peerlist's weekly newsletter
+
+---
+
+### 5D-4. Uneed
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://www.uneed.best/submit-a-tool |
+| **Cost** | Free (with backlink badge) / $19 Lite / $39 Premium / $99 Super |
+| **DR** | 59 (dofollow backlinks) |
+| **Monthly Traffic** | 91K visitors |
+
+**How to submit:**
+1. Go to https://www.uneed.best/submit-a-tool
+2. Create an account
+3. Fill in:
+   - **Product Name:** `Signal Pilot`
+   - **URL:** `https://www.signalpilot.io`
+   - **Description:** Use medium description from Section 1
+   - **Screenshots:** Chart screenshots + indicator overview
+   - **Category:** Fintech / Trading / SaaS
+4. For the **free plan**: You must add a Uneed badge/backlink to signalpilot.io
+5. For **Lite ($19)**: No backlink required + social media promotion
+6. For **Premium ($39)**: DR 78+ guaranteed backlink + premium badge + 15-day promotion
+7. For **Super ($99)**: Top of homepage for 15 days
+
+**Recommendation:** Start with Lite ($19) — it's a one-time fee and removes the badge requirement.
+
+**Tips:**
+- Vote on other products daily for 5 consecutive days → get 2x voting points
+- Respond to any comments on your listing
+
+---
+
+### 5D-5. Dev Hunt
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://devhunt.org |
+| **Cost** | Free (waiting period) / paid for expedited |
+| **DR** | 57 (dofollow backlinks) |
+| **Monthly Traffic** | 62K visitors |
+
+**How to submit:**
+1. Log in with your **GitHub account** (required)
+2. Click "Submit" and fill in:
+   - **Product Name:** `Signal Pilot`
+   - **URL:** `https://www.signalpilot.io`
+   - **Description:** Use medium description. Emphasize the technical side — this audience is developers.
+   - **Screenshots:** Chart screenshots + any technical architecture if relevant
+   - **Category:** Developer Tool / Fintech / Trading
+
+**Tips:**
+- DevHunt's audience is developers, so lean into the technical aspects: Pine Script, non-repainting algorithm, multi-timeframe analysis
+- Votes from GitHub accounts with real repos/commits carry more weight
+- Free submissions have a waiting period; paid options get expedited review
+
+---
+
+### 5D-6. Microlaunch
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://microlaunch.net |
+| **Cost** | Free / Premium available |
+| **DR** | 44 (dofollow backlinks) |
+| **Monthly Traffic** | 79K visitors |
+
+**How to submit:**
+1. Sign up at microlaunch.net
+2. Submit your product:
+   - **Product Name:** `Signal Pilot`
+   - **URL:** `https://www.signalpilot.io`
+   - **Description:** Use medium description from Section 1
+   - **Screenshots + Video**
+3. Your launch lasts a **full month** (not 24 hours like Product Hunt)
+4. Products get "roasted" or "boosted" based on community feedback
+
+**Tips:**
+- The month-long launch gives you time to iterate and improve based on feedback
+- Engage with the community — respond to all roasts constructively
+- Consider their Premium tier for featured spots and DR56+ backlinks
+
+---
+
+### 5D-7. Fazier
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://fazier.com/submit |
+| **Cost** | Free (with badge) / $19 Lite / $39 Premium / $99 Super |
+| **DR** | 58 |
+| **Monthly Traffic** | 17K visitors |
+
+**How to submit:**
+1. Sign up at fazier.com (Google or Email)
+2. Go to https://fazier.com/launch
+3. Fill in:
+   - **Product Name:** `Signal Pilot`
+   - **URL:** `https://www.signalpilot.io`
+   - **Description:** Use medium description from Section 1
+   - **Screenshots:** Indicator charts
+4. **Free tier:** Requires adding a Fazier badge/backlink to your site
+5. **Lite ($19 one-time):** No backlink required, instant publish, social promotion
+6. **Premium ($39):** DR 78+ guaranteed backlink, premium badge, 15-day promo
+7. **Super ($99):** Top of homepage for 15 days
+
+---
+
+### 5D-8. Pitchwall
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://pitchwall.co/product/submit |
+| **Cost** | Free (30+ day queue) / Featured listing (paid, instant) |
+| **DR** | 65 (nofollow backlinks) |
+| **Monthly Traffic** | 16K visitors |
+
+**How to submit:**
+1. Register at pitchwall.co
+2. Click Submit in the menu
+3. Fill in:
+   - **Product Name:** `Signal Pilot`
+   - **Website URL:** `https://www.signalpilot.io`
+   - **Description:** Use medium description from Section 1
+   - **Tags:** `fintech`, `trading`, `saas`, `tradingview`, `indicators`
+   - **Images:** Logo + chart screenshots
+4. All submissions are manually reviewed
+5. Free listings wait 30+ days; Featured Listings are instant
+
+**Tips:**
+- Alpha/Beta stage products are welcome — you don't need to be fully launched
+- Clean UI/UX and concise messaging matter for approval
+- You can edit your listing anytime after approval
+
+---
+
+### 5D-9. BetaList
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://betalist.com |
+| **Criteria** | https://betalist.com/criteria |
+| **Cost** | Free (weeks wait) / $129 expedited |
+| **DR** | 74 (dofollow backlinks) |
+
+**How to submit:**
+1. Sign up at betalist.com
+2. Review criteria at https://betalist.com/criteria
+3. Submit your startup:
+   - **Product Name:** `Signal Pilot`
+   - **URL:** `https://www.signalpilot.io`
+   - **Description:** Use short + medium descriptions from Section 1
+   - **What makes it unique:** Non-repainting audited indicators, 5-phase cycle detection, 82-lesson free education hub
+4. Requirements:
+   - Must be recently launched or pre-launch
+   - Must have a custom-designed landing page (not a template)
+   - Must have a way for people to sign up or get access
+   - Should NOT have significant press coverage already
+5. Free review takes ~1 week for decision, ~2 months for feature
+6. Expedited review ($129) gets reviewed in days
+
+**Tips:**
+- Your signalpilot.io site has a custom design — that's good
+- Highlight the free education hub as a unique angle
+- Each startup gets 2 opportunities to be featured
+
+---
+
+### 5D-10. AlternativeTo
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://alternativeto.net |
+| **Cost** | Free |
+| **DR** | Very high (85+) |
+
+**How to submit:**
+1. Register at alternativeto.net
+2. Go to your profile → "Add new application" (or "Suggest new application")
+3. Fill in:
+   - **Step 1 — Describe your product:**
+     - **Name:** `Signal Pilot`
+     - **Description:** Use medium description from Section 1
+     - **URL:** `https://www.signalpilot.io`
+   - **Step 2 — External stores:** Skip (not in App Store/Mac Store)
+   - **Step 3 — Main data:**
+     - **Price:** Paid (list tiers)
+     - **Platforms:** Web-based (TradingView)
+     - **Open Source:** No
+     - **Tags:** Be generous — `trading indicators`, `technical analysis`, `TradingView`, `cycle detection`, `non-repainting`, `fintech`, `market analysis`, `volume analysis`, `trading tools`, `Pine Script`
+     - **Images:** Upload professional screenshots
+   - **Step 4 — Suggest alternatives:**
+     - List: `LuxAlgo`, `TradingView built-in indicators`, `TrendSpider`, `Ticker Nerd`, `Stock Screener`, `TradingIndicators`, etc.
+     - Be generous with alternatives — each creates an "alternative to X" page
+4. Wait 1-2 days for approval
+
+**Tips:**
+- Encourage users to leave reviews — positive votes push you up in category rankings
+- Submit alternatives regularly to increase internal references
+- This drives long-tail SEO traffic ("Signal Pilot alternative to LuxAlgo", etc.)
+
+---
+
+### 5D-11. Additional Free Directories
+
+Submit to all of these using the same materials:
+
+| Platform | Submit URL | DR | Notes |
+|----------|------------|-----|-------|
+| **Ctrl Alt CC** | https://ctrl.alt.cc | 37 | 16K/mo traffic |
+| **Twelve Tools** | https://twelvetools.com | 16 | Small but growing |
+| **Futurepedia** | https://www.futurepedia.io | High | AI tools directory — position the cycle detection as AI-powered |
+| **There's An AI For That** | https://theresanaiforthat.com | High | If you can position any feature as AI |
+| **Toolify.ai** | https://www.toolify.ai | High | AI tools directory |
+| **ListMySaaS** | https://listmysaas.com | Varies | Curated directory of 100+ places to list SaaS |
+| **StartupBase** | https://startupbase.io | Varies | Startup directory |
+| **Launching Next** | https://www.launchingnext.com | Varies | Startup discovery |
+| **StartupStash** | https://startupstash.com | Varies | Curated directory |
+| **SideProjectors** | https://www.sideprojectors.com | Varies | For side projects |
+| **Startup Lister** | https://startuplister.com | Varies | Automated listing service |
+| **Firsto** | https://firsto.com | Varies | Curated, quality-focused |
+
+**What to write for all of them:**
+- **Product Name:** Signal Pilot
+- **URL:** https://www.signalpilot.io
+- **Short Description:** Use the 260-char version from Section 1
+- **Long Description:** Use the medium description from Section 1
+- **Category:** Fintech / Trading / SaaS
+- **Screenshots:** Same chart images you used for Product Hunt
+
+---
+
+## 6. Category E: Community & Social Channels
+
+Free distribution through communities where your target buyers hang out.
+
+---
+
+### 6E-1. Hacker News (Show HN)
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://news.ycombinator.com/submit |
+| **Guidelines** | https://news.ycombinator.com/showhn.html |
+| **Cost** | Free |
+
+**How to post:**
+1. Create an account at news.ycombinator.com (your username should NOT be "SignalPilot" — use your personal name)
+2. Click "Submit" at the top
+3. Fill in:
+   - **Title:** `Show HN: Signal Pilot – 7 non-repainting TradingView indicators for cycle trading`
+   - **URL:** `https://www.signalpilot.io`
+   - **Text:** Leave blank (put your story in the comments instead)
+4. Immediately post a first comment:
+
+```
+I built Signal Pilot because I was tired of TradingView indicators that repaint — they look
+great on historical charts but are useless in real-time.
+
+The core system (Pentarch) maps five phases of market reversals instead of just saying
+"overbought/oversold." The full suite has 7 indicators covering cycles, volume, key levels,
+and momentum.
+
+Technical details:
+- All indicators are 100% non-repainting (audited)
+- Built in Pine Script v5
+- Multi-timeframe analysis across 3 TFs simultaneously
+- 200+ preset configurations
+
+I also built a free education hub with 82 lessons (250K+ words) covering everything from
+basic TA to institutional order flow.
+
+Happy to answer any questions about the approach or the tech.
+```
+
+**Critical rules:**
+- Do NOT ask anyone to upvote — HN detects vote rings and will penalize you
+- Do NOT use marketing language — talk like a builder
+- Do NOT have team members post booster comments
+- Be ready to respond to criticism constructively — "act like critics are doing you a favor"
+- Best time: Tuesday-Thursday, 9 AM - 12 PM Pacific Time
+- If your post doesn't gain traction, HN moderators may give it a "second chance"
+
+---
+
+### 6E-2. Reddit
+
+**Subreddits to post in:**
+
+| Subreddit | Subscribers | What to Post |
+|-----------|-------------|--------------|
+| r/TradingView | 50K+ | Showcase individual indicators with chart examples |
+| r/algotrading | 200K+ | Technical deep-dive on the Pentarch algorithm |
+| r/Daytrading | 1M+ | "How I use cycle detection to improve entries" |
+| r/swingtrading | 100K+ | Multi-timeframe analysis examples using Janus Atlas |
+| r/Forex | 500K+ | Volume Oracle and Plutus Flow on forex pairs |
+| r/CryptoCurrency | 7M+ | Indicator examples on crypto (be careful of promo rules) |
+| r/SideProject | 100K+ | "I built a suite of non-repainting TradingView indicators" |
+| r/SaaS | 50K+ | Business story: pricing, growth, building a trading SaaS |
+| r/IndieBiz | 20K+ | Building and marketing Signal Pilot as a solo/small team |
+| r/startups | 1M+ | Your journey building Signal Pilot |
+
+**Template post for trading subreddits:**
+```
+Title: I built 7 non-repainting TradingView indicators focused on cycle detection — here's
+what I learned
+
+[Include 2-3 chart screenshots showing the indicators in action]
+
+After years of frustration with repainting indicators, I built Signal Pilot — a suite of 7
+TradingView indicators that are 100% audited non-repainting.
+
+The core is Pentarch, which maps five phases of market cycles:
+- TD (Trend Depletion)
+- IGN (Ignition)
+- WRN (Warning)
+- CAP (Capitulation)
+- BDN (Breakdown)
+
+Instead of just "overbought/oversold," you see exactly where you are in the cycle.
+
+[Describe 1-2 specific trade setups using the indicators]
+
+I also built a free education hub with 82 lessons if anyone wants to learn more about
+cycle-based trading.
+
+Happy to answer questions about the methodology or share more chart examples.
+```
+
+**Reddit rules:**
+- Do NOT hard-sell — provide value first, mention the product naturally
+- Follow each subreddit's self-promotion rules (usually 10:1 ratio — 10 value posts per 1 self-promo)
+- Use a personal account, not a brand account
+- Engage in comments genuinely
+
+---
+
+### 6E-3. Indie Hackers
+
+| Field | Details |
+|-------|---------|
+| **URL** | https://www.indiehackers.com |
+| **Cost** | Free |
+
+**How to post:**
+1. Create an account and **participate in the community first** (comment on other posts, be helpful)
+2. New accounts don't have posting access immediately — moderators look for "authentic contribution patterns"
+3. Once you have posting access:
+   - **Title:** "I built 7 TradingView indicators that never repaint — here's the journey"
+   - **Body:** Use the maker story from Section 1, but expand on:
+     - Revenue numbers (IH community loves transparency)
+     - Marketing strategy and what's worked
+     - Technical challenges of building non-repainting indicators
+     - Your pricing decisions ($69/mo → $999 lifetime)
+4. Add your product to your IH profile
+
+**Tips:**
+- Share revenue milestones openly — this community rewards transparency
+- Post regular updates ("Month 3: $X MRR, here's what I learned")
+- Answer questions in the trading/fintech threads
+
+---
+
+### 6E-4. Discord Trading Communities
+
+**Strategy:** Partner with existing trading Discord servers to offer exclusive deals.
+
+**Approach:**
+1. Find large trading Discords (search "trading Discord" on Disboard.org or Google)
+2. Reach out to server owners and propose:
+   - Exclusive discount for their members (e.g., 30% off)
+   - Revenue share / affiliate commission (20-30% recurring)
+   - Free access for the server owner to review and showcase
+3. Offer to do a live demo / AMA in their voice channel
+
+---
+
+### 6E-5. YouTube Trading Channels
+
+**Strategy:** Partner with trading YouTubers for reviews and affiliate deals.
+
+**Approach:**
+1. Find YouTubers who review TradingView indicators (search "TradingView indicator review")
+2. Reach out via email with:
+   - Free lifetime access for an honest review
+   - Affiliate link with 20-30% recurring commission
+   - A custom promo code for their audience
+3. Provide them with:
+   - Access to all 7 indicators
+   - Key talking points / feature highlights
+   - Chart screenshots and video clips they can use
+
+---
+
+## 7. Assets Checklist
+
+Prepare these assets **before** submitting anywhere:
+
+### Images
+- [ ] **Logo (square):** 240×240px, 500×500px, 1000×1000px versions
+- [ ] **Banner/Hero:** 1600×400px (for Patreon, social media)
+- [ ] **Gallery images:** 1270×760px (for Product Hunt) — minimum 3, ideally 5-8
+  - Image 1: Hero shot — "7 Non-Repainting Indicators" with all indicator names
+  - Image 2: Pentarch in action on a chart (showing the 5 phases)
+  - Image 3: OmniDeck overlay on a chart
+  - Image 4: Volume Oracle regime detection
+  - Image 5: Augury Grid watchlist scanner
+  - Image 6: Pricing comparison chart
+  - Image 7: Education hub screenshot
+  - Image 8: Customer testimonial / review screenshot
+- [ ] **Screenshots:** At least 5 different chart screenshots (different timeframes, different assets)
+- [ ] **Feature comparison chart** vs. LuxAlgo, TradingView built-ins, etc.
+
+### Video
+- [ ] **Demo video (short):** 20-45 seconds — quick overview of the indicator suite on a chart
+- [ ] **Demo video (long):** 2-3 minutes — full walkthrough of each indicator with live chart examples
+- [ ] **Screen recording:** Simple recording of you applying the indicators to a chart and explaining
+
+### Written
+- [ ] All descriptions from Section 1 saved in a Google Doc for quick copy-paste
+- [ ] Customer testimonials (collect from Gumroad reviews, Discord, email)
+- [ ] FAQ document covering common questions
+
+### Technical
+- [ ] Promo codes ready:
+  - `PRODUCTHUNT20` — 20% off (for Product Hunt)
+  - `PEERLIST15` — 15% off (for Peerlist)
+  - `REDDIT10` — 10% off (for Reddit)
+  - `APPSUMO` — Custom deal price (for AppSumo)
+- [ ] UTM tracking links for each platform:
+  - `https://www.signalpilot.io?utm_source=producthunt&utm_medium=listing`
+  - `https://www.signalpilot.io?utm_source=saashub&utm_medium=directory`
+  - `https://www.signalpilot.io?utm_source=uneed&utm_medium=directory`
+  - (etc. for each platform)
+- [ ] Google Analytics goals set up to track conversions per source
+
+---
+
+## 8. Launch Calendar
+
+Recommended order of execution:
+
+### Week 1: Free Directories (Quick Wins)
+- [ ] Submit to SaaS Hub (358K/mo traffic, DR 72)
+- [ ] Submit to AlternativeTo (huge DR, long-tail SEO)
+- [ ] Submit to Uneed ($19 Lite — one-time, DR 59)
+- [ ] Submit to Fazier (free or $19 Lite)
+- [ ] Submit to Pitchwall (free)
+- [ ] Submit to DevHunt (free, GitHub login)
+- [ ] Submit to BetaList (free or $129 expedited, DR 74)
+- [ ] Submit to all additional directories from Section 5D-11
+
+### Week 2: Community Posts
+- [ ] Post on Reddit (r/TradingView, r/algotrading, r/Daytrading) — space posts 2-3 days apart
+- [ ] Start engaging on Indie Hackers (comment on posts, build karma)
+- [ ] Publish free TradingView scripts (invite-only, with link to full suite)
+
+### Week 3: Product Launches
+- [ ] Launch on Peerlist (Monday launch)
+- [ ] Launch on Microlaunch (month-long launch)
+- [ ] Prepare Product Hunt launch assets
+
+### Week 4: Major Launches
+- [ ] Launch on Product Hunt (Tuesday-Thursday)
+- [ ] Post Show HN on Hacker News
+- [ ] Post journey story on Indie Hackers (if you have posting access by now)
+
+### Month 2: Marketplace & Deals
+- [ ] Apply to AppSumo (partner application)
+- [ ] Apply to PitchGround (partner application)
+- [ ] Set up Sellfy or Payhip store (as Gumroad alternative or additional channel)
+- [ ] Reach out to YouTube trading channels for affiliate partnerships
+- [ ] Reach out to Discord trading communities for partnerships
+
+### Ongoing
+- [ ] Submit to PineIndicators.com and TradingIndicators.store
+- [ ] Post regular content on Reddit (value-first, not promotional)
+- [ ] Update listings with new features, screenshots, reviews
+- [ ] Collect and showcase customer testimonials across all platforms
+- [ ] Track analytics per platform and double down on what works
+
+---
+
+## Quick Reference — All Submit URLs
+
+| Platform | Submit URL |
+|----------|-----------|
+| TradingView Scripts | Pine Editor → Publish Script |
+| PineIndicators | https://pineindicators.com/tradingview-script-marketplace/ |
+| MQL5 Market | https://www.mql5.com/en/market/seller |
+| Sellfy | https://sellfy.com |
+| Payhip | https://payhip.com |
+| Podia | https://podia.com |
+| Patreon | https://patreon.com |
+| SuperProfile | https://superprofile.bio |
+| Kit (ConvertKit) | https://kit.com |
+| AppSumo | https://appsumo.com/partner-apply/ |
+| PitchGround | https://partners.pitchground.com |
+| Product Hunt | https://www.producthunt.com/posts/new |
+| SaaS Hub | https://www.saashub.com/services/submit |
+| Peerlist | https://peerlist.io/projects |
+| Uneed | https://www.uneed.best/submit-a-tool |
+| DevHunt | https://devhunt.org |
+| Microlaunch | https://microlaunch.net |
+| Fazier | https://fazier.com/submit |
+| Pitchwall | https://pitchwall.co/product/submit |
+| BetaList | https://betalist.com |
+| AlternativeTo | https://alternativeto.net (profile → Add new application) |
+| Hacker News | https://news.ycombinator.com/submit |
+| Indie Hackers | https://www.indiehackers.com |
+| Reddit | Post in relevant subreddits |
+| ListMySaaS | https://listmysaas.com |
+
+---
+
+*Last updated: February 24, 2026*
+*Generated for Signal Pilot — https://www.signalpilot.io*


### PR DESCRIPTION
## Summary
Added a complete platform listing and distribution guide for SignalPilot, a suite of 7 non-repainting TradingView indicators. This document serves as a strategic resource for maximizing product discovery across multiple marketplace categories.

## Key Changes
- **Pre-written copy templates**: Standardized product descriptions (tagline, short/medium/long formats) ready for copy-paste across platforms
- **Trading-specific marketplaces**: Detailed submission instructions for TradingView Community Scripts, PineIndicators.com, TradingIndicators.store, and MQL5 Market
- **Digital product alternatives**: Step-by-step guides for Sellfy, Payhip, Podia, Patreon, SuperProfile, and ConvertKit Commerce as Whop alternatives
- **Lifetime deal platforms**: Application strategies for AppSumo, PitchGround, and other LTD marketplaces with revenue split details
- **Free discovery directories**: Comprehensive listings for 11+ platforms (Product Hunt, SaaS Hub, Peerlist, Uneed, DevHunt, Microlaunch, Fazier, Pitchwall, BetaList, AlternativeTo, etc.) with submission URLs and domain authority metrics
- **Community channels**: Strategies for Hacker News, Reddit, Indie Hackers, Discord, and YouTube partnerships
- **Assets checklist**: Required images, videos, and written materials with specifications
- **Launch calendar**: Phased execution plan spanning 8 weeks with specific platform priorities

## Notable Details
- Includes platform-specific copy variations and submission requirements
- Provides revenue split comparisons across marketplace options
- Contains ready-to-use promo codes and UTM tracking templates
- Organized by category with clear prioritization (trading-specific → general marketplaces → free directories → communities)
- Quick reference table with all submission URLs for easy access

https://claude.ai/code/session_01C4GmQGJp8XAfC9vf5AJtBw