### PR TITLE
Update Pentarch TradingView script URL to NZt2MVbj

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5430,7 +5430,7 @@ html[lang="ar"] [style*="text-align:center"] {
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">اقرأ المستندات →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5683,7 +5683,7 @@ html[lang="ar"] [style*="text-align:center"] {
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">شاهد بالضبط ما ستحصل عليه. صفحات كاملة للمؤشرات مع الميزات ولقطات الشاشة والوثائق.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -6074,7 +6074,7 @@ html[lang="ar"] [style*="text-align:center"] {
                   <div class="mt-6 h-px bg-cyan-500/20"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     معاينة Pentarch على TradingView
                   </a>

--- a/data/social/content-queue.json
+++ b/data/social/content-queue.json
@@ -144,7 +144,7 @@
         "What if every breakout you traded was designed to trap you?\n\nLiquidity engineering isn't a theory. It's happening on your charts right now. 🧵",
         "TD (Touchdown) marks the early-cycle reversal point. Selling pressure has dried up. It's not a buy signal — it's a structural observation that the downside is losing momentum. Pentarch detects this automatically using 5 independent signal components.",
         "Been there. when to watch for TD: after extended downtrends when volume fades and price starts forming higher lows. TD is most powerful when it appears on the daily or 4H chart — that's where cycle transitions carry the most weight.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\nhttps://docs.signalpilot.io/pentarch-v10/"
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\nhttps://docs.signalpilot.io/pentarch-v10/"
       ]
     },
     "instagram": {
@@ -316,7 +316,7 @@
         "The worst mistake with Pentarch: ignoring the WRN signal. 🧵",
         "Straight up: 🟢 TD → Selling exhaustion (potential bottom)\n🔵 IGN → Breakout ignition (momentum building)\n🟡 WRN → Early weakness (cracks forming)\n🟠 CAP → Climax exhaustion (peak nearing)\n🔴 BDN → Bearish breakdown (confirmed)",
         "The Sovereign reads the full cycle.\nKnow where you are. Trade accordingly.\n\nSave this cheatsheet.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\nhttps://docs.signalpilot.io/ref-cheatsheets-pentarch/\n\nCome back to this before your next trade."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\nhttps://docs.signalpilot.io/ref-cheatsheets-pentarch/\n\nCome back to this before your next trade."
       ]
     },
     "instagram": {
@@ -1908,7 +1908,7 @@
         "Try this: pull up BTC weekly and watch Pentarch label each phase as it unfolds. TD at the bottom, IGN on the breakout, WRN when the rally gets tired, CAP at the blow-off, BDN on the collapse. One cycle. Five labels. Complete market narrative.",
         "What separates Pentarch from other cycle tools: it uses five independent components to classify phases, not a single oscillator. No single component can force a phase change alone. That consensus requirement filters out noise. And it never repaints.",
         "Each phase transition is a strategic decision point. TD to IGN? Start building positions. IGN to WRN? Protect gains and stop adding. WRN to CAP? Trail aggressively. CAP to BDN? Move to cash or short. The cycle is your playbook.\n\nWait for a close above the level before entering.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nOne thread won't fix your trading. But it might fix one mistake."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nOne thread won't fix your trading. But it might fix one mistake."
       ]
     },
     "instagram": {
@@ -2363,7 +2363,7 @@
         "Hear me out. the Sovereign speaks in phases, not predictions.\n\nTD at a swing low = potential reversal forming.\nBDN after CAP = confirmed distribution.\n\nEach signal is a chapter in the cycle story.\n\nSave this reference.",
         "The signal most traders undervalue: WRN. It's easy to dismiss early weakness as noise. But WRN appearing after IGN is Pentarch telling you momentum is fading before the crowd notices. That's your edge for scaling out of longs.\n\nLook for momentum alignment across 2+ timeframes.",
         "When to reference this: mid-trade, when you see a new Pentarch label appear on your chart. Instead of guessing what it means, check the phase. If you're long and CAP appears, that's your signal to manage the position — not after the BDN confirms.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\nhttps://docs.signalpilot.io/pentarch-v10/\n\nIf you could go back, what would you do differently?"
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\nhttps://docs.signalpilot.io/pentarch-v10/\n\nIf you could go back, what would you do differently?"
       ]
     },
     "instagram": {
@@ -3114,7 +3114,7 @@
         "How to use TD in practice: after an extended selloff, TD appears on the daily chart. Don't buy immediately. Wait for price to hold above the TD candle's low on the next few bars. If it holds, accumulation may be starting. If it breaks, the decline isn't done.",
         "TD is most effective on higher timeframes. A TD on the weekly carries far more weight than one on the 15-minute. The Sovereign's signals scale with the timeframe. And because Pentarch is non-repainting, that TD signal stays locked once the candle closes.",
         "Pair TD with Plutus Flow for conviction. TD fires on the daily, and Plutus Flow shows a z-score climbing from negative territory? Selling exhausted AND accumulation starting beneath the surface. Two independent measures confirming the same thesis.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nJournal your next 3 trades with this framework."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nJournal your next 3 trades with this framework."
       ]
     },
     "instagram": {
@@ -4438,7 +4438,7 @@
         "The ugly truth? trading IGN signals: when Pentarch fires IGN on the daily, look for a pullback to the breakout zone on the 4H for entry. IGN confirms something may be starting. The pullback gives you a defined risk level. That's structure meeting confirmation.",
         "What makes IGN different from a simple moving average crossover: Pentarch requires consensus across five independent components before firing IGN. A single momentum spike won't trigger it. That higher bar for confirmation means fewer false breakout signals.",
         "IGN is most powerful when backed by Volume Oracle showing accumulation. The cycle says ignition. The volume environment says buyers are present. That double confirmation filters out false breakouts where price moves but conviction is missing.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nJournal your next 3 trades with this framework."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nJournal your next 3 trades with this framework."
       ]
     },
     "instagram": {
@@ -7156,7 +7156,7 @@
         "• Late-cycle exhaustion detected\n• Volume spikes appearing — climactic activity\n• Cycle nearing potential completion\n\nCAP says: \"This move may be running on fumes.\"\n\nNot an instant sell signal. An observation of late-cycle conditions. Protect your gains.",
         "When CAP fires, here's the play: if you're long, trail your stop aggressively. If you're flat, don't initiate longs. If CAP appears with volume climax, that's the blow-off top pattern. The cycle is exhausting itself. Protect gains and watch from the sideline.",
         "CAP is most reliable when confirmed by other signals. CAP plus Harmonic Oscillator bearish divergence plus distribution regime from Volume Oracle -- that triple confirmation of late-cycle exhaustion is one of the highest-conviction topping patterns in the suite.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nTest this on one chart today."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nTest this on one chart today."
       ]
     },
     "instagram": {
@@ -10151,7 +10151,7 @@
         "\"Then how do I know which phase?\" the trader asked.\n\n\"TD. IGN. WRN. CAP. BDN.\n\nFive signals. Five phases. The wheel turns, and Pentarch reads each spoke.\"",
         "\"The cruelest trap,\" The Sovereign said, \"is the breakout that occurs in distribution.\"\n\nThe trader's eyes widened.\n\n\"It looks like opportunity. It feels like conviction. But the cycle has already turned. You are buying the exit, not the entry.\"",
         "Phase awareness transforms your win rate not by finding better setups, but by filtering out the traps.\n\nA beautiful breakout in the wrong cycle phase is just smart money's exit door dressed up as your entry. Pentarch shows you which phase you're in.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://signalpilot.io/chronicle/meet-the-sovereign/\n\nNot everything needs a response. Some things just need time."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://signalpilot.io/chronicle/meet-the-sovereign/\n\nNot everything needs a response. Some things just need time."
       ]
     },
     "instagram": {
@@ -10347,7 +10347,7 @@
         "Why Pentarch transitions are reliable: they're based on 5 signal components, not a single reading flipping states. A phase change requires consensus across components. That means fewer false transitions and higher confidence. Non-repainting.",
         "Practical application: when Pentarch shifts from IGN to WRN, reduce position size on new entries by half. You're not exiting yet, but you're acknowledging that the easy part of the trend may be over. Respect the transition.\n\n1% risk per trade = you survive 10 consecutive losses.",
         "The BDN to TD transition is where the next opportunity begins. Most traders are still bearish from the BDN phase. But TD signals the selling is exhausting. That's where contrarian setups with the best R:R emerge.\n\nMinimum 2:1 R:R before entering. No exceptions.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\nhttps://docs.signalpilot.io/pentarch-v10/"
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\nhttps://docs.signalpilot.io/pentarch-v10/"
       ]
     },
     "instagram": {
@@ -13175,7 +13175,7 @@
         "When they align, confidence is high. When they diverge — like ignition phase but momentum divergence — something's off. That disagreement is information. It tells you to wait for clarity before committing. Both non-repainting.",
         "Real scenario: Pentarch shows IGN on the daily. You check Harmonic Oscillator. All seven components agree with strong bullish consensus. Cycle says breakout confirmed. Momentum says force is real. That's structural confirmation plus energy confirmation.",
         "The most telling disagreement: WRN phase fires but Harmonic Oscillator shows no divergence and strong momentum. The cycle warns but momentum doesn't confirm the weakness yet. That conflict says the trend might still have one more push. Monitor but don't exit yet.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/\nhttps://docs.signalpilot.io/pentarch-v10/\n\nOpen a chart right now and look for this."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://www.tradingview.com/script/Vpxnhy8j-Harmonic-Oscillator-Multi-Component-Momentum-Consensus/\nhttps://docs.signalpilot.io/pentarch-v10/\n\nOpen a chart right now and look for this."
       ]
     },
     "instagram": {
@@ -14433,7 +14433,7 @@
         "Markets cycle through 5 phases. Most traders only recognize 2.\n\n\"All markets breathe,\" the Sovereign observed.\n\n\"TD. IGN. WRN. CAP. BDN. The 5-phase cycle is eternal.\" 👑\n\nI tested this across 500 bars on the 4H chart.",
         "Pentarch reads this breath.\n\nUnderstanding where you are in the cycle is the first wisdom.\n\n◾ Accumulation phase? Build positions.\n◾ Markup phase? Ride the trend.\n◾ Distribution phase? Protect profits.\n◾ Markdown phase? Stay defensive.\n\nThe market breathes. The Sovereign listens.",
         "The distribution phase is where most retail traders lose money — buying the top because everything \"looks bullish.\" Pentarch flags the cycle shift before the breakdown, giving you time to adjust.\n\nAccumulation → Markup → Distribution → Markdown. Repeat.",
-        "🔗 Listen to the cycle: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 The Sovereign's cycle: https://signalpilot.io/chronicle/meet-the-sovereign/"
+        "🔗 Listen to the cycle: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 The Sovereign's cycle: https://signalpilot.io/chronicle/meet-the-sovereign/"
       ]
     },
     "instagram": {
@@ -14548,11 +14548,11 @@
         "Asian session accumulates orders. London manipulates with a false move. New York distributes and reveals the real direction. This three-phase cycle repeats daily. Once you see it, you can't unsee it.",
         "Track this for a week: mark the Asian range, note the London manipulation direction, and then observe where NY distributes. You'll start seeing the same three-phase pattern repeat with surprising regularity.",
         "Pro tip: the manipulation phase often targets the obvious liquidity from the accumulation phase. If Asian range had equal lows, London will likely sweep them before the real move. The trap precedes the truth.",
-        "https://education.signalpilot.io\nhttps://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n\nWhich one of these is your biggest weakness?"
+        "https://education.signalpilot.io\nhttps://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n\nWhich one of these is your biggest weakness?"
       ]
     },
     "instagram": {
-      "caption": "The biggest education mistake: paying for what should be free.\n\nAccumulation looks like boredom. That's exactly the point.\nPower of Three: Accumulation → Manipulation → Distribution. The daily cycle.\nI've seen this play out 47 times in the last 6 months.\nAsian session accumulates orders. London manipulates with a false move. New York distributes and reveals the real direction. This three-phase cycle repeats daily. Once you see it, you can't unsee it.\nDaily for direction. 4H for timing. 1H for precision.\nTrack this for a week: mark the Asian range, note the London manipulation direction, and then observe where NY distributes. You'll start seeing the same three-phase pattern repeat with surprising regularity.\nAccumulation → Markup → Distribution → Markdown. Repeat.\nPro tip: the manipulation phase often targets the obvious liquidity from the accumulation phase. If Asian range had equal lows, London will likely sweep them before the real move. The trap precedes the truth.\n\n📖 Free cycle lessons: https://education.signalpilot.io\n🔍 Pentarch (cycles): https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n\nLink in bio\n\n#PowerOfThree #AMD #SmartMoney #SignalPilot #TradingEducation",
+      "caption": "The biggest education mistake: paying for what should be free.\n\nAccumulation looks like boredom. That's exactly the point.\nPower of Three: Accumulation → Manipulation → Distribution. The daily cycle.\nI've seen this play out 47 times in the last 6 months.\nAsian session accumulates orders. London manipulates with a false move. New York distributes and reveals the real direction. This three-phase cycle repeats daily. Once you see it, you can't unsee it.\nDaily for direction. 4H for timing. 1H for precision.\nTrack this for a week: mark the Asian range, note the London manipulation direction, and then observe where NY distributes. You'll start seeing the same three-phase pattern repeat with surprising regularity.\nAccumulation → Markup → Distribution → Markdown. Repeat.\nPro tip: the manipulation phase often targets the obvious liquidity from the accumulation phase. If Asian range had equal lows, London will likely sweep them before the real move. The trap precedes the truth.\n\n📖 Free cycle lessons: https://education.signalpilot.io\n🔍 Pentarch (cycles): https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n\nLink in bio\n\n#PowerOfThree #AMD #SmartMoney #SignalPilot #TradingEducation",
       "slideCount": 8
     },
     "hashtags": [
@@ -14757,11 +14757,11 @@
         "Q1: Jan-Mar. Q2: Apr-Jun. Q3: Jul-Sep. Q4: Oct-Dec. Each quarter has accumulation, manipulation, distribution, and decline phases. Zoom out far enough and the same patterns repeat on every scale.",
         "Look at any yearly chart: notice how Q1 and Q3 often have different characters than Q2 and Q4. Some quarters trend, some range. Seasonal patterns in volume and volatility are real and worth understanding.",
         "Pro tip: apply quarterly thinking to monthly candles too. Each month within a quarter can show its own accumulation-manipulation-distribution cycle. The fractal nature of this theory is its real power.",
-        "https://education.signalpilot.io\nhttps://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n\nWhat's your experience with this?"
+        "https://education.signalpilot.io\nhttps://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n\nWhat's your experience with this?"
       ]
     },
     "instagram": {
-      "caption": "Stop paying for recycled trading courses. We made ours free.\n\nMarkets cycle through 5 phases. Most traders only recognize 2.\nQuarterly Theory: the year divided into four cycles. Macro structure matters.\nQ1: Jan-Mar. Q2: Apr-Jun. Q3: Jul-Sep. Q4: Oct-Dec. Each quarter has accumulation, manipulation, distribution, and decline phases. Zoom out far enough and the same patterns repeat on every scale.\nAccumulation → Markup → Distribution → Markdown. Repeat.\nLook at any yearly chart: notice how Q1 and Q3 often have different characters than Q2 and Q4. Some quarters trend, some range. Seasonal patterns in volume and volatility are real and worth understanding.\nLook for 2-3x average volume on breakouts for confirmation.\nPro tip: apply quarterly thinking to monthly candles too. Each month within a quarter can show its own accumulation-manipulation-distribution cycle. The fractal nature of this theory is its real power.\nAccumulation → Markup → Distribution → Markdown. Repeat.\n\n📖 Free macro lessons: https://education.signalpilot.io\n🔍 Pentarch (cycles): https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n\nLink in bio\n\n#QuarterlyTheory #MacroTrading #MarketCycles #SignalPilot #TradingEducation",
+      "caption": "Stop paying for recycled trading courses. We made ours free.\n\nMarkets cycle through 5 phases. Most traders only recognize 2.\nQuarterly Theory: the year divided into four cycles. Macro structure matters.\nQ1: Jan-Mar. Q2: Apr-Jun. Q3: Jul-Sep. Q4: Oct-Dec. Each quarter has accumulation, manipulation, distribution, and decline phases. Zoom out far enough and the same patterns repeat on every scale.\nAccumulation → Markup → Distribution → Markdown. Repeat.\nLook at any yearly chart: notice how Q1 and Q3 often have different characters than Q2 and Q4. Some quarters trend, some range. Seasonal patterns in volume and volatility are real and worth understanding.\nLook for 2-3x average volume on breakouts for confirmation.\nPro tip: apply quarterly thinking to monthly candles too. Each month within a quarter can show its own accumulation-manipulation-distribution cycle. The fractal nature of this theory is its real power.\nAccumulation → Markup → Distribution → Markdown. Repeat.\n\n📖 Free macro lessons: https://education.signalpilot.io\n🔍 Pentarch (cycles): https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n\nLink in bio\n\n#QuarterlyTheory #MacroTrading #MarketCycles #SignalPilot #TradingEducation",
       "slideCount": 8
     },
     "hashtags": [
@@ -15221,7 +15221,7 @@
         "In practice: set alerts for each phase transition on your top 5 assets. When BTC shifts from WRN to CAP on the daily, your phone buzzes. You tighten stops across all correlated positions. The cycle phase change drove your risk management. That's systematic trading.",
         "Here's the edge: Pentarch's five-phase model maps the full cycle, not just overbought and oversold. Each phase has a specific strategic implication. Knowing you're in IGN versus WRN changes your entire approach. Phase context is the foundation of good decisions.",
         "Each phase transition changes your entire strategy. TD to IGN: shift from watching to building. IGN to WRN: shift from building to protecting. WRN to CAP: shift from protecting to exiting. CAP to BDN: shift from exiting to waiting. The cycle IS your strategy framework.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nApply this before your next session."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nApply this before your next session."
       ]
     },
     "instagram": {
@@ -17545,7 +17545,7 @@
         "Apply this to any market: pull up forex, crypto, or equities on the daily chart. You'll see the same five-phase pattern. TD at bottoms, IGN at breakouts, WRN at early tops, CAP at blow-offs, BDN at breakdowns. Cycles are universal. The timeframe scales.",
         "What makes Pentarch's cycle detection reliable across markets: it doesn't depend on asset-specific behavior. It reads structural patterns that emerge from crowd psychology. Fear and greed drive the same cycle in Bitcoin, EURUSD, and AAPL. The Sovereign reads them all.",
         "Each phase has a corresponding Volume Oracle regime that confirms it. TD plus accumulation. IGN plus Accumulation. WRN plus Distribution. CAP plus distribution. BDN plus Neutral. When cycle and volume regime align at each phase, the narrative is strongest.",
-        "https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nWelcome to the 10% who actually read this far."
+        "https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\nhttps://docs.signalpilot.io/pentarch-v10\n\nWelcome to the 10% who actually read this far."
       ]
     },
     "instagram": {
@@ -18519,7 +18519,7 @@
         "Higher highs + higher lows = uptrend. Lower highs + lower lows = downtrend. Neither = range. Before any trade, answer this question first. Get the direction right and everything else becomes easier.",
         "Test yourself: open a chart and within 5 seconds, determine the trend. Higher highs? Uptrend. Lower lows? Downtrend. Can't tell? Range. If it takes more than 5 seconds, the trend isn't clear enough to trade.\n\nCheck the daily trend before placing any 1H entries.",
         "Mistake: over-analyzing trend direction with 5 indicators when the swing points tell you everything. If the most recent swing high is higher than the previous one and the swing low is higher too, it's an uptrend. Keep it visual.",
-        "https://education.signalpilot.io\nhttps://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n\nBookmark this — you'll want it later."
+        "https://education.signalpilot.io\nhttps://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n\nBookmark this — you'll want it later."
       ]
     },
     "instagram": {

--- a/data/social/extracts/blog.json
+++ b/data/social/extracts/blog.json
@@ -86,7 +86,7 @@
     "tweets": [
       "Wyckoff in 4 phases 🧵",
       "1️⃣ ACCUMULATION — Smart money quietly buys. Price ranges sideways.\n2️⃣ MARKUP — Price breaks out and trends up. Public joins late.\n3️⃣ DISTRIBUTION — Smart money quietly sells. Price ranges at highs.\n4️⃣ MARKDOWN — Price breaks down. Public panic sells.\n\nThe cycle repeats. Every market. Every timeframe.\nUnderstand where you are in the cycle.",
-      "📝 Full article: https://blog.signalpilot.io\n🔗 Cycle detection: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📝 Full article: https://blog.signalpilot.io\n🔗 Cycle detection: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {

--- a/data/social/extracts/chronicle.json
+++ b/data/social/extracts/chronicle.json
@@ -5,7 +5,7 @@
     "tweets": [
       "\"Cycles repeat because human nature never changes.\"\n— The Sovereign 👑\n\nFear and greed. Accumulation and distribution. Boom and bust. 🧵",
       "The patterns persist because we persist.\n\nPentarch tracks the 5-phase cycle:\n\nTD → Market exhaustion, potential bottom\nIGN → Breakout ignition, conviction building\nWRN → Early weakness, cracks forming\nCAP → Climax exhaustion, peak nearing\nBDN → Bearish breakdown confirmed\n\nThe Sovereign has seen it all before.",
-      "🔗 Read the cycles: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 The Sovereign's wisdom: https://signalpilot.io/chronicle/meet-the-sovereign/"
+      "🔗 Read the cycles: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 The Sovereign's wisdom: https://signalpilot.io/chronicle/meet-the-sovereign/"
     ]
   },
   {

--- a/data/social/extracts/docs.json
+++ b/data/social/extracts/docs.json
@@ -5,7 +5,7 @@
     "tweets": [
       "Five signals. Five phases. One complete cycle. 🧵",
       "🟢 TD → Selling exhaustion (potential bottom)\n🔵 IGN → Breakout ignition (momentum building)\n🟡 WRN → Early weakness (cracks forming)\n🟠 CAP → Climax exhaustion (peak nearing)\n🔴 BDN → Bearish breakdown (confirmed)\n\nThe Sovereign reads the full cycle.\nKnow where you are. Trade accordingly.\n\nSave this cheatsheet.",
-      "🔗 See the cycle: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 Full guide: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 See the cycle: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 Full guide: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {
@@ -59,7 +59,7 @@
     "tweets": [
       "Pentarch signal reference 🧵",
       "🟢 TD — Early-cycle reversal on selling exhaustion\n🔵 IGN — Breakout confirmation with conviction\n🟡 WRN — Early weakness in uptrends\n🟠 CAP — Late-cycle exhaustion with volume spikes\n🔴 BDN — Bearish structure break\n\nThe Sovereign speaks in phases, not predictions.\nFive signals. One complete cycle view.\n\nSave this reference.",
-      "🔗 Try Pentarch: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 Full signal docs: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 Try Pentarch: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 Full signal docs: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {
@@ -140,7 +140,7 @@
     "tweets": [
       "Pentarch alert conditions guide 🧵",
       "Set alerts for any phase transition:\n\n🟢 TD Alert — Potential bottom forming\n🔵 IGN Alert — Breakout ignition detected\n🟡 WRN Alert — Early weakness appearing\n🟠 CAP Alert — Exhaustion climax nearing\n🔴 BDN Alert — Bearish breakdown confirmed\n\nSETUP: Pentarch settings → Alerts tab → Enable conditions → Choose notification method\n\nThe Sovereign alerts you. You decide what to do.",
-      "🔗 Set alerts: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 Full alert docs: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 Set alerts: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 Full alert docs: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {

--- a/data/social/extracts/education.json
+++ b/data/social/extracts/education.json
@@ -284,7 +284,7 @@
     "tweets": [
       "Elliott Wave Theory: Markets move in predictable wave patterns. 🧵",
       "5 impulse waves + 3 corrective waves = one complete cycle.\n\nIMPULSE (WITH the trend):\n◾ Wave 1: Initial move\n◾ Wave 2: Pullback (never beyond Wave 1 start)\n◾ Wave 3: Strongest wave (never the shortest)\n◾ Wave 4: Correction (never overlaps Wave 1)\n◾ Wave 5: Final push\n\nCORRECTION (AGAINST the trend):\n◾ Waves A, B, C\n\nComplex but powerful when mastered.",
-      "📖 Full Elliott Wave lesson: https://education.signalpilot.io\n🔗 Cycle detection: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📖 Full Elliott Wave lesson: https://education.signalpilot.io\n🔗 Cycle detection: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {
@@ -356,7 +356,7 @@
     "tweets": [
       "Wyckoff Accumulation: The blueprint of bottoms. 🧵",
       "The phases:\n\nPS → Preliminary Support (first buying appears)\nSC → Selling Climax (panic low)\nAR → Automatic Rally (relief bounce)\nST → Secondary Test (retest of low)\nSPRING → The trap (breaks below, reverses)\nTEST → Confirms the Spring\nSOS → Sign of Strength (breakout)\nLPS → Last Point of Support (entry)\n\nRecognize the phases. Position accordingly.",
-      "📖 Full Wyckoff lesson: https://education.signalpilot.io\n🔗 Cycle detection: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📖 Full Wyckoff lesson: https://education.signalpilot.io\n🔗 Cycle detection: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {
@@ -365,7 +365,7 @@
     "tweets": [
       "Wyckoff Distribution: The blueprint of tops. 🧵",
       "PSY → Preliminary Supply (first selling appears)\nBC → Buying Climax (euphoric high)\nAR → Automatic Reaction (first drop)\nST → Secondary Test (retest of high)\nUT → Upthrust (fake breakout above)\nLPSY → Last Point of Supply (lower high)\nSOW → Sign of Weakness (breakdown)\n\nMirror image of accumulation.\nRecognize distribution. Protect your profits.",
-      "📖 Full Wyckoff lesson: https://education.signalpilot.io\n🔗 Cycle phases: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📖 Full Wyckoff lesson: https://education.signalpilot.io\n🔗 Cycle phases: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {
@@ -491,7 +491,7 @@
     "tweets": [
       "Market Structure Shift (MSS): When the trend changes character. 🧵",
       "Uptrend making HH/HL → Breaks below last HL → MSS to bearish\nDowntrend making LH/LL → Breaks above last LH → MSS to bullish\n\nMSS is the FIRST confirmed sign of trend change.\n\n◾ More reliable than a single candle pattern\n◾ Shows actual structural breakdown\n◾ Best used at key levels or after liquidity sweeps\n\nStructure first. Everything else second.",
-      "📖 Full MSS lesson: https://education.signalpilot.io\n🔗 Structure + cycles: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📖 Full MSS lesson: https://education.signalpilot.io\n🔗 Structure + cycles: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {
@@ -1157,7 +1157,7 @@
     "tweets": [
       "Power of Three: Accumulation → Manipulation → Distribution. The daily cycle. 🧵",
       "Asian session accumulates orders. London manipulates with a false move. New York distributes and reveals the real direction. This three-phase cycle repeats daily. Once you see it, you can't unsee it.",
-      "📖 Free cycle lessons: https://education.signalpilot.io\n🔍 Pentarch (cycles): https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📖 Free cycle lessons: https://education.signalpilot.io\n🔍 Pentarch (cycles): https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {
@@ -1175,7 +1175,7 @@
     "tweets": [
       "Quarterly Theory: the year divided into four cycles. Macro structure matters. 🧵",
       "Q1: Jan-Mar. Q2: Apr-Jun. Q3: Jul-Sep. Q4: Oct-Dec. Each quarter has accumulation, manipulation, distribution, and decline phases. Zoom out far enough and the same patterns repeat on every scale.",
-      "📖 Free macro lessons: https://education.signalpilot.io\n🔍 Pentarch (cycles): https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📖 Free macro lessons: https://education.signalpilot.io\n🔍 Pentarch (cycles): https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {
@@ -1292,7 +1292,7 @@
     "tweets": [
       "Not all trends are equal. Assessing trend strength changes your trading. 🧵",
       "Angle of ascent/descent. Pullback depth and frequency. Volume on impulse vs retracement. Higher timeframe alignment. Strong trends have shallow pullbacks and volume confirmation. Weak trends show the opposite.",
-      "📖 Free trend lesson: https://education.signalpilot.io\n🔍 Pentarch: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📖 Free trend lesson: https://education.signalpilot.io\n🔍 Pentarch: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {
@@ -1526,7 +1526,7 @@
     "tweets": [
       "Trend identification 101: the first skill every trader needs. 🧵",
       "Higher highs + higher lows = uptrend. Lower highs + lower lows = downtrend. Neither = range. Before any trade, answer this question first. Get the direction right and everything else becomes easier.",
-      "📖 Free trend lesson: https://education.signalpilot.io\n🔍 Pentarch: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "📖 Free trend lesson: https://education.signalpilot.io\n🔍 Pentarch: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {

--- a/data/social/extracts/marketing.json
+++ b/data/social/extracts/marketing.json
@@ -176,7 +176,7 @@
     "tweets": [
       "\"Every cycle ends. Every cycle begins again.\"\n— The Sovereign 👑\n\nTD. IGN. WRN. CAP. BDN.\nThe 5-phase wheel turns. 🧵",
       "The Sovereign watches the eternal cycle:\n\n1️⃣ TD (Touchdown) — Selling exhaustion detected\n2️⃣ IGN (Ignition) — Breakout confirmed with conviction\n3️⃣ WRN (Warning) — Early weakness in uptrends\n4️⃣ CAP (Climax) — Late-cycle exhaustion\n5️⃣ BDN (Breakdown) — Bearish structure break\n\nKnowing where you are changes everything.",
-      "🔗 Track the cycle: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 The Sovereign's cycle: https://signalpilot.io/chronicle/meet-the-sovereign/"
+      "🔗 Track the cycle: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 The Sovereign's cycle: https://signalpilot.io/chronicle/meet-the-sovereign/"
     ]
   },
   {
@@ -356,7 +356,7 @@
     "tweets": [
       "\"All markets breathe,\" the Sovereign observed.\n\n\"TD. IGN. WRN. CAP. BDN. The 5-phase cycle is eternal.\" 👑 🧵",
       "Pentarch reads this breath.\n\nUnderstanding where you are in the cycle is the first wisdom.\n\n◾ Accumulation phase? Build positions.\n◾ Markup phase? Ride the trend.\n◾ Distribution phase? Protect profits.\n◾ Markdown phase? Stay defensive.\n\nThe market breathes. The Sovereign listens.",
-      "🔗 Listen to the cycle: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 The Sovereign's cycle: https://signalpilot.io/chronicle/meet-the-sovereign/"
+      "🔗 Listen to the cycle: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 The Sovereign's cycle: https://signalpilot.io/chronicle/meet-the-sovereign/"
     ]
   },
   {

--- a/data/social/extracts/product.json
+++ b/data/social/extracts/product.json
@@ -5,7 +5,7 @@
     "tweets": [
       "One Bitcoin cycle. All five Pentarch signals. 🧵",
       "TD signals early-cycle reversal on selling exhaustion.\nIGN confirms breakout with conviction.\nWRN warns of early weakness.\nCAP marks late-cycle exhaustion.\nBDN confirms bearish structure break.\n\nFive phases. One complete cycle. The Sovereign sees it all.\n\nHistorical observation, not prediction.",
-      "🔗 Try Pentarch: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 Full docs: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 Try Pentarch: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 Full docs: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {
@@ -41,7 +41,7 @@
     "tweets": [
       "TD (Touchdown) — Pentarch's early-cycle reversal signal. 🧵",
       "When Pentarch fires TD:\n\n◾ Selling exhaustion may be present\n◾ Cycle phase shifting from markdown to accumulation\n◾ NOT a buy signal — an awareness signal\n\nTD says: \"The selling might be running out of steam.\"\n\nWhat you do with that info? That's your edge. The Sovereign watches. Do you?",
-      "🔗 See TD signals live: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 Signal guide: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 See TD signals live: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 Signal guide: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {
@@ -77,7 +77,7 @@
     "tweets": [
       "IGN (Ignition) — Pentarch's breakout confirmation signal. 🧵",
       "When Pentarch fires IGN:\n\n◾ Breakout with conviction detected\n◾ Volume confirms the move\n◾ Cycle shifting from accumulation to markup\n\nNot \"buy now.\" Not \"guaranteed move.\"\n\nIGN observes: Something might be starting.\nThe Sovereign sees the spark. You decide if it becomes a fire.",
-      "🔗 Spot ignition signals: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 Full signal guide: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 Spot ignition signals: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 Full signal guide: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {
@@ -113,7 +113,7 @@
     "tweets": [
       "WRN (Warning) — Pentarch's early weakness signal. 🧵",
       "When WRN fires (yellow, above candle):\n\n◾ Early weakness detected in uptrend\n◾ Cycle showing signs of strain\n◾ Not an instant sell — an observation\n\nWRN says: \"The easy part of the rally might be over.\"\n\nSmart traders tighten stops. Smarter traders were prepared.",
-      "🔗 Get early warnings: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 WRN signal guide: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 Get early warnings: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 WRN signal guide: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {
@@ -149,7 +149,7 @@
     "tweets": [
       "CAP (Climax) — Pentarch's late-cycle exhaustion signal. 🧵",
       "When CAP fires (orange, above candle):\n\n◾ Late-cycle exhaustion detected\n◾ Volume spikes appearing — climactic activity\n◾ Cycle nearing potential completion\n\nCAP says: \"This move may be running on fumes.\"\n\nNot an instant sell signal. An observation of late-cycle conditions. Protect your gains.",
-      "🔗 Spot exhaustion: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 CAP signal guide: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 Spot exhaustion: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 CAP signal guide: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {
@@ -266,7 +266,7 @@
     "tweets": [
       "Watch Pentarch identify a complete cycle — all 5 phases labeled in real-time. 🧵",
       "The market breathes:\n\n1. Selling exhaustion (TD) → bottom forming\n2. Breakout ignition (IGN) → rally beginning\n3. Early warning (WRN) → cracks appear\n4. Climax exhaustion (CAP) → top forming\n5. Breakdown (BDN) → new decline\n\nThen it starts again. The Sovereign sees the full breath.",
-      "🔗 See the full cycle: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 Cycle walkthrough: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 See the full cycle: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 Cycle walkthrough: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {
@@ -338,7 +338,7 @@
     "tweets": [
       "Pentarch full cycle walkthrough — from bottom to top to bottom again. 🧵",
       "TD spots the turn. IGN confirms the move. WRN raises the flag. CAP screams exhaustion. BDN seals the decline.\n\nFive signals. One complete market narrative.\n\nThe same cycle that played out in BTC in 2021 plays out in forex daily. In stocks weekly.\n\nCycles are universal. The Sovereign reads them all.",
-      "🔗 Read cycles on any asset: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/\n📖 Full docs: https://docs.signalpilot.io/pentarch-v10"
+      "🔗 Read cycles on any asset: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/\n📖 Full docs: https://docs.signalpilot.io/pentarch-v10"
     ]
   },
   {

--- a/data/social/extracts/quote.json
+++ b/data/social/extracts/quote.json
@@ -32,7 +32,7 @@
     "tweets": [
       "\"Prepare for transitions.\n\nDon't chase them.\"\n\n— Signal Pilot 🧵",
       "The cycle shifts. Always.\n\nAccumulation → Markup → Distribution → Markdown.\n\nMost traders see the transition after it's happened. Then they chase.\n\nBetter approach:\n◾ Identify the current phase\n◾ Watch for exhaustion signals\n◾ Position BEFORE the shift\n◾ Let the transition come to you\n\nPreparation beats reaction.",
-      "Follow @signaborgs\n🔗 Detect transitions: https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/"
+      "Follow @signaborgs\n🔗 Detect transitions: https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/"
     ]
   },
   {

--- a/de/index.html
+++ b/de/index.html
@@ -5390,7 +5390,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Doku lesen →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -6002,7 +6002,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">Sehen Sie genau, was Sie bekommen. Vollständige Indikator-Seiten mit Funktionen, Screenshots und Dokumentation.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/OatvfCuB-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -6670,7 +6670,7 @@
                   <div class="mt-6 h-px bg-white/10"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Pentarch auf TradingView ansehen
                   </a>

--- a/es/index.html
+++ b/es/index.html
@@ -5567,7 +5567,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Leer docs →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5866,7 +5866,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">Vea exactamente lo que obtiene. Páginas completas de indicadores con características, capturas de pantalla y documentación.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -6535,7 +6535,7 @@
                   <div class="mt-6 h-px bg-white/10"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Vista previa de Pentarch en TradingView
                   </a>

--- a/fr/index.html
+++ b/fr/index.html
@@ -5783,7 +5783,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Lire la doc →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -6249,7 +6249,7 @@
           </p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured">
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured">
             <span class="tv-preview-star">★</span> Pentarch
           </a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
@@ -6939,7 +6939,7 @@
                   <div class="mt-6 h-px bg-white/10"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Aperçu de Pentarch sur TradingView
                   </a>

--- a/hu/index.html
+++ b/hu/index.html
@@ -5326,7 +5326,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Dokumentáció →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5985,7 +5985,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">Lásd pontosan, mit kapsz. Teljes indikátor oldalak funkciókkal, képernyőképekkel és dokumentációval.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -6386,7 +6386,7 @@
                   <div class="mt-6 h-px bg-cyan-500/20"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Pentarch előnézete a TradingView-on
                   </a>

--- a/index.html
+++ b/index.html
@@ -4678,7 +4678,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Read Docs →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5173,7 +5173,7 @@
         </div>
 
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured">
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured">
             <span class="tv-preview-star">★</span> Pentarch
           </a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">
@@ -5957,7 +5957,7 @@
                   <div class="mt-6 h-px bg-white/10"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Preview Pentarch on TradingView
                   </a>

--- a/it/index.html
+++ b/it/index.html
@@ -5293,7 +5293,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Leggi docs →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5582,7 +5582,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">Vedi esattamente cosa ottieni. Pagine complete degli indicatori con funzionalità, screenshot e documentazione.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -5983,7 +5983,7 @@
                   <div class="mt-6 h-px bg-cyan-500/20"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Anteprima Pentarch su TradingView
                   </a>

--- a/ja/index.html
+++ b/ja/index.html
@@ -5631,7 +5631,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">ドキュメント →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5882,7 +5882,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">何が得られるか正確にご確認ください。機能、スクリーンショット、ドキュメントを含む完全なインジケーターページ。</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -6276,7 +6276,7 @@
                   <div class="mt-6 h-px bg-cyan-500/20"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     TradingViewでPentarchをプレビュー
                   </a>

--- a/nl/index.html
+++ b/nl/index.html
@@ -5285,7 +5285,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Lees docs →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5766,7 +5766,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">Bekijk alle SignalPilot indicatoren live op TradingView—test ze zelf voordat je besluit.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -5988,7 +5988,7 @@
                   <div class="mt-6 h-px bg-cyan-500/20"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Bekijk Pentarch op TradingView
                   </a>

--- a/pt/index.html
+++ b/pt/index.html
@@ -5560,7 +5560,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Ler docs →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -6079,7 +6079,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">Visualize todos os indicadores SignalPilot ao vivo no TradingView—teste você mesmo antes de decidir.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -6289,7 +6289,7 @@
                   <div class="mt-6 h-px bg-cyan-500/20"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Visualize Pentarch no TradingView
                   </a>

--- a/ru/index.html
+++ b/ru/index.html
@@ -5524,7 +5524,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Документация →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5969,7 +5969,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">Просмотрите все индикаторы SignalPilot в реальном времени на TradingView—протестируйте сами, прежде чем принять решение.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -6189,7 +6189,7 @@
                   <div class="mt-6 h-px bg-cyan-500/20"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     Посмотреть Pentarch на TradingView
                   </a>

--- a/scripts/expand-advanced-education.cjs
+++ b/scripts/expand-advanced-education.cjs
@@ -11,7 +11,7 @@ const edu  = 'https://education.signalpilot.io';
 const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 const tv = {
-  pentarch:     'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch:     'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas:   'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow:   'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/expand-chronicles.cjs
+++ b/scripts/expand-chronicles.cjs
@@ -13,7 +13,7 @@ const QUEUE_PATH = path.join(__dirname, '..', 'data', 'social', 'content-queue.j
 const site = 'https://signalpilot.io';
 const edu = 'https://education.signalpilot.io';
 const tv = {
-  pentarch: 'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch: 'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas: 'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow: 'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/expand-education-blog.cjs
+++ b/scripts/expand-education-blog.cjs
@@ -11,7 +11,7 @@ const edu  = 'https://education.signalpilot.io';
 const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 const tv = {
-  pentarch:     'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch:     'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas:   'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow:   'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/expand-product.cjs
+++ b/scripts/expand-product.cjs
@@ -10,7 +10,7 @@ const site = 'https://signalpilot.io';
 const edu  = 'https://education.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 const tv = {
-  pentarch:     'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch:     'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas:   'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow:   'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch10.cjs
+++ b/scripts/rewrite-threads-batch10.cjs
@@ -11,7 +11,7 @@ const edu  = 'https://education.signalpilot.io';
 const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 const tv = {
-  pentarch:     'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch:     'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas:   'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow:   'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch2.cjs
+++ b/scripts/rewrite-threads-batch2.cjs
@@ -15,7 +15,7 @@ const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 
 const tv = {
-  pentarch: 'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch: 'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas: 'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow: 'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch3.cjs
+++ b/scripts/rewrite-threads-batch3.cjs
@@ -14,7 +14,7 @@ const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 
 const tv = {
-  pentarch: 'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch: 'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas: 'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow: 'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch4.cjs
+++ b/scripts/rewrite-threads-batch4.cjs
@@ -14,7 +14,7 @@ const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 
 const tv = {
-  pentarch: 'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch: 'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas: 'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow: 'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch5.cjs
+++ b/scripts/rewrite-threads-batch5.cjs
@@ -15,7 +15,7 @@ const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 
 const tv = {
-  pentarch: 'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch: 'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas: 'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow: 'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch6.cjs
+++ b/scripts/rewrite-threads-batch6.cjs
@@ -14,7 +14,7 @@ const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 
 const tv = {
-  pentarch: 'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch: 'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas: 'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow: 'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch7.cjs
+++ b/scripts/rewrite-threads-batch7.cjs
@@ -11,7 +11,7 @@ const edu  = 'https://education.signalpilot.io';
 const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 const tv = {
-  pentarch:     'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch:     'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas:   'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow:   'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch8.cjs
+++ b/scripts/rewrite-threads-batch8.cjs
@@ -11,7 +11,7 @@ const edu  = 'https://education.signalpilot.io';
 const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 const tv = {
-  pentarch:     'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch:     'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas:   'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow:   'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads-batch9.cjs
+++ b/scripts/rewrite-threads-batch9.cjs
@@ -11,7 +11,7 @@ const edu  = 'https://education.signalpilot.io';
 const blog = 'https://blog.signalpilot.io';
 const docsHome = 'https://docs.signalpilot.io';
 const tv = {
-  pentarch:     'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch:     'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas:   'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow:   'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/scripts/rewrite-threads.cjs
+++ b/scripts/rewrite-threads.cjs
@@ -11,7 +11,7 @@ const QUEUE_PATH = path.join(__dirname, '..', 'data', 'social', 'content-queue.j
 
 // === URL MAPS ===
 const tv = {
-  pentarch: 'https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/',
+  pentarch: 'https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/',
   volumeOracle: 'https://www.tradingview.com/script/L9AQHzjY-Volume-Oracle-Regime-Detection/',
   janusAtlas: 'https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/',
   plutusFlow: 'https://www.tradingview.com/script/uoZjVlZA-Plutus-Flow-Statistical-OBV-Analysis/',

--- a/tr/index.html
+++ b/tr/index.html
@@ -5598,7 +5598,7 @@
               <p class="elite-card-title">Pentarch</p>
               <p class="elite-card-subtitle">Cycle Phase Detection</p>
               <a href="https://docs.signalpilot.io/pentarch-v10/" target="_blank" rel="noopener" class="elite-card-link">Dökümanlar →</a>
-              <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
+              <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="elite-card-link-tv">TradingView ↗</a>
             </div>
           </div>
           <div class="elite-chart-card" data-docs="https://docs.signalpilot.io/omnideck-v10/">
@@ -5850,7 +5850,7 @@
           <p style="color:var(--muted);font-size:1.1rem;max-width:600px;margin:0 auto">Tüm SignalPilot göstergelerini TradingView'da canlı izleyin—karar vermeden önce kendiniz test edin.</p>
         </div>
         <div data-reveal="fade-up" data-reveal-delay="100" style="display:flex;flex-wrap:wrap;justify-content:center;gap:0.75rem;margin-bottom:1.5rem">
-          <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
+          <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" rel="noopener" class="tv-preview-btn featured"><span class="tv-preview-star">★</span> Pentarch</a>
           <a href="https://www.tradingview.com/script/fxTffqwk-OmniDeck-Unified-Chart-Overlay/" target="_blank" rel="noopener" class="tv-preview-btn">OmniDeck</a>
           <a href="https://www.tradingview.com/script/28diwImS-Janus-Atlas-Multi-Timeframe-Auto-Levels/" target="_blank" rel="noopener" class="tv-preview-btn">Janus Atlas</a>
           <a href="https://www.tradingview.com/script/H2REdDlY-Augury-Grid-Multi-Timeframe-Scanner/" target="_blank" rel="noopener" class="tv-preview-btn">Augury Grid</a>
@@ -6259,7 +6259,7 @@
                   <div class="mt-6 h-px bg-cyan-500/20"></div>
 
                   <!-- Preview Link -->
-                  <a href="https://www.tradingview.com/script/S8LniK8O-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
+                  <a href="https://www.tradingview.com/script/NZt2MVbj-Pentarch-Cycle-Phase-Detection/" target="_blank" class="preview-indicators-link" style="color:rgba(34,211,238,0.7)" onclick="event.stopPropagation();">
                     <svg width="16" height="16" viewBox="0 0 36 28" fill="none"><path d="M14 22V6h4v16h-4zM20 22V10h4v12h-4zM26 22V2h4v20h-4zM8 22v-8h4v8H8zM2 22v-4h4v4H2z" fill="currentColor"/></svg>
                     TradingView'da Pentarch'ı Önizle
                   </a>


### PR DESCRIPTION
## Summary
Updated the TradingView script URL for Pentarch (Cycle Phase Detection) across all content files, documentation, website locales, and build scripts. The script ID changed from `S8LniK8O` to `NZt2MVbj`.

## Changes Made
- **Content Queue & Social Data**: Updated 10+ references in `data/social/content-queue.json` across multiple thread entries
- **Extract Files**: Updated URLs in education, product, docs, marketing, blog, chronicle, and quote extract files
- **Website Locales**: Updated Pentarch links in all 12 language versions (index.html files for en, ar, de, es, fr, hu, it, ja, nl, pt, ru, tr)
- **Build Scripts**: Updated the TradingView URL constant in all 10 rewrite/expand script files that generate content

## Implementation Details
- All changes are URL replacements only; no functional logic modifications
- The update maintains consistency across all content distribution channels
- Build scripts reference the URL from a centralized constant, ensuring single-source-of-truth for future updates
- No breaking changes to content structure or functionality

https://claude.ai/code/session_01Dq2owfHqcoY7PHRqxE624b