### PR TITLE
Remove "The Problem" and "How It Works" sections from homepage

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -5281,45 +5281,7 @@ html[lang="ar"] [style*="text-align:center"] {
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">المشكلة</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">يبدو مألوفاً؟</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Pain Point 1 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">مؤشرات تعيد الرسم</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">تبدو الإشارات مثالية في السجل لكنها تتغير في الوقت الفعلي. نقاط دخولك لم تكن حقيقية أبداً.</p>
-          </div>
-          <!-- Pain Point 2 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">تكديس الأدوات يخلق ضوضاء</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">مؤشرات أكثر، ارتباك أكثر. إشارات متناقضة من أدوات لا تتواصل مع بعضها.</p>
-          </div>
-          <!-- Pain Point 3 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">خدمات الإشارات تخلق التبعية</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">شخص يرسل إشعاراً، أنت تنقر شراء. فاتك التنبيه، فاتتك الصفقة. لن تتعلم أبداً حقاً.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ANTI-PITCH SECTION (MOVED UP) -->
+    <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:700px">
 
@@ -5356,43 +5318,6 @@ html[lang="ar"] [style*="text-align:center"] {
           </p>
         </div>
 
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">كيف يعمل</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">نظام واحد. قراءة كاملة للسوق.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Step 1 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch يقرأ الدورة</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">خمس مراحل — Touchdown (تراكم)، Ignition (صعود)، Warning (توزيع)، Climax و Breakdown (هبوط). بدون إعادة رسم، في الوقت الفعلي.</p>
-          </div>
-          <!-- Step 2 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">المجموعة تؤكد الحدث</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (الحجم)، Harmonic Oscillator (الزخم) و Janus Atlas (المستويات) يؤكدون أو يرفضون المرحلة.</p>
-          </div>
-          <!-- Step 3 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck يوحّد التحليل</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">طبقة واحدة، أي سوق، أي إطار زمني. مرحلة الدورة، المستويات الرئيسية والزخم — الكل في رسم بياني واحد.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>جرّب مجاناً ←</span>
-          </a>
-        </div>
       </div>
     </section>
 

--- a/de/index.html
+++ b/de/index.html
@@ -5239,41 +5239,6 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">Das Problem</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Kommt dir das bekannt vor?</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Repaintende Indikatoren</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Signale sehen im Verlauf perfekt aus, ändern sich aber in Echtzeit. Deine Einstiege waren nie real.</p>
-          </div>
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Mehr Tools = mehr Rauschen</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Mehr Indikatoren, mehr Verwirrung. Widersprüchliche Signale von Tools, die nicht zusammenarbeiten.</p>
-          </div>
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Signal-Dienste machen abhängig</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Jemand pingt dein Handy, du klickst auf Kaufen. Alarm verpasst, Trade verpasst. Du lernst nie wirklich.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
     <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:700px">
@@ -5311,40 +5276,6 @@
           </p>
         </div>
 
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">So funktioniert's</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Ein System. Vollständige Marktanalyse.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch liest den Zyklus</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Fünf Phasen — Touchdown (Akkumulation), Ignition (Markup), Warning (Distribution), Climax und Breakdown (Rückgang). Kein Repainting, in Echtzeit.</p>
-          </div>
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Die Suite bestätigt das Ereignis</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (Volumen), Harmonic Oscillator (Momentum) und Janus Atlas (Levels) bestätigen oder widerlegen die Phase.</p>
-          </div>
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck vereint die Analyse</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Ein Overlay, jeder Markt, jeder Zeitrahmen. Zyklusphase, Schlüssel-Levels und Momentum — alles auf einem Chart.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>Kostenlos testen →</span>
-          </a>
-        </div>
       </div>
     </section>
 

--- a/es/index.html
+++ b/es/index.html
@@ -5430,33 +5430,6 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">El Problema</span>
-          <h2 class="headline impact" style="margin-top:1.5rem"><span class="shimmer-text">¿Te suena familiar?</span></h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg></div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Indicadores que repintan</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Las señales lucen perfectas en el historial pero cambian en tiempo real. Tus entradas nunca fueron reales.</p>
-          </div>
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg></div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Acumular herramientas crea ruido</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Más indicadores, más confusión. Señales contradictorias de herramientas que no se comunican entre sí.</p>
-          </div>
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg></div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Los servicios de señales crean dependencia</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Alguien te avisa, tú compras. Pierdes la alerta, pierdes el trade. Nunca aprendes realmente.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
     <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:700px">
@@ -5494,36 +5467,6 @@
           </p>
         </div>
 
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Cómo Funciona</span>
-          <h2 class="headline impact" style="margin-top:1.5rem"><span class="shimmer-text">Un sistema. Lectura completa del mercado.</span></h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch lee el ciclo</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Cinco fases — Touchdown (acumulación), Ignition (markup), Warning (distribución), Climax y Breakdown (declive). Sin repintado, en tiempo real.</p>
-          </div>
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">La suite confirma el evento</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (volumen), Harmonic Oscillator (momentum) y Janus Atlas (niveles) validan o rechazan la fase.</p>
-          </div>
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck unifica la lectura</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Un overlay, cualquier mercado, cualquier temporalidad. Fase del ciclo, niveles clave y momentum — todo en un solo gráfico.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto"><span>Probar Gratis →</span></a>
-        </div>
       </div>
     </section>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -5615,45 +5615,7 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">Le Problème</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Ça vous dit quelque chose ?</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Pain Point 1 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Indicateurs qui repeignent</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Les signaux semblent parfaits sur l'historique mais changent en temps réel. Vos entrées n'étaient jamais réelles.</p>
-          </div>
-          <!-- Pain Point 2 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Empiler les outils crée du bruit</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Plus d'indicateurs, plus de confusion. Des signaux contradictoires d'outils qui ne communiquent pas entre eux.</p>
-          </div>
-          <!-- Pain Point 3 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Les services de signaux créent la dépendance</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Quelqu'un vous alerte, vous cliquez acheter. Alerte manquée, trade manqué. Vous n'apprenez jamais vraiment.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ANTI-PITCH SECTION (MOVED UP) -->
+    <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(91,138,255,.02) 0%,transparent 100%)">
       <style>
         .anti-pitch-headline { font-size:2.5rem; }
@@ -5700,43 +5662,6 @@
             C'est plus difficile. Et c'est le dernier outil de trading que vous achèterez.
           </p>
 
-        </div>
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Comment ça marche</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Un système. Lecture complète du marché.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Step 1 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch lit le cycle</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Cinq phases — Touchdown (accumulation), Ignition (markup), Warning (distribution), Climax et Breakdown (déclin). Sans repeinture, en temps réel.</p>
-          </div>
-          <!-- Step 2 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">La suite confirme l'événement</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (volume), Harmonic Oscillator (momentum) et Janus Atlas (niveaux) valident ou rejettent la phase.</p>
-          </div>
-          <!-- Step 3 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck unifie la lecture</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Un overlay, tout marché, toute temporalité. Phase du cycle, niveaux clés et momentum — tout sur un seul graphique.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>Essayer Gratuitement →</span>
-          </a>
         </div>
       </div>
     </section>

--- a/hu/index.html
+++ b/hu/index.html
@@ -5166,45 +5166,7 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">A Probléma</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Ismerős?</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Pain Point 1 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Újrafestő indikátorok</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">A jelzések tökéletesnek tűnnek a múltban, de valós időben változnak. A belépéseid sosem voltak valósak.</p>
-          </div>
-          <!-- Pain Point 2 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Több eszköz = több zaj</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Több indikátor, több zűrzavar. Egymásnak ellentmondó jelzések olyan eszközöktől, amelyek nem kommunikálnak egymással.</p>
-          </div>
-          <!-- Pain Point 3 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">A jelzésszolgáltatások függőséget teremtenek</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Valaki küld egy értesítést, te rákattintasz a vételre. Lemaradtál az értesítésről, lemaradtál a kereskedésről. Sosem tanulsz igazán.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ANTI-PITCH SECTION (MOVED UP) -->
+    <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(91,138,255,.02) 0%,transparent 100%)">
       <style>
         .anti-pitch-headline { font-size:2.5rem; }
@@ -5251,43 +5213,6 @@
             Nehezebb. És ez az utolsó kereskedési eszköz, amit valaha vásárolsz.
           </p>
 
-        </div>
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Hogyan Működik</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Egy rendszer. Teljes piacelemzés.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Step 1 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch olvassa a ciklust</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Öt fázis — Touchdown (felhalmozás), Ignition (emelkedés), Warning (elosztás), Climax és Breakdown (hanyatlás). Nincs újrafestés, valós időben.</p>
-          </div>
-          <!-- Step 2 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">A csomag megerősíti az eseményt</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (forgalom), Harmonic Oscillator (momentum) és Janus Atlas (szintek) megerősítik vagy elvetik a fázist.</p>
-          </div>
-          <!-- Step 3 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck egyesíti az elemzést</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Egy overlay, bármely piac, bármely időkeret. Ciklusfázis, kulcsszintek és momentum — minden egy grafikonon.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>Próbáld ki ingyen →</span>
-          </a>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -4513,45 +4513,7 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">The Problem</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Sound familiar?</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Pain Point 1 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Repainting indicators</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Signals look perfect on history but change in real-time. Your entries were never real.</p>
-          </div>
-          <!-- Pain Point 2 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Stacking tools creates noise</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">More indicators, more confusion. Conflicting signals from tools that don't talk to each other.</p>
-          </div>
-          <!-- Pain Point 3 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Signal services create dependency</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Someone pings your phone, you click buy. Miss the alert, miss the trade. You never actually learn.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ANTI-PITCH SECTION (MOVED UP) -->
+    <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(91,138,255,.02) 0%,transparent 100%)">
       <style>
         .anti-pitch-headline { font-size:2.5rem; }
@@ -4598,43 +4560,6 @@
             It's harder. And it's the last trading tool you'll buy.
           </p>
 
-        </div>
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">How It Works</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">One system. Complete market read.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Step 1 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch reads the cycle</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Five phases — Touchdown (accumulation), Ignition (markup), Warning (distribution), Climax, and Breakdown (decline). Non-repainting, real-time.</p>
-          </div>
-          <!-- Step 2 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">The suite confirms the event</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (volume), Harmonic Oscillator (momentum), and Janus Atlas (levels) align to validate or reject the phase.</p>
-          </div>
-          <!-- Step 3 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck unifies the read</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">One overlay, any market, any timeframe. Cycle phase, key levels, and momentum — all on a single chart.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>Try It Free →</span>
-          </a>
         </div>
       </div>
     </section>

--- a/it/index.html
+++ b/it/index.html
@@ -5133,45 +5133,7 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">Il Problema</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Ti suona familiare?</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Pain Point 1 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Indicatori che ridipingono</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">I segnali sembrano perfetti nello storico ma cambiano in tempo reale. I tuoi ingressi non erano mai reali.</p>
-          </div>
-          <!-- Pain Point 2 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Accumulare strumenti crea rumore</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Più indicatori, più confusione. Segnali contraddittori da strumenti che non comunicano tra loro.</p>
-          </div>
-          <!-- Pain Point 3 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">I servizi di segnali creano dipendenza</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Qualcuno ti avvisa, tu clicchi compra. Perdi l'avviso, perdi il trade. Non impari mai davvero.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ANTI-PITCH SECTION (MOVED UP) -->
+    <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(91,138,255,.02) 0%,transparent 100%)">
       <style>
         .anti-pitch-headline { font-size:2.5rem; }
@@ -5218,43 +5180,6 @@
             È più difficile. Ed è l'ultimo strumento di trading che comprerai.
           </p>
 
-        </div>
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Come Funziona</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Un sistema. Lettura completa del mercato.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Step 1 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch legge il ciclo</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Cinque fasi — Touchdown (accumulo), Ignition (markup), Warning (distribuzione), Climax e Breakdown (declino). Senza ridipintura, in tempo reale.</p>
-          </div>
-          <!-- Step 2 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">La suite conferma l'evento</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (volume), Harmonic Oscillator (momentum) e Janus Atlas (livelli) validano o respingono la fase.</p>
-          </div>
-          <!-- Step 3 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck unifica la lettura</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Un overlay, qualsiasi mercato, qualsiasi timeframe. Fase del ciclo, livelli chiave e momentum — tutto su un unico grafico.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>Prova Gratis →</span>
-          </a>
         </div>
       </div>
     </section>

--- a/ja/index.html
+++ b/ja/index.html
@@ -5482,44 +5482,6 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">問題点</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">心当たりはありませんか？</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Pain Point 1 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">リペイントするインジケーター</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">シグナルは履歴上では完璧に見えますが、リアルタイムでは変化します。あなたのエントリーは本物ではありませんでした。</p>
-          </div>
-          <!-- Pain Point 2 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">ツールの積み重ねはノイズを生む</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">インジケーターが増えるほど混乱も増えます。互いに連携しないツールからの矛盾したシグナル。</p>
-          </div>
-          <!-- Pain Point 3 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">シグナルサービスは依存を生む</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">誰かが通知を送り、あなたは買いをクリック。アラートを逃せばトレードも逃す。本当の学びは得られません。</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
     <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:700px">
@@ -5557,43 +5519,6 @@
           </p>
         </div>
 
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">仕組み</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">1つのシステム。完全な市場分析。</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Step 1 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarchがサイクルを読む</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">5つのフェーズ — Touchdown（蓄積）、Ignition（上昇）、Warning（分配）、Climax、Breakdown（下落）。リペイントなし、リアルタイム。</p>
-          </div>
-          <!-- Step 2 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">スイートがイベントを確認</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow（出来高）、Harmonic Oscillator（モメンタム）、Janus Atlas（レベル）がフェーズを検証または否定します。</p>
-          </div>
-          <!-- Step 3 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeckが分析を統合</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">1つのオーバーレイ、あらゆる市場、あらゆる時間軸。サイクルフェーズ、重要レベル、モメンタム — すべてが1つのチャートに。</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>無料で試す →</span>
-          </a>
-        </div>
       </div>
     </section>
 

--- a/nl/index.html
+++ b/nl/index.html
@@ -5160,33 +5160,6 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">Het Probleem</span>
-          <h2 class="headline impact" style="margin-top:1.5rem"><span class="shimmer-text">Klinkt dit bekend?</span></h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg></div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Repaintende indicatoren</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Signalen zien er perfect uit op de historie, maar veranderen in real-time. Je entries waren nooit echt.</p>
-          </div>
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg></div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Meer tools = meer ruis</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Meer indicatoren, meer verwarring. Tegenstrijdige signalen van tools die niet met elkaar communiceren.</p>
-          </div>
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg></div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Signaaldiensten creëren afhankelijkheid</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Iemand stuurt een melding, jij klikt kopen. Melding gemist, trade gemist. Je leert nooit echt.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
     <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:700px">
@@ -5217,36 +5190,6 @@
           <p style="font-size:1.25rem;font-weight:600;color:var(--text);line-height:1.6">
             Het is moeilijker. En het is de laatste trading tool die je koopt.
           </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Hoe Het Werkt</span>
-          <h2 class="headline impact" style="margin-top:1.5rem"><span class="shimmer-text">Eén systeem. Complete marktanalyse.</span></h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch leest de cyclus</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Vijf fasen — Touchdown (accumulatie), Ignition (markup), Warning (distributie), Climax en Breakdown (daling). Geen repainting, real-time.</p>
-          </div>
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">De suite bevestigt het event</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (volume), Harmonic Oscillator (momentum) en Janus Atlas (niveaus) valideren of verwerpen de fase.</p>
-          </div>
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck verenigt de analyse</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Eén overlay, elke markt, elk tijdsframe. Cyclusfase, belangrijke niveaus en momentum — alles op één grafiek.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto"><span>Gratis Proberen →</span></a>
         </div>
       </div>
     </section>

--- a/pt/index.html
+++ b/pt/index.html
@@ -5417,41 +5417,6 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">O Problema</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Soa familiar?</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Indicadores que repintam</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Os sinais parecem perfeitos no histórico mas mudam em tempo real. Suas entradas nunca foram reais.</p>
-          </div>
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Acumular ferramentas cria ruído</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Mais indicadores, mais confusão. Sinais contraditórios de ferramentas que não se comunicam.</p>
-          </div>
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Serviços de sinais criam dependência</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Alguém te avisa, você clica comprar. Perdeu o alerta, perdeu o trade. Você nunca aprende de verdade.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
     <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:4rem 0;">
       <div class="container" style="max-width:700px">
@@ -5489,40 +5454,6 @@
           </p>
         </div>
 
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Como Funciona</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Um sistema. Leitura completa do mercado.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch lê o ciclo</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Cinco fases — Touchdown (acumulação), Ignition (markup), Warning (distribuição), Climax e Breakdown (declínio). Sem repintura, em tempo real.</p>
-          </div>
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">A suite confirma o evento</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (volume), Harmonic Oscillator (momentum) e Janus Atlas (níveis) validam ou rejeitam a fase.</p>
-          </div>
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck unifica a leitura</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Um overlay, qualquer mercado, qualquer timeframe. Fase do ciclo, níveis-chave e momentum — tudo em um único gráfico.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>Experimente Grátis →</span>
-          </a>
-        </div>
       </div>
     </section>
 

--- a/ru/index.html
+++ b/ru/index.html
@@ -5364,45 +5364,7 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">Проблема</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Звучит знакомо?</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Pain Point 1 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Перерисовывающиеся индикаторы</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Сигналы выглядят идеально на истории, но меняются в реальном времени. Ваши входы никогда не были настоящими.</p>
-          </div>
-          <!-- Pain Point 2 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Накопление инструментов создаёт шум</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Больше индикаторов — больше путаницы. Противоречивые сигналы от инструментов, которые не взаимодействуют друг с другом.</p>
-          </div>
-          <!-- Pain Point 3 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Сигнальные сервисы создают зависимость</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Кто-то шлёт уведомление, вы нажимаете «купить». Пропустили оповещение — пропустили сделку. Вы никогда не учитесь по-настоящему.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ANTI-PITCH SECTION (MOVED UP) -->
+    <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(91,138,255,.02) 0%,transparent 100%)">
       <style>
         .anti-pitch-headline { font-size:2.5rem; }
@@ -5449,43 +5411,6 @@
             Это сложнее. И это последний торговый инструмент, который вы купите.
           </p>
 
-        </div>
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Как это работает</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Одна система. Полный анализ рынка.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Step 1 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch читает цикл</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Пять фаз — Touchdown (накопление), Ignition (разгон), Warning (распределение), Climax и Breakdown (снижение). Без перерисовки, в реальном времени.</p>
-          </div>
-          <!-- Step 2 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Набор подтверждает событие</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (объём), Harmonic Oscillator (моментум) и Janus Atlas (уровни) подтверждают или отвергают фазу.</p>
-          </div>
-          <!-- Step 3 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck объединяет анализ</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Один оверлей, любой рынок, любой таймфрейм. Фаза цикла, ключевые уровни и моментум — всё на одном графике.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>Попробовать бесплатно →</span>
-          </a>
         </div>
       </div>
     </section>

--- a/tr/index.html
+++ b/tr/index.html
@@ -5438,45 +5438,7 @@
 
     </section>
 
-    <!-- THE PROBLEM -->
-    <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(239,68,68,.03) 0%,transparent 100%)">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.1);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:#f87171">Sorun</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Tanıdık geldi mi?</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.5rem" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Pain Point 1 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Yeniden boyanan indikatörler</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Sinyaller geçmişte mükemmel görünür ama gerçek zamanlı olarak değişir. Girişleriniz hiç gerçek olmadı.</p>
-          </div>
-          <!-- Pain Point 2 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Araç yığmak gürültü yaratır</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Daha fazla indikatör, daha fazla karmaşa. Birbirleriyle iletişim kurmayan araçlardan çelişkili sinyaller.</p>
-          </div>
-          <!-- Pain Point 3 -->
-          <div style="padding:2rem;border-radius:12px;border:1px solid rgba(239,68,68,.15);background:rgba(239,68,68,.04)">
-            <div style="width:40px;height:40px;border-radius:10px;background:rgba(239,68,68,.1);display:flex;align-items:center;justify-content:center;margin-bottom:1.25rem">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2"/><rect x="3" y="4" width="18" height="18" rx="2"/><circle cx="12" cy="10" r="2"/><line x1="8" y1="2" x2="8" y2="4"/><line x1="16" y1="2" x2="16" y2="4"/></svg>
-            </div>
-            <h3 style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:0.75rem">Sinyal servisleri bağımlılık yaratır</h3>
-            <p style="color:var(--muted);font-size:0.95rem;line-height:1.6">Biri telefonunuza bildirim gönderir, siz al'a tıklarsınız. Bildirimi kaçırdınız, işlemi kaçırdınız. Aslında hiç öğrenmezsiniz.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ANTI-PITCH SECTION (MOVED UP) -->
+    <!-- ANTI-PITCH SECTION -->
     <section class="section" style="padding:5rem 0;background:linear-gradient(180deg,rgba(91,138,255,.02) 0%,transparent 100%)">
       <style>
         .anti-pitch-headline { font-size:2.5rem; }
@@ -5523,43 +5485,6 @@
             Daha zor. Ve satın alacağınız son trading aracı.
           </p>
 
-        </div>
-      </div>
-    </section>
-
-    <!-- HOW IT WORKS -->
-    <section class="section" style="padding:5rem 0">
-      <div class="container" style="max-width:900px">
-        <div style="text-align:center;margin-bottom:3rem" data-reveal="fade-up">
-          <span style="display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;border:1px solid rgba(91,138,255,0.3);background:rgba(91,138,255,0.15);padding:.5rem 1rem;font-size:.75rem;font-weight:500;color:var(--brand)">Nasıl Çalışır</span>
-          <h2 class="headline impact" style="margin-top:1.5rem">
-            <span class="shimmer-text">Tek sistem. Eksiksiz piyasa analizi.</span>
-          </h2>
-        </div>
-        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:2rem;text-align:center" data-reveal="fade-up" data-reveal-delay="200">
-          <!-- Step 1 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">1</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Pentarch döngüyü okur</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Beş faz — Touchdown (birikim), Ignition (yükseliş), Warning (dağıtım), Climax ve Breakdown (düşüş). Yeniden boyama yok, gerçek zamanlı.</p>
-          </div>
-          <!-- Step 2 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">2</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">Paket olayı doğrular</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Plutus Flow (hacim), Harmonic Oscillator (momentum) ve Janus Atlas (seviyeler) fazı doğrular veya reddeder.</p>
-          </div>
-          <!-- Step 3 -->
-          <div style="padding:2rem 1.5rem;border-radius:12px;border:1px solid rgba(91,138,255,.1);background:rgba(91,138,255,.03)">
-            <div style="width:48px;height:48px;border-radius:50%;background:rgba(91,138,255,.1);border:1px solid rgba(91,138,255,.3);display:flex;align-items:center;justify-content:center;margin:0 auto 1.25rem;font-size:1.25rem;font-weight:700;color:var(--brand)">3</div>
-            <h3 style="font-size:1.1rem;font-weight:700;color:var(--text);margin-bottom:0.5rem">OmniDeck analizi birleştirir</h3>
-            <p style="color:var(--muted);font-size:0.9rem;line-height:1.6">Tek overlay, her piyasa, her zaman dilimi. Döngü fazı, önemli seviyeler ve momentum — hepsi tek bir grafikte.</p>
-          </div>
-        </div>
-        <div style="text-align:center;margin-top:2.5rem" data-reveal="fade-up" data-reveal-delay="400">
-          <a href="#trial" class="shiny-cta" style="width:auto;padding:.875rem 2rem;height:auto">
-            <span>Ücretsiz Dene →</span>
-          </a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
Removed two informational sections from the homepage to streamline the page layout and improve content flow. The "Anti-Pitch" section has been repositioned as the primary messaging area following the hero section.

## Changes Made
- **Removed "The Problem" section** (~38 lines): Eliminated the pain points section that highlighted issues with repainting indicators, stacking tools, and signal service dependency
- **Removed "How It Works" section** (~43 lines): Deleted the three-step explanation of how Pentarch reads market cycles, how the suite confirms events, and how OmniDeck unifies the read
- **Repositioned "Anti-Pitch" section**: Now serves as the primary value proposition section immediately after the hero, with updated comment from "(MOVED UP)" to standard "ANTI-PITCH SECTION"

## Implementation Details
- Both removed sections used consistent styling patterns (gradient backgrounds, card layouts, reveal animations)
- The "How It Works" section included a CTA button that has been removed
- No functional changes to remaining sections; this is purely a content reorganization
- The page now flows directly from hero to anti-pitch messaging to the "What's Inside: The Elite 7" section

https://claude.ai/code/session_01Dfb2i8RtQ6DNVQgdYToXue