### PR TITLE
Remove social media cron jobs from Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -314,36 +314,8 @@
   },
   "crons": [
     {
-      "path": "/api/social/post-twitter/",
-      "schedule": "0 3,7,12,16,21 * * *"
-    },
-    {
-      "path": "/api/social/post-instagram/",
-      "schedule": "0 10,16,19 * * *"
-    },
-    {
-      "path": "/api/social/post-reels/",
-      "schedule": "0 10,15,20 * * *"
-    },
-    {
-      "path": "/api/social/post-story/",
-      "schedule": "0 8,11,14,17,20 * * *"
-    },
-    {
-      "path": "/api/social/refresh-ig-token/",
-      "schedule": "0 3 * * *"
-    },
-    {
-      "path": "/api/social/cron-queue-posts/",
-      "schedule": "0 2,8,14,20 * * *"
-    },
-    {
-      "path": "/api/social/post-retry/",
-      "schedule": "*/15 * * * *"
-    },
-    {
       "path": "/api/gumroad-fiscalize-retry/",
-      "schedule": "*/30 * * * *"
+      "schedule": "0 3 * * *"
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary
This PR removes all social media-related cron job configurations from the Vercel deployment settings and updates the remaining Gumroad cron job schedule.

## Key Changes
- Removed 7 social media cron jobs:
  - Twitter posting schedule (0 3,7,12,16,21 * * *)
  - Instagram posting schedule (0 10,16,19 * * *)
  - Reels posting schedule (0 10,15,20 * * *)
  - Story posting schedule (0 8,11,14,17,20 * * *)
  - Instagram token refresh (0 3 * * *)
  - Queue posts cron (0 2,8,14,20 * * *)
  - Post retry mechanism (*/15 * * * *)
- Updated Gumroad fiscalize retry schedule from every 30 minutes (*/30 * * * *) to daily at 3 AM (0 3 * * *)

## Implementation Details
The crons array in vercel.json now contains only the Gumroad fiscalize retry job. This change likely indicates that social media posting functionality has been migrated to a different service, removed entirely, or consolidated into a different scheduling mechanism.

https://claude.ai/code/session_01U7LpKEFMkg2Q61zdAMQ8S2