### PR TITLE
Add URL redirects for /pricing routes to pricing section

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -102,6 +102,16 @@
       "permanent": true
     },
     {
+      "source": "/pricing",
+      "destination": "/#pricing",
+      "permanent": false
+    },
+    {
+      "source": "/pricing/",
+      "destination": "/#pricing",
+      "permanent": false
+    },
+    {
       "source": "/free",
       "destination": "https://education.signalpilot.io/free/",
       "permanent": true


### PR DESCRIPTION
## Summary
Added URL redirect rules to route `/pricing` and `/pricing/` paths to the pricing section anchor (`/#pricing`) on the homepage.

## Changes
- Added two new redirect rules in `vercel.json`:
  - `/pricing` → `/#pricing` (non-permanent redirect)
  - `/pricing/` → `/#pricing` (non-permanent redirect)

## Implementation Details
- Both redirects use `permanent: false` to allow for future changes without caching issues
- Routes users to the pricing section anchor on the homepage rather than a separate page
- Handles both trailing slash and non-trailing slash variants for consistent user experience

https://claude.ai/code/session_011qaYqHqokbhiTyaUk8Nvst